### PR TITLE
feat: add Command Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install agent skills onto your coding agents from any git repository.
 
 <!-- agent-list:start -->
-Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [13 more](#available-agents).
+Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [14 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Quick Start
@@ -87,6 +87,7 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | Clawdbot | `clawdbot` | `skills/` | `~/.clawdbot/skills/` |
 | Codex | `codex` | `.codex/skills/` | `~/.codex/skills/` |
+| Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Cursor | `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |
 | Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
 | Gemini CLI | `gemini-cli` | `.gemini/skills/` | `~/.gemini/skills/` |
@@ -159,6 +160,7 @@ The CLI searches for skills in these locations within a repository:
 - `.claude/skills/`
 - `./skills/`
 - `.codex/skills/`
+- `.commandcode/skills/`
 - `.cursor/skills/`
 - `.factory/skills/`
 - `.gemini/skills/`
@@ -179,12 +181,12 @@ If no skills are found in standard locations, a recursive search is performed.
 
 Skills are generally compatible across agents since they follow a shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature | OpenCode | Claude Code | Codex | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | Clawdbot | Neovate |
-|---------|----------|-------------|-------|----------|--------|-------------|----------|----------------|-----|----------|---------|
-| Basic skills | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `allowed-tools` | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `context: fork` | No | Yes | No | No | No | No | No | No | No | No | No |
-| Hooks | No | Yes | No | No | No | No | No | No | No | No | No |
+| Feature | OpenCode | Claude Code | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | Clawdbot | Neovate |
+|---------|----------|-------------|-------|--------------|----------|--------|-------------|----------|----------------|-----|----------|---------|
+| Basic skills | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `allowed-tools` | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `context: fork` | No | Yes | No | No | No | No | No | No | No | No | No | No |
+| Hooks | No | Yes | No | No | No | No | No | No | No | No | No | No |
 
 ## Troubleshooting
 
@@ -224,6 +226,7 @@ Telemetry is also automatically disabled in CI environments.
 - [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)
 - [Clawdbot Skills Documentation](https://docs.clawd.bot/tools/skills)
 - [Codex Skills Documentation](https://developers.openai.com/codex/skills)
+- [Command Code Skills Documentation](https://commandcode.ai/docs/skills)
 - [Cursor Skills Documentation](https://cursor.com/docs/context/skills)
 - [Gemini CLI Skills Documentation](https://geminicli.com/docs/cli/skills/)
 - [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "claude-code",
     "clawdbot",
     "codex",
+    "command-code",
     "cursor",
     "droid",
     "gemini-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -53,6 +53,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.codex'));
     },
   },
+  'command-code': {
+    name: 'command-code',
+    displayName: 'Command Code',
+    skillsDir: '.commandcode/skills',
+    globalSkillsDir: join(home, '.commandcode/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.commandcode'));
+    },
+  },
   cursor: {
     name: 'cursor',
     displayName: 'Cursor',

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ interface Options {
 program
   .name('add-skill')
   .description(
-    'Install skills onto coding agents (OpenCode, Claude Code, Codex, Cursor, Antigravity, Github Copilot, Roo Code)'
+    'Install skills onto coding agents (OpenCode, Claude Code, Command Code, Codex, Cursor, Antigravity, Github Copilot, Roo Code)'
   )
   .version(version)
   .argument(
@@ -74,7 +74,7 @@ program
   .option('-g, --global', 'Install skill globally (user-level) instead of project-level')
   .option(
     '-a, --agent <agents...>',
-    'Specify agents to install to (opencode, claude-code, codex, cursor, antigravity, gitub-copilot, roo)'
+    'Specify agents to install to (opencode, claude-code, command-code, codex, cursor, antigravity, github-copilot, roo)'
   )
   .option('-s, --skill <skills...>', 'Specify skill names to install (skip selection prompt)')
   .option('-l, --list', 'List available skills in the repository without installing')

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -85,6 +85,7 @@ export async function discoverSkills(basePath: string, subpath?: string): Promis
     join(searchPath, '.agents/skills'),
     join(searchPath, '.claude/skills'),
     join(searchPath, '.codex/skills'),
+    join(searchPath, '.commandcode/skills'),
     join(searchPath, '.cursor/skills'),
     join(searchPath, '.github/skills'),
     join(searchPath, '.goose/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type AgentType =
   | 'claude-code'
   | 'clawdbot'
   | 'codex'
+  | 'command-code'
   | 'cursor'
   | 'droid'
   | 'gemini-cli'


### PR DESCRIPTION
This PR adds support for [Command Code](https://commandcode.ai) agent. We've supported skills from day one. 

For the skill.sh site please use this [symbol.svg](https://raw.githubusercontent.com/ahmadawais/stuff/refs/heads/master/commandcode/design/logo/symbol/symbol.svg) file. 

To put here. 
<img width="1118" height="318" alt="image" src="https://github.com/user-attachments/assets/9030e09a-e23b-458e-8ee6-2ddfcaf3f4d1" />

## Summary

- Add Command Code as a supported coding agent
- Project-level skills path: `.commandcode/skills/`
- Global skills path: `~/.commandcode/skills/`
- Agent detection via `~/.commandcode` directory

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Format check passes (`pnpm format:check`)
- [x] Tested installation with `-a command-code -g -y`
- [x] Verified symlinks created correctly in `~/.commandcode/skills/`