### PR TITLE
fix(droid): detect installation by .factory dir instead of skills subdir

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -86,7 +86,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     skillsDir: '.factory/skills',
     globalSkillsDir: join(home, '.factory/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.factory/skills'));
+      return existsSync(join(home, '.factory'));
     },
   },
   'gemini-cli': {


### PR DESCRIPTION
The skills directory may not exist until the first skill is installed.
Check for .factory directory like other agents do with their base dirs.