### PR TITLE
feat: addd npm package source support for skills installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ npx skills add git@github.com:vercel-labs/agent-skills.git
 
 # Local path
 npx skills add ./my-local-skills
+
+# npm package
+npx skills add npm:@vercel/skills
+
+# npm package with version
+npx skills add npm:@scope/skill@1.2.3
+
+# npm package with custom registry
+npx skills add npm:my-skill --registry=https://registry.npmmirror.com
 ```
 
 ### Options
@@ -46,6 +55,7 @@ npx skills add ./my-local-skills
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+| `--registry <url>`        | Custom npm registry URL (for `npm:` sources, default: `https://registry.npmjs.org`)                                                                |
 
 ### Examples
 
@@ -67,6 +77,9 @@ npx skills add vercel-labs/agent-skills --skill frontend-design -g -a claude-cod
 
 # Install all skills from a repo to all agents
 npx skills add vercel-labs/agent-skills --all
+
+# Install from npm package
+npx skills add npm:@vercel/skills -g -y
 ```
 
 ### Installation Scope

--- a/package.json
+++ b/package.json
@@ -90,10 +90,14 @@
     "prettier": "^3.8.1",
     "simple-git": "^3.27.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "@types/tar": "^6.1.13"
   },
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "pnpm@10.17.1"
+  "packageManager": "pnpm@10.17.1",
+  "dependencies": {
+    "tar": "^7.5.7"
+  }
 }

--- a/src/add.ts
+++ b/src/add.ts
@@ -17,6 +17,7 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
+import { downloadNpmPackage, NpmDownloadError } from './npm.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
   installSkillForAgent,
@@ -228,6 +229,7 @@ export interface AddOptions {
   skill?: string[];
   list?: boolean;
   all?: boolean;
+  registry?: string;
 }
 
 /**
@@ -1381,10 +1383,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const spinner = p.spinner();
 
     spinner.start('Parsing source...');
-    const parsed = parseSource(source);
+    const parsed = parseSource(source, { registry: options.registry });
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
+
+    if (options.registry && parsed.type !== 'npm') {
+      p.log.warn('--registry is only used with npm: sources (e.g., npm:@scope/pkg)');
+    }
 
     // Handle direct URL skills (Mintlify, HuggingFace, etc.) via provider system
     if (parsed.type === 'direct-url') {
@@ -1400,7 +1406,26 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     let skillsDir: string;
 
-    if (parsed.type === 'local') {
+    if (parsed.type === 'npm') {
+      spinner.start(`Downloading npm package ${parsed.packageName}...`);
+      try {
+        const result = await downloadNpmPackage(
+          parsed.packageName!,
+          parsed.version,
+          parsed.registry
+        );
+        skillsDir = result.dir;
+        tempDir = result.tempDir;
+      } catch (error) {
+        if (error instanceof NpmDownloadError) {
+          spinner.stop(pc.red('Download failed'));
+          p.outro(pc.red(error.message));
+          process.exit(1);
+        }
+        throw error;
+      }
+      spinner.stop('Package downloaded');
+    } else if (parsed.type === 'local') {
       // Use local path directly, no cloning needed
       spinner.start('Validating local path...');
       if (!existsSync(parsed.localPath!)) {
@@ -2012,6 +2037,11 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg === '--registry') {
+      i++;
+      options.registry = args[i];
+    } else if (arg?.startsWith('--registry=')) {
+      options.registry = arg.slice('--registry='.length);
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,0 +1,129 @@
+import { existsSync } from 'fs';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import tar from 'tar';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+
+export class NpmDownloadError extends Error {
+  readonly packageName: string;
+
+  constructor(message: string, packageName: string) {
+    super(message);
+    this.name = 'NpmDownloadError';
+    this.packageName = packageName;
+  }
+}
+
+interface NpmPackageResult {
+  /** Path to extracted package contents (the "package/" subdirectory) */
+  dir: string;
+  /** Path to the temporary directory (parent of dir, for cleanup) */
+  tempDir: string;
+  /** Cleanup function to remove the temporary directory */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Download and extract an npm package to a temporary directory.
+ *
+ * 1. Fetches package metadata from the registry
+ * 2. Downloads the tarball
+ * 3. Extracts it using `tar`
+ * 4. Returns the path to the extracted contents
+ */
+export async function downloadNpmPackage(
+  packageName: string,
+  version?: string,
+  registry?: string
+): Promise<NpmPackageResult> {
+  const registryUrl = (registry || DEFAULT_REGISTRY).replace(/\/$/, '');
+  const tempDir = await mkdtemp(join(tmpdir(), 'skills-npm-'));
+
+  const cleanupFn = async () => {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  };
+
+  try {
+    // Fetch package metadata to get the tarball URL
+    // Scoped packages need URL encoding: @scope/pkg → @scope%2Fpkg
+    const encodedName = packageName.startsWith('@')
+      ? `@${encodeURIComponent(packageName.slice(1))}`
+      : packageName;
+    const metadataUrl = `${registryUrl}/${encodedName}`;
+    const res = await fetch(metadataUrl);
+
+    if (!res.ok) {
+      throw new NpmDownloadError(
+        `Failed to fetch package metadata: ${res.status} ${res.statusText}`,
+        packageName
+      );
+    }
+
+    const metadata = (await res.json()) as {
+      'dist-tags'?: Record<string, string>;
+      versions?: Record<string, { dist?: { tarball?: string } }>;
+    };
+
+    // Resolve the version
+    const resolvedVersion = version
+      ? metadata['dist-tags']?.[version] || version
+      : metadata['dist-tags']?.['latest'];
+
+    if (!resolvedVersion) {
+      throw new NpmDownloadError(`Could not resolve version for ${packageName}`, packageName);
+    }
+
+    const versionData = metadata.versions?.[resolvedVersion];
+    if (!versionData?.dist?.tarball) {
+      throw new NpmDownloadError(
+        `No tarball found for ${packageName}@${resolvedVersion}`,
+        packageName
+      );
+    }
+
+    const tarballUrl = versionData.dist.tarball;
+
+    // Download the tarball
+    const tarballRes = await fetch(tarballUrl);
+    if (!tarballRes.ok) {
+      throw new NpmDownloadError(
+        `Failed to download tarball: ${tarballRes.status} ${tarballRes.statusText}`,
+        packageName
+      );
+    }
+
+    const tarballPath = join(tempDir, 'package.tgz');
+    const arrayBuffer = await tarballRes.arrayBuffer();
+    await writeFile(tarballPath, Buffer.from(arrayBuffer));
+
+    // Extract the tarball
+    await tar.extract({ file: tarballPath, cwd: tempDir });
+
+    // npm tarballs extract to a "package/" subdirectory
+    const packageDir = join(tempDir, 'package');
+
+    if (!existsSync(packageDir)) {
+      throw new NpmDownloadError(
+        `Extracted tarball does not contain a "package" directory for ${packageName}`,
+        packageName
+      );
+    }
+
+    return {
+      dir: packageDir,
+      tempDir,
+      cleanup: cleanupFn,
+    };
+  } catch (error) {
+    await cleanupFn();
+    if (error instanceof NpmDownloadError) {
+      throw error;
+    }
+    throw new NpmDownloadError(
+      `Failed to download npm package ${packageName}: ${error instanceof Error ? error.message : String(error)}`,
+      packageName
+    );
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,13 +51,19 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'direct-url' | 'well-known';
+  type: 'github' | 'gitlab' | 'git' | 'local' | 'direct-url' | 'well-known' | 'npm';
   url: string;
   subpath?: string;
   localPath?: string;
   ref?: string;
   /** Skill name extracted from @skill syntax (e.g., owner/repo@skill-name) */
   skillFilter?: string;
+  /** npm package name (e.g., @vercel/skills) — only for type 'npm' */
+  packageName?: string;
+  /** npm package version (e.g., 1.2.3) — only for type 'npm' */
+  version?: string;
+  /** npm registry URL — only for type 'npm' */
+  registry?: string;
 }
 
 export interface MintlifySkill {

--- a/tests/npm.test.ts
+++ b/tests/npm.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Unit tests for npm.ts
+ *
+ * Tests the npm package download and extraction logic.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { downloadNpmPackage, NpmDownloadError } from '../src/npm.ts';
+import { parseAddOptions } from '../src/add.ts';
+import { existsSync } from 'fs';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock tar
+vi.mock('tar', () => ({
+  default: { extract: vi.fn().mockResolvedValue(undefined) },
+}));
+
+// Mock fs (existsSync)
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+  };
+});
+
+// Mock fs/promises
+vi.mock('fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('fs/promises')>('fs/promises');
+  return {
+    ...actual,
+    mkdtemp: vi.fn().mockResolvedValue('/tmp/skills-npm-abc123'),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const mockExistsSync = vi.mocked(existsSync);
+
+describe('downloadNpmPackage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(true);
+  });
+
+  it('throws NpmDownloadError when package metadata fetch fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    await expect(downloadNpmPackage('nonexistent-pkg')).rejects.toThrow(
+      /Failed to fetch package metadata/
+    );
+  });
+
+  it('throws NpmDownloadError when version cannot be resolved', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        'dist-tags': {},
+        versions: {},
+      }),
+    });
+
+    await expect(downloadNpmPackage('some-pkg')).rejects.toThrow(/Could not resolve version/);
+  });
+
+  it('throws NpmDownloadError when no tarball URL found', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': { dist: {} },
+        },
+      }),
+    });
+
+    await expect(downloadNpmPackage('some-pkg')).rejects.toThrow(/No tarball found/);
+  });
+
+  it('resolves dist-tag version (e.g., latest) to actual version', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '2.0.0', beta: '3.0.0-beta.1' },
+          versions: {
+            '2.0.0': {
+              dist: { tarball: 'https://registry.npmjs.org/pkg/-/pkg-2.0.0.tgz' },
+            },
+            '3.0.0-beta.1': {
+              dist: { tarball: 'https://registry.npmjs.org/pkg/-/pkg-3.0.0-beta.1.tgz' },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(0),
+      });
+
+    const result = await downloadNpmPackage('pkg', 'beta');
+    expect(result.dir).toBe('/tmp/skills-npm-abc123/package');
+    expect(result.tempDir).toBe('/tmp/skills-npm-abc123');
+    expect(mockFetch).toHaveBeenCalledWith('https://registry.npmjs.org/pkg');
+    expect(mockFetch).toHaveBeenCalledWith('https://registry.npmjs.org/pkg/-/pkg-3.0.0-beta.1.tgz');
+    await result.cleanup();
+  });
+
+  it('uses custom registry URL', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.0.0' },
+          versions: {
+            '1.0.0': {
+              dist: { tarball: 'https://custom.registry.com/pkg/-/pkg-1.0.0.tgz' },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(0),
+      });
+
+    const result = await downloadNpmPackage('pkg', undefined, 'https://custom.registry.com');
+    expect(mockFetch).toHaveBeenCalledWith('https://custom.registry.com/pkg');
+    await result.cleanup();
+  });
+
+  it('URL-encodes scoped package names for registry API', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.0.0' },
+          versions: {
+            '1.0.0': {
+              dist: { tarball: 'https://registry.npmjs.org/@scope/pkg/-/pkg-1.0.0.tgz' },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(0),
+      });
+
+    const result = await downloadNpmPackage('@scope/pkg');
+    // The slash in @scope/pkg should be encoded as %2F
+    expect(mockFetch).toHaveBeenCalledWith('https://registry.npmjs.org/@scope%2Fpkg');
+    await result.cleanup();
+  });
+
+  it('downloads and extracts package successfully', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.0.0' },
+          versions: {
+            '1.0.0': {
+              dist: { tarball: 'https://registry.npmjs.org/my-skill/-/my-skill-1.0.0.tgz' },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(10),
+      });
+
+    const result = await downloadNpmPackage('my-skill');
+    expect(result.dir).toBe('/tmp/skills-npm-abc123/package');
+    expect(result.tempDir).toBe('/tmp/skills-npm-abc123');
+    expect(typeof result.cleanup).toBe('function');
+    await result.cleanup();
+  });
+
+  it('throws NpmDownloadError when tarball download fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.0.0' },
+          versions: {
+            '1.0.0': {
+              dist: { tarball: 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz' },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+    await expect(downloadNpmPackage('pkg')).rejects.toThrow(/Failed to download tarball/);
+  });
+
+  it('throws NpmDownloadError when extracted tarball has no package/ directory', async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          'dist-tags': { latest: '1.0.0' },
+          versions: {
+            '1.0.0': {
+              dist: { tarball: 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz' },
+            },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(10),
+      });
+
+    await expect(downloadNpmPackage('pkg')).rejects.toThrow(
+      /Extracted tarball does not contain a "package" directory/
+    );
+  });
+});
+
+describe('NpmDownloadError', () => {
+  it('has correct name and packageName', () => {
+    const error = new NpmDownloadError('test error', '@scope/pkg');
+    expect(error.name).toBe('NpmDownloadError');
+    expect(error.packageName).toBe('@scope/pkg');
+    expect(error.message).toBe('test error');
+  });
+});
+
+describe('parseAddOptions --registry', () => {
+  it('should parse --registry flag with separate value', () => {
+    const { options } = parseAddOptions(['npm:foo', '--registry', 'https://my-registry.com']);
+    expect(options.registry).toBe('https://my-registry.com');
+  });
+
+  it('should parse --registry= flag with inline value', () => {
+    const { options } = parseAddOptions(['npm:foo', '--registry=https://my-registry.com']);
+    expect(options.registry).toBe('https://my-registry.com');
+  });
+
+  it('should not set registry when flag is absent', () => {
+    const { options } = parseAddOptions(['npm:foo', '-g', '-y']);
+    expect(options.registry).toBeUndefined();
+  });
+
+  it('should parse source alongside --registry', () => {
+    const { source, options } = parseAddOptions([
+      'npm:@scope/pkg',
+      '--registry',
+      'https://r.com',
+      '-g',
+    ]);
+    expect(source).toEqual(['npm:@scope/pkg']);
+    expect(options.registry).toBe('https://r.com');
+    expect(options.global).toBe(true);
+  });
+});

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -136,6 +136,54 @@ describe('parseSource', () => {
     });
   });
 
+  describe('npm package tests', () => {
+    it('npm: prefix - simple package', () => {
+      const result = parseSource('npm:foo');
+      expect(result.type).toBe('npm');
+      expect(result.packageName).toBe('foo');
+      expect(result.version).toBeUndefined();
+      expect(result.url).toBe('npm:foo');
+    });
+
+    it('npm: prefix - scoped package', () => {
+      const result = parseSource('npm:@scope/foo');
+      expect(result.type).toBe('npm');
+      expect(result.packageName).toBe('@scope/foo');
+      expect(result.version).toBeUndefined();
+      expect(result.url).toBe('npm:@scope/foo');
+    });
+
+    it('npm: prefix - scoped package with version', () => {
+      const result = parseSource('npm:@scope/foo@1.2.3');
+      expect(result.type).toBe('npm');
+      expect(result.packageName).toBe('@scope/foo');
+      expect(result.version).toBe('1.2.3');
+      expect(result.url).toBe('npm:@scope/foo@1.2.3');
+    });
+
+    it('npm: prefix - simple package with version', () => {
+      const result = parseSource('npm:foo@2.0.0');
+      expect(result.type).toBe('npm');
+      expect(result.packageName).toBe('foo');
+      expect(result.version).toBe('2.0.0');
+      expect(result.url).toBe('npm:foo@2.0.0');
+    });
+
+    it('npm: prefix - package with latest tag', () => {
+      const result = parseSource('npm:foo@latest');
+      expect(result.type).toBe('npm');
+      expect(result.packageName).toBe('foo');
+      expect(result.version).toBe('latest');
+    });
+
+    it('npm: prefix - with registry option', () => {
+      const result = parseSource('npm:foo', { registry: 'https://my-registry.com' });
+      expect(result.type).toBe('npm');
+      expect(result.packageName).toBe('foo');
+      expect(result.registry).toBe('https://my-registry.com');
+    });
+  });
+
   describe('Git URL fallback tests', () => {
     it('Git URL - SSH format', () => {
       const result = parseSource('git@github.com:owner/repo.git');


### PR DESCRIPTION
Support installing skills from npm packages via `npm:` prefix (e.g., `npx skills add npm:@scope/pkg@1.2.3 --registry=https://...`). Adds source parsing, tarball download/extraction, and integrates with the existing skill discovery and installation flow.