### PR TITLE
feat: add support for local path installation

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -2,74 +2,6 @@ import simpleGit from 'simple-git';
 import { join, normalize, resolve, sep } from 'path';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
-import type { ParsedSource } from './types.js';
-
-export function parseSource(input: string): ParsedSource {
-  // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
-  const githubTreeMatch = input.match(
-    /github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/
-  );
-  if (githubTreeMatch) {
-    const [, owner, repo, , subpath] = githubTreeMatch;
-    return {
-      type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
-      subpath,
-    };
-  }
-
-  // GitHub URL: https://github.com/owner/repo
-  const githubRepoMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
-  if (githubRepoMatch) {
-    const [, owner, repo] = githubRepoMatch;
-    const cleanRepo = repo!.replace(/\.git$/, '');
-    return {
-      type: 'github',
-      url: `https://github.com/${owner}/${cleanRepo}.git`,
-    };
-  }
-
-  // GitLab URL with path: https://gitlab.com/owner/repo/-/tree/branch/path
-  const gitlabTreeMatch = input.match(
-    /gitlab\.com\/([^/]+)\/([^/]+)\/-\/tree\/([^/]+)\/(.+)/
-  );
-  if (gitlabTreeMatch) {
-    const [, owner, repo, , subpath] = gitlabTreeMatch;
-    return {
-      type: 'gitlab',
-      url: `https://gitlab.com/${owner}/${repo}.git`,
-      subpath,
-    };
-  }
-
-  // GitLab URL: https://gitlab.com/owner/repo
-  const gitlabRepoMatch = input.match(/gitlab\.com\/([^/]+)\/([^/]+)/);
-  if (gitlabRepoMatch) {
-    const [, owner, repo] = gitlabRepoMatch;
-    const cleanRepo = repo!.replace(/\.git$/, '');
-    return {
-      type: 'gitlab',
-      url: `https://gitlab.com/${owner}/${cleanRepo}.git`,
-    };
-  }
-
-  // GitHub shorthand: owner/repo or owner/repo/path/to/skill
-  const shorthandMatch = input.match(/^([^/]+)\/([^/]+)(?:\/(.+))?$/);
-  if (shorthandMatch && !input.includes(':')) {
-    const [, owner, repo, subpath] = shorthandMatch;
-    return {
-      type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
-      subpath,
-    };
-  }
-
-  // Fallback: treat as direct git URL
-  return {
-    type: 'git',
-    url: input,
-  };
-}
 
 export async function cloneRepo(url: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'add-skill-'));
@@ -82,7 +14,7 @@ export async function cleanupTempDir(dir: string): Promise<void> {
   // Validate that the directory path is within tmpdir to prevent deletion of arbitrary paths
   const normalizedDir = normalize(resolve(dir));
   const normalizedTmpDir = normalize(resolve(tmpdir()));
-  
+
   if (!normalizedDir.startsWith(normalizedTmpDir + sep) && normalizedDir !== normalizedTmpDir) {
     throw new Error('Attempted to clean up directory outside of temp directory');
   }

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -1,0 +1,100 @@
+import { isAbsolute, resolve } from 'path';
+import type { ParsedSource } from './types.js';
+
+/**
+ * Check if a string represents a local file system path
+ */
+function isLocalPath(input: string): boolean {
+    return (
+        isAbsolute(input) ||
+        input.startsWith('./') ||
+        input.startsWith('../') ||
+        input === '.' ||
+        input === '..' ||
+        // Windows absolute paths like C:\ or D:\
+        /^[a-zA-Z]:[/\\]/.test(input)
+    );
+}
+
+/**
+ * Parse a source string into a structured format
+ * Supports: local paths, GitHub URLs, GitLab URLs, GitHub shorthand, and direct git URLs
+ */
+export function parseSource(input: string): ParsedSource {
+    // Local path: absolute, relative, or current directory
+    if (isLocalPath(input)) {
+        const resolvedPath = resolve(input);
+        // Return local type even if path doesn't exist - we'll handle validation in main flow
+        return {
+            type: 'local',
+            url: resolvedPath, // Store resolved path in url for consistency
+            localPath: resolvedPath,
+        };
+    }
+
+    // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
+    const githubTreeMatch = input.match(
+        /github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/
+    );
+    if (githubTreeMatch) {
+        const [, owner, repo, , subpath] = githubTreeMatch;
+        return {
+            type: 'github',
+            url: `https://github.com/${owner}/${repo}.git`,
+            subpath,
+        };
+    }
+
+    // GitHub URL: https://github.com/owner/repo
+    const githubRepoMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
+    if (githubRepoMatch) {
+        const [, owner, repo] = githubRepoMatch;
+        const cleanRepo = repo!.replace(/\.git$/, '');
+        return {
+            type: 'github',
+            url: `https://github.com/${owner}/${cleanRepo}.git`,
+        };
+    }
+
+    // GitLab URL with path: https://gitlab.com/owner/repo/-/tree/branch/path
+    const gitlabTreeMatch = input.match(
+        /gitlab\.com\/([^/]+)\/([^/]+)\/-\/tree\/([^/]+)\/(.+)/
+    );
+    if (gitlabTreeMatch) {
+        const [, owner, repo, , subpath] = gitlabTreeMatch;
+        return {
+            type: 'gitlab',
+            url: `https://gitlab.com/${owner}/${repo}.git`,
+            subpath,
+        };
+    }
+
+    // GitLab URL: https://gitlab.com/owner/repo
+    const gitlabRepoMatch = input.match(/gitlab\.com\/([^/]+)\/([^/]+)/);
+    if (gitlabRepoMatch) {
+        const [, owner, repo] = gitlabRepoMatch;
+        const cleanRepo = repo!.replace(/\.git$/, '');
+        return {
+            type: 'gitlab',
+            url: `https://gitlab.com/${owner}/${cleanRepo}.git`,
+        };
+    }
+
+    // GitHub shorthand: owner/repo or owner/repo/path/to/skill
+    // Exclude paths that start with . or / to avoid matching local paths
+    const shorthandMatch = input.match(/^([^/]+)\/([^/]+)(?:\/(.+))?$/);
+    if (shorthandMatch && !input.includes(':') && !input.startsWith('.') && !input.startsWith('/')) {
+        const [, owner, repo, subpath] = shorthandMatch;
+        return {
+            type: 'github',
+            url: `https://github.com/${owner}/${repo}.git`,
+            subpath,
+        };
+    }
+
+    // Fallback: treat as direct git URL
+    return {
+        type: 'git',
+        url: input,
+    };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,8 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git';
+  type: 'github' | 'gitlab' | 'git' | 'local';
   url: string;
   subpath?: string;
+  localPath?: string;
 }


### PR DESCRIPTION
   Users can now install skills from local directories without needing to push                         
   to a git repository first. This is particularly useful for:                                         
   - Local skill development and testing                                                               
   - Offline usage                                                                                     
   - CI/CD workflows with pre-cloned repositories                                                      
                                                                                                       
   Changes:                                                                                                                       
   - Added 'local' type to ParsedSource interface                                                      
   - Modified main flow to skip git clone for local paths                                              
   - Added path validation with clear error messages                                                   
   - Updated CLI help text to document local path support 
   - Created new source-parser.ts module for better code organization                                                    
                                                                                                       
   Supported path formats:                                                                             
   - Absolute paths: /path/to/skill or C:\path\to\skill                                                
   - Relative paths: ./skill or ../skill                                                               
   - Current directory: .                                                                              
                                                                                                       
   Example usage:                                                                                      
     npx add-skill ./my-skill                                                                          
     npx add-skill /absolute/path/to/skill                                                             
     npx add-skill ../parent-dir/skill                                                             
     npx add-skill ~/.claude/skills/skill

Resolves #21