### PR TITLE
ci: use lts version of node

### DIFF
--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: lts/*
           cache: pnpm
 
       - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: lts/*
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   pull_request:
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
   push:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
 
 jobs:
   checks:
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
Forgot to update `ci.yml` in #150 🤦🏼‍♂️ this updates to use LTS alias.