### PR TITLE
feat(agents): add CodeBuddy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install agent skills onto your coding agents from any git repository.
 
 <!-- agent-list:start -->
-Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [23 more](#available-agents).
+Supports **Opencode**, **Claude Code**, **Codex**, **Cursor**, and [24 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Quick Start
@@ -88,6 +88,7 @@ Skills can be installed to any of these supported agents. Use `-g, --global` to 
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | Clawdbot | `clawdbot` | `skills/` | `~/.clawdbot/skills/` |
 | Cline | `cline` | `.cline/skills/` | `~/.cline/skills/` |
+| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codex | `codex` | `.codex/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
@@ -169,6 +170,7 @@ The CLI searches for skills in these locations within a repository:
 - `.claude/skills/`
 - `./skills/`
 - `.cline/skills/`
+- `.codebuddy/skills/`
 - `.codex/skills/`
 - `.commandcode/skills/`
 - `.continue/skills/`

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "claude-code",
     "clawdbot",
     "cline",
+    "codebuddy",
     "codex",
     "command-code",
     "continue",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -54,6 +54,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.cline'));
     },
   },
+  codebuddy: {
+    name: 'codebuddy',
+    displayName: 'CodeBuddy',
+    skillsDir: '.codebuddy/skills',
+    globalSkillsDir: join(home, '.codebuddy/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.codebuddy'));
+    },
+  },
   codex: {
     name: 'codex',
     displayName: 'Codex',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -86,6 +86,7 @@ export async function discoverSkills(basePath: string, subpath?: string): Promis
     join(searchPath, '.agents/skills'),
     join(searchPath, '.claude/skills'),
     join(searchPath, '.cline/skills'),
+    join(searchPath, '.codebuddy/skills'),
     join(searchPath, '.codex/skills'),
     join(searchPath, '.commandcode/skills'),
     join(searchPath, '.continue/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type AgentType =
   | 'claude-code'
   | 'clawdbot'
   | 'cline'
+  | 'codebuddy'
   | 'codex'
   | 'command-code'
   | 'continue'


### PR DESCRIPTION
This pull request adds support for a new agent called "CodeBuddy" across the codebase and documentation. The changes ensure that CodeBuddy is recognized as a valid agent, can have skills installed, and is included in all relevant listings and detection logic.

**Agent Support Additions:**

* Added `codebuddy` to the supported agents in the `package.json` keywords and the `AgentType` type in `src/types.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R37) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR7)
* Implemented CodeBuddy agent configuration in `src/agents.ts`, including detection logic and skills directory paths.

**Skills Discovery and Installation:**

* Updated the skills discovery logic in `src/skills.ts` to search for `.codebuddy/skills` directories.

**Documentation Updates:**

* Updated `README.md` to list CodeBuddy as a supported agent, added it to the agent table, and included its skills directory in the relevant documentation sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173)Add support for Tencent CodeBuddy agent with skills installation.
- Project-level: .codebuddy/skills/
- Global-level: ~/.codebuddy/skills/

It is **official** commit.  