### PR TITLE
feat(installer): hint text on all multiselect options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,21 @@ function formatList(items: string[], maxShow: number = 5): string {
   return `${shown.join(', ')} +${remaining} more`;
 }
 
+/**
+ * Wrapper around p.multiselect that adds a hint for keyboard usage
+ */
+function multiselect<Option extends { value: unknown; label: string; hint?: string }>(opts: {
+  message: string;
+  options: Option[];
+  initialValues?: Option['value'][];
+  required?: boolean;
+}) {
+  return p.multiselect({
+    ...opts,
+    message: `${opts.message} ${chalk.dim('(space to toggle)')}`,
+  }) as Promise<Option['value'][] | symbol>;
+}
+
 const version = packageJson.version;
 setVersion(version);
 
@@ -208,7 +223,7 @@ async function handleRemoteSkill(
           label: config.displayName,
         }));
 
-        const selected = await p.multiselect({
+        const selected = await multiselect({
           message: 'Select agents to install skills to',
           options: allAgentChoices,
           required: true,
@@ -239,7 +254,7 @@ async function handleRemoteSkill(
         hint: `${options.global ? agents[a].globalSkillsDir : agents[a].skillsDir}`,
       }));
 
-      const selected = await p.multiselect({
+      const selected = await multiselect({
         message: 'Select agents to install skills to',
         options: agentChoices,
         required: true,
@@ -550,7 +565,7 @@ async function handleDirectUrlSkillLegacy(
           label: config.displayName,
         }));
 
-        const selected = await p.multiselect({
+        const selected = await multiselect({
           message: 'Select agents to install skills to',
           options: allAgentChoices,
           required: true,
@@ -581,7 +596,7 @@ async function handleDirectUrlSkillLegacy(
         hint: `${options.global ? agents[a].globalSkillsDir : agents[a].skillsDir}`,
       }));
 
-      const selected = await p.multiselect({
+      const selected = await multiselect({
         message: 'Select agents to install skills to',
         options: agentChoices,
         required: true,
@@ -929,7 +944,7 @@ async function main(source: string, options: Options) {
         hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
       }));
 
-      const selected = await p.multiselect({
+      const selected = await multiselect({
         message: 'Select skills to install',
         options: skillChoices,
         required: true,
@@ -980,7 +995,7 @@ async function main(source: string, options: Options) {
             label: config.displayName,
           }));
 
-          const selected = await p.multiselect({
+          const selected = await multiselect({
             message: 'Select agents to install skills to',
             options: allAgentChoices,
             required: true,
@@ -1012,7 +1027,7 @@ async function main(source: string, options: Options) {
           hint: `${options.global ? agents[a].globalSkillsDir : agents[a].skillsDir}`,
         }));
 
-        const selected = await p.multiselect({
+        const selected = await multiselect({
           message: 'Select agents to install skills to',
           options: agentChoices,
           required: true,


### PR DESCRIPTION

| Before | After |
|---|---|
| <img width="1000" height="670" alt="CleanShot 2026-01-25 at 01 18 00@2x" src="https://github.com/user-attachments/assets/3b906049-6d75-4d2b-b1d1-cfe09c24b41f" />  | <img width="944" height="670" alt="CleanShot 2026-01-25 at 01 17 33@2x" src="https://github.com/user-attachments/assets/bb0b2e10-9204-421b-abbf-a67c106a1066" /> |

Reason:
I have installed ~4 skills using the commands and thought the bug was you could only chose 1 agent to install it to (I was hitting "enter" on the one i wanted). I had to ask cc to look at the repo and see if i could select multiple somehow and thats when I learned space was the action here. I don't think it was too self explanatory hence the proposal

Code:
Decided using a function around `p.multiselect` was a better move than adding it to each individually causing some tech debt of having to remember for uniformity. The function resulting in slightly less tech debt since all multiselects should have the same hint


