### PR TITLE
feat: support custom GitLab domains with subgroup paths

### DIFF
--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { parseSource } from './source-parser.js';
+
+describe('source-parser', () => {
+  describe('GitLab Custom Domains & Subgroups', () => {
+    it('parses custom gitlab domain with deep subgroup paths', () => {
+      const result = parseSource('https://git.corp.com/group/subgroup/project/-/tree/main/src');
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://git.corp.com/group/subgroup/project.git',
+        ref: 'main',
+        subpath: 'src',
+      });
+    });
+
+    it('parses gitlab tree with branch but no path', () => {
+      const result = parseSource('https://gitlab.example.com/org/repo/-/tree/v1.0');
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://gitlab.example.com/org/repo.git',
+        ref: 'v1.0',
+      });
+    });
+
+    it('parses custom gitlab domain with port number', () => {
+      const result = parseSource('https://git.corp.com:8443/group/repo/-/tree/main');
+      expect(result).toMatchObject({
+        type: 'gitlab',
+        url: 'https://git.corp.com:8443/group/repo.git',
+        ref: 'main',
+      });
+    });
+
+    it('parses http protocol (non-ssl)', () => {
+      const result = parseSource('http://git.local/group/repo/-/tree/dev');
+      expect(result).toMatchObject({
+        type: 'gitlab',
+        url: 'http://git.local/group/repo.git',
+      });
+    });
+
+    it('parses personal project path (~user)', () => {
+      const result = parseSource('https://gitlab.com/~user/project/-/tree/main');
+      expect(result).toMatchObject({
+        type: 'gitlab',
+        url: 'https://gitlab.com/~user/project.git',
+      });
+    });
+  });
+
+  describe('Simplified Git Strategy', () => {
+    it('treats custom domains with .git as generic git', () => {
+      const result = parseSource('https://git.mycompany.com/my-group/my-repo.git');
+      expect(result).toEqual({
+        type: 'git',
+        url: 'https://git.mycompany.com/my-group/my-repo.git',
+      });
+    });
+
+    it('prevents false positives for generic URLs (falls through to well-known)', () => {
+      const result = parseSource('https://google.com/search/result');
+      expect(result.type).toBe('well-known');
+      expect(result.url).toBe('https://google.com/search/result');
+    });
+
+    it('retains official gitlab.com parsing for convenience', () => {
+      const result = parseSource('https://gitlab.com/owner/repo');
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://gitlab.com/owner/repo.git',
+      });
+    });
+  });
+
+  describe('Existing GitHub Support', () => {
+    it('parses github shorthand', () => {
+      const result = parseSource('vercel-labs/agent-skills');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.com/vercel-labs/agent-skills.git',
+        subpath: undefined,
+      });
+    });
+
+    it('parses github full URL', () => {
+      const result = parseSource('https://github.com/owner/repo/tree/main/path');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.com/owner/repo.git',
+        ref: 'main',
+        subpath: 'path',
+      });
+    });
+  });
+});

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -127,32 +127,39 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
-  // GitLab URL with path: https://gitlab.com/owner/repo/-/tree/branch/path
+  // GitLab URL with path (any GitLab instance): https://gitlab.com/owner/repo/-/tree/branch/path
+  // Key identifier is the "/-/tree/" path pattern unique to GitLab.
+  // Supports subgroups by using a non-greedy match for the repository path.
   const gitlabTreeWithPathMatch = input.match(
-    /gitlab\.com\/([^/]+)\/([^/]+)\/-\/tree\/([^/]+)\/(.+)/
+    /^(https?):\/\/([^/]+)\/(.+?)\/-\/tree\/([^/]+)\/(.+)/
   );
   if (gitlabTreeWithPathMatch) {
-    const [, owner, repo, ref, subpath] = gitlabTreeWithPathMatch;
-    return {
-      type: 'gitlab',
-      url: `https://gitlab.com/${owner}/${repo}.git`,
-      ref,
-      subpath,
-    };
+    const [, protocol, hostname, repoPath, ref, subpath] = gitlabTreeWithPathMatch;
+    if (hostname !== 'github.com' && repoPath) {
+      return {
+        type: 'gitlab',
+        url: `${protocol}://${hostname}/${repoPath.replace(/\.git$/, '')}.git`,
+        ref,
+        subpath,
+      };
+    }
   }
 
-  // GitLab URL with branch only: https://gitlab.com/owner/repo/-/tree/branch
-  const gitlabTreeMatch = input.match(/gitlab\.com\/([^/]+)\/([^/]+)\/-\/tree\/([^/]+)$/);
+  // GitLab URL with branch only (any GitLab instance): https://gitlab.com/owner/repo/-/tree/branch
+  const gitlabTreeMatch = input.match(/^(https?):\/\/([^/]+)\/(.+?)\/-\/tree\/([^/]+)$/);
   if (gitlabTreeMatch) {
-    const [, owner, repo, ref] = gitlabTreeMatch;
-    return {
-      type: 'gitlab',
-      url: `https://gitlab.com/${owner}/${repo}.git`,
-      ref,
-    };
+    const [, protocol, hostname, repoPath, ref] = gitlabTreeMatch;
+    if (hostname !== 'github.com' && repoPath) {
+      return {
+        type: 'gitlab',
+        url: `${protocol}://${hostname}/${repoPath.replace(/\.git$/, '')}.git`,
+        ref,
+      };
+    }
   }
 
-  // GitLab URL: https://gitlab.com/owner/repo
+  // GitLab.com URL: https://gitlab.com/owner/repo
+  // Only for the official gitlab.com domain for user convenience.
   const gitlabRepoMatch = input.match(/gitlab\.com\/([^/]+)\/([^/]+)/);
   if (gitlabRepoMatch) {
     const [, owner, repo] = gitlabRepoMatch;


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                         
  - Support any GitLab instance by matching `/-/tree/` path pattern                                                                                                                                                                                                  
  - Works with gitlab.com, self-hosted GitLab, and custom domains                                                                                                                                                                                                    
  - Support GitLab subgroups (group/subgroup/repo structure)                                                                                                                                                                                                         
  - Extract protocol (http/https), hostname, ref (branch), and subpath                                                                                                                                                                                               
  - Add hostname check to prevent GitHub URLs from being matched                                                                                                                                                                                                     
  - Add comprehensive test cases for various GitLab URL formats                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                                                                       
  - [x] Test with custom GitLab domain URLs                                                                                                                                                                                                                          
  - [x] Test with GitLab subgroup paths                                                                                                                                                                                                                              
  - [x] Test with different protocols (http/https)                                                                                                                                                                                                                   
  - [x] Test that GitHub URLs still work correctly                                                                                                                                                                                                                   
  - [x] Test port number support                                                                                                                                                                                                                                     
  - [x] Test personal project paths (~user)     