### PR TITLE
feat: add -b to specify github branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ npx skills add git@github.com:vercel-labs/agent-skills.git
 
 # Local path
 npx skills add ./my-local-skills
+
+# Branch with slashes (use --branch flag)
+npx skills add owner/repo --branch feature/some-skill
 ```
 
 ### Options
@@ -41,6 +44,7 @@ npx skills add ./my-local-skills
 | `-g, --global`            | Install to user directory instead of project                                                                                                       |
 | `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). Use `'*'` for all agents<!-- agent-names:end -->                  |
 | `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
+| `-b, --branch <branch>`   | Specify branch name explicitly (useful for branches with slashes like `feature/some-skill`)                                                            |
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
@@ -71,6 +75,10 @@ npx skills add vercel-labs/agent-skills --skill '*' -a claude-code
 
 # Install specific skills to all agents
 npx skills add vercel-labs/agent-skills --agent '*' --skill frontend-design
+
+# Install from a branch with slashes in the name
+npx skills add owner/repo --branch feature/some-skill
+npx skills add https://github.com/owner/repo -b develop/some-skill
 ```
 
 ### Installation Scope

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -384,6 +384,32 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse --branch flag', () => {
+    const result = parseAddOptions(['source', '--branch', 'feature/some-skill']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('feature/some-skill');
+  });
+
+  it('should parse -b flag (branch shorthand)', () => {
+    const result = parseAddOptions(['source', '-b', 'develop']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('develop');
+  });
+
+  it('should parse branch with complex names', () => {
+    const result = parseAddOptions(['source', '-b', 'feature/my-feature/sub-task']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('feature/my-feature/sub-task');
+  });
+
+  it('should parse branch with other flags', () => {
+    const result = parseAddOptions(['source', '-b', 'main', '-g', '-y']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('main');
+    expect(result.options.global).toBe(true);
+    expect(result.options.yes).toBe(true);
+  });
 });
 
 describe('find-skills prompt with -y flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -232,6 +232,7 @@ export interface AddOptions {
   list?: boolean;
   all?: boolean;
   fullDepth?: boolean;
+  branch?: string;
 }
 
 /**
@@ -1409,7 +1410,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const spinner = p.spinner();
 
     spinner.start('Parsing source...');
-    const parsed = parseSource(source);
+    const parsed = parseSource(source, options.branch);
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
@@ -2058,6 +2059,11 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg === '-b' || arg === '--branch') {
+      i++;
+      if (i < args.length && args[i] && !args[i]!.startsWith('-')) {
+        options.branch = args[i];
+      }
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
     } else if (arg && !arg.startsWith('-')) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,6 +111,7 @@ ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
   -s, --skill <skills>   Specify skill names to install (use '*' for all skills)
+  -b, --branch <branch>  Specify branch name (useful for branches with slashes like feature/some-skill)
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --all                  Shorthand for --skill '*' --agent '*' -y

--- a/tests/branch-with-slash.test.ts
+++ b/tests/branch-with-slash.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/source-parser.ts';
+
+describe('parseSource with branch parameter', () => {
+  it('should parse branch with slashes when explicitBranch is provided (shorthand)', () => {
+    const result = parseSource('owner/repo', 'feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should parse branch with slashes when explicitBranch is provided (full URL with tree)', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/feature', 'feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should parse branch with slashes when explicitBranch is provided (URL with tree and path)', () => {
+    const result = parseSource(
+      'https://github.com/owner/repo/tree/feature/some-skill',
+      'feature/some-skill'
+    );
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should treat path as subpath when no explicitBranch is provided', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/main/path/to/skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'main',
+      subpath: 'path/to/skill',
+    });
+  });
+
+  it('should override URL branch with explicitBranch when both are present', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/main', 'feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should work with complex branch names', () => {
+    const result = parseSource('owner/repo', 'feature/my-feature/sub-task');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/my-feature/sub-task',
+    });
+  });
+
+  it('should not affect normal branch parsing without explicitBranch', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/main');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'main',
+    });
+  });
+
+  it('should work with shorthand owner/repo/path when no explicitBranch', () => {
+    const result = parseSource('owner/repo/path/to/skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      subpath: 'path/to/skill',
+    });
+  });
+
+  it('should incorrectly parse branch with slashes as ref+subpath when explicitBranch is NOT provided (bad case)', () => {
+    // This demonstrates the problem: when branch name has slashes like "feature/some-skill"
+    // and you don't provide explicitBranch, it gets incorrectly parsed as ref + subpath
+    const result = parseSource('https://github.com/owner/repo/tree/feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature', // ❌ Wrong: only first part is treated as branch
+      subpath: 'some-skill', // ❌ Wrong: rest is treated as path
+    });
+    // This is why you need to use --branch flag for branches with slashes
+  });
+});


### PR DESCRIPTION
## Background

Currently, when a Git branch name contains slashes (e.g. `feature/some-skill`), the CLI **incorrectly parses it as a file path instead of a branch name**.

For example:

```
https://github.com/owner/repo/tree/feature/some-skill
```

is parsed as:

* **branch**: `feature`
* **path**: `some-skill`

This leads to unexpected behavior and clone failures.

---

## Root Cause

The parser cannot reliably distinguish between the following two valid but ambiguous cases:

1. **Branch name with slashes (intended behavior)**

   ```
   feature/some-skill
   ```

2. **Path inside a branch (standard GitHub convention)**

   ```
   main/path/to/skill
   ```

Since both share the same URL structure, automatic inference is unreliable.

---

## Solution

We introduced a dedicated `-b / --branch` flag to **explicitly specify the branch name**.

This makes branch selection **orthogonal to path parsing**, avoids ambiguity, and prevents unexpected parsing errors.

---

## Examples

### ❌ Without `--branch` (incorrect)

The CLI treats `feature/some-skill` as `branch + path`:

```bash
npx skills add https://github.com/owner/repo/tree/feature/some-skill
```

Result:

* branch: `feature`
* path: `some-skill`
* ❗ clone fails

---

### ✅ With `--branch` (correct)

Explicitly specify the branch name:

```bash
npx skills add https://github.com/owner/repo --branch feature/some-skill
```

or shorthand:

```bash
npx skills add owner/repo -b feature/some-skill
```

Result:

* branch: `feature/some-skill`
* path: *(none)*
* ✅ works as expected

---

## Summary

* URLs alone are **ambiguous** when branch names contain `/`
* Automatic parsing is unreliable
* `--branch` provides an **explicit, predictable, and future-proof** solution

