### PR TITLE
fix: dereference symlinked files in the original remote skill dir

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -229,8 +229,9 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
         // If the file is a symlink to elsewhere in a remote skill, it may not
         // resolve correctly once it has been copied to the local location.
         // `dereference: true` tells Node to copy the file instead of copying
-        // the symlink.
+        // the symlink. `recursive: true` handles symlinks pointing to directories.
         dereference: true,
+        recursive: true,
       });
     }
   }


### PR DESCRIPTION
When copying files from a remote skill dir, the `skills` dir may contain symlinks to elsewhere in the checkout (like andrewimm/spaa does). The default `cp` behavior in Node is to copy the symlink directly. This will either leave it linked to the temporary checkout, which will eventually get cleaned up, or it will be a relative path to a file that may not exist.

Passing `dereference: true` means copy the contents of the file to the destination, not the pointer to the file.

Once updated, my skill installs cleanly.