### PR TITLE
Disable telemetry for private GitHub repositories

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,20 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { parseSource, getOwnerRepo } from './source-parser.ts';
+import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
+
+/**
+ * Check if a source identifier (owner/repo format) represents a private GitHub repo.
+ * Returns true if private, false if public, null if unable to determine or not a GitHub repo.
+ */
+async function isSourcePrivate(source: string): Promise<boolean | null> {
+  const ownerRepo = parseOwnerRepo(source);
+  if (!ownerRepo) {
+    // Not in owner/repo format, assume not private (could be other providers)
+    return false;
+  }
+  return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
+}
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName } from './skills.ts';
 import {
@@ -480,15 +493,20 @@ async function handleRemoteSkill(
   const failed = results.filter((r) => !r.success);
 
   // Track installation with provider-specific source identifier
-  track({
-    event: 'install',
-    source: remoteSkill.sourceIdentifier,
-    skills: remoteSkill.installName,
-    agents: targetAgents.join(','),
-    ...(installGlobally && { global: '1' }),
-    skillFiles: JSON.stringify({ [remoteSkill.installName]: url }),
-    sourceType: remoteSkill.providerId,
-  });
+  // Skip telemetry for private GitHub repos
+  const isPrivate = await isSourcePrivate(remoteSkill.sourceIdentifier);
+  if (isPrivate !== true) {
+    // Only send telemetry if repo is public (isPrivate === false) or we can't determine (null for non-GitHub sources)
+    track({
+      event: 'install',
+      source: remoteSkill.sourceIdentifier,
+      skills: remoteSkill.installName,
+      agents: targetAgents.join(','),
+      ...(installGlobally && { global: '1' }),
+      skillFiles: JSON.stringify({ [remoteSkill.installName]: url }),
+      sourceType: remoteSkill.providerId,
+    });
+  }
 
   // Add to skill lock file for update tracking (only for global installs)
   if (successful.length > 0 && installGlobally) {
@@ -904,15 +922,20 @@ async function handleWellKnownSkills(
     skillFiles[skill.installName] = skill.sourceUrl;
   }
 
-  track({
-    event: 'install',
-    source: sourceIdentifier,
-    skills: selectedSkills.map((s) => s.installName).join(','),
-    agents: targetAgents.join(','),
-    ...(installGlobally && { global: '1' }),
-    skillFiles: JSON.stringify(skillFiles),
-    sourceType: 'well-known',
-  });
+  // Skip telemetry for private GitHub repos
+  const isPrivate = await isSourcePrivate(sourceIdentifier);
+  if (isPrivate !== true) {
+    // Only send telemetry if repo is public (isPrivate === false) or we can't determine (null for non-GitHub sources)
+    track({
+      event: 'install',
+      source: sourceIdentifier,
+      skills: selectedSkills.map((s) => s.installName).join(','),
+      agents: targetAgents.join(','),
+      ...(installGlobally && { global: '1' }),
+      skillFiles: JSON.stringify(skillFiles),
+      sourceType: 'well-known',
+    });
+  }
 
   // Add to skill lock file for update tracking (only for global installs)
   if (successful.length > 0 && installGlobally) {
@@ -1233,6 +1256,7 @@ async function handleDirectUrlSkillLegacy(
   const failed = results.filter((r) => !r.success);
 
   // Track installation
+  // Skip telemetry for private GitHub repos (mintlify/com is not a GitHub repo, so always send)
   track({
     event: 'install',
     source: 'mintlify/com',
@@ -1731,16 +1755,35 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Normalize source to owner/repo format for telemetry
     const normalizedSource = getOwnerRepo(parsed);
 
-    // Only track if we have a valid remote source
+    // Only track if we have a valid remote source and it's not a private repo
     if (normalizedSource) {
-      track({
-        event: 'install',
-        source: normalizedSource,
-        skills: selectedSkills.map((s) => s.name).join(','),
-        agents: targetAgents.join(','),
-        ...(installGlobally && { global: '1' }),
-        skillFiles: JSON.stringify(skillFiles),
-      });
+      const ownerRepo = parseOwnerRepo(normalizedSource);
+      if (ownerRepo) {
+        // Check if repo is private - skip telemetry for private repos
+        const isPrivate = await isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
+        // Only send telemetry if repo is public (isPrivate === false)
+        // If we can't determine (null), err on the side of caution and skip telemetry
+        if (isPrivate === false) {
+          track({
+            event: 'install',
+            source: normalizedSource,
+            skills: selectedSkills.map((s) => s.name).join(','),
+            agents: targetAgents.join(','),
+            ...(installGlobally && { global: '1' }),
+            skillFiles: JSON.stringify(skillFiles),
+          });
+        }
+      } else {
+        // If we can't parse owner/repo, still send telemetry (for non-GitHub sources)
+        track({
+          event: 'install',
+          source: normalizedSource,
+          skills: selectedSkills.map((s) => s.name).join(','),
+          agents: targetAgents.join(','),
+          ...(installGlobally && { global: '1' }),
+          skillFiles: JSON.stringify(skillFiles),
+        });
+      }
     }
 
     // Add to skill lock file for update tracking (only for global installs)

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,6 +1,7 @@
 import * as readline from 'readline';
 import { runAdd, parseAddOptions } from './add.ts';
 import { track } from './telemetry.ts';
+import { isRepoPrivate, parseOwnerRepo } from './source-parser.ts';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -248,12 +249,10 @@ function getOwnerRepoFromString(pkg: string): { owner: string; repo: string } | 
 }
 
 async function isRepoPublic(owner: string, repo: string): Promise<boolean> {
-  try {
-    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
-    return res.ok;
-  } catch {
-    return false;
-  }
+  const isPrivate = await isRepoPrivate(owner, repo);
+  // Return true only if we know it's public (isPrivate === false)
+  // Return false if private or unable to determine
+  return isPrivate === false;
 }
 
 export async function runFind(args: string[]): Promise<void> {

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -20,6 +20,40 @@ export function getOwnerRepo(parsed: ParsedSource): string | null {
 }
 
 /**
+ * Extract owner and repo from an owner/repo string.
+ * Returns null if the format is invalid.
+ */
+export function parseOwnerRepo(ownerRepo: string): { owner: string; repo: string } | null {
+  const match = ownerRepo.match(/^([^/]+)\/([^/]+)$/);
+  if (match) {
+    return { owner: match[1]!, repo: match[2]! };
+  }
+  return null;
+}
+
+/**
+ * Check if a GitHub repository is private.
+ * Returns true if private, false if public, null if unable to determine.
+ * Only works for GitHub repositories (GitLab not supported).
+ */
+export async function isRepoPrivate(owner: string, repo: string): Promise<boolean | null> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
+    
+    // If repo doesn't exist or we don't have access, assume private to be safe
+    if (!res.ok) {
+      return null; // Unable to determine
+    }
+    
+    const data = await res.json() as { private?: boolean };
+    return data.private === true;
+  } catch {
+    // On error, return null to indicate we couldn't determine
+    return null;
+  }
+}
+
+/**
  * Check if a string represents a local file system path
  */
 function isLocalPath(input: string): boolean {


### PR DESCRIPTION
This PR disables telemetry for private GitHub repositories.

## Changes
- Disables telemetry collection when working with private repositories

## Why
We have some internal skills repos that I'd love to direct teammates to use `npx skills add ...` to install, but I don't want them showing up on skills.sh