### PR TITLE
fix: preserve port in wellknown URLs

### DIFF
--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -97,16 +97,16 @@ export class WellKnownProvider implements HostProvider {
       const urlsToTry = [
         // Path-relative: https://example.com/docs/.well-known/skills/index.json
         {
-          indexUrl: `${parsed.protocol}//${parsed.hostname}${basePath}/${this.WELL_KNOWN_PATH}/${this.INDEX_FILE}`,
-          baseUrl: `${parsed.protocol}//${parsed.hostname}${basePath}`,
+          indexUrl: `${parsed.protocol}//${parsed.host}${basePath}/${this.WELL_KNOWN_PATH}/${this.INDEX_FILE}`,
+          baseUrl: `${parsed.protocol}//${parsed.host}${basePath}`,
         },
       ];
 
       // Also try root if we have a path
       if (basePath && basePath !== '') {
         urlsToTry.push({
-          indexUrl: `${parsed.protocol}//${parsed.hostname}/${this.WELL_KNOWN_PATH}/${this.INDEX_FILE}`,
-          baseUrl: `${parsed.protocol}//${parsed.hostname}`,
+          indexUrl: `${parsed.protocol}//${parsed.host}/${this.WELL_KNOWN_PATH}/${this.INDEX_FILE}`,
+          baseUrl: `${parsed.protocol}//${parsed.host}`,
         });
       }
 
@@ -340,12 +340,12 @@ export class WellKnownProvider implements HostProvider {
       const pathMatch = parsed.pathname.match(/\/.well-known\/skills\/([^/]+)\/?$/);
       if (pathMatch && pathMatch[1]) {
         const basePath = parsed.pathname.replace(/\/.well-known\/skills\/.*$/, '');
-        return `${parsed.protocol}//${parsed.hostname}${basePath}/${this.WELL_KNOWN_PATH}/${pathMatch[1]}/SKILL.md`;
+        return `${parsed.protocol}//${parsed.host}${basePath}/${this.WELL_KNOWN_PATH}/${pathMatch[1]}/SKILL.md`;
       }
 
       // Otherwise, return the index URL
       const basePath = parsed.pathname.replace(/\/$/, '');
-      return `${parsed.protocol}//${parsed.hostname}${basePath}/${this.WELL_KNOWN_PATH}/${this.INDEX_FILE}`;
+      return `${parsed.protocol}//${parsed.host}${basePath}/${this.WELL_KNOWN_PATH}/${this.INDEX_FILE}`;
     } catch {
       return url;
     }


### PR DESCRIPTION
## Problem

URLs with non-standard ports (e.g., `http://localhost:3333`) fail to discover skills because `parsed.hostname` strips the port.

## Fix

Use `parsed.host` instead of `parsed.hostname` when constructing URLs for HTTP requests. The difference:
- `hostname` = domain only (`localhost`)
- `host` = domain + port (`localhost:3333`)

## Test

```bash
# Before: "No skills found"
# After: "Found 1 skill"
npx skills add http://localhost:3333 --list
```