### PR TITLE
feat: add Terramind (Nucleus) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Skills can be installed to any of these agents:
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
+| Terramind | `terramind` | `.terramind/skills/` | `~/.terramind/skills/` |
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
 | Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
 | Zencoder | `zencoder` | `.zencoder/skills/` | `~/.zencoder/skills/` |
@@ -284,6 +285,7 @@ The CLI searches for skills in these locations within a repository:
 - `.qoder/skills/`
 - `.qwen/skills/`
 - `.roo/skills/`
+- `.terramind/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`
 - `.zencoder/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -264,6 +264,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.roo'));
     },
   },
+  terramind: {
+    name: 'terramind',
+    displayName: 'Terramind',
+    skillsDir: '.terramind/skills',
+    globalSkillsDir: join(home, '.terramind/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.terramind'));
+    },
+  },
   trae: {
     name: 'trae',
     displayName: 'Trae',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -132,6 +132,7 @@ export async function discoverSkills(
     join(searchPath, '.pi/skills'),
     join(searchPath, '.qoder/skills'),
     join(searchPath, '.roo/skills'),
+    join(searchPath, '.terramind/skills'),
     join(searchPath, '.trae/skills'),
     join(searchPath, '.windsurf/skills'),
     join(searchPath, '.zencoder/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type AgentType =
   | 'qoder'
   | 'qwen-code'
   | 'roo'
+  | 'terramind'
   | 'trae'
   | 'windsurf'
   | 'zencoder'


### PR DESCRIPTION
## Summary

Adds [Terramind Nucleus](https://nucleus.terramind.com) as a supported agent in the skills CLI.

- **Agent key:** `terramind`
- **Display name:** Terramind
- **Project skills dir:** `.terramind/skills/`
- **Global skills dir:** `~/.terramind/skills/`
- **Detection:** Checks for `~/.terramind` directory

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Added `'terramind'` to the `AgentType` union |
| `src/agents.ts` | Added `terramind` agent config entry |
| `src/skills.ts` | Added `.terramind/skills/` to discovery search paths |
| `README.md` | Added Terramind to the supported agents table and skill discovery list |

## Context

[Terramind Nucleus](https://nucleus.terramind.com) is a VS Code-based AI IDE with built-in Agent Skills support. It discovers skills from `.terramind/skills/` in project directories and `~/.terramind/skills/` globally, and includes a `terramind_install_skill` tool that lets the agent install skills from GitHub repos using the same conventions as the skills CLI.

---

*This PR was created by Nucleus Agent — [nucleus.terramind.com](https://nucleus.terramind.com)*