### PR TITLE
feat: local lockfile

### DIFF
--- a/src/list.ts
+++ b/src/list.ts
@@ -13,6 +13,7 @@ const YELLOW = '\x1b[33m';
 interface ListOptions {
   global?: boolean;
   agent?: string[];
+  localLock?: boolean;
 }
 
 /**
@@ -48,6 +49,8 @@ export function parseListOptions(args: string[]): ListOptions {
     const arg = args[i];
     if (arg === '-g' || arg === '--global') {
       options.global = true;
+    } else if (arg === '--lock') {
+      options.localLock = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       // Collect all following arguments until next flag

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -13,6 +13,7 @@ export interface RemoveOptions {
   agent?: string[];
   yes?: boolean;
   all?: boolean;
+  localLock?: boolean;
 }
 
 export async function removeCommand(skillNames: string[], options: RemoveOptions) {
@@ -170,12 +171,12 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
       const canonicalPath = getCanonicalPath(skillName, { global: isGlobal, cwd });
       await rm(canonicalPath, { recursive: true, force: true });
 
-      const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
+      const lockEntry = isGlobal ? await getSkillFromLock(skillName, options.localLock) : null;
       const effectiveSource = lockEntry?.source || 'local';
       const effectiveSourceType = lockEntry?.sourceType || 'local';
 
       if (isGlobal) {
-        await removeSkillFromLock(skillName);
+        await removeSkillFromLock(skillName, options.localLock);
       }
 
       results.push({
@@ -254,6 +255,8 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
       options.yes = true;
     } else if (arg === '--all') {
       options.all = true;
+    } else if (arg === '--lock') {
+      options.localLock = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       i++;


### PR DESCRIPTION
This PR introduces project-local `skill-lock.json` support via the `--lock` flag.

Running `npx skills install --lock` in a project with no arguments installs locked skills.

This enables declarative, reproducible skill management per project, similar to dependency locking in package managers.

```
# Adding skill
npx skills add vercel-labs/skills --lock 

# Installing from a lock in a fresh clone
npx skills install --lock
```

---

**Note:** This is similar to #134. Using **lockfile-only** as the declaration source and reusing what we already have for global mode.

**Story:** While setting up my `pi0/skills`, I needed a way to manage and version external skills. I came across a nice idea by @antfu (`GENERATION.md` containing source/hash). Digging deeper, I realized that `skill-lock.json` is already implemented in CLI for global mode, then i though, why not just extend it!

---

TODO:
- [ ] Discuss the validity of the idea (/cc @quuu, @huozhi)
- [ ] Add commit-hash to lockfile to make it reproducible
- [ ] Tests