### PR TITLE
feat(agents): add Qwen Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
+| Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
 | Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
@@ -178,6 +179,7 @@ The CLI searches for skills in these locations within a repository:
 - `.openhands/skills/`
 - `.pi/skills/`
 - `.qoder/skills/`
+- `.qwen/skills/`
 - `.roo/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`
@@ -243,6 +245,7 @@ Telemetry is also automatically disabled in CI environments.
 - [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
 - [Kiro CLI Skills Documentation](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources)
 - [OpenCode Skills Documentation](https://opencode.ai/docs/skills)
+- [Qwen Code Skills Documentation](https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/)
 - [OpenHands Skills Documentation](https://docs.openhands.ai/modules/usage/how-to/using-skills)
 - [Pi Skills Documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md)
 - [Qoder Skills Documentation](https://docs.qoder.com/cli/Skills)

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -170,6 +170,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.qoder'));
     },
   },
+  'qwen-code': {
+    name: 'qwen-code',
+    displayName: 'Qwen Code',
+    skillsDir: '.qwen/skills',
+    globalSkillsDir: join(home, '.qwen/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.qwen'));
+    },
+  },
   roo: {
     name: 'roo',
     displayName: 'Roo Code',

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type AgentType =
   | 'openhands'
   | 'pi'
   | 'qoder'
+  | 'qwen-code'
   | 'roo'
   | 'trae'
   | 'windsurf'


### PR DESCRIPTION
Add **Qwen Code** as a new supported coding agent.

[Qwen Code](https://github.com/QwenLM/qwen-code) is an AI-powered coding agent built on Alibaba's Qwen team. This PR enables users to install and manage skills for Qwen Code through the `add-skill` CLI.

## Changes

### Core Changes
- Add `qwen-code` agent configuration in `src/agents.ts`
  - Project-level skills directory: `.qwen/skills/`
  - Global skills directory: `~/.qwen/skills/`
  - Detection: checks for `~/.qwen` directory existence
- Add `'qwen-code'` to the `AgentType` union in `src/types.ts`

### Documentation
- Update README.md with Qwen Code in the supported agents list
- Add documentation link for Qwen Code

## Testing

### Build & Install Skills

```bash
# Build the project
npm run build

# Install a skill (e.g., from GitHub)
node dist/index.js https://github.com/vercel-labs/agent-skills
```
<img width="1498" height="1066" alt="image" src="https://github.com/user-attachments/assets/7be04530-5e49-4cdc-b270-1a504ca717aa" />

### Verify in Qwen Code

1. Install Qwen Code globally:
   ```bash
   npm install -g @qwen-code/qwen-code@latest
   ```

2. Launch with experimental skills support:
   ```bash
   qwen --experimental-skills
   ```

3. Use the `/skills` command to verify installed skills are detected

<img width="1904" height="778" alt="image" src="https://github.com/user-attachments/assets/c100f8d2-7439-4ac6-8c3a-8eeb6f016596" />


