### PR TITLE
fix: respect CLAUDE_CONFIG_DIR for Claude Code & OpenCode

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -187,7 +187,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     skillsDir: '.opencode/skills',
     globalSkillsDir: join(home, '.config/opencode/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.config/opencode')) || existsSync(join(home, '.claude/skills'));
+      return existsSync(join(home, '.config/opencode')) || existsSync(join(claudeHome, 'skills'));
     },
   },
   openhands: {


### PR DESCRIPTION
fixes #136 

changes made:
- add a claudeHome variable that respects CLAUDE_CONFIG_DIR and falls back to ~/.claude if not set
- updates all references under claude-code & opencode to use claudeHome

