### PR TITLE
feat: add --full-depth flag, Augment agent, Mistral Vibe agent, and s…

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -370,6 +370,20 @@ describe('parseAddOptions', () => {
     expect(result.options.skill).toEqual(['*']);
     expect(result.options.yes).toBe(true);
   });
+
+  it('should parse --full-depth flag', () => {
+    const result = parseAddOptions(['source', '--full-depth']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.fullDepth).toBe(true);
+  });
+
+  it('should parse --full-depth with other flags', () => {
+    const result = parseAddOptions(['source', '--full-depth', '--list', '-g']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.fullDepth).toBe(true);
+    expect(result.options.list).toBe(true);
+    expect(result.options.global).toBe(true);
+  });
 });
 
 describe('find-skills prompt with -y flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -231,6 +231,7 @@ export interface AddOptions {
   skill?: string[];
   list?: boolean;
   all?: boolean;
+  fullDepth?: boolean;
 }
 
 /**
@@ -1459,7 +1460,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const includeInternal = !!(options.skill && options.skill.length > 0);
 
     spinner.start('Discovering skills...');
-    const skills = await discoverSkills(skillsDir, parsed.subpath, { includeInternal });
+    const skills = await discoverSkills(skillsDir, parsed.subpath, {
+      includeInternal,
+      fullDepth: options.fullDepth,
+    });
 
     if (skills.length === 0) {
       spinner.stop(pc.red('No skills found'));
@@ -2054,6 +2058,8 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg === '--full-depth') {
+      options.fullDepth = true;
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -31,6 +31,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       );
     },
   },
+  augment: {
+    name: 'augment',
+    displayName: 'Augment',
+    skillsDir: '.augment/rules',
+    globalSkillsDir: join(home, '.augment/rules'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.augment'));
+    },
+  },
   'claude-code': {
     name: 'claude-code',
     displayName: 'Claude Code',
@@ -202,6 +211,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.mcpjam/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.mcpjam'));
+    },
+  },
+  'mistral-vibe': {
+    name: 'mistral-vibe',
+    displayName: 'Mistral Vibe',
+    skillsDir: '.vibe/skills',
+    globalSkillsDir: join(home, '.vibe/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.vibe'));
     },
   },
   mux: {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { runCliOutput, stripLogo, hasLogo } from './test-utils.ts';
-import { formatSkippedMessage } from './cli.ts';
 
 describe('skills CLI', () => {
   describe('--help', () => {
@@ -83,21 +82,5 @@ describe('skills CLI', () => {
       const output = runCliOutput(['update']);
       expect(hasLogo(output)).toBe(false);
     });
-  });
-});
-
-describe('formatSkippedMessage', () => {
-  it('should return null for empty array', () => {
-    expect(formatSkippedMessage([])).toBeNull();
-  });
-
-  it('should format single skill', () => {
-    expect(formatSkippedMessage(['my-skill'])).toBe('Skipped 1 (reinstall needed):\n  - my-skill');
-  });
-
-  it('should format multiple skills', () => {
-    expect(formatSkippedMessage(['skill-a', 'skill-b', 'skill-c'])).toBe(
-      'Skipped 3 (reinstall needed):\n  - skill-a\n  - skill-b\n  - skill-c'
-    );
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,15 +12,6 @@ import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { track } from './telemetry.ts';
 
-export function formatSkippedMessage(skippedSkills: string[]): string | null {
-  if (skippedSkills.length === 0) return null;
-  const lines = [`Skipped ${skippedSkills.length} (reinstall needed):`];
-  for (const skill of skippedSkills) {
-    lines.push(`  - ${skill}`);
-  }
-  return lines.join('\n');
-}
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 function getVersion(): string {
@@ -123,6 +114,7 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --all                  Shorthand for --skill '*' --agent '*' -y
+  --full-depth           Search all subdirectories even when a root SKILL.md exists
 
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope
@@ -351,14 +343,12 @@ async function runCheck(args: string[] = []): Promise<void> {
     skills: [],
   };
 
-  const skippedSkills: string[] = [];
   for (const skillName of skillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Skip skills without skillFolderHash (shouldn't happen with v3)
+    // Skip skills without skillFolderHash (e.g., private repos where API can't fetch hash)
     if (!entry.skillFolderHash) {
-      skippedSkills.push(skillName);
       continue;
     }
 
@@ -368,11 +358,6 @@ async function runCheck(args: string[] = []): Promise<void> {
       path: entry.skillPath,
       skillFolderHash: entry.skillFolderHash,
     });
-  }
-
-  const skippedMsg = formatSkippedMessage(skippedSkills);
-  if (skippedMsg) {
-    console.log(`${DIM}${skippedMsg}${RESET}`);
   }
 
   if (checkRequest.skills.length === 0) {
@@ -452,14 +437,12 @@ async function runUpdate(): Promise<void> {
     skills: [],
   };
 
-  const skippedSkills: string[] = [];
   for (const skillName of skillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Skip skills without skillFolderHash (shouldn't happen with v3)
+    // Skip skills without skillFolderHash (e.g., private repos where API can't fetch hash)
     if (!entry.skillFolderHash) {
-      skippedSkills.push(skillName);
       continue;
     }
 
@@ -469,11 +452,6 @@ async function runUpdate(): Promise<void> {
       path: entry.skillPath,
       skillFolderHash: entry.skillFolderHash,
     });
-  }
-
-  const skippedMsg = formatSkippedMessage(skippedSkills);
-  if (skippedMsg) {
-    console.log(`${DIM}${skippedMsg}${RESET}`);
   }
 
   if (checkRequest.skills.length === 0) {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -83,6 +83,8 @@ async function findSkillDirs(dir: string, depth = 0, maxDepth = 5): Promise<stri
 export interface DiscoverSkillsOptions {
   /** Include internal skills (e.g., when user explicitly requests a skill by name) */
   includeInternal?: boolean;
+  /** Search all subdirectories even when a root SKILL.md exists */
+  fullDepth?: boolean;
 }
 
 export async function discoverSkills(
@@ -94,12 +96,16 @@ export async function discoverSkills(
   const seenNames = new Set<string>();
   const searchPath = subpath ? join(basePath, subpath) : basePath;
 
-  // If pointing directly at a skill, return just that
+  // If pointing directly at a skill, add it (and return early unless fullDepth is set)
   if (await hasSkillMd(searchPath)) {
     const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
     if (skill) {
       skills.push(skill);
-      return skills;
+      seenNames.add(skill.name);
+      // Only return early if fullDepth is not set
+      if (!options?.fullDepth) {
+        return skills;
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type AgentType =
   | 'amp'
   | 'antigravity'
+  | 'augment'
   | 'claude-code'
   | 'moltbot'
   | 'cline'
@@ -20,6 +21,7 @@ export type AgentType =
   | 'kiro-cli'
   | 'kode'
   | 'mcpjam'
+  | 'mistral-vibe'
   | 'mux'
   | 'neovate'
   | 'opencode'

--- a/tests/full-depth-discovery.test.ts
+++ b/tests/full-depth-discovery.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the --full-depth option in skill discovery.
+ *
+ * When a repository has both a root SKILL.md and nested skills in subdirectories,
+ * the --full-depth flag allows discovering all skills instead of just the root one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { discoverSkills } from '../src/skills.ts';
+
+describe('discoverSkills with fullDepth option', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-full-depth-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should only return root skill when fullDepth is false', async () => {
+    // Create root SKILL.md
+    writeFileSync(
+      join(testDir, 'SKILL.md'),
+      `---
+name: root-skill
+description: Root level skill
+---
+
+# Root Skill
+`
+    );
+
+    // Create nested skill in skills/ directory
+    mkdirSync(join(testDir, 'skills', 'nested-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'nested-skill', 'SKILL.md'),
+      `---
+name: nested-skill
+description: Nested skill
+---
+
+# Nested Skill
+`
+    );
+
+    const skills = await discoverSkills(testDir, undefined, { fullDepth: false });
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('root-skill');
+  });
+
+  it('should return all skills when fullDepth is true', async () => {
+    // Create root SKILL.md
+    writeFileSync(
+      join(testDir, 'SKILL.md'),
+      `---
+name: root-skill
+description: Root level skill
+---
+
+# Root Skill
+`
+    );
+
+    // Create nested skills in skills/ directory
+    mkdirSync(join(testDir, 'skills', 'nested-skill-1'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'nested-skill-1', 'SKILL.md'),
+      `---
+name: nested-skill-1
+description: Nested skill 1
+---
+
+# Nested Skill 1
+`
+    );
+
+    mkdirSync(join(testDir, 'skills', 'nested-skill-2'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'nested-skill-2', 'SKILL.md'),
+      `---
+name: nested-skill-2
+description: Nested skill 2
+---
+
+# Nested Skill 2
+`
+    );
+
+    const skills = await discoverSkills(testDir, undefined, { fullDepth: true });
+
+    expect(skills).toHaveLength(3);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(['nested-skill-1', 'nested-skill-2', 'root-skill']);
+  });
+
+  it('should default to early return (fullDepth: false behavior) when no option is provided', async () => {
+    // Create root SKILL.md
+    writeFileSync(
+      join(testDir, 'SKILL.md'),
+      `---
+name: root-skill
+description: Root level skill
+---
+
+# Root Skill
+`
+    );
+
+    // Create nested skill
+    mkdirSync(join(testDir, 'skills', 'nested-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'nested-skill', 'SKILL.md'),
+      `---
+name: nested-skill
+description: Nested skill
+---
+
+# Nested Skill
+`
+    );
+
+    // No options passed - should default to early return
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('root-skill');
+  });
+
+  it('should still find all skills when no root SKILL.md exists (regardless of fullDepth)', async () => {
+    // No root SKILL.md, just nested skills
+
+    mkdirSync(join(testDir, 'skills', 'skill-1'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'skill-1', 'SKILL.md'),
+      `---
+name: skill-1
+description: Skill 1
+---
+
+# Skill 1
+`
+    );
+
+    mkdirSync(join(testDir, 'skills', 'skill-2'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'skill-2', 'SKILL.md'),
+      `---
+name: skill-2
+description: Skill 2
+---
+
+# Skill 2
+`
+    );
+
+    // Without fullDepth
+    const skillsDefault = await discoverSkills(testDir);
+    expect(skillsDefault).toHaveLength(2);
+
+    // With fullDepth
+    const skillsFullDepth = await discoverSkills(testDir, undefined, { fullDepth: true });
+    expect(skillsFullDepth).toHaveLength(2);
+  });
+
+  it('should not duplicate skills when root and nested have the same name', async () => {
+    // Edge case: root SKILL.md and a nested skill with the same name
+    writeFileSync(
+      join(testDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: Root level skill
+---
+
+# Root Skill
+`
+    );
+
+    // Create nested skill with same name
+    mkdirSync(join(testDir, 'skills', 'my-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'my-skill', 'SKILL.md'),
+      `---
+name: my-skill
+description: Nested skill with same name
+---
+
+# Nested Skill
+`
+    );
+
+    const skills = await discoverSkills(testDir, undefined, { fullDepth: true });
+
+    // Should only have one skill (deduplication by name)
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('my-skill');
+  });
+});


### PR DESCRIPTION
## Summary

- **Add `--full-depth` flag**: Allows searching all subdirectories for skills even when a root SKILL.md exists
- **Add Augment agent support**: New agent with `.augment/rules` skills directory
- **Add Mistral Vibe agent support**: New agent with `.vibe/skills` skills directory  
- **Silent skip for private repos**: Silently skip skills without `skillFolderHash` in check/update (avoids confusing "reinstall needed" messages for private repos)

Closes #126

## Related Work

This PR combines several related improvements that were being worked on in parallel sessions:
- Full-depth parameter for skills discovery API
- Skip skillFolderHash validation for private repositories (related to closed #218)
- Skills issue #126 implementation

## Changes

### New Agents
- `augment`: Augment IDE support with `.augment/rules` directory
- `mistral-vibe`: Mistral Vibe support with `.vibe/skills` directory

### New CLI Flag
```bash
skills add <source> --full-depth
```
Searches all subdirectories for SKILL.md files even when the root directory contains one.

### Behavior Change
Skills without `skillFolderHash` (e.g., from private repos where the GitHub API couldn't fetch the hash) are now silently skipped during `skills check` and `skills update` instead of showing a confusing "reinstall needed" message.