### PR TITLE
Update skills directory paths in augment configuration

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -34,8 +34,8 @@ export const agents: Record<AgentType, AgentConfig> = {
   augment: {
     name: 'augment',
     displayName: 'Augment',
-    skillsDir: '.augment/rules',
-    globalSkillsDir: join(home, '.augment/rules'),
+    skillsDir: '.augment/skills',
+    globalSkillsDir: join(home, '.augment/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.augment'));
     },


### PR DESCRIPTION
Follow up to https://github.com/vercel-labs/skills/pull/220 to support correct `.augment/skills` path

Augment supports skills natively in the CLI under the proper path now

https://docs.augmentcode.com/cli/skills
