### PR TITLE
fix: show skipped skill names in update/check output

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -76,12 +76,12 @@ describe('formatSkippedMessage', () => {
   });
 
   it('should format single skill', () => {
-    expect(formatSkippedMessage(['my-skill'])).toBe('Skipped 1 (reinstall needed): my-skill');
+    expect(formatSkippedMessage(['my-skill'])).toBe('Skipped 1 (reinstall needed):\n  - my-skill');
   });
 
   it('should format multiple skills', () => {
     expect(formatSkippedMessage(['skill-a', 'skill-b', 'skill-c'])).toBe(
-      'Skipped 3 (reinstall needed): skill-a, skill-b, skill-c'
+      'Skipped 3 (reinstall needed):\n  - skill-a\n  - skill-b\n  - skill-c'
     );
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,11 @@ import { track } from './telemetry.ts';
 
 export function formatSkippedMessage(skippedSkills: string[]): string | null {
   if (skippedSkills.length === 0) return null;
-  return `Skipped ${skippedSkills.length} (reinstall needed): ${skippedSkills.join(', ')}`;
+  const lines = [`Skipped ${skippedSkills.length} (reinstall needed):`];
+  for (const skill of skippedSkills) {
+    lines.push(`  - ${skill}`);
+  }
+  return lines.join('\n');
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Shows which skills need reinstallation instead of just a count
- Extracts `formatSkippedMessage` helper for testability
- Adds unit tests for the new function

**Before:** `Skipped 1 (reinstall needed)`
**After:** `Skipped 1 (reinstall needed): nestjs-best-practices`

Fixes #142

Before:
<img width="204" height="64" alt="Screenshot 2026-01-26 at 21 25 50" src="https://github.com/user-attachments/assets/eec2039c-7c91-4e31-b239-2a7911e9547f" />


After:
<img width="353" height="69" alt="Screenshot 2026-01-26 at 21 26 37" src="https://github.com/user-attachments/assets/58e2b583-a8ab-47f9-94f0-ee01fab555fa" />


## Test plan
- [x] `npm test` passes (87 tests)
- [x] Manual test with `npx skills update` shows skill names