### PR TITLE
feat: add inference.sh agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [36 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [37 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -39,7 +39,7 @@ npx skills add ./my-local-skills
 | Option                    | Description                                                                                                                                        |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-g, --global`            | Install to user directory instead of project                                                                                                       |
-| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Supported Agents](#supported-agents)<!-- agent-names:end -->                  |
+| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Available Agents](#available-agents)<!-- agent-names:end -->                  |
 | `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
@@ -226,6 +226,7 @@ Skills can be installed to any of these agents:
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
+| inference.sh | `inference-sh` | `.inferencesh/skills/` | `~/.inferencesh/skills/` |
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
@@ -334,6 +335,7 @@ The CLI searches for skills in these locations within a repository:
 - `.goose/skills/`
 - `.junie/skills/`
 - `.iflow/skills/`
+- `.inferencesh/skills/`
 - `.kilocode/skills/`
 - `.kiro/skills/`
 - `.kode/skills/`
@@ -422,6 +424,7 @@ Telemetry is automatically disabled in CI environments.
 - [Gemini CLI Skills Documentation](https://geminicli.com/docs/cli/skills/)
 - [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
 - [iFlow CLI Skills Documentation](https://platform.iflow.cn/en/cli/examples/skill)
+- [inference.sh Skills Documentation](https://inference.sh/docs)
 - [Kimi Code CLI Skills Documentation](https://moonshotai.github.io/kimi-cli/en/customization/skills.html)
 - [Kiro CLI Skills Documentation](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources)
 - [Kode Skills Documentation](https://github.com/shareAI-lab/kode/blob/main/docs/skills.md)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "goose",
     "junie",
     "iflow-cli",
+    "inference-sh",
     "kilo",
     "kimi-cli",
     "kiro-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -183,6 +183,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.iflow'));
     },
   },
+  'inference-sh': {
+    name: 'inference-sh',
+    displayName: 'inference.sh',
+    skillsDir: '.inferencesh/skills',
+    globalSkillsDir: join(home, '.inferencesh/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.inferencesh'));
+    },
+  },
   kilo: {
     name: 'kilo',
     displayName: 'Kilo Code',

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type AgentType =
   | 'github-copilot'
   | 'goose'
   | 'iflow-cli'
+  | 'inference-sh'
   | 'junie'
   | 'kilo'
   | 'kimi-cli'


### PR DESCRIPTION
Add first-class support for inference.sh as an agent target.
- Project path: .inferencesh/skills/
- Global path: ~/.inferencesh/skills/
- Docs: https://inference.sh/docs