### PR TITLE
feat(agents): add Crush support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | Cline | `cline` | `.cline/skills/` | `~/.cline/skills/` |
 | Codex | `codex` | `.codex/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
+| Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
 | Cursor | `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |
 | Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
 | Gemini CLI | `gemini-cli` | `.gemini/skills/` | `~/.gemini/skills/` |
@@ -168,6 +169,7 @@ The CLI searches for skills in these locations within a repository:
 - `.cline/skills/`
 - `.codex/skills/`
 - `.commandcode/skills/`
+- `.crush/skills/`
 - `.cursor/skills/`
 - `.factory/skills/`
 - `.gemini/skills/`
@@ -240,6 +242,7 @@ Telemetry is also automatically disabled in CI environments.
 - [Cline Skills Documentation](https://docs.cline.bot/features/skills)
 - [Codex Skills Documentation](https://developers.openai.com/codex/skills)
 - [Command Code Skills Documentation](https://commandcode.ai/docs/skills)
+- [Crush Skills Documentation](https://github.com/charmbracelet/crush?tab=readme-ov-file#agent-skills)
 - [Cursor Skills Documentation](https://cursor.com/docs/context/skills)
 - [Gemini CLI Skills Documentation](https://geminicli.com/docs/cli/skills/)
 - [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -71,6 +71,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.commandcode'));
     },
   },
+  crush: {
+    name: 'crush',
+    displayName: 'Crush',
+    skillsDir: '.crush/skills',
+    globalSkillsDir: join(home, '.config/crush/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.config/crush'));
+    },
+  },
   cursor: {
     name: 'cursor',
     displayName: 'Cursor',

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type AgentType =
   | 'cline'
   | 'codex'
   | 'command-code'
+  | 'crush'
   | 'cursor'
   | 'droid'
   | 'gemini-cli'


### PR DESCRIPTION
Add **Crush** as a new supported coding agent.

[Crush](https://github.com/charmbracelet/crush) is an AI-powered coding agent built by [Charm](https://charm.land/). This PR enables users to install and manage skills for Crush through the add-skill CLI.

## Changes
### Core Changes
- Add `crush` agent configuration in `src/agents.ts`
    - Project-level skills directory: `.crush/skills/`
    - Global skills directory: `~/config/.crush/skills/`
    - Detection: checks for `~/config/.crush` directory existence
- Add `'crush'` to the AgentType union in `src/types.ts`

### Documentation

- Update README.md with Crush in the supported agents list
- Add documentation link for Crush

## Testing

### Build & install skills

```
# Build the project
pnpm run build

# Install a skill (e.g., from GitHub)
node dist/index.js https://github.com/vercel-labs/agent-skills
```

<img width="751" height="886" alt="image" src="https://github.com/user-attachments/assets/be5730f1-9bed-4cb7-8055-a7792a2ca4b1" />

### Verify in Crush

1. Install Crush globally:
```
npm install -g @charmland/crush
```

2. Check if the skill is properly installed:

<img width="943" height="1029" alt="image" src="https://github.com/user-attachments/assets/6b8aaba9-1a0d-431c-a21f-9abd2b47514e" />
