### PR TITLE
feat: add windsurf-next agent support (#46)

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -133,6 +133,16 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.codeium/windsurf'));
     },
   },
+
+  'windsurf-next': {
+    name: 'windsurf-next',
+    displayName: 'Windsurf Next',
+    skillsDir: '.windsurf-next/skills',
+    globalSkillsDir: join(home, '.codeium/windsurf-next/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.codeium/windsurf-next'));
+    },
+  },
 };
 
 export async function detectInstalledAgents(): Promise<AgentType[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type AgentType = 'opencode' | 'claude-code' | 'codex' | 'cursor' | 'amp' | 'kilo' | 'roo' | 'goose' | 'antigravity' | 'gemini-cli' | 'github-copilot' | 'clawdbot' | 'droid' | 'windsurf';
+export type AgentType = 'opencode' | 'claude-code' | 'codex' | 'cursor' | 'amp' | 'kilo' | 'roo' | 'goose' | 'antigravity' | 'gemini-cli' | 'github-copilot' | 'clawdbot' | 'droid' | 'windsurf' | 'windsurf-next';
 
 export interface Skill {
   name: string;


### PR DESCRIPTION
- Add 'windsurf-next' to AgentType union
- Add windsurf-next agent configuration with:
  - Project skills dir: .windsurf-next/skills
  - Global skills dir: ~/.codeium/windsurf-next/skills
  - Detection via ~/.codeium/windsurf-next directory

Fixes #46