### PR TITLE
feat(skills): add skill metadata, Claude Plugin support, and validation workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "skills",
+  "owner": {
+    "name": "Vercel"
+  },
+  "metadata": {
+    "description": "The open agent skills ecosystem - discover, install, and manage agent skills",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "find-skills",
+      "source": "./skills/find-skills",
+      "description": "Helps discover and install agent skills when users ask about extending capabilities",
+      "version": "1.0.0",
+      "author": {
+        "name": "Vercel"
+      },
+      "license": "MIT",
+      "keywords": ["skills", "discovery", "install", "search"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "skills",
+  "description": "The open agent skills ecosystem - discover, install, and manage agent skills",
+  "version": "1.0.0",
+  "author": {
+    "name": "Vercel"
+  },
+  "license": "MIT",
+  "homepage": "https://skills.sh",
+  "repository": "https://github.com/vercel-labs/skills"
+}

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,65 @@
+name: Validate Skills
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+concurrency:
+  group: validate-skill-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-slim
+    if: github.event.pull_request.draft != true && github.actor != 'dependabot[bot]'
+    outputs:
+      skills: ${{ steps.changed-skills.outputs.skills }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get changed skills
+        id: changed-skills
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+            HEAD=${{ github.event.pull_request.head.sha }}
+          else
+            BASE=${{ github.event.before }}
+            HEAD=${{ github.event.after }}
+          fi
+
+          # Find changed SKILL.md files and extract skill directories
+          SKILLS=$(git diff --name-only $BASE $HEAD | \
+            grep 'SKILL.md$' | \
+            xargs -I {} dirname {} | \
+            sort -u | \
+            jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          echo "skills=$SKILLS" >> $GITHUB_OUTPUT
+          echo "Changed skills: $SKILLS"
+
+  validate:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.skills != '[]'
+    runs-on: ubuntu-slim
+    strategy:
+      fail-fast: false
+      matrix:
+        skill: ${{ fromJson(needs.detect-changes.outputs.skills) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate ${{ matrix.skill }}
+        uses: Flash-Brew-Digital/validate-skill@v1
+        with:
+          path: ${{ matrix.skill }}

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: find-skills
 description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+compatibility: npx skills
+license: MIT
+allowed-tools: Bash(npx skills:*)
+metadata:
+  author: vercel
+  version: "1.0.0"
 ---
 
 # Find Skills


### PR DESCRIPTION
## Summary

This PR enhances the skills infrastructure with:

- **Spec-compliant metadata for find-skills**: Added `license`, `compatibility`, `allowed-tools`, and `metadata` (author, version) fields per the [Agent Skills specification](https://agentskills.io/specification.md)

- **Claude Plugin support**: Added `.claude-plugin/plugin.json` manifest at project root, enabling installation in Claude Code via `/plugin install` or `--plugin-dir`

- **Claude Plugin marketplace**: Added `.claude-plugin/marketplace.json` for plugin distribution via `/plugin marketplace add vercel-labs/skills`

- **Validation workflow**: Added GitHub Actions workflow that validates SKILL.md files on push/PR using the `Flash-Brew-Digital/validate-skill@v1` action

## Changes

- `skills/find-skills/SKILL.md` - Added spec-compliant frontmatter fields
- `.claude-plugin/plugin.json` - New Claude Plugin manifest
- `.claude-plugin/marketplace.json` - New Claude Plugin marketplace catalog
- `.github/workflows/validate-skills.yml` - New validation workflow