### PR TITLE
refactor: use `picocolors` instead of `chalk`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "chalk": "^5.4.1",
     "gray-matter": "^4.0.3",
+    "picocolors": "^1.1.1",
     "simple-git": "^3.27.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
-      chalk:
-        specifier: ^5.4.1
-        version: 5.6.2
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       simple-git:
         specifier: ^3.27.0
         version: 3.30.0
@@ -451,10 +451,6 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1232,8 +1228,6 @@ snapshots:
   cac@6.7.14: {}
 
   chai@6.2.2: {}
-
-  chalk@5.6.2: {}
 
   chokidar@4.0.3:
     dependencies:

--- a/src/add.ts
+++ b/src/add.ts
@@ -1,5 +1,5 @@
 import * as p from '@clack/prompts';
-import chalk from 'chalk';
+import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { parseSource, getOwnerRepo } from './source-parser.js';
@@ -70,7 +70,7 @@ function multiselect<Value>(opts: {
     ...opts,
     // Cast is safe: our options always have labels, which satisfies p.Option requirements
     options: opts.options as p.Option<Value>[],
-    message: `${opts.message} ${chalk.dim('(space to toggle)')}`,
+    message: `${opts.message} ${pc.dim('(space to toggle)')}`,
   }) as Promise<Value[] | symbol>;
 }
 
@@ -159,9 +159,9 @@ async function handleRemoteSkill(
   const providerSkill = await provider.fetchSkill(url);
 
   if (!providerSkill) {
-    spinner.stop(chalk.red('Invalid skill'));
+    spinner.stop(pc.red('Invalid skill'));
     p.outro(
-      chalk.red('Could not fetch skill.md or missing required frontmatter (name, description).')
+      pc.red('Could not fetch skill.md or missing required frontmatter (name, description).')
     );
     process.exit(1);
   }
@@ -178,19 +178,19 @@ async function handleRemoteSkill(
     metadata: providerSkill.metadata,
   };
 
-  spinner.stop(`Found skill: ${chalk.cyan(remoteSkill.installName)}`);
+  spinner.stop(`Found skill: ${pc.cyan(remoteSkill.installName)}`);
 
-  p.log.info(`Skill: ${chalk.cyan(remoteSkill.name)}`);
-  p.log.message(chalk.dim(remoteSkill.description));
-  p.log.message(chalk.dim(`Source: ${remoteSkill.sourceIdentifier}`));
+  p.log.info(`Skill: ${pc.cyan(remoteSkill.name)}`);
+  p.log.message(pc.dim(remoteSkill.description));
+  p.log.message(pc.dim(`Source: ${remoteSkill.sourceIdentifier}`));
 
   if (options.list) {
     console.log();
-    p.log.step(chalk.bold('Skill Details'));
-    p.log.message(`  ${chalk.cyan('Name:')} ${remoteSkill.name}`);
-    p.log.message(`  ${chalk.cyan('Install as:')} ${remoteSkill.installName}`);
-    p.log.message(`  ${chalk.cyan('Provider:')} ${provider.displayName}`);
-    p.log.message(`  ${chalk.cyan('Description:')} ${remoteSkill.description}`);
+    p.log.step(pc.bold('Skill Details'));
+    p.log.message(`  ${pc.cyan('Name:')} ${remoteSkill.name}`);
+    p.log.message(`  ${pc.cyan('Install as:')} ${remoteSkill.installName}`);
+    p.log.message(`  ${pc.cyan('Provider:')} ${provider.displayName}`);
+    p.log.message(`  ${pc.cyan('Description:')} ${remoteSkill.description}`);
     console.log();
     p.outro('Run without --list to install');
     process.exit(0);
@@ -247,10 +247,10 @@ async function handleRemoteSkill(
       targetAgents = installedAgents;
       if (installedAgents.length === 1) {
         const firstAgent = installedAgents[0]!;
-        p.log.info(`Installing to: ${chalk.cyan(agents[firstAgent].displayName)}`);
+        p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
       } else {
         p.log.info(
-          `Installing to: ${installedAgents.map((a) => chalk.cyan(agents[a].displayName)).join(', ')}`
+          `Installing to: ${installedAgents.map((a) => pc.cyan(agents[a].displayName)).join(', ')}`
         );
       }
     } else {
@@ -336,11 +336,11 @@ async function handleRemoteSkill(
   if (installMode === 'symlink') {
     const canonicalPath = getCanonicalPath(remoteSkill.installName, { global: installGlobally });
     const shortCanonical = shortenPath(canonicalPath, cwd);
-    summaryLines.push(`${chalk.cyan(shortCanonical)}`);
-    summaryLines.push(`  ${chalk.dim('symlink →')} ${formatList(agentNames)}`);
+    summaryLines.push(`${pc.cyan(shortCanonical)}`);
+    summaryLines.push(`  ${pc.dim('symlink →')} ${formatList(agentNames)}`);
   } else {
-    summaryLines.push(`${chalk.cyan(remoteSkill.installName)}`);
-    summaryLines.push(`  ${chalk.dim('copy →')} ${formatList(agentNames)}`);
+    summaryLines.push(`${pc.cyan(remoteSkill.installName)}`);
+    summaryLines.push(`  ${pc.dim('copy →')} ${formatList(agentNames)}`);
   }
 
   const overwriteAgents = targetAgents
@@ -348,7 +348,7 @@ async function handleRemoteSkill(
     .map((a) => agents[a].displayName);
 
   if (overwriteAgents.length > 0) {
-    summaryLines.push(`  ${chalk.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
+    summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
   }
 
   console.log();
@@ -433,31 +433,31 @@ async function handleRemoteSkill(
     const firstResult = successful[0]!;
 
     if (firstResult.mode === 'copy') {
-      resultLines.push(`${chalk.green('✓')} ${remoteSkill.installName} ${chalk.dim('(copied)')}`);
+      resultLines.push(`${pc.green('✓')} ${remoteSkill.installName} ${pc.dim('(copied)')}`);
       for (const r of successful) {
         const shortPath = shortenPath(r.path, cwd);
-        resultLines.push(`  ${chalk.dim('→')} ${shortPath}`);
+        resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
       }
     } else {
       // Symlink mode
       if (firstResult.canonicalPath) {
         const shortPath = shortenPath(firstResult.canonicalPath, cwd);
-        resultLines.push(`${chalk.green('✓')} ${shortPath}`);
+        resultLines.push(`${pc.green('✓')} ${shortPath}`);
       } else {
-        resultLines.push(`${chalk.green('✓')} ${remoteSkill.installName}`);
+        resultLines.push(`${pc.green('✓')} ${remoteSkill.installName}`);
       }
       const symlinked = successful.filter((r) => !r.symlinkFailed).map((r) => r.agent);
       const copied = successful.filter((r) => r.symlinkFailed).map((r) => r.agent);
 
       if (symlinked.length > 0) {
-        resultLines.push(`  ${chalk.dim('symlink →')} ${formatList(symlinked)}`);
+        resultLines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
       }
       if (copied.length > 0) {
-        resultLines.push(`  ${chalk.yellow('copied →')} ${formatList(copied)}`);
+        resultLines.push(`  ${pc.yellow('copied →')} ${formatList(copied)}`);
       }
     }
 
-    const title = chalk.green(
+    const title = pc.green(
       `Installed 1 skill to ${successful.length} agent${successful.length !== 1 ? 's' : ''}`
     );
     p.note(resultLines.join('\n'), title);
@@ -466,9 +466,9 @@ async function handleRemoteSkill(
     const symlinkFailures = successful.filter((r) => r.mode === 'symlink' && r.symlinkFailed);
     if (symlinkFailures.length > 0) {
       const copiedAgentNames = symlinkFailures.map((r) => r.agent);
-      p.log.warn(chalk.yellow(`Symlinks failed for: ${formatList(copiedAgentNames)}`));
+      p.log.warn(pc.yellow(`Symlinks failed for: ${formatList(copiedAgentNames)}`));
       p.log.message(
-        chalk.dim(
+        pc.dim(
           '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
         )
       );
@@ -477,14 +477,14 @@ async function handleRemoteSkill(
 
   if (failed.length > 0) {
     console.log();
-    p.log.error(chalk.red(`Failed to install ${failed.length}`));
+    p.log.error(pc.red(`Failed to install ${failed.length}`));
     for (const r of failed) {
-      p.log.message(`  ${chalk.red('✗')} ${r.skill} → ${r.agent}: ${chalk.dim(r.error)}`);
+      p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
     }
   }
 
   console.log();
-  p.outro(chalk.green('Done!'));
+  p.outro(pc.green('Done!'));
 
   // Prompt for find-skills after successful install
   await promptForFindSkills();
@@ -506,34 +506,34 @@ async function handleWellKnownSkills(
   const skills = await wellKnownProvider.fetchAllSkills(url);
 
   if (skills.length === 0) {
-    spinner.stop(chalk.red('No skills found'));
+    spinner.stop(pc.red('No skills found'));
     p.outro(
-      chalk.red(
+      pc.red(
         'No skills found at this URL. Make sure the server has a /.well-known/skills/index.json file.'
       )
     );
     process.exit(1);
   }
 
-  spinner.stop(`Found ${chalk.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
+  spinner.stop(`Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
 
   // Log discovered skills
   for (const skill of skills) {
-    p.log.info(`Skill: ${chalk.cyan(skill.installName)}`);
-    p.log.message(chalk.dim(skill.description));
+    p.log.info(`Skill: ${pc.cyan(skill.installName)}`);
+    p.log.message(pc.dim(skill.description));
     if (skill.files.size > 1) {
-      p.log.message(chalk.dim(`  Files: ${Array.from(skill.files.keys()).join(', ')}`));
+      p.log.message(pc.dim(`  Files: ${Array.from(skill.files.keys()).join(', ')}`));
     }
   }
 
   if (options.list) {
     console.log();
-    p.log.step(chalk.bold('Available Skills'));
+    p.log.step(pc.bold('Available Skills'));
     for (const skill of skills) {
-      p.log.message(`  ${chalk.cyan(skill.installName)}`);
-      p.log.message(`    ${chalk.dim(skill.description)}`);
+      p.log.message(`  ${pc.cyan(skill.installName)}`);
+      p.log.message(`    ${pc.dim(skill.description)}`);
       if (skill.files.size > 1) {
-        p.log.message(`    ${chalk.dim(`Files: ${skill.files.size}`)}`);
+        p.log.message(`    ${pc.dim(`Files: ${skill.files.size}`)}`);
       }
     }
     console.log();
@@ -563,12 +563,12 @@ async function handleWellKnownSkills(
     }
 
     p.log.info(
-      `Selected ${selectedSkills.length} skill${selectedSkills.length !== 1 ? 's' : ''}: ${selectedSkills.map((s) => chalk.cyan(s.installName)).join(', ')}`
+      `Selected ${selectedSkills.length} skill${selectedSkills.length !== 1 ? 's' : ''}: ${selectedSkills.map((s) => pc.cyan(s.installName)).join(', ')}`
     );
   } else if (skills.length === 1) {
     selectedSkills = skills;
     const firstSkill = skills[0]!;
-    p.log.info(`Skill: ${chalk.cyan(firstSkill.installName)}`);
+    p.log.info(`Skill: ${pc.cyan(firstSkill.installName)}`);
   } else if (options.yes) {
     selectedSkills = skills;
     p.log.info(`Installing all ${skills.length} skills`);
@@ -648,10 +648,10 @@ async function handleWellKnownSkills(
       targetAgents = installedAgents;
       if (installedAgents.length === 1) {
         const firstAgent = installedAgents[0]!;
-        p.log.info(`Installing to: ${chalk.cyan(agents[firstAgent].displayName)}`);
+        p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
       } else {
         p.log.info(
-          `Installing to: ${installedAgents.map((a) => chalk.cyan(agents[a].displayName)).join(', ')}`
+          `Installing to: ${installedAgents.map((a) => pc.cyan(agents[a].displayName)).join(', ')}`
         );
       }
     } else {
@@ -742,14 +742,14 @@ async function handleWellKnownSkills(
     if (installMode === 'symlink') {
       const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
       const shortCanonical = shortenPath(canonicalPath, cwd);
-      summaryLines.push(`${chalk.cyan(shortCanonical)}`);
-      summaryLines.push(`  ${chalk.dim('symlink →')} ${formatList(agentNames)}`);
+      summaryLines.push(`${pc.cyan(shortCanonical)}`);
+      summaryLines.push(`  ${pc.dim('symlink →')} ${formatList(agentNames)}`);
       if (skill.files.size > 1) {
-        summaryLines.push(`  ${chalk.dim('files:')} ${skill.files.size}`);
+        summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
       }
     } else {
-      summaryLines.push(`${chalk.cyan(skill.installName)}`);
-      summaryLines.push(`  ${chalk.dim('copy →')} ${formatList(agentNames)}`);
+      summaryLines.push(`${pc.cyan(skill.installName)}`);
+      summaryLines.push(`  ${pc.dim('copy →')} ${formatList(agentNames)}`);
     }
 
     const skillOverwrites = overwriteStatus.get(skill.installName);
@@ -758,7 +758,7 @@ async function handleWellKnownSkills(
       .map((a) => agents[a].displayName);
 
     if (overwriteAgents.length > 0) {
-      summaryLines.push(`  ${chalk.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
+      summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
     }
   }
 
@@ -856,41 +856,41 @@ async function handleWellKnownSkills(
 
       if (firstResult.mode === 'copy') {
         // Copy mode: show skill name and list all agent paths
-        resultLines.push(`${chalk.green('✓')} ${skillName} ${chalk.dim('(copied)')}`);
+        resultLines.push(`${pc.green('✓')} ${skillName} ${pc.dim('(copied)')}`);
         for (const r of skillResults) {
           const shortPath = shortenPath(r.path, cwd);
-          resultLines.push(`  ${chalk.dim('→')} ${shortPath}`);
+          resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
         }
       } else {
         // Symlink mode: show canonical path and symlinked agents
         if (firstResult.canonicalPath) {
           const shortPath = shortenPath(firstResult.canonicalPath, cwd);
-          resultLines.push(`${chalk.green('✓')} ${shortPath}`);
+          resultLines.push(`${pc.green('✓')} ${shortPath}`);
         } else {
-          resultLines.push(`${chalk.green('✓')} ${skillName}`);
+          resultLines.push(`${pc.green('✓')} ${skillName}`);
         }
         const symlinked = skillResults.filter((r) => !r.symlinkFailed).map((r) => r.agent);
         const copied = skillResults.filter((r) => r.symlinkFailed).map((r) => r.agent);
 
         if (symlinked.length > 0) {
-          resultLines.push(`  ${chalk.dim('symlink →')} ${formatList(symlinked)}`);
+          resultLines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
         }
         if (copied.length > 0) {
-          resultLines.push(`  ${chalk.yellow('copied →')} ${formatList(copied)}`);
+          resultLines.push(`  ${pc.yellow('copied →')} ${formatList(copied)}`);
         }
       }
     }
 
-    const title = chalk.green(
+    const title = pc.green(
       `Installed ${skillCount} skill${skillCount !== 1 ? 's' : ''} to ${agentCount} agent${agentCount !== 1 ? 's' : ''}`
     );
     p.note(resultLines.join('\n'), title);
 
     // Show symlink failure warning (only for symlink mode)
     if (symlinkFailures.length > 0) {
-      p.log.warn(chalk.yellow(`Symlinks failed for: ${formatList(copiedAgents)}`));
+      p.log.warn(pc.yellow(`Symlinks failed for: ${formatList(copiedAgents)}`));
       p.log.message(
-        chalk.dim(
+        pc.dim(
           '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
         )
       );
@@ -899,14 +899,14 @@ async function handleWellKnownSkills(
 
   if (failed.length > 0) {
     console.log();
-    p.log.error(chalk.red(`Failed to install ${failed.length}`));
+    p.log.error(pc.red(`Failed to install ${failed.length}`));
     for (const r of failed) {
-      p.log.message(`  ${chalk.red('✗')} ${r.skill} → ${r.agent}: ${chalk.dim(r.error)}`);
+      p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
     }
   }
 
   console.log();
-  p.outro(chalk.green('Done!'));
+  p.outro(pc.green('Done!'));
 
   // Prompt for find-skills after successful install
   await promptForFindSkills();
@@ -926,9 +926,9 @@ async function handleDirectUrlSkillLegacy(
   const mintlifySkill = await fetchMintlifySkill(url);
 
   if (!mintlifySkill) {
-    spinner.stop(chalk.red('Invalid skill'));
+    spinner.stop(pc.red('Invalid skill'));
     p.outro(
-      chalk.red(
+      pc.red(
         'Could not fetch skill.md or missing required frontmatter (name, description, mintlify-proj).'
       )
     );
@@ -946,17 +946,17 @@ async function handleDirectUrlSkillLegacy(
     sourceIdentifier: 'mintlify/com',
   };
 
-  spinner.stop(`Found skill: ${chalk.cyan(remoteSkill.installName)}`);
+  spinner.stop(`Found skill: ${pc.cyan(remoteSkill.installName)}`);
 
-  p.log.info(`Skill: ${chalk.cyan(remoteSkill.name)}`);
-  p.log.message(chalk.dim(remoteSkill.description));
+  p.log.info(`Skill: ${pc.cyan(remoteSkill.name)}`);
+  p.log.message(pc.dim(remoteSkill.description));
 
   if (options.list) {
     console.log();
-    p.log.step(chalk.bold('Skill Details'));
-    p.log.message(`  ${chalk.cyan('Name:')} ${remoteSkill.name}`);
-    p.log.message(`  ${chalk.cyan('Site:')} ${remoteSkill.installName}`);
-    p.log.message(`  ${chalk.cyan('Description:')} ${remoteSkill.description}`);
+    p.log.step(pc.bold('Skill Details'));
+    p.log.message(`  ${pc.cyan('Name:')} ${remoteSkill.name}`);
+    p.log.message(`  ${pc.cyan('Site:')} ${remoteSkill.installName}`);
+    p.log.message(`  ${pc.cyan('Description:')} ${remoteSkill.description}`);
     console.log();
     p.outro('Run without --list to install');
     process.exit(0);
@@ -1013,10 +1013,10 @@ async function handleDirectUrlSkillLegacy(
       targetAgents = installedAgents;
       if (installedAgents.length === 1) {
         const firstAgent = installedAgents[0]!;
-        p.log.info(`Installing to: ${chalk.cyan(agents[firstAgent].displayName)}`);
+        p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
       } else {
         p.log.info(
-          `Installing to: ${installedAgents.map((a) => chalk.cyan(agents[a].displayName)).join(', ')}`
+          `Installing to: ${installedAgents.map((a) => pc.cyan(agents[a].displayName)).join(', ')}`
         );
       }
     } else {
@@ -1078,15 +1078,15 @@ async function handleDirectUrlSkillLegacy(
   const agentNames = targetAgents.map((a) => agents[a].displayName);
   const canonicalPath = getCanonicalPath(remoteSkill.installName, { global: installGlobally });
   const shortCanonical = shortenPath(canonicalPath, cwd);
-  summaryLines.push(`${chalk.cyan(shortCanonical)}`);
-  summaryLines.push(`  ${chalk.dim('symlink →')} ${formatList(agentNames)}`);
+  summaryLines.push(`${pc.cyan(shortCanonical)}`);
+  summaryLines.push(`  ${pc.dim('symlink →')} ${formatList(agentNames)}`);
 
   const overwriteAgents = targetAgents
     .filter((a) => overwriteStatus.get(a))
     .map((a) => agents[a].displayName);
 
   if (overwriteAgents.length > 0) {
-    summaryLines.push(`  ${chalk.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
+    summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
   }
 
   console.log();
@@ -1167,21 +1167,21 @@ async function handleDirectUrlSkillLegacy(
 
     if (firstResult.canonicalPath) {
       const shortPath = shortenPath(firstResult.canonicalPath, cwd);
-      resultLines.push(`${chalk.green('✓')} ${shortPath}`);
+      resultLines.push(`${pc.green('✓')} ${shortPath}`);
     } else {
-      resultLines.push(`${chalk.green('✓')} ${remoteSkill.installName}`);
+      resultLines.push(`${pc.green('✓')} ${remoteSkill.installName}`);
     }
     const symlinked = successful.filter((r) => !r.symlinkFailed).map((r) => r.agent);
     const copied = successful.filter((r) => r.symlinkFailed).map((r) => r.agent);
 
     if (symlinked.length > 0) {
-      resultLines.push(`  ${chalk.dim('symlink →')} ${formatList(symlinked)}`);
+      resultLines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
     }
     if (copied.length > 0) {
-      resultLines.push(`  ${chalk.yellow('copied →')} ${formatList(copied)}`);
+      resultLines.push(`  ${pc.yellow('copied →')} ${formatList(copied)}`);
     }
 
-    const title = chalk.green(
+    const title = pc.green(
       `Installed 1 skill to ${successful.length} agent${successful.length !== 1 ? 's' : ''}`
     );
     p.note(resultLines.join('\n'), title);
@@ -1190,9 +1190,9 @@ async function handleDirectUrlSkillLegacy(
     const symlinkFailures = successful.filter((r) => r.mode === 'symlink' && r.symlinkFailed);
     if (symlinkFailures.length > 0) {
       const copiedAgentNames = symlinkFailures.map((r) => r.agent);
-      p.log.warn(chalk.yellow(`Symlinks failed for: ${formatList(copiedAgentNames)}`));
+      p.log.warn(pc.yellow(`Symlinks failed for: ${formatList(copiedAgentNames)}`));
       p.log.message(
-        chalk.dim(
+        pc.dim(
           '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
         )
       );
@@ -1201,14 +1201,14 @@ async function handleDirectUrlSkillLegacy(
 
   if (failed.length > 0) {
     console.log();
-    p.log.error(chalk.red(`Failed to install ${failed.length}`));
+    p.log.error(pc.red(`Failed to install ${failed.length}`));
     for (const r of failed) {
-      p.log.message(`  ${chalk.red('✗')} ${r.skill} → ${r.agent}: ${chalk.dim(r.error)}`);
+      p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
     }
   }
 
   console.log();
-  p.outro(chalk.green('Done!'));
+  p.outro(pc.green('Done!'));
 
   // Prompt for find-skills after successful install
   await promptForFindSkills();
@@ -1221,7 +1221,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   const showInstallTip = (): void => {
     if (installTipShown) return;
     p.log.message(
-      chalk.dim('Tip: use the --yes (-y) and --global (-g) flags to install without prompts.')
+      pc.dim('Tip: use the --yes (-y) and --global (-g) flags to install without prompts.')
     );
     installTipShown = true;
   };
@@ -1229,16 +1229,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   if (!source) {
     console.log();
     console.log(
-      chalk.bgRed.white.bold(' ERROR ') + ' ' + chalk.red('Missing required argument: source')
+      pc.bgRed(pc.white(pc.bold(' ERROR '))) + ' ' + pc.red('Missing required argument: source')
     );
     console.log();
-    console.log(chalk.dim('  Usage:'));
-    console.log(
-      `    ${chalk.cyan('npx skills add')} ${chalk.yellow('<source>')} ${chalk.dim('[options]')}`
-    );
+    console.log(pc.dim('  Usage:'));
+    console.log(`    ${pc.cyan('npx skills add')} ${pc.yellow('<source>')} ${pc.dim('[options]')}`);
     console.log();
-    console.log(chalk.dim('  Example:'));
-    console.log(`    ${chalk.cyan('npx skills add')} ${chalk.yellow('vercel-labs/agent-skills')}`);
+    console.log(pc.dim('  Example:'));
+    console.log(`    ${pc.cyan('npx skills add')} ${pc.yellow('vercel-labs/agent-skills')}`);
     console.log();
     process.exit(1);
   }
@@ -1249,7 +1247,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   }
 
   console.log();
-  p.intro(chalk.bgCyan.black(' skills '));
+  p.intro(pc.bgCyan(pc.black(' skills ')));
 
   if (!process.stdin.isTTY) {
     showInstallTip();
@@ -1263,7 +1261,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     spinner.start('Parsing source...');
     const parsed = parseSource(source);
     spinner.stop(
-      `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${chalk.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}`
+      `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}`
     );
 
     // Handle direct URL skills (Mintlify, HuggingFace, etc.) via provider system
@@ -1284,8 +1282,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Use local path directly, no cloning needed
       spinner.start('Validating local path...');
       if (!existsSync(parsed.localPath!)) {
-        spinner.stop(chalk.red('Path not found'));
-        p.outro(chalk.red(`Local path does not exist: ${parsed.localPath}`));
+        spinner.stop(pc.red('Path not found'));
+        p.outro(pc.red(`Local path does not exist: ${parsed.localPath}`));
         process.exit(1);
       }
       skillsDir = parsed.localPath!;
@@ -1302,24 +1300,24 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const skills = await discoverSkills(skillsDir, parsed.subpath);
 
     if (skills.length === 0) {
-      spinner.stop(chalk.red('No skills found'));
+      spinner.stop(pc.red('No skills found'));
       p.outro(
-        chalk.red('No valid skills found. Skills require a SKILL.md with name and description.')
+        pc.red('No valid skills found. Skills require a SKILL.md with name and description.')
       );
       await cleanup(tempDir);
       process.exit(1);
     }
 
     spinner.stop(
-      `Found ${chalk.green(skills.length)} skill${skills.length > 1 ? 's' : ''} ${chalk.dim('(via Well-known Agent Skill Discovery)')}`
+      `Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''} ${pc.dim('(via Well-known Agent Skill Discovery)')}`
     );
 
     if (options.list) {
       console.log();
-      p.log.step(chalk.bold('Available Skills'));
+      p.log.step(pc.bold('Available Skills'));
       for (const skill of skills) {
-        p.log.message(`  ${chalk.cyan(getSkillDisplayName(skill))}`);
-        p.log.message(`    ${chalk.dim(skill.description)}`);
+        p.log.message(`  ${pc.cyan(getSkillDisplayName(skill))}`);
+        p.log.message(`    ${pc.dim(skill.description)}`);
       }
       console.log();
       p.outro('Use --skill <name> to install specific skills');
@@ -1349,13 +1347,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       p.log.info(
-        `Selected ${selectedSkills.length} skill${selectedSkills.length !== 1 ? 's' : ''}: ${selectedSkills.map((s) => chalk.cyan(getSkillDisplayName(s))).join(', ')}`
+        `Selected ${selectedSkills.length} skill${selectedSkills.length !== 1 ? 's' : ''}: ${selectedSkills.map((s) => pc.cyan(getSkillDisplayName(s))).join(', ')}`
       );
     } else if (skills.length === 1) {
       selectedSkills = skills;
       const firstSkill = skills[0]!;
-      p.log.info(`Skill: ${chalk.cyan(getSkillDisplayName(firstSkill))}`);
-      p.log.message(chalk.dim(firstSkill.description));
+      p.log.info(`Skill: ${pc.cyan(getSkillDisplayName(firstSkill))}`);
+      p.log.message(pc.dim(firstSkill.description));
     } else if (options.yes) {
       selectedSkills = skills;
       p.log.info(`Installing all ${skills.length} skills`);
@@ -1437,10 +1435,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         targetAgents = installedAgents;
         if (installedAgents.length === 1) {
           const firstAgent = installedAgents[0]!;
-          p.log.info(`Installing to: ${chalk.cyan(agents[firstAgent].displayName)}`);
+          p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
         } else {
           p.log.info(
-            `Installing to: ${installedAgents.map((a) => chalk.cyan(agents[a].displayName)).join(', ')}`
+            `Installing to: ${installedAgents.map((a) => pc.cyan(agents[a].displayName)).join(', ')}`
           );
         }
       } else {
@@ -1534,11 +1532,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       if (installMode === 'symlink') {
         const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally });
         const shortCanonical = shortenPath(canonicalPath, cwd);
-        summaryLines.push(`${chalk.cyan(shortCanonical)}`);
-        summaryLines.push(`  ${chalk.dim('symlink →')} ${formatList(agentNames)}`);
+        summaryLines.push(`${pc.cyan(shortCanonical)}`);
+        summaryLines.push(`  ${pc.dim('symlink →')} ${formatList(agentNames)}`);
       } else {
-        summaryLines.push(`${chalk.cyan(getSkillDisplayName(skill))}`);
-        summaryLines.push(`  ${chalk.dim('copy →')} ${formatList(agentNames)}`);
+        summaryLines.push(`${pc.cyan(getSkillDisplayName(skill))}`);
+        summaryLines.push(`  ${pc.dim('copy →')} ${formatList(agentNames)}`);
       }
 
       const skillOverwrites = overwriteStatus.get(skill.name);
@@ -1547,7 +1545,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         .map((a) => agents[a].displayName);
 
       if (overwriteAgents.length > 0) {
-        summaryLines.push(`  ${chalk.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
+        summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
       }
     }
 
@@ -1679,41 +1677,41 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
         if (firstResult.mode === 'copy') {
           // Copy mode: show skill name and list all agent paths
-          resultLines.push(`${chalk.green('✓')} ${skillName} ${chalk.dim('(copied)')}`);
+          resultLines.push(`${pc.green('✓')} ${skillName} ${pc.dim('(copied)')}`);
           for (const r of skillResults) {
             const shortPath = shortenPath(r.path, cwd);
-            resultLines.push(`  ${chalk.dim('→')} ${shortPath}`);
+            resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
           }
         } else {
           // Symlink mode: show canonical path and symlinked agents
           if (firstResult.canonicalPath) {
             const shortPath = shortenPath(firstResult.canonicalPath, cwd);
-            resultLines.push(`${chalk.green('✓')} ${shortPath}`);
+            resultLines.push(`${pc.green('✓')} ${shortPath}`);
           } else {
-            resultLines.push(`${chalk.green('✓')} ${skillName}`);
+            resultLines.push(`${pc.green('✓')} ${skillName}`);
           }
           const symlinked = skillResults.filter((r) => !r.symlinkFailed).map((r) => r.agent);
           const copied = skillResults.filter((r) => r.symlinkFailed).map((r) => r.agent);
 
           if (symlinked.length > 0) {
-            resultLines.push(`  ${chalk.dim('symlink →')} ${formatList(symlinked)}`);
+            resultLines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
           }
           if (copied.length > 0) {
-            resultLines.push(`  ${chalk.yellow('copied →')} ${formatList(copied)}`);
+            resultLines.push(`  ${pc.yellow('copied →')} ${formatList(copied)}`);
           }
         }
       }
 
-      const title = chalk.green(
+      const title = pc.green(
         `Installed ${skillCount} skill${skillCount !== 1 ? 's' : ''} to ${agentCount} agent${agentCount !== 1 ? 's' : ''}`
       );
       p.note(resultLines.join('\n'), title);
 
       // Show symlink failure warning (only for symlink mode)
       if (symlinkFailures.length > 0) {
-        p.log.warn(chalk.yellow(`Symlinks failed for: ${formatList(copiedAgents)}`));
+        p.log.warn(pc.yellow(`Symlinks failed for: ${formatList(copiedAgents)}`));
         p.log.message(
-          chalk.dim(
+          pc.dim(
             '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
           )
         );
@@ -1722,29 +1720,29 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     if (failed.length > 0) {
       console.log();
-      p.log.error(chalk.red(`Failed to install ${failed.length}`));
+      p.log.error(pc.red(`Failed to install ${failed.length}`));
       for (const r of failed) {
-        p.log.message(`  ${chalk.red('✗')} ${r.skill} → ${r.agent}: ${chalk.dim(r.error)}`);
+        p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
       }
     }
 
     console.log();
-    p.outro(chalk.green('Done!'));
+    p.outro(pc.green('Done!'));
 
     // Prompt for find-skills after successful install
     await promptForFindSkills();
   } catch (error) {
     if (error instanceof GitCloneError) {
-      p.log.error(chalk.red('Failed to clone repository'));
+      p.log.error(pc.red('Failed to clone repository'));
       // Print each line of the error message separately for better formatting
       for (const line of error.message.split('\n')) {
-        p.log.message(chalk.dim(line));
+        p.log.message(pc.dim(line));
       }
     } else {
       p.log.error(error instanceof Error ? error.message : 'Unknown error occurred');
     }
     showInstallTip();
-    p.outro(chalk.red('Installation failed'));
+    p.outro(pc.red('Installation failed'));
     process.exit(1);
   } finally {
     await cleanup(tempDir);
@@ -1785,9 +1783,9 @@ async function promptForFindSkills(): Promise<void> {
     }
 
     console.log();
-    p.log.message(chalk.dim("One-time prompt - you won't be asked again if you dismiss."));
+    p.log.message(pc.dim("One-time prompt - you won't be asked again if you dismiss."));
     const install = await p.confirm({
-      message: `Install the ${chalk.cyan('find-skills')} skill? It helps your agent discover and suggest skills.`,
+      message: `Install the ${pc.cyan('find-skills')} skill? It helps your agent discover and suggest skills.`,
     });
 
     if (p.isCancel(install)) {
@@ -1813,13 +1811,13 @@ async function promptForFindSkills(): Promise<void> {
         });
       } catch {
         p.log.warn('Failed to install find-skills. You can try again with:');
-        p.log.message(chalk.dim('  npx skills add vercel-labs/skills@find-skills -g -y --all'));
+        p.log.message(pc.dim('  npx skills add vercel-labs/skills@find-skills -g -y --all'));
       }
     } else {
       // User declined - dismiss the prompt
       await dismissPrompt('findSkillsPrompt');
       p.log.message(
-        chalk.dim('You can install it later with: npx skills add vercel-labs/skills@find-skills')
+        pc.dim('You can install it later with: npx skills add vercel-labs/skills@find-skills')
       );
     }
   } catch {


### PR DESCRIPTION
This PR reduces package install size by [43.4 kB](https://packagephobia.com/result?p=chalk) by migrating to `picocolors` (it is a shared dependency with `@clack/prompts`)