### PR TITLE
Add git submodule support to skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ The CLI searches for skills in these locations within a repository:
 
 If no skills are found in standard locations, a recursive search is performed.
 
+### Git Submodules
+
+Repositories with git submodules are fully supported. Submodules are automatically checked out during cloning, and skills within them are discovered using the same search logic. This enables organizations to maintain a central hub repository that references team-owned skill repositories as submodules.
+
 ## Compatibility
 
 Skills are generally compatible across agents since they follow a shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "add-skill",
-  "version": "1.0.10",
+  "version": "1.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "add-skill",
-      "version": "1.0.10",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
@@ -1045,6 +1045,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1319,6 +1320,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1685,6 +1687,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -1703,6 +1706,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/git.ts
+++ b/src/git.ts
@@ -7,8 +7,8 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'add-skill-'));
   const git = simpleGit();
   const cloneOptions = ref
-    ? ['--depth', '1', '--branch', ref]
-    : ['--depth', '1'];
+    ? ['--depth', '1', '--branch', ref, '--recurse-submodules', '--shallow-submodules']
+    : ['--depth', '1', '--recurse-submodules', '--shallow-submodules'];
   await git.clone(url, tempDir, cloneOptions);
   return tempDir;
 }


### PR DESCRIPTION
## Summary
Enable add-skill to checkout and discover skills within git submodules. This allows organizations to maintain a central hub repository that references team-owned skill repositories as submodules, enabling distributed skill ownership while maintaining centralized discovery.

## Changes
- Add `--recurse-submodules` and `--shallow-submodules` flags to git clone operations
- Add documentation explaining submodule support
- Existing skill discovery automatically finds skills in submodule directories

## Testing
Built project successfully with `npm run build`. Git clone flags are valid and tested with real repositories.