### PR TITLE
Add Neovate coding agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install agent skills onto your coding agents from any git repository.
 
 <!-- agent-list:start -->
-Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [12 more](#available-agents).
+Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [13 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Quick Start
@@ -98,6 +98,7 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
 | Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
 <!-- available-agents:end -->
 
 > [!NOTE]
@@ -169,6 +170,7 @@ The CLI searches for skills in these locations within a repository:
 - `.roo/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`
+- `.neovate/skills/`
 <!-- skill-discovery:end -->
 
 If no skills are found in standard locations, a recursive search is performed.
@@ -177,12 +179,12 @@ If no skills are found in standard locations, a recursive search is performed.
 
 Skills are generally compatible across agents since they follow a shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature | OpenCode | Claude Code | Codex | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | Clawdbot |
-|---------|----------|-------------|-------|----------|--------|-------------|----------|----------------|-----|----------|
-| Basic skills | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `allowed-tools` | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes |
-| `context: fork` | No | Yes | No | No | No | No | No | No | No | No |
-| Hooks | No | Yes | No | No | No | No | No | No | No | No |
+| Feature | OpenCode | Claude Code | Codex | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | Clawdbot | Neovate |
+|---------|----------|-------------|-------|----------|--------|-------------|----------|----------------|-----|----------|---------|
+| Basic skills | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `allowed-tools` | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `context: fork` | No | Yes | No | No | No | No | No | No | No | No | No |
+| Hooks | No | Yes | No | No | No | No | No | No | No | No | No |
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "opencode",
     "roo",
     "trae",
-    "windsurf"
+    "windsurf",
+    "neovate"
   ],
   "repository": {
     "type": "git",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -150,6 +150,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.codeium/windsurf'));
     },
   },
+  neovate: {
+    name: 'neovate',
+    displayName: 'Neovate',
+    skillsDir: '.neovate/skills',
+    globalSkillsDir: join(home, '.neovate/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.neovate'));
+    },
+  },
 };
 
 export async function detectInstalledAgents(): Promise<AgentType[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type AgentType = 'amp' | 'antigravity' | 'claude-code' | 'clawdbot' | 'codex' | 'cursor' | 'droid' | 'gemini-cli' | 'github-copilot' | 'goose' | 'kilo' | 'kiro-cli' | 'opencode' | 'roo' | 'trae' | 'windsurf';
+export type AgentType = 'amp' | 'antigravity' | 'claude-code' | 'clawdbot' | 'codex' | 'cursor' | 'droid' | 'gemini-cli' | 'github-copilot' | 'goose' | 'kilo' | 'kiro-cli' | 'opencode' | 'roo' | 'trae' | 'windsurf' | 'neovate';
 
 export interface Skill {
   name: string;


### PR DESCRIPTION
Add Neovate as a supported coding agent with:
- Agent type and configuration
- Skills directory paths (.neovate/skills/)
- Detection for installed agent
- Documentation in README