### PR TITLE
perf: use module compile cache

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import module from 'node:module';
+
+// https://nodejs.org/api/module.html#module-compile-cache
+if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    module.enableCompileCache();
+  } catch {
+    // Ignore errors
+  }
+}
+
+await import('../dist/cli.mjs');

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "The open agent skills ecosystem",
   "type": "module",
   "bin": {
-    "skills": "./dist/cli.mjs",
-    "add-skill": "./dist/cli.mjs"
+    "skills": "./bin/cli.mjs",
+    "add-skill": "./bin/cli.mjs"
   },
   "files": [
     "dist",
+    "bin",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
Followup #152 Use Node.js [module compile cache](https://nodejs.org/api/module.html#module-compile-cache) to speed up subsequent CLI runs.

Boosts **~10%** on node v22 / MBP M4

```
 hyperfine "node ./bin/cli.mjs" "node ./dist/cli.mjs"      
Benchmark 1: node ./bin/cli.mjs
  Time (mean ± σ):      31.9 ms ±   1.2 ms    [User: 27.1 ms, System: 5.6 ms]
  Range (min … max):    30.3 ms …  39.7 ms    85 runs
 
Benchmark 2: node ./dist/cli.mjs
  Time (mean ± σ):      35.5 ms ±   1.4 ms    [User: 30.8 ms, System: 5.5 ms]
  Range (min … max):    33.3 ms …  41.4 ms    68 runs
 
Summary
  node ./bin/cli.mjs ran
    1.11 ± 0.06 times faster than node ./dist/cli.mjs
```