### PR TITLE
Add Clawdbot as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [32 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [34 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -39,7 +39,7 @@ npx skills add ./my-local-skills
 | Option                    | Description                                                                                                                                        |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-g, --global`            | Install to user directory instead of project                                                                                                       |
-| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). Use `'*'` for all agents<!-- agent-names:end -->                  |
+| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Available Agents](#available-agents)<!-- agent-names:end -->                  |
 | `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
@@ -213,6 +213,7 @@ Skills can be installed to any of these agents:
 | Antigravity        | `antigravity`     | `.agent/skills/`       | `~/.gemini/antigravity/global_skills/` |
 | Claude Code        | `claude-code`     | `.claude/skills/`      | `~/.claude/skills/`                    |
 | Moltbot            | `moltbot`         | `skills/`              | `~/.moltbot/skills/`                   |
+| Clawdbot           | `clawdbot`        | `skills/`              | `~/.clawdbot/skills/`                  |
 | Cline              | `cline`           | `.cline/skills/`       | `~/.cline/skills/`                     |
 | CodeBuddy          | `codebuddy`       | `.codebuddy/skills/`   | `~/.codebuddy/skills/`                 |
 | Codex              | `codex`           | `.codex/skills/`       | `~/.codex/skills/`                     |
@@ -244,6 +245,7 @@ Skills can be installed to any of these agents:
 | OpenClaude IDE     | `openclaude`      | `.openclaude/skills/`  | `~/.openclaude/skills/`                |
 | Neovate            | `neovate`         | `.neovate/skills/`     | `~/.neovate/skills/`                   |
 | Pochi              | `pochi`           | `.pochi/skills/`       | `~/.pochi/skills/`                     |
+| AdaL               | `adal`            | `.adal/skills/`        | `~/.adal/skills/`                      |
 
 <!-- supported-agents:end -->
 
@@ -347,6 +349,7 @@ The CLI searches for skills in these locations within a repository:
 - `.zencoder/skills/`
 - `.neovate/skills/`
 - `.pochi/skills/`
+- `.adal/skills/`
 <!-- skill-discovery:end -->
 
 If no skills are found in standard locations, a recursive search is performed.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "antigravity",
     "claude-code",
     "moltbot",
+    "clawdbot",
     "cline",
     "codebuddy",
     "codex",
@@ -69,7 +70,8 @@
     "windsurf",
     "zencoder",
     "neovate",
-    "pochi"
+    "pochi",
+    "adal"
   ],
   "repository": {
     "type": "git",

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -23,11 +23,16 @@ function generateAvailableAgentsTable(): string {
   // Group agents by their paths
   const pathGroups = new Map<
     string,
-    { keys: string[]; displayNames: string[]; skillsDir: string; globalSkillsDir: string }
+    {
+      keys: string[];
+      displayNames: string[];
+      skillsDir: string;
+      globalSkillsDir: string | undefined;
+    }
   >();
 
   for (const [key, a] of Object.entries(agents)) {
-    const pathKey = `${a.skillsDir}|${a.globalSkillsDir}`;
+    const pathKey = `${a.skillsDir}|${a.globalSkillsDir ?? ''}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
         keys: [],
@@ -42,10 +47,12 @@ function generateAvailableAgentsTable(): string {
   }
 
   const rows = Array.from(pathGroups.values()).map((group) => {
-    const globalPath = group.globalSkillsDir.replace(homedir(), '~');
+    const globalPath = group.globalSkillsDir
+      ? group.globalSkillsDir.replace(homedir(), '~')
+      : 'N/A';
     const names = group.displayNames.join(', ');
     const keys = group.keys.map((k) => `\`${k}\``).join(', ');
-    return `| ${names} | ${keys} | \`${group.skillsDir}/\` | \`${globalPath}/\` |`;
+    return `| ${names} | ${keys} | \`${group.skillsDir}/\` | \`${globalPath}${globalPath === 'N/A' ? '' : '/'}\` |`;
   });
   return [
     '| Agent | `--agent` | Project Path | Global Path |',

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -44,11 +44,18 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'moltbot',
     displayName: 'Moltbot',
     skillsDir: 'skills',
-    globalSkillsDir: existsSync(join(home, '.clawdbot'))
-      ? join(home, '.clawdbot/skills')
-      : join(home, '.moltbot/skills'),
+    globalSkillsDir: join(home, '.moltbot/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.moltbot')) || existsSync(join(home, '.clawdbot'));
+      return existsSync(join(home, '.moltbot'));
+    },
+  },
+  clawdbot: {
+    name: 'clawdbot',
+    displayName: 'Clawdbot',
+    skillsDir: 'skills',
+    globalSkillsDir: join(home, '.clawdbot/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.clawdbot'));
     },
   },
   cline: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type AgentType =
   | 'antigravity'
   | 'claude-code'
   | 'moltbot'
+  | 'clawdbot'
   | 'cline'
   | 'codebuddy'
   | 'codex'


### PR DESCRIPTION
This PR adds first-class **Clawdbot** support to the skills.sh CLI.

### Changes
- Add `clawdbot` as an `--agent` option
  - Project path: `skills/`
  - Global path: `~/.clawdbot/skills/`
- Stop implicitly treating `~/.clawdbot` as **Moltbot** during agent detection
- Fix `scripts/sync-agents.ts` to handle agents with no global install directory (e.g. `replit`)

### Motivation
The README already mentions Clawdbot in the compatibility matrix and links to Clawdbot docs, and the CLI currently checks for `~/.clawdbot` in Moltbot detection — but users cannot explicitly target Clawdbot via `--agent clawdbot`.

### Testing
- `pnpm test`
