### PR TITLE
polish: skip logo for some info critical cmd

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { runCliOutput, stripLogo } from './test-utils.ts';
+import { runCliOutput, stripLogo, hasLogo } from './test-utils.ts';
 import { formatSkippedMessage } from './cli.ts';
 
 describe('skills CLI', () => {
@@ -66,6 +66,28 @@ describe('skills CLI', () => {
         Run skills --help for usage.
         "
       `);
+    });
+  });
+
+  describe('logo display', () => {
+    it('should not display logo for list command', () => {
+      const output = runCliOutput(['list']);
+      expect(hasLogo(output)).toBe(false);
+    });
+
+    it('should not display logo for check command', () => {
+      const output = runCliOutput(['check']);
+      expect(hasLogo(output)).toBe(false);
+    });
+
+    it('should not display logo for update command', () => {
+      const output = runCliOutput(['update']);
+      expect(hasLogo(output)).toBe(false);
+    });
+
+    it('should not display logo for generate-lock command', () => {
+      const output = runCliOutput(['generate-lock']);
+      expect(hasLogo(output)).toBe(false);
     });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -737,25 +737,17 @@ async function main(): Promise<void> {
     }
     case 'list':
     case 'ls':
-      showLogo();
-      console.log();
       await runList(restArgs);
       break;
     case 'check':
-      showLogo();
-      console.log();
       runCheck(restArgs);
       break;
     case 'update':
     case 'upgrade':
-      showLogo();
-      console.log();
       runUpdate();
       break;
     case 'generate-lock':
     case 'gen-lock':
-      showLogo();
-      console.log();
       runGenerateLock(restArgs);
       break;
     case '--help':

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -16,6 +16,10 @@ export function stripLogo(str: string): string {
     .replace(/^\n+/, '');
 }
 
+export function hasLogo(str: string): boolean {
+  return str.includes('███') || str.includes('╔') || str.includes('╚');
+}
+
 export function runCli(
   args: string[],
   cwd?: string,


### PR DESCRIPTION
We don't need to show logo for all the cmds, e.g. list, generate-lock, they're more focus on performing the actions rather than promoting the CLI with the cmd. 

### Summary

- Skip displaying the SKILLS logo banner for frequently-used, info-dense commands: list, check, update, and
generate-lock
- Keep the logo for onboarding/ceremonial commands: add, init, find

This saves terminal space for commands that are run often and output information the user wants to see quickly.