### PR TITLE
fix: dedupe Gemini CLI agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install agent skills onto your coding agents from any git repository.
 
 <!-- agent-list:start -->
-Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [11 more](#available-agents).
+Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [10 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Quick Start
@@ -95,7 +95,6 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | GitHub Copilot | `.github/skills/` | `~/.copilot/skills/` |
 | Clawdbot | `skills/` | `~/.clawdbot/skills/` |
 | Droid | `.factory/skills/` | `~/.factory/skills/` |
-| Gemini CLI | `.gemini/skills/` | `~/.gemini/skills/` |
 | Windsurf | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
 <!-- available-agents:end -->
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -123,15 +123,6 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.factory/skills'));
     },
   },
-  gemini: {
-    name: 'gemini',
-    displayName: 'Gemini CLI',
-    skillsDir: '.gemini/skills',
-    globalSkillsDir: join(home, '.gemini/skills'),
-    detectInstalled: async () => {
-      return existsSync(join(home, '.gemini'));
-    },
-  },
   windsurf: {
     name: 'windsurf',
     displayName: 'Windsurf',

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,12 @@ interface Options {
   list?: boolean;
 }
 
+function normalizeAgentInput(agent: string): string {
+  // Backwards compatibility: `gemini` was an alias for `gemini-cli`.
+  if (agent === 'gemini') return 'gemini-cli';
+  return agent;
+}
+
 program
   .name('add-skill')
   .description('Install skills onto coding agents (OpenCode, Claude Code, Codex, Cursor, Antigravity, Github Copilot, Roo Code)')
@@ -154,7 +160,8 @@ let tempDir: string | null = null;
     const validAgents = Object.keys(agents);
 
     if (options.agent && options.agent.length > 0) {
-      const invalidAgents = options.agent.filter(a => !validAgents.includes(a));
+      const requestedAgents = [...new Set(options.agent.map(normalizeAgentInput))];
+      const invalidAgents = requestedAgents.filter(a => !validAgents.includes(a));
 
       if (invalidAgents.length > 0) {
         p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
@@ -163,7 +170,7 @@ let tempDir: string | null = null;
         process.exit(1);
       }
 
-      targetAgents = options.agent as AgentType[];
+      targetAgents = requestedAgents as AgentType[];
     } else {
       spinner.start('Detecting installed agents...');
       const installedAgents = await detectInstalledAgents();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type AgentType = 'opencode' | 'claude-code' | 'codex' | 'cursor' | 'amp' | 'kilo' | 'roo' | 'goose' | 'antigravity' | 'gemini-cli' | 'github-copilot' | 'clawdbot' | 'droid' | 'gemini' | 'windsurf';
+export type AgentType = 'opencode' | 'claude-code' | 'codex' | 'cursor' | 'amp' | 'kilo' | 'roo' | 'goose' | 'antigravity' | 'gemini-cli' | 'github-copilot' | 'clawdbot' | 'droid' | 'windsurf';
 
 export interface Skill {
   name: string;


### PR DESCRIPTION
### Problem

During the interactive install flow, **Gemini CLI** shows up twice in the agent multiselect.

Root cause: we had two agent entries (gemini-cli and gemini) with the same display name, paths, and detection logic, so both were detected and rendered.

### Changes

- Remove the duplicate gemini agent entry (keep gemini-cli).
- Keep backwards compatibility by treating --agent gemini as an alias for gemini-cli and de-duping requested agents.
- Regenerate the README agent table.

### How to test

1. Run: npx add-skill OWNER/REPO
2. Select any skill and continue to the agent selection step.
3. Verify the list contains a single “Gemini CLI” entry.
4. Verify: npx add-skill OWNER/REPO --skill SOME_SKILL -a gemini (alias still works)
