### PR TITLE
Add Trae CN agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Skills can be installed to any of these agents:
 | Qwen Code          | `qwen-code`       | `.qwen/skills/`        | `~/.qwen/skills/`                      |
 | Roo Code           | `roo`             | `.roo/skills/`         | `~/.roo/skills/`                       |
 | Trae               | `trae`            | `.trae/skills/`        | `~/.trae/skills/`                      |
+| Trae CN            | `trae-cn`         | `.trae/skills/`        | `~/.trae-cn/skills/`                   |
 | Windsurf           | `windsurf`        | `.windsurf/skills/`    | `~/.codeium/windsurf/skills/`          |
 | Zencoder           | `zencoder`        | `.zencoder/skills/`    | `~/.zencoder/skills/`                  |
 | Neovate            | `neovate`         | `.neovate/skills/`     | `~/.neovate/skills/`                   |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -273,6 +273,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.trae'));
     },
   },
+  'trae-cn': {
+    name: 'trae-cn',
+    displayName: 'Trae CN',
+    skillsDir: '.trae/skills',
+    globalSkillsDir: join(home, '.trae-cn/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.trae-cn'));
+    },
+  },
   windsurf: {
     name: 'windsurf',
     displayName: 'Windsurf',

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -39,13 +39,13 @@ export function parseOwnerRepo(ownerRepo: string): { owner: string; repo: string
 export async function isRepoPrivate(owner: string, repo: string): Promise<boolean | null> {
   try {
     const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
-    
+
     // If repo doesn't exist or we don't have access, assume private to be safe
     if (!res.ok) {
       return null; // Unable to determine
     }
-    
-    const data = await res.json() as { private?: boolean };
+
+    const data = (await res.json()) as { private?: boolean };
     return data.private === true;
   } catch {
     // On error, return null to indicate we couldn't determine

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export type AgentType =
   | 'qwen-code'
   | 'roo'
   | 'trae'
+  | 'trae-cn'
   | 'windsurf'
   | 'zencoder'
   | 'pochi';


### PR DESCRIPTION
### Motivation
- Support the Trae China product by adding a new agent type that uses the same project skill path but a separate global skills directory at `~/.trae-cn/skills`.

### Description
- Add `trae-cn` to the `AgentType` union in `src/types.ts`.
- Add a new agent configuration for `trae-cn` in `src/agents.ts` with `skillsDir` set to `.trae/skills` and `globalSkillsDir` set to `join(home, '.trae-cn/skills')`, and a `detectInstalled` check against `~/.trae-cn`.
- Document the new `trae-cn` entry in the supported agents table in `README.md`.
- Apply formatting changes to source files (Prettier) for consistency.

### Testing
- Ran code formatting with `pnpm format`, which completed successfully.