### PR TITLE
fix: remove duplicate gemini agent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install agent skills onto your coding agents from any git repository.
 
 <!-- agent-list:start -->
-Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [11 more](#available-agents).
+Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [10 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Quick Start
@@ -95,7 +95,6 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | GitHub Copilot | `.github/skills/` | `~/.copilot/skills/` |
 | Clawdbot | `skills/` | `~/.clawdbot/skills/` |
 | Droid | `.factory/skills/` | `~/.factory/skills/` |
-| Gemini CLI | `.gemini/skills/` | `~/.gemini/skills/` |
 | Windsurf | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
 <!-- available-agents:end -->
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -123,15 +123,6 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.factory/skills'));
     },
   },
-  gemini: {
-    name: 'gemini',
-    displayName: 'Gemini CLI',
-    skillsDir: '.gemini/skills',
-    globalSkillsDir: join(home, '.gemini/skills'),
-    detectInstalled: async () => {
-      return existsSync(join(home, '.gemini'));
-    },
-  },
   windsurf: {
     name: 'windsurf',
     displayName: 'Windsurf',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type AgentType = 'opencode' | 'claude-code' | 'codex' | 'cursor' | 'amp' | 'kilo' | 'roo' | 'goose' | 'antigravity' | 'gemini-cli' | 'github-copilot' | 'clawdbot' | 'droid' | 'gemini' | 'windsurf';
+export type AgentType = 'opencode' | 'claude-code' | 'codex' | 'cursor' | 'amp' | 'kilo' | 'roo' | 'goose' | 'antigravity' | 'gemini-cli' | 'github-copilot' | 'clawdbot' | 'droid' | 'windsurf';
 
 export interface Skill {
   name: string;


### PR DESCRIPTION
The 'gemini' and 'gemini-cli' agents were duplicate entries with identical                          
   configuration pointing to the same paths (.gemini/skills). This caused                              
   confusion and potential issues with agent detection.                                                
                                                                                                       
   Changes:                                                                                            
   - Removed duplicate 'gemini' entry from src/agents.ts                                               
   - Updated AgentType to remove 'gemini' from src/types.ts                                            
   - Updated README.md to reflect 14 total agents (down from 15)                                       
                                                                                                       
   The 'gemini-cli' agent is preserved as it was added first (PR #27) and                              
   is the canonical name for Gemini CLI support.