### PR TITLE
Exclude unnecessary files when installing skills

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -37,12 +37,27 @@ export async function installSkillForAgent(
   }
 }
 
+const EXCLUDE_FILES = new Set([
+  'README.md',
+  'metadata.json',
+]);
+
+const isExcluded = (name: string): boolean => {
+  if (EXCLUDE_FILES.has(name)) return true;
+  if (name.startsWith('_')) return true; // Templates, section definitions
+  return false;
+};
+
 async function copyDirectory(src: string, dest: string): Promise<void> {
   await mkdir(dest, { recursive: true });
 
   const entries = await readdir(src, { withFileTypes: true });
 
   for (const entry of entries) {
+    if (isExcluded(entry.name)) {
+      continue;
+    }
+
     const srcPath = join(src, entry.name);
     const destPath = join(dest, entry.name);
 


### PR DESCRIPTION
## Summary
  - Exclude files that are not needed for skill execution when installing
  
  <img width="831" height="816" alt="スクリーンショット 2026-01-15 16 50 07" src="https://github.com/user-attachments/assets/052efd84-2394-454c-b600-9de575c4c873" />



  ## Changes
  - Skip `README.md` (developer documentation)
  - Skip `metadata.json` (build script metadata)
  - Skip files starting with `_` (templates, section definitions)

  ## Why
  These files are only used for:
  - Development/contribution guides (README.md)
  - Build process (metadata.json, _sections.md, _template.md)

  Claude only needs:
  - `SKILL.md` (skill definition)
  - `AGENTS.md` (detailed rules)
  - `rules/*.md` (actual rule files, excluding _ prefixed)
  
  ## Test
  Tested with `vercel-labs/agent-skills` react-best-practices skill.
 
 
<img width="674" height="674" alt="スクリーンショット 2026-01-15 17 14 49" src="https://github.com/user-attachments/assets/6d9d832c-13e3-45e2-a1c2-6d3b932133a9" />

  