### PR TITLE
fix(antigravity): correct global skills directory path

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -24,7 +24,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'antigravity',
     displayName: 'Antigravity',
     skillsDir: '.agent/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity/global_skills'),
+    globalSkillsDir: join(home, '.gemini/antigravity/skills'),
     detectInstalled: async () => {
       return (
         existsSync(join(process.cwd(), '.agent')) || existsSync(join(home, '.gemini/antigravity'))


### PR DESCRIPTION
## Problem Description
The global skills directory path for Antigravity is incorrectly configured. The current configuration uses ~/.gemini/antigravity/global_skills/, but Antigravity actually expects ~/.gemini/antigravity/skills/.

## Changes
Fixed the globalSkillsDir configuration for Antigravity in src/agents.ts.

Changed the directory name from global_skills to skills.

## Testing
[ ] Verified the path correctness locally.
[ ] Aligned with official Antigravity tutorials.

## Related Links
Antigravity Skills Tutorial: https://codelabs.developers.google.com/getting-started-with-antigravity-skills#3