### PR TITLE
feat: add Cline agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | Antigravity | `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | Clawdbot | `clawdbot` | `skills/` | `~/.clawdbot/skills/` |
+| Cline | `cline` | `.cline/skills/` | `~/.cline/skills/` |
 | Codex | `codex` | `.codex/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Cursor | `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |
@@ -158,6 +159,7 @@ The CLI searches for skills in these locations within a repository:
 - `.agents/skills/`
 - `.agent/skills/`
 - `.claude/skills/`
+- `.cline/skills/`
 - `./skills/`
 - `.codex/skills/`
 - `.commandcode/skills/`
@@ -181,12 +183,12 @@ If no skills are found in standard locations, a recursive search is performed.
 
 Skills are generally compatible across agents since they follow a shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature | OpenCode | Claude Code | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | Clawdbot | Neovate |
-|---------|----------|-------------|-------|--------------|----------|--------|-------------|----------|----------------|-----|----------|---------|
-| Basic skills | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `allowed-tools` | Yes | Yes | Yes | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| `context: fork` | No | Yes | No | No | No | No | No | No | No | No | No | No |
-| Hooks | No | Yes | No | No | No | No | No | No | No | No | No | No |
+| Feature | OpenCode | Claude Code | Codex | Cline | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | Clawdbot | Neovate |
+|---------|----------|-------------|-------|-------|--------------|----------|--------|-------------|----------|----------------|-----|----------|---------|
+| Basic skills | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `allowed-tools` | Yes | Yes | Yes | No | Yes | No | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| `context: fork` | No | Yes | No | No | No | No | No | No | No | No | No | No | No |
+| Hooks | No | Yes | No | No | No | No | No | No | No | No | No | No | No |
 
 ## Troubleshooting
 
@@ -225,6 +227,7 @@ Telemetry is also automatically disabled in CI environments.
 - [Antigravity Skills Documentation](https://antigravity.google/docs/skills)
 - [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)
 - [Clawdbot Skills Documentation](https://docs.clawd.bot/tools/skills)
+- [Cline Skills Documentation](https://docs.cline.bot/features/skills)
 - [Codex Skills Documentation](https://developers.openai.com/codex/skills)
 - [Command Code Skills Documentation](https://commandcode.ai/docs/skills)
 - [Cursor Skills Documentation](https://cursor.com/docs/context/skills)

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -44,6 +44,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.clawdbot'));
     },
   },
+  cline: {
+    name: 'cline',
+    displayName: 'Cline',
+    skillsDir: '.cline/skills',
+    globalSkillsDir: join(home, '.cline/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.cline'));
+    },
+  },
   codex: {
     name: 'codex',
     displayName: 'Codex',

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type AgentType =
   | 'antigravity'
   | 'claude-code'
   | 'clawdbot'
+  | 'cline'
   | 'codex'
   | 'command-code'
   | 'cursor'


### PR DESCRIPTION
Add Cline as a supported agent with:
- Project skills: .cline/skills/
- Global skills: ~/.cline/skills/
- Detection: checks for ~/.cline directory

Cline supports basic skills only (no allowed-tools, context: fork, or hooks).