### PR TITLE
fix: use absolute paths for symlinks to handle symlinked directories

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -136,10 +136,14 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
     const linkDir = dirname(linkPath);
     await mkdir(linkDir, { recursive: true });
 
-    const relativePath = relative(linkDir, target);
+    // Use absolute path for symlinks to avoid issues when the link directory
+    // itself is a symlink. When linkPath is inside a symlinked directory
+    // (e.g., ~/.claude/skills/ -> ~/.dotfiles/claude/skills/), the relative
+    // path calculation uses the logical path but the symlink is created at
+    // the physical path, causing the relative path to resolve incorrectly.
     const symlinkType = platform() === 'win32' ? 'junction' : undefined;
 
-    await symlink(relativePath, linkPath, symlinkType);
+    await symlink(resolvedTarget, linkPath, symlinkType);
     return true;
   } catch {
     return false;

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -3,7 +3,17 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile, lstat, readFile, symlink } from 'node:fs/promises';
+import {
+  mkdtemp,
+  mkdir,
+  rm,
+  writeFile,
+  lstat,
+  readFile,
+  symlink,
+  readlink,
+  realpath,
+} from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
@@ -42,6 +52,70 @@ describe('installer symlink regression', () => {
 
       const contents = await readFile(join(installedPath, 'SKILL.md'), 'utf-8');
       expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates working symlink when agent skills dir is itself a symlink', async () => {
+    // Regression test for: when ~/.claude/skills/ is a symlink to ~/.dotfiles/claude/skills/,
+    // relative symlinks computed from the logical path resolve incorrectly from the physical path.
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+
+    // Simulate: ~/.dotfiles/claude/skills/ (real directory)
+    const realSkillsDir = join(root, 'dotfiles', 'claude', 'skills');
+    await mkdir(realSkillsDir, { recursive: true });
+
+    // Simulate: project/.claude/skills -> realSkillsDir (symlinked agent skills dir)
+    const projectDir = join(root, 'project');
+    const logicalSkillsDir = join(projectDir, '.claude', 'skills');
+    await mkdir(join(projectDir, '.claude'), { recursive: true });
+    await symlink(realSkillsDir, logicalSkillsDir);
+
+    // Create canonical location for skill source
+    const skillName = 'symlinked-dir-skill';
+    const canonicalBase = join(projectDir, '.agents', 'skills');
+    await mkdir(canonicalBase, { recursive: true });
+    const sourceSkillDir = join(root, 'source-skill');
+    await mkdir(sourceSkillDir, { recursive: true });
+    await writeFile(
+      join(sourceSkillDir, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: test\n---\n`,
+      'utf-8'
+    );
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: sourceSkillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBeUndefined();
+
+      // The symlink should be created at the logical path
+      const installedPath = join(logicalSkillsDir, skillName);
+      const stats = await lstat(installedPath);
+      expect(stats.isSymbolicLink()).toBe(true);
+
+      // The symlink target should resolve correctly (be readable)
+      const contents = await readFile(join(installedPath, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+
+      // Verify it's an absolute symlink (the fix)
+      const linkTarget = await readlink(installedPath);
+      expect(linkTarget.startsWith('/')).toBe(true);
+
+      // Verify the physical path also works
+      const physicalPath = join(realSkillsDir, skillName);
+      const physicalStats = await lstat(physicalPath);
+      expect(physicalStats.isSymbolicLink()).toBe(true);
+
+      // The symlink should resolve to the canonical location
+      const resolvedPath = await realpath(installedPath);
+      const expectedCanonical = await realpath(join(projectDir, '.agents', 'skills', skillName));
+      expect(resolvedPath).toBe(expectedCanonical);
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Fixes symlink creation when the agent's skills directory is itself a symlink to another location.

**The Problem:**

When the agent's skills directory is a symlink (e.g., `~/.claude/skills/` → `~/.dotfiles/claude/skills/`), the relative path calculation was incorrect:

1. `linkPath` = `~/.claude/skills/my-skill`
2. `linkDir` (logical) = `~/.claude/skills/`
3. Relative path computed: `../../.agents/skills/my-skill`
4. Actual symlink location: `~/.dotfiles/claude/skills/my-skill`
5. `../../.agents` from there resolves to `~/.dotfiles/.agents` ❌

The `relative()` call computed the path from the logical dirname of `linkPath`, but the symlink was actually created at the physical path after following the directory symlink.

**The Fix:**

Use absolute paths instead of relative paths. This is more robust and avoids issues with symlinked directory layouts.

## Test plan

- [x] All existing tests pass (255 tests)
- [x] Verified manually by installing a skill to a symlinked skills directory