### PR TITLE
fix: update opencode skill directory to use 'skill' instead of 'skills'

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
-| OpenCode | `opencode` | `.opencode/skills/` | `~/.config/opencode/skills/` |
+| OpenCode | `opencode` | `.opencode/skill/` | `~/.config/opencode/skill/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
 | Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
@@ -166,7 +166,7 @@ The CLI searches for skills in these locations within a repository:
 - `.goose/skills/`
 - `.kilocode/skills/`
 - `.kiro/skills/`
-- `.opencode/skills/`
+- `.opencode/skill/`
 - `.roo/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -117,8 +117,8 @@ export const agents: Record<AgentType, AgentConfig> = {
   opencode: {
     name: 'opencode',
     displayName: 'OpenCode',
-    skillsDir: '.opencode/skills',
-    globalSkillsDir: join(home, '.config/opencode/skills'),
+    skillsDir: '.opencode/skill',
+    globalSkillsDir: join(home, '.config/opencode/skill'),
     detectInstalled: async () => {
       return existsSync(join(home, '.config/opencode')) || existsSync(join(home, '.claude/skills'));
     },

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -90,7 +90,7 @@ export async function discoverSkills(basePath: string, subpath?: string): Promis
     join(searchPath, '.goose/skills'),
     join(searchPath, '.kilocode/skills'),
     join(searchPath, '.kiro/skills'),
-    join(searchPath, '.opencode/skills'),
+    join(searchPath, '.opencode/skill'),
     join(searchPath, '.roo/skills'),
     join(searchPath, '.trae/skills'),
   ];


### PR DESCRIPTION
I have REVIEWED this PR carefully instead of just letting AI do all the stuffs.

This pull request updates the directory naming convention for OpenCode agent skills from `skills` to `skill` to ensure consistency across the codebase and documentation. The change affects both the local and global skill directories, as well as the skill discovery logic.

**OpenCode Agent Skill Directory Updates:**

* Updated the OpenCode agent's skill directory from `.opencode/skills/` to `.opencode/skill/` and the global directory from `~/.config/opencode/skills/` to `~/.config/opencode/skill/` in the `README.md` and `src/agents.ts`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R97) [[2]](diffhunk://#diff-0dd7b6150e3673f42fe6a289e0656e83bb3c0f4d0b60ee357ce3a6f7db7292c0L120-R121)
* Changed the skill discovery paths to use `.opencode/skill/` instead of `.opencode/skills/` in both the documentation and the `src/skills.ts` file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L169-R169) [[2]](diffhunk://#diff-ca133957b406af3fc0facfd68509bbcb3ff453a3dfda7b088ede09ca7d874b14L93-R93)

This fixed the following issues that have been closed without any fixes merged:
- https://github.com/vercel-labs/add-skill/issues/49
- https://github.com/vercel-labs/add-skill/issues/54

Btw, opencode's [official documentation](https://opencode.ai/docs/skills/) is incorrect in terms of the skill path. The program only respect `skill` path.