### PR TITLE
Respect CODEX_HOME for Codex skills

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'fs';
 import type { AgentConfig, AgentType } from './types.js';
 
 const home = homedir();
+const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 
 export const agents: Record<AgentType, AgentConfig> = {
   amp: {
@@ -57,9 +58,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'codex',
     displayName: 'Codex',
     skillsDir: '.codex/skills',
-    globalSkillsDir: join(home, '.codex/skills'),
+    globalSkillsDir: join(codexHome, 'skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.codex'));
+      return existsSync(codexHome) || existsSync('/etc/codex');
     },
   },
   'command-code': {


### PR DESCRIPTION
## Summary
Codex loads user skills from CODEX_HOME/skills with ~/.codex as the default and admin skills from /etc/codex/skills. Today we always install globally to ~/.codex/skills, which is wrong when CODEX_HOME is set. This change makes the installer honor CODEX_HOME and recognize the admin location.

## Documentation
From https://developers.openai.com/codex/skills/

> `REPO` `$CWD/.codex/skills`
> `REPO` `$CWD/../.codex/skills`
> `REPO` `$REPO_ROOT/.codex/skills`
> `USER` `$CODEX_HOME/skills`
> `ADMIN` `/etc/codex/skills`

## Observed behavior
With CODEX_HOME set to a custom directory, a global install still goes to ~/.codex/skills and Codex does not discover the skill.

## Fix
- Use process.env.CODEX_HOME to compute the global skills directory and fall back to ~/.codex when it is not set
- Treat /etc/codex as a valid install location during detection

## Why this works
This aligns the installer with documented Codex lookup paths and respects explicit configuration while keeping the default path unchanged when CODEX_HOME is unset.

## Tests and intent
I validated manually with CODEX_HOME=/tmp/codex and confirmed installs land in /tmp/codex/skills.
