### PR TITLE
docs: add --agent column to Available Agents table

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,22 +80,22 @@ npx add-skill vercel-labs/agent-skills -y -g
 Skills can be installed to any of these supported agents. Use `-g, --global` to install to the global path instead of project-level.
 
 <!-- available-agents:start -->
-| Agent | Project Path | Global Path |
-|-------|--------------|-------------|
-| OpenCode | `.opencode/skill/` | `~/.config/opencode/skill/` |
-| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
-| Codex | `.codex/skills/` | `~/.codex/skills/` |
-| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
-| Amp | `.agents/skills/` | `~/.config/agents/skills/` |
-| Kilo Code | `.kilocode/skills/` | `~/.kilocode/skills/` |
-| Roo Code | `.roo/skills/` | `~/.roo/skills/` |
-| Goose | `.goose/skills/` | `~/.config/goose/skills/` |
-| Gemini CLI | `.gemini/skills/` | `~/.gemini/skills/` |
-| Antigravity | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
-| GitHub Copilot | `.github/skills/` | `~/.copilot/skills/` |
-| Clawdbot | `skills/` | `~/.clawdbot/skills/` |
-| Droid | `.factory/skills/` | `~/.factory/skills/` |
-| Windsurf | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| Agent | `--agent` | Project Path | Global Path |
+|-------|-----------|--------------|-------------|
+| OpenCode | `opencode` | `.opencode/skill/` | `~/.config/opencode/skill/` |
+| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
+| Codex | `codex` | `.codex/skills/` | `~/.codex/skills/` |
+| Cursor | `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |
+| Amp | `amp` | `.agents/skills/` | `~/.config/agents/skills/` |
+| Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
+| Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
+| Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Gemini CLI | `gemini-cli` | `.gemini/skills/` | `~/.gemini/skills/` |
+| Antigravity | `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
+| GitHub Copilot | `github-copilot` | `.github/skills/` | `~/.copilot/skills/` |
+| Clawdbot | `clawdbot` | `skills/` | `~/.clawdbot/skills/` |
+| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
+| Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
 <!-- available-agents:end -->
 
 ## Agent Detection


### PR DESCRIPTION
## Summary

  The `Available Agents` table in the README now includes a `--agent` column showing the CLI key for each agent.

  ## Motivation

  When reading the README, I noticed that the Options section mentions:

  > `-a, --agent <agents...>` Target specific agents (e.g., `claude-code`, `codex`). See [Available Agents](#available-agents)

  However, the referenced Available Agents table only showed display names (e.g., "Claude Code", "Gemini CLI") without the actual CLI keys (e.g., `claude-code`,
  `gemini-cli`). This made it unclear what value to pass to the `--agent` option, requiring users to guess or check the source code.

  ## Changes

  - Added `--agent` column to the Available Agents table
  - Each row now shows the exact CLI key to use (e.g., `opencode`, `claude-code`, `gemini-cli`)

  ## Before

  | Agent | Project Path | Global Path |
  |-------|--------------|-------------|
  | Claude Code | `.claude/skills/` | `~/.claude/skills/` |

  ## After

  | Agent | `--agent` | Project Path | Global Path |
  |-------|-----------|--------------|-------------|
  | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |