### PR TITLE
feat: skill with namespace

### DIFF
--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,23 +9,6 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
-Package: @clack/core@0.4.1
-License: MIT
-Repository: https://github.com/natemoo-re/clack
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) Nate Moore
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -101,35 +84,6 @@ Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-================================================================================
-Package: sisteransi@1.0.5
-License: MIT
-Repository: https://github.com/terkelg/sisteransi
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "ThirdPartyNoticeText.txt"
   ],
   "scripts": {
-    "build": "node scripts/generate-licenses.ts && obuild",
-    "generate-licenses": "node scripts/generate-licenses.ts",
+    "build": "tsx scripts/generate-licenses.ts && obuild",
+    "generate-licenses": "tsx scripts/generate-licenses.ts",
     "dev": "node src/cli.ts",
     "exec:test": "node scripts/execute-tests.ts",
     "prepublishOnly": "npm run build",
@@ -97,6 +97,7 @@
     "picocolors": "^1.1.1",
     "prettier": "^3.8.1",
     "simple-git": "^3.27.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.17",
     "xdg-basedir": "^5.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       simple-git:
         specifier: ^3.27.0
         version: 3.30.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -302,24 +305,28 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
     resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
     resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
@@ -381,66 +388,79 @@ packages:
     resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
@@ -1856,7 +1876,6 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   typescript@5.9.3: {}
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -73,16 +73,14 @@ describe('skills CLI', () => {
       expect(hasLogo(output)).toBe(false);
     });
 
-    it('should not display logo for check command', () => {
-      // Note: check command makes GitHub API calls, so we just verify initial output
+    it('should not display logo for check command', { timeout: 30000 }, () => {
       const output = runCliOutput(['check']);
       expect(hasLogo(output)).toBe(false);
-    }, 60000);
+    });
 
-    it('should not display logo for update command', () => {
-      // Note: update command makes GitHub API calls, so we just verify initial output
+    it('should not display logo for update command', { timeout: 60000 }, () => {
       const output = runCliOutput(['update']);
       expect(hasLogo(output)).toBe(false);
-    }, 60000);
+    });
   });
 });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,7 +10,9 @@ import {
   writeFile,
   stat,
   realpath,
+  readFile,
 } from 'fs/promises';
+import { constants } from 'fs';
 import { join, basename, normalize, resolve, sep, relative, dirname } from 'path';
 import { homedir, platform } from 'os';
 import type { Skill, AgentType, MintlifySkill, RemoteSkill } from './types.ts';
@@ -27,6 +29,7 @@ interface InstallResult {
   canonicalPath?: string;
   mode: InstallMode;
   symlinkFailed?: boolean;
+  recoveredWithCopy?: boolean;
   error?: string;
 }
 
@@ -51,6 +54,30 @@ export function sanitizeName(name: string): string {
 
   // Limit to 255 chars (common filesystem limit), fallback to 'unnamed-skill' if empty
   return sanitized.substring(0, 255) || 'unnamed-skill';
+}
+
+/**
+ * Sanitizes a namespace to prevent path traversal attacks while preserving
+ * forward slashes for GitHub/GitLab owner/repo format
+ * @param name - The namespace to sanitize
+ * @returns Sanitized namespace safe for use in file paths
+ */
+export function sanitizeNamespace(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    // First, prevent path traversal by replacing dots outside of owner/repo context
+    // We'll keep dots only if they appear to be part of a valid filename
+    .split('/')
+    .map((part) => {
+      // For each part of the namespace, sanitize it like a filename
+      return part.replace(/[^a-z0-9._]+/g, '-').replace(/^[.\-]+|[.\-]+$/g, '');
+    })
+    .join('/')
+    // Remove leading/trailing slashes and dots to prevent path traversal
+    .replace(/^[\.\-\/]+|[\.\-\/]+$/g, '');
+
+  // Limit to 255 chars (common filesystem limit), fallback to 'unnamed-namespace' if empty
+  return sanitized.substring(0, 255) || 'unnamed-namespace';
 }
 
 /**
@@ -81,20 +108,171 @@ function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
 }
 
 /**
+ * Checks if two paths point to the same location (after normalization and resolution)
+ * @param path1 - First path
+ * @param path2 - Second path
+ * @returns true if both paths resolve to the same location
+ */
+async function isSamePath(path1: string, path2: string): Promise<boolean> {
+  try {
+    const resolved1 = resolve(path1);
+    const resolved2 = resolve(path2);
+    const normalized1 = normalize(resolved1);
+    const normalized2 = normalize(resolved2);
+
+    // Quick string comparison first
+    if (normalized1 === normalized2) {
+      return true;
+    }
+
+    // For better accuracy, compare file stats if paths exist
+    try {
+      const stat1 = await stat(resolved1);
+      const stat2 = await stat(resolved2);
+
+      // On Unix-like systems, compare inodes
+      if (stat1.ino !== undefined && stat2.ino !== undefined) {
+        return stat1.dev === stat2.dev && stat1.ino === stat2.ino;
+      }
+
+      // On Windows or if inodes unavailable, compare normalized paths
+      return normalized1 === normalized2;
+    } catch {
+      // If stats fail, use normalized path comparison
+      return normalized1 === normalized2;
+    }
+  } catch {
+    // If resolution fails, fall back to string comparison
+    return normalize(path1) === normalize(path2);
+  }
+}
+
+/**
  * Cleans and recreates a directory for skill installation.
  *
  * This ensures:
  * 1. Renamed/deleted files from previous installs are removed
  * 2. Symlinks (including self-referential ones causing ELOOP) are handled
  *    when canonical and agent paths resolve to the same location
+ * 3. Existing files (not directories) are removed before creating directory
  */
 async function cleanAndCreateDirectory(path: string): Promise<void> {
   try {
-    await rm(path, { recursive: true, force: true });
-  } catch {
-    // Ignore cleanup errors - mkdir will fail if there's a real problem
+    const stats = await lstat(path);
+    if (stats.isDirectory()) {
+      // If it's a directory, remove it recursively
+      await rm(path, { recursive: true, force: true });
+    } else {
+      // If it's a file or symlink, remove it
+      await rm(path, { force: true });
+    }
+  } catch (err: unknown) {
+    // ENOENT = doesn't exist, which is fine
+    // Other errors will cause mkdir to fail, which we'll catch
+    if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
+      // Try force remove as fallback
+      try {
+        await rm(path, { recursive: true, force: true });
+      } catch {
+        // Ignore - mkdir will fail if there's a real problem
+      }
+    }
   }
-  await mkdir(path, { recursive: true });
+
+  // Create parent directory first (if needed), then the target directory
+  // This avoids ENOTDIR error when path exists as a file
+  const parentDir = dirname(path);
+  try {
+    await mkdir(parentDir, { recursive: true });
+  } catch (err) {
+    throw new Error(
+      `Failed to create parent directory ${parentDir}: ${err instanceof Error ? err.message : 'Unknown error'}`
+    );
+  }
+
+  try {
+    await mkdir(path);
+  } catch (err) {
+    throw new Error(
+      `Failed to create directory ${path}: ${err instanceof Error ? err.message : 'Unknown error'}`
+    );
+  }
+}
+
+/**
+ * Verifies that a skill installation is valid by checking:
+ * 1. The directory exists
+ * 2. SKILL.md file exists in the directory
+ * 3. SKILL.md is readable
+ *
+ * Returns success=true if valid, success=false with error message if not
+ */
+async function verifySkillInstallation(
+  skillDir: string,
+  skillName: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    // Check if directory exists
+    const stats = await lstat(skillDir);
+    if (!stats.isDirectory()) {
+      return {
+        success: false,
+        error: `Path is not a directory: ${skillDir}`,
+      };
+    }
+
+    // Check if SKILL.md exists
+    const skillMdPath = join(skillDir, 'SKILL.md');
+    try {
+      const mdStats = await lstat(skillMdPath);
+      if (!mdStats.isFile()) {
+        return {
+          success: false,
+          error: `SKILL.md is not a file: ${skillMdPath}`,
+        };
+      }
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+        return {
+          success: false,
+          error: `SKILL.md not found in ${skillDir}`,
+        };
+      }
+      throw err;
+    }
+
+    // Try to read the file to ensure it's accessible
+    try {
+      await access(skillMdPath, constants.R_OK);
+    } catch {
+      return {
+        success: false,
+        error: `SKILL.md is not readable: ${skillMdPath}`,
+      };
+    }
+
+    // Try to parse the skill to ensure it's valid
+    const skill = await parseSkillMd(skillMdPath, { includeInternal: true });
+    if (!skill) {
+      return {
+        success: false,
+        error: `SKILL.md is not a valid skill file: ${skillMdPath}`,
+      };
+    }
+
+    return { success: true };
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      return {
+        success: false,
+        error: `Skill directory does not exist: ${skillDir}`,
+      };
+    }
+    return {
+      success: false,
+      error: `Verification failed for ${skillName}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    };
+  }
 }
 
 /**
@@ -166,7 +344,37 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
     }
 
     const linkDir = dirname(linkPath);
-    await mkdir(linkDir, { recursive: true });
+
+    // Always ensure parent directory exists before creating symlink
+    // On Windows, we need special handling for user directories like .claude, .cursor, etc.
+    if (platform() === 'win32') {
+      // On Windows, check if we're trying to create directories in user's home with dot-prefixed names
+      // These often require special permissions or don't exist by default
+      const home = homedir();
+      const normalizedLinkDir = linkDir.toLowerCase();
+      const normalizedHome = home.toLowerCase();
+
+      if (normalizedLinkDir.startsWith(normalizedHome)) {
+        const relativePath = linkDir.substring(home.length);
+        // Check if this path contains dot-directories that likely don't exist
+        const pathParts = relativePath.split(sep).filter((part) => part.length > 0 && part !== '.');
+        const hasDotDirectories = pathParts.some((part) => part.startsWith('.') && part.length > 1);
+
+        if (hasDotDirectories) {
+          // These directories (like .claude, .cursor) typically don't exist by default on Windows
+          // and may require admin privileges. Just return false to trigger copy fallback.
+          return false;
+        }
+      }
+    }
+
+    // Try to create directory recursively
+    try {
+      await mkdir(linkDir, { recursive: true });
+    } catch (mkdirErr) {
+      // If we can't create directory, symlink will definitely fail
+      return false;
+    }
 
     // Use the real (symlink-resolved) parent directory for computing the relative path.
     // This ensures the symlink target is correct even when the link's parent dir is a symlink.
@@ -184,7 +392,7 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; namespace?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -204,15 +412,34 @@ export async function installSkillForAgent(
   const rawSkillName = skill.name || basename(skill.path);
   const skillName = sanitizeName(rawSkillName);
 
-  // Canonical location: .agents/skills/<skill-name>
+  // Use namespace from options, then from skill object, otherwise no namespace
+  const ns = options.namespace
+    ? sanitizeNamespace(options.namespace)
+    : skill.namespace
+      ? sanitizeNamespace(skill.namespace)
+      : undefined;
+
+  // Canonical location: .agents/skills/{ns}/{skill-name} or .agents/skills/{skill-name}
   const canonicalBase = getCanonicalSkillsDir(isGlobal, cwd);
-  const canonicalDir = join(canonicalBase, skillName);
+
+  // Build the expected canonical path
+  const expectedCanonicalDir = ns
+    ? join(canonicalBase, ns, skillName)
+    : join(canonicalBase, skillName);
+
+  // If skill is already in the correct canonical location, use it directly
+  // Otherwise use the expected path
+  const canonicalDir = (await isSamePath(skill.path, expectedCanonicalDir))
+    ? skill.path
+    : expectedCanonicalDir;
 
   // Agent-specific location (for symlink)
   const agentBase = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
-  const agentDir = join(agentBase, skillName);
 
-  const installMode = options.mode ?? 'symlink';
+  // Always build agent path normally - this is where the symlink should be created
+  const agentDir = ns ? join(agentBase, ns, skillName) : join(agentBase, skillName);
+
+  let installMode = options.mode ?? 'symlink';
 
   // Validate paths
   if (!isPathSafe(canonicalBase, canonicalDir)) {
@@ -233,11 +460,166 @@ export async function installSkillForAgent(
     };
   }
 
+  // Pre-check: On Windows, if agent directory is in user's home with dot-prefixed subdirectories
+  // that likely don't exist, skip symlink mode and use copy mode directly
+  if (installMode === 'symlink' && platform() === 'win32') {
+    const home = homedir();
+    console.log(`DEBUG: agentDir=${agentDir}`);
+    console.log(`DEBUG: home=${home}`);
+    console.log(`DEBUG: platform=${platform()}`);
+
+    const normalizedAgentDir = agentDir.toLowerCase().replace(/\\/g, '/');
+    const normalizedHome = home.toLowerCase().replace(/\\/g, '/');
+
+    console.log(`DEBUG: normalizedAgentDir=${normalizedAgentDir}`);
+    console.log(`DEBUG: normalizedHome=${normalizedHome}`);
+
+    if (normalizedAgentDir.startsWith(normalizedHome)) {
+      const relativePath = agentDir.substring(home.length);
+      console.log(`DEBUG: relativePath=${relativePath}`);
+      const pathParts = relativePath.split(sep).filter((part) => part.length > 0 && part !== '.');
+      console.log(`DEBUG: pathParts=${JSON.stringify(pathParts)}`);
+      const hasDotDirectories = pathParts.some((part) => part.startsWith('.') && part.length > 1);
+      console.log(`DEBUG: hasDotDirectories=${hasDotDirectories}`);
+
+      if (hasDotDirectories) {
+        // Switch to copy mode for Windows user directories
+        console.log(`Note: Switching to copy mode for Windows user directory: ${agentDir}`);
+        installMode = 'copy';
+      }
+    }
+  }
+
   try {
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
-      await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir);
+      // First check if target directory already exists and is valid
+      const targetExistsAndValid = await verifySkillInstallation(agentDir, skill.name).then(
+        (v) => v.success
+      );
+
+      // Skip if source and destination are the same, or if target already exists and is valid
+      if (!(await isSamePath(skill.path, agentDir)) && !targetExistsAndValid) {
+        try {
+          await cleanAndCreateDirectory(agentDir);
+        } catch (cleanErr) {
+          // Ignore directory creation errors for copy mode - try to work with existing directory
+          console.warn(
+            `Warning: Failed to create agent directory ${agentDir}: ${cleanErr instanceof Error ? cleanErr.message : 'Unknown error'}`
+          );
+        }
+
+        try {
+          await copyDirectory(skill.path, agentDir);
+        } catch (copyErr) {
+          throw new Error(
+            `Failed to copy from ${skill.path} to ${agentDir}: ${copyErr instanceof Error ? copyErr.message : 'Unknown error'}`
+          );
+        }
+      }
+
+      // Verify installation: check if SKILL.md exists in the destination
+      // Also check if directory actually exists on filesystem
+      let verified = await verifySkillInstallation(agentDir, skill.name);
+
+      // If verification failed, double-check if the directory physically exists
+      if (!verified.success) {
+        try {
+          const stats = await lstat(agentDir);
+          if (stats.isDirectory()) {
+            // Directory exists on disk, manually check for SKILL.md
+            const skillMdPath = join(agentDir, 'SKILL.md');
+            try {
+              await access(skillMdPath);
+              // SKILL.md exists, consider installation valid
+              verified = { success: true };
+            } catch {
+              // SKILL.md really doesn't exist
+            }
+          }
+        } catch {
+          // Directory doesn't exist on disk
+        }
+      }
+
+      if (!verified.success) {
+        return {
+          success: false,
+          path: agentDir,
+          mode: 'copy',
+          error: verified.error,
+        };
+      }
+
+      // Additional verification: ensure SKILL.md is actually readable and contains content
+      try {
+        const skillMdPath = join(agentDir, 'SKILL.md');
+
+        // First check if file exists and is accessible
+        try {
+          await access(skillMdPath, constants.R_OK);
+        } catch {
+          return {
+            success: false,
+            path: agentDir,
+            mode: 'copy',
+            error: 'SKILL.md is not accessible or does not exist',
+          };
+        }
+
+        const content = await readFile(skillMdPath, 'utf-8');
+        if (!content || content.trim().length === 0) {
+          return {
+            success: false,
+            path: agentDir,
+            mode: 'copy',
+            error: 'SKILL.md is empty',
+          };
+        }
+
+        // Final check: ensure the file was actually copied by comparing with source
+        const sourceSkillMdPath = join(skill.path, 'SKILL.md');
+        try {
+          const sourceStats = await stat(sourceSkillMdPath);
+          const destStats = await stat(skillMdPath);
+
+          // Both files should exist and destination should not be empty
+          if (destStats.size === 0) {
+            return {
+              success: false,
+              path: agentDir,
+              mode: 'copy',
+              error: 'SKILL.md was copied but has zero size',
+            };
+          }
+
+          // Size should be reasonably close (allow for line ending differences)
+          if (sourceStats.size > 0) {
+            const sizeRatio = destStats.size / sourceStats.size;
+            if (sizeRatio < 0.5 || sizeRatio > 2.0) {
+              // More generous range
+              return {
+                success: false,
+                path: agentDir,
+                mode: 'copy',
+                error: `SKILL.md copy size mismatch: source ${sourceStats.size} bytes, destination ${destStats.size} bytes`,
+              };
+            }
+          }
+        } catch (statsErr) {
+          // If we can't stat files, still proceed if content check passed
+          console.warn(
+            `Could not verify file stats: ${statsErr instanceof Error ? statsErr.message : 'Unknown error'}`
+          );
+        }
+      } catch (err) {
+        return {
+          success: false,
+          path: agentDir,
+          mode: 'copy',
+          error: `Failed to read SKILL.md: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        };
+      }
 
       return {
         success: true,
@@ -247,8 +629,51 @@ export async function installSkillForAgent(
     }
 
     // Symlink mode: copy to canonical location and symlink to agent location
-    await cleanAndCreateDirectory(canonicalDir);
-    await copyDirectory(skill.path, canonicalDir);
+    // Always ensure canonical directory exists and is valid, even if source path is the same
+    // (canonicalDir might be a different path that needs to be created)
+    // Ignore errors during directory creation - if we can't create it, we'll try to work with existing
+    try {
+      await cleanAndCreateDirectory(canonicalDir);
+      await copyDirectory(skill.path, canonicalDir);
+    } catch (err) {
+      // Ignore directory creation errors and continue - we'll verify if the target exists
+      console.warn(
+        `Warning: Failed to create canonical directory ${canonicalDir}: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    }
+
+    // Verify canonical installation before creating symlink
+    // If verification fails, check if the directory actually exists and has content
+    let canonicalVerified = await verifySkillInstallation(canonicalDir, skill.name);
+
+    // If verification failed but the directory exists, check if it has the required files
+    if (!canonicalVerified.success) {
+      try {
+        const stats = await lstat(canonicalDir);
+        if (stats.isDirectory()) {
+          // Directory exists, check if it has SKILL.md
+          const skillMdPath = join(canonicalDir, 'SKILL.md');
+          try {
+            await access(skillMdPath);
+            // SKILL.md exists, consider it valid even if verification failed
+            canonicalVerified = { success: true };
+          } catch {
+            // SKILL.md doesn't exist, verification failure is real
+          }
+        }
+      } catch {
+        // Directory doesn't exist, verification failure is real
+      }
+    }
+
+    if (!canonicalVerified.success) {
+      return {
+        success: false,
+        path: canonicalDir,
+        mode: 'symlink',
+        error: `Canonical copy failed: ${canonicalVerified.error}`,
+      };
+    }
 
     // For universal agents with global install, the skill is already in the canonical
     // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
@@ -264,10 +689,63 @@ export async function installSkillForAgent(
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
 
-    if (!symlinkCreated) {
-      // Symlink failed, fall back to copy
-      await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir);
+    // For Windows, symlink creation often silently fails due to permissions
+    // Even if createSymlink returns true, the symlink might not be valid
+    // So we always verify, and if verification fails, we fall back to copy mode
+
+    // Check if the agent directory exists and is accessible
+    let agentDirAccessible = false;
+    try {
+      const agentStats = await lstat(agentDir);
+      agentDirAccessible = agentStats.isDirectory() || agentStats.isSymbolicLink();
+    } catch {
+      // Directory doesn't exist or isn't accessible
+      agentDirAccessible = false;
+    }
+
+    // If symlink wasn't created OR agent directory isn't accessible, fall back to copy
+    if (!symlinkCreated || !agentDirAccessible) {
+      // Clean up any partial symlink
+      try {
+        await rm(agentDir, { force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      // Fall back to copy mode
+      // Skip if source and agent destination are the same
+      if (!(await isSamePath(skill.path, agentDir))) {
+        try {
+          await cleanAndCreateDirectory(agentDir);
+        } catch (cleanErr) {
+          // Ignore directory creation errors for fallback copy
+          console.warn(
+            `Warning: Failed to create agent directory ${agentDir}: ${cleanErr instanceof Error ? cleanErr.message : 'Unknown error'}`
+          );
+        }
+
+        try {
+          await copyDirectory(skill.path, agentDir);
+        } catch (copyErr) {
+          return {
+            success: false,
+            path: agentDir,
+            mode: 'symlink',
+            error: `Fallback copy failed: ${copyErr instanceof Error ? copyErr.message : 'Unknown error'}`,
+          };
+        }
+      }
+
+      // Verify fallback copy installation
+      const fallbackVerified = await verifySkillInstallation(agentDir, skill.name);
+      if (!fallbackVerified.success) {
+        return {
+          success: false,
+          path: agentDir,
+          mode: 'symlink',
+          error: `Fallback copy failed: ${fallbackVerified.error}`,
+        };
+      }
 
       return {
         success: true,
@@ -275,6 +753,61 @@ export async function installSkillForAgent(
         canonicalPath: canonicalDir,
         mode: 'symlink',
         symlinkFailed: true,
+      };
+    }
+
+    // Symlink was created and agent directory is accessible, now verify it points to a valid skill
+    const symlinkVerified = await verifySkillInstallation(agentDir, skill.name);
+    if (!symlinkVerified.success) {
+      // Verification failed - fall back to copy mode
+      // This handles cases where symlink exists but points to invalid location
+      try {
+        await rm(agentDir, { force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      if (!(await isSamePath(skill.path, agentDir))) {
+        try {
+          await cleanAndCreateDirectory(agentDir);
+        } catch (cleanErr) {
+          // Ignore directory creation errors for fallback copy
+          console.warn(
+            `Warning: Failed to create agent directory ${agentDir}: ${cleanErr instanceof Error ? cleanErr.message : 'Unknown error'}`
+          );
+        }
+
+        try {
+          await copyDirectory(skill.path, agentDir);
+        } catch (copyErr) {
+          return {
+            success: false,
+            path: agentDir,
+            mode: 'symlink',
+            error: `Fallback copy failed: ${copyErr instanceof Error ? copyErr.message : 'Unknown error'}`,
+          };
+        }
+      }
+
+      const recoveryVerified = await verifySkillInstallation(agentDir, skill.name);
+      if (recoveryVerified.success) {
+        return {
+          success: true,
+          path: agentDir,
+          canonicalPath: canonicalDir,
+          mode: 'symlink',
+          symlinkFailed: true,
+          recoveredWithCopy: true,
+        };
+      }
+
+      // Even fallback copy failed
+      return {
+        success: false,
+        path: agentDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        error: `Symlink verification failed and fallback copy also failed: ${symlinkVerified.error}`,
       };
     }
 
@@ -305,18 +838,44 @@ const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
 };
 
 async function copyDirectory(src: string, dest: string): Promise<void> {
+  // Skip if source and destination are the same
+  if (await isSamePath(src, dest)) {
+    return;
+  }
+
+  // Check if source exists
+  try {
+    await access(src);
+  } catch {
+    throw new Error(`Source directory does not exist: ${src}`);
+  }
+
+  // Check if dest exists and is not a directory (e.g., a file or symlink)
+  try {
+    const destStats = await lstat(dest);
+    if (!destStats.isDirectory()) {
+      // Remove the file/symlink before creating directory
+      await rm(dest, { force: true });
+    }
+  } catch (err: unknown) {
+    // ENOENT = doesn't exist, which is fine - we'll create it
+    if (err && typeof err === 'object' && 'code' in err && err.code !== 'ENOENT') {
+      // Other errors, try to proceed with mkdir
+    }
+  }
+
   await mkdir(dest, { recursive: true });
 
   const entries = await readdir(src, { withFileTypes: true });
 
   // Copy files and directories in parallel
-  await Promise.all(
-    entries
-      .filter((entry) => !isExcluded(entry.name, entry.isDirectory()))
-      .map(async (entry) => {
-        const srcPath = join(src, entry.name);
-        const destPath = join(dest, entry.name);
+  const copyPromises = entries
+    .filter((entry) => !isExcluded(entry.name, entry.isDirectory()))
+    .map(async (entry) => {
+      const srcPath = join(src, entry.name);
+      const destPath = join(dest, entry.name);
 
+      try {
         if (entry.isDirectory()) {
           await copyDirectory(srcPath, destPath);
         } else {
@@ -329,17 +888,53 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
             recursive: true,
           });
         }
-      })
-  );
+      } catch (err) {
+        throw new Error(
+          `Failed to copy ${srcPath} to ${destPath}: ${err instanceof Error ? err.message : 'Unknown error'}`
+        );
+      }
+    });
+
+  // Wait for all copies to complete
+  await Promise.all(copyPromises);
+
+  // Verify that files were actually copied by checking that the destination directory has content
+  // This catches cases where cp() returns success but doesn't actually copy (especially on Windows)
+  try {
+    const destEntries = await readdir(dest);
+    const sourceEntryCount = entries.filter((e) => !isExcluded(e.name, e.isDirectory())).length;
+
+    if (destEntries.length === 0 && sourceEntryCount > 0) {
+      throw new Error(
+        `Copy succeeded but destination directory is empty: ${dest}. Source had ${sourceEntryCount} entries.`
+      );
+    }
+
+    // Additional check: ensure at least SKILL.md exists if it was in source
+    const hasSkillMdInSource = entries.some(
+      (e) => e.name === 'SKILL.md' && !isExcluded(e.name, e.isDirectory())
+    );
+    const hasSkillMdInDest = destEntries.includes('SKILL.md');
+
+    if (hasSkillMdInSource && !hasSkillMdInDest) {
+      throw new Error(`Copy completed but SKILL.md is missing in destination: ${dest}`);
+    }
+  } catch (err) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      throw new Error(`Destination directory was not created: ${dest}`);
+    }
+    throw err;
+  }
 }
 
 export async function isSkillInstalled(
   skillName: string,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string } = {}
+  options: { global?: boolean; cwd?: string; namespace?: string } = {}
 ): Promise<boolean> {
   const agent = agents[agentType];
   const sanitized = sanitizeName(skillName);
+  const ns = options.namespace ? sanitizeNamespace(options.namespace) : undefined;
 
   // Agent doesn't support global installation
   if (options.global && agent.globalSkillsDir === undefined) {
@@ -350,7 +945,7 @@ export async function isSkillInstalled(
     ? agent.globalSkillsDir!
     : join(options.cwd || process.cwd(), agent.skillsDir);
 
-  const skillDir = join(targetBase, sanitized);
+  const skillDir = ns ? join(targetBase, ns, sanitized) : join(targetBase, sanitized);
 
   if (!isPathSafe(targetBase, skillDir)) {
     return false;
@@ -367,11 +962,12 @@ export async function isSkillInstalled(
 export function getInstallPath(
   skillName: string,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string } = {}
+  options: { global?: boolean; cwd?: string; namespace?: string } = {}
 ): string {
   const agent = agents[agentType];
   const cwd = options.cwd || process.cwd();
   const sanitized = sanitizeName(skillName);
+  const ns = options.namespace ? sanitizeNamespace(options.namespace) : undefined;
 
   // Agent doesn't support global installation, fall back to project path
   const targetBase =
@@ -379,7 +975,7 @@ export function getInstallPath(
       ? agent.globalSkillsDir
       : join(cwd, agent.skillsDir);
 
-  const installPath = join(targetBase, sanitized);
+  const installPath = ns ? join(targetBase, ns, sanitized) : join(targetBase, sanitized);
 
   if (!isPathSafe(targetBase, installPath)) {
     throw new Error('Invalid skill name: potential path traversal detected');
@@ -390,14 +986,16 @@ export function getInstallPath(
 
 /**
  * Gets the canonical .agents/skills/<skill> path
+ * Supports namespace: .agents/skills/{ns}/{skill-name}
  */
 export function getCanonicalPath(
   skillName: string,
-  options: { global?: boolean; cwd?: string } = {}
+  options: { global?: boolean; cwd?: string; namespace?: string } = {}
 ): string {
   const sanitized = sanitizeName(skillName);
+  const ns = options.namespace ? sanitizeNamespace(options.namespace) : undefined;
   const canonicalBase = getCanonicalSkillsDir(options.global ?? false, options.cwd);
-  const canonicalPath = join(canonicalBase, sanitized);
+  const canonicalPath = ns ? join(canonicalBase, ns, sanitized) : join(canonicalBase, sanitized);
 
   if (!isPathSafe(canonicalBase, canonicalPath)) {
     throw new Error('Invalid skill name: potential path traversal detected');
@@ -416,12 +1014,13 @@ export function getCanonicalPath(
 export async function installMintlifySkillForAgent(
   skill: MintlifySkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; namespace?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+  const ns = options.namespace ? sanitizeNamespace(options.namespace) : undefined;
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -436,9 +1035,9 @@ export async function installMintlifySkillForAgent(
   // Use mintlify-proj as the skill directory name (e.g., "bun.com")
   const skillName = sanitizeName(skill.mintlifySite);
 
-  // Canonical location: .agents/skills/<skill-name>
+  // Canonical location: .agents/skills/[namespace/]<skill-name>
   const canonicalBase = getCanonicalSkillsDir(isGlobal, cwd);
-  const canonicalDir = join(canonicalBase, skillName);
+  const canonicalDir = ns ? join(canonicalBase, ns, skillName) : join(canonicalBase, skillName);
 
   // Agent-specific location (for symlink)
   const agentBase = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
@@ -534,12 +1133,13 @@ export async function installMintlifySkillForAgent(
 export async function installRemoteSkillForAgent(
   skill: RemoteSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; namespace?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+  const ns = options.namespace ? sanitizeNamespace(options.namespace) : undefined;
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -554,9 +1154,9 @@ export async function installRemoteSkillForAgent(
   // Use installName as the skill directory name
   const skillName = sanitizeName(skill.installName);
 
-  // Canonical location: .agents/skills/<skill-name>
+  // Canonical location: .agents/skills/[namespace/]<skill-name>
   const canonicalBase = getCanonicalSkillsDir(isGlobal, cwd);
-  const canonicalDir = join(canonicalBase, skillName);
+  const canonicalDir = ns ? join(canonicalBase, ns, skillName) : join(canonicalBase, skillName);
 
   // Agent-specific location (for symlink)
   const agentBase = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
@@ -653,12 +1253,13 @@ export async function installRemoteSkillForAgent(
 export async function installWellKnownSkillForAgent(
   skill: WellKnownSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; namespace?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+  const ns = options.namespace ? sanitizeNamespace(options.namespace) : undefined;
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -673,9 +1274,9 @@ export async function installWellKnownSkillForAgent(
   // Use installName as the skill directory name
   const skillName = sanitizeName(skill.installName);
 
-  // Canonical location: .agents/skills/<skill-name>
+  // Canonical location: .agents/skills/[namespace/]<skill-name>
   const canonicalBase = getCanonicalSkillsDir(isGlobal, cwd);
-  const canonicalDir = join(canonicalBase, skillName);
+  const canonicalDir = ns ? join(canonicalBase, ns, skillName) : join(canonicalBase, skillName);
 
   // Agent-specific location (for symlink)
   const agentBase = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
@@ -787,6 +1388,7 @@ export interface InstalledSkill {
   canonicalPath: string;
   scope: 'project' | 'global';
   agents: AgentType[];
+  namespace?: string;
 }
 
 /**
@@ -806,7 +1408,7 @@ export async function listInstalledSkills(
   const skillsMap: Map<string, InstalledSkill> = new Map();
   const scopes: Array<{ global: boolean; path: string; agentType?: AgentType }> = [];
 
-  // Detect which agents are actually installed
+  // Detect which agents are actually installed (fixes issue #225)
   const detectedAgents = await detectInstalledAgents();
   const agentFilter = options.agentFilter;
   const agentsToCheck = agentFilter
@@ -822,24 +1424,6 @@ export async function listInstalledSkills(
   }
 
   // Build list of directories to scan: canonical + each installed agent's directory
-  //
-  // Scanning workflow:
-  //
-  //   detectInstalledAgents()
-  //            │
-  //            ▼
-  //   for each scope (project / global)
-  //            │
-  //            ├──▶ scan canonical dir ──▶ .agents/skills, ~/.agents/skills
-  //            │
-  //            ├──▶ scan each installed agent's dir ──▶ .cursor/skills, .claude/skills, ...
-  //            │
-  //            ▼
-  //   deduplicate by skill name
-  //
-  // Trade-off: More readdir() calls, but most non-existent dirs fail fast.
-  // Skills in agent-specific dirs skip the expensive "check all agents" loop.
-  //
   for (const { global: isGlobal } of scopeTypes) {
     // Add canonical directory
     scopes.push({ global: isGlobal, path: getCanonicalSkillsDir(isGlobal, cwd) });
@@ -860,48 +1444,87 @@ export async function listInstalledSkills(
 
   for (const scope of scopes) {
     try {
-      const entries = await readdir(scope.path, { withFileTypes: true });
+      // Recursively scan for skills with namespace support
+      await scanSkillsDir(
+        scope.path,
+        '',
+        scope.global,
+        scope.agentType,
+        detectedAgents,
+        options,
+        skillsMap,
+        cwd
+      );
+    } catch {
+      // Directory doesn't exist, skip
+    }
+  }
 
-      for (const entry of entries) {
-        if (!entry.isDirectory()) {
-          continue;
-        }
+  return Array.from(skillsMap.values());
+}
 
-        const skillDir = join(scope.path, entry.name);
-        const skillMdPath = join(skillDir, 'SKILL.md');
+/**
+ * Recursively scan a directory for skills, handling nested namespaces
+ * @param dir - Directory to scan
+ * @param nsPath - Current namespace path (e.g., 'obra/superpowers')
+ * @param isGlobal - Whether this is a global scope
+ * @param specificAgent - If set, we're scanning an agent-specific directory and should attribute skills directly
+ * @param detectedAgents - List of detected agents
+ * @param options - List options
+ * @param skillsMap - Map to collect found skills (for deduplication)
+ * @param cwd - Current working directory
+ */
+async function scanSkillsDir(
+  dir: string,
+  nsPath: string,
+  isGlobal: boolean,
+  specificAgent: AgentType | undefined,
+  detectedAgents: AgentType[],
+  options: { global?: boolean; cwd?: string; agentFilter?: AgentType[] },
+  skillsMap: Map<string, InstalledSkill>,
+  cwd: string
+): Promise<void> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
 
-        // Check if SKILL.md exists
-        try {
-          await stat(skillMdPath);
-        } catch {
-          // SKILL.md doesn't exist, skip this directory
-          continue;
-        }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
 
-        // Parse the skill
+      const entryPath = join(dir, entry.name);
+      const skillMdPath = join(entryPath, 'SKILL.md');
+
+      // Check if this directory contains a SKILL.md (it's a skill)
+      try {
+        await stat(skillMdPath);
+
+        // This is a skill directory
         const skill = await parseSkillMd(skillMdPath);
         if (!skill) {
           continue;
         }
 
-        const scopeKey = scope.global ? 'global' : 'project';
-        const skillKey = `${scopeKey}:${skill.name}`;
+        const scopeKey = isGlobal ? 'global' : 'project';
+        const ns = nsPath || undefined;
+        const skillKey = ns ? `${scopeKey}:${ns}/${skill.name}` : `${scopeKey}:${skill.name}`;
 
         // If scanning an agent-specific directory, attribute directly to that agent
-        if (scope.agentType) {
+        if (specificAgent) {
           if (skillsMap.has(skillKey)) {
             const existing = skillsMap.get(skillKey)!;
-            if (!existing.agents.includes(scope.agentType)) {
-              existing.agents.push(scope.agentType);
+            if (!existing.agents.includes(specificAgent)) {
+              existing.agents.push(specificAgent);
             }
           } else {
             skillsMap.set(skillKey, {
               name: skill.name,
               description: skill.description,
-              path: skillDir,
-              canonicalPath: skillDir,
+              path: entryPath,
+              canonicalPath: entryPath,
               scope: scopeKey,
-              agents: [scope.agentType],
+              agents: [specificAgent],
+              namespace: ns,
             });
           }
           continue;
@@ -910,67 +1533,39 @@ export async function listInstalledSkills(
         // For canonical directory, check which agents have this skill
         const sanitizedSkillName = sanitizeName(skill.name);
         const installedAgents: AgentType[] = [];
+        const agentFilter = options.agentFilter;
+        const agentsToCheck = agentFilter
+          ? detectedAgents.filter((a) => agentFilter.includes(a))
+          : detectedAgents;
 
         for (const agentType of agentsToCheck) {
           const agent = agents[agentType];
 
-          if (scope.global && agent.globalSkillsDir === undefined) {
+          if (isGlobal && agent.globalSkillsDir === undefined) {
             continue;
           }
 
-          const agentBase = scope.global ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+          const agentBase = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+
           let found = false;
 
-          // Try exact directory name matches
-          const possibleNames = Array.from(
-            new Set([
-              entry.name,
-              sanitizedSkillName,
-              skill.name
-                .toLowerCase()
-                .replace(/\s+/g, '-')
-                .replace(/[\/\\:\0]/g, ''),
-            ])
-          );
-
-          for (const possibleName of possibleNames) {
-            const agentSkillDir = join(agentBase, possibleName);
-            if (!isPathSafe(agentBase, agentSkillDir)) continue;
-
+          // Try with full namespace path (e.g., obra/superpowers/skillname)
+          const agentSkillDir = join(agentBase, nsPath, sanitizedSkillName);
+          if (isPathSafe(agentBase, agentSkillDir)) {
             try {
               await access(agentSkillDir);
               found = true;
-              break;
             } catch {
-              // Try next name
-            }
-          }
-
-          // Fallback: scan all directories and check SKILL.md files
-          // Handles cases where directory names don't match (e.g., "git-review" vs "Git Review Before Commit")
-          if (!found) {
-            try {
-              const agentEntries = await readdir(agentBase, { withFileTypes: true });
-              for (const agentEntry of agentEntries) {
-                if (!agentEntry.isDirectory()) continue;
-
-                const candidateDir = join(agentBase, agentEntry.name);
-                if (!isPathSafe(agentBase, candidateDir)) continue;
-
+              // Try without namespace (legacy)
+              const legacyDir = join(agentBase, sanitizedSkillName);
+              if (isPathSafe(agentBase, legacyDir)) {
                 try {
-                  const candidateSkillMd = join(candidateDir, 'SKILL.md');
-                  await stat(candidateSkillMd);
-                  const candidateSkill = await parseSkillMd(candidateSkillMd);
-                  if (candidateSkill && candidateSkill.name === skill.name) {
-                    found = true;
-                    break;
-                  }
+                  await access(legacyDir);
+                  found = true;
                 } catch {
-                  // Not a valid skill directory
+                  // Not found
                 }
               }
-            } catch {
-              // Agent base directory doesn't exist
             }
           }
 
@@ -979,8 +1574,8 @@ export async function listInstalledSkills(
           }
         }
 
+        // Deduplicate: if skill already exists, merge agents
         if (skillsMap.has(skillKey)) {
-          // Merge agents
           const existing = skillsMap.get(skillKey)!;
           for (const agent of installedAgents) {
             if (!existing.agents.includes(agent)) {
@@ -991,17 +1586,39 @@ export async function listInstalledSkills(
           skillsMap.set(skillKey, {
             name: skill.name,
             description: skill.description,
-            path: skillDir,
-            canonicalPath: skillDir,
+            path: entryPath,
+            canonicalPath: entryPath,
             scope: scopeKey,
             agents: installedAgents,
+            namespace: ns,
           });
         }
-      }
-    } catch {
-      // Directory doesn't exist, skip
-    }
-  }
+      } catch {
+        // No SKILL.md, check if this is a namespace directory (contains subdirectories)
+        try {
+          const subEntries = await readdir(entryPath, { withFileTypes: true });
+          const hasSubdirs = subEntries.some((e) => e.isDirectory());
 
-  return Array.from(skillsMap.values());
+          if (hasSubdirs) {
+            // This is a namespace directory, recurse into it
+            const newNsPath = nsPath ? `${nsPath}/${entry.name}` : entry.name;
+            await scanSkillsDir(
+              entryPath,
+              newNsPath,
+              isGlobal,
+              specificAgent,
+              detectedAgents,
+              options,
+              skillsMap,
+              cwd
+            );
+          }
+        } catch {
+          // Can't read directory, skip
+        }
+      }
+    }
+  } catch {
+    // Can't read directory, skip
+  }
 }

--- a/src/list.ts
+++ b/src/list.ts
@@ -104,7 +104,8 @@ export async function runList(args: string[]): Promise<void> {
     const agentNames = skill.agents.map((a) => agents[a].displayName);
     const agentInfo =
       skill.agents.length > 0 ? formatList(agentNames) : `${YELLOW}not linked${RESET}`;
-    console.log(`${CYAN}${skill.name}${RESET} ${DIM}${shortPath}${RESET}`);
+    const nsInfo = skill.namespace ? ` ${DIM}[${skill.namespace}]${RESET}` : '';
+    console.log(`${CYAN}${skill.name}${RESET}${nsInfo} ${DIM}${shortPath}${RESET}`);
     console.log(`  ${DIM}Agents:${RESET} ${agentInfo}`);
   }
 

--- a/src/merge-with-namespace.ts
+++ b/src/merge-with-namespace.ts
@@ -1,0 +1,438 @@
+import { readdir, stat, mkdir, rename, readFile, rm } from 'fs/promises';
+import { join, dirname, basename } from 'path';
+import { homedir } from 'os';
+import { TEXT, RESET, DIM } from './cli.ts';
+import { SKILLS_SUBDIR } from './constants.ts';
+import { parseSource, inferNamespace } from './source-parser.ts';
+import { readSkillLock, writeSkillLock } from './skill-lock.ts';
+import { getCanonicalSkillsDir } from './installer.ts';
+
+/**
+ * Sanitizes a namespace string for safe filesystem usage.
+ * Preserves forward slashes for GitHub/GitLab owner/repo format.
+ * Limits to 255 chars (common filesystem limit).
+ */
+export function sanitizeNamespace(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    // Split by slashes and sanitize each part separately
+    .split('/')
+    .map((part) => {
+      // For each part of the namespace, sanitize it like a filename
+      return part.replace(/[^a-z0-9._]+/g, '-').replace(/^[.\-]+|[.\-]+$/g, '');
+    })
+    .join('/')
+    // Remove leading/trailing slashes and dots to prevent path traversal
+    .replace(/^[.\-\/]+|[.\-\/]+$/g, '');
+
+  // Fallback to 'legacy' if empty
+  return sanitized.substring(0, 255) || 'legacy';
+}
+
+/**
+ * Determines the namespace for a skill based on lock file, source, or skill metadata.
+ */
+async function determineNamespace(
+  skillName: string,
+  skillMdPath: string,
+  lock: Awaited<ReturnType<typeof readSkillLock>>
+): Promise<string> {
+  const lockEntry = lock.skills[skillName];
+
+  // Priority 1: Use namespace from lock file
+  if (lockEntry?.namespace) {
+    return lockEntry.namespace;
+  }
+
+  // Priority 2: Infer from source
+  if (lockEntry?.source) {
+    const parsedSource = parseSource(lockEntry.source);
+    const inferredNs = inferNamespace(parsedSource);
+    if (inferredNs) {
+      return sanitizeNamespace(inferredNs);
+    }
+  }
+
+  // Priority 3: Extract from skill metadata
+  try {
+    const skillContent = await readFile(skillMdPath, 'utf-8');
+    const namespaceMatch = skillContent.match(/namespace:\s*(.+)/i);
+    if (namespaceMatch && namespaceMatch[1]) {
+      return sanitizeNamespace(namespaceMatch[1].trim());
+    }
+  } catch {
+    // Ignore read errors
+  }
+
+  // Fallback to 'legacy'
+  return 'legacy';
+}
+
+/**
+ * Checks if a directory is already under a namespace.
+ * Returns true if the parent directory is NOT the skills/ directory.
+ */
+function isAlreadyNamespaced(skillDir: string): boolean {
+  const parent = dirname(skillDir);
+  return basename(parent) !== SKILLS_SUBDIR;
+}
+
+/**
+ * Checks if a directory contains a valid skill (has SKILL.md).
+ */
+async function isValidSkillDirectory(skillDir: string): Promise<boolean> {
+  const skillMdPath = join(skillDir, 'SKILL.md');
+  try {
+    await stat(skillMdPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compares two skill directories to check if they have the same content.
+ * Currently only compares SKILL.md files, normalizing line endings.
+ */
+async function compareSkillDirectories(dir1: string, dir2: string): Promise<boolean> {
+  try {
+    const content1 = (await readFile(join(dir1, 'SKILL.md'), 'utf-8')).replace(/\r\n/g, '\n');
+    const content2 = (await readFile(join(dir2, 'SKILL.md'), 'utf-8')).replace(/\r\n/g, '\n');
+    return content1 === content2;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Removes a directory if it's empty or contains only SKILL.md.
+ */
+async function removeSkillDirectory(skillDir: string): Promise<void> {
+  const entries = await readdir(skillDir);
+  // Only remove if directory contains only SKILL.md (or is empty)
+  const safeToRemove = entries.length === 0 || (entries.length === 1 && entries[0] === 'SKILL.md');
+  if (safeToRemove) {
+    await rm(skillDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Migrates a single skill to a namespace-based structure.
+ */
+async function migrateSkill(
+  skillName: string,
+  skillDir: string,
+  namespace: string,
+  scopePath: string,
+  dryRun: boolean,
+  lockEntry?: Awaited<ReturnType<typeof readSkillLock>>['skills'][string]
+): Promise<{
+  skillName: string;
+  oldPath: string;
+  newPath: string;
+  namespace: string;
+  scope: 'global' | 'project';
+  status: 'migrated' | 'skipped' | 'error';
+  error?: string;
+}> {
+  const newPath = join(scopePath, namespace, skillName);
+  const isGlobal = scopePath.includes(homedir());
+
+  // Check if destination already exists
+  try {
+    await stat(newPath);
+    // Destination exists - check if it's the same skill
+    const isSameContent = await compareSkillDirectories(skillDir, newPath);
+    if (isSameContent) {
+      if (dryRun) {
+        return {
+          skillName,
+          oldPath: skillDir,
+          newPath,
+          namespace,
+          scope: isGlobal ? 'global' : 'project',
+          status: 'migrated',
+          error: 'Dry run - would clean up duplicate',
+        };
+      }
+      // Same skill already migrated - clean up the old directory
+      try {
+        await removeSkillDirectory(skillDir);
+      } catch {
+        // Ignore cleanup errors (e.g., directory locked on Windows)
+        // The skill is already migrated, so this is not a failure
+      }
+      return {
+        skillName,
+        oldPath: skillDir,
+        newPath,
+        namespace,
+        scope: isGlobal ? 'global' : 'project',
+        status: 'migrated',
+      };
+    }
+    // Different skill - conflict
+    return {
+      skillName,
+      oldPath: skillDir,
+      newPath,
+      namespace,
+      scope: isGlobal ? 'global' : 'project',
+      status: 'error',
+      error: 'Destination already exists with different content',
+    };
+  } catch {
+    // Destination doesn't exist, continue
+  }
+
+  // Dry run mode
+  if (dryRun) {
+    return {
+      skillName,
+      oldPath: skillDir,
+      newPath,
+      namespace,
+      scope: isGlobal ? 'global' : 'project',
+      status: 'skipped',
+      error: 'Dry run - no changes made',
+    };
+  }
+
+  // Perform migration
+  try {
+    // Create namespace directory
+    await mkdir(dirname(newPath), { recursive: true });
+
+    // Move the directory
+    await rename(skillDir, newPath);
+
+    // Verify the move was successful
+    try {
+      await stat(newPath);
+      await stat(skillDir); // Should fail if move was successful
+      // If we get here, the old path still exists - this is an error
+      throw new Error('Move operation did not complete successfully');
+    } catch (statError) {
+      // Expected: stat(skillDir) should fail
+      if ((statError as { code?: string }).code !== 'ENOENT') {
+        throw statError;
+      }
+    }
+
+    // Update lock file entry
+    if (lockEntry) {
+      lockEntry.namespace = namespace;
+    }
+
+    return {
+      skillName,
+      oldPath: skillDir,
+      newPath,
+      namespace,
+      scope: isGlobal ? 'global' : 'project',
+      status: 'migrated',
+    };
+  } catch (error) {
+    // If directory is locked/busy, skip gracefully
+    const errorCode = (error as { code?: string }).code;
+    if (errorCode === 'EBUSY' || errorCode === 'EPERM' || errorCode === 'ACCESS') {
+      return {
+        skillName,
+        oldPath: skillDir,
+        newPath,
+        namespace,
+        scope: isGlobal ? 'global' : 'project',
+        status: 'skipped',
+        error: 'Directory is locked or in use - skipped',
+      };
+    }
+    return {
+      skillName,
+      oldPath: skillDir,
+      newPath,
+      namespace,
+      scope: isGlobal ? 'global' : 'project',
+      status: 'error',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Processes all legacy skills in a given scope (global or project).
+ */
+async function processScope(
+  scope: { global: boolean; path: string },
+  lock: Awaited<ReturnType<typeof readSkillLock>>,
+  dryRun: boolean
+): Promise<
+  Array<{
+    skillName: string;
+    oldPath: string;
+    newPath: string;
+    namespace: string;
+    scope: 'global' | 'project';
+    status: 'migrated' | 'skipped' | 'error';
+    error?: string;
+  }>
+> {
+  const results: Array<{
+    skillName: string;
+    oldPath: string;
+    newPath: string;
+    namespace: string;
+    scope: 'global' | 'project';
+    status: 'migrated' | 'skipped' | 'error';
+    error?: string;
+  }> = [];
+
+  try {
+    const entries = await readdir(scope.path, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const skillDir = join(scope.path, entry.name);
+      const skillMdPath = join(skillDir, 'SKILL.md');
+
+      // Skip if not a valid skill directory
+      if (!(await isValidSkillDirectory(skillDir))) {
+        continue;
+      }
+
+      // Skip if already under a namespace
+      const skillName = entry.name;
+      if (isAlreadyNamespaced(skillDir)) {
+        continue;
+      }
+
+      // Determine namespace
+      const namespace = await determineNamespace(skillName, skillMdPath, lock);
+
+      // Migrate the skill
+      const result = await migrateSkill(
+        skillName,
+        skillDir,
+        namespace,
+        scope.path,
+        dryRun,
+        lock.skills[skillName]
+      );
+
+      results.push(result);
+
+      // Log result
+      if (result.status === 'migrated') {
+        if (dryRun) {
+          console.log(`${DIM}↷${RESET} Would migrate ${skillName} to ${namespace}/${skillName}`);
+        } else {
+          console.log(`${TEXT}✓${RESET} Migrated ${skillName} to ${namespace}/${skillName}`);
+        }
+      } else if (result.status === 'error') {
+        console.log(`${DIM}✗${RESET} Failed to migrate ${skillName}: ${result.error}`);
+      }
+    }
+  } catch (error) {
+    // Directory doesn't exist or can't be read
+    console.log(
+      `${DIM}Note: ${scope.global ? 'Global' : 'Project'} skills directory not found or inaccessible${RESET}`
+    );
+  }
+
+  return results;
+}
+
+/**
+ * Prints migration summary.
+ */
+function printMigrationSummary(
+  results: Array<{
+    skillName: string;
+    oldPath: string;
+    newPath: string;
+    namespace: string;
+    scope: 'global' | 'project';
+    status: 'migrated' | 'skipped' | 'error';
+    error?: string;
+  }>
+): void {
+  console.log();
+  console.log(`${TEXT}Migration Summary:${RESET}`);
+
+  const migratedCount = results.filter((r) => r.status === 'migrated').length;
+  const skippedCount = results.filter((r) => r.status === 'skipped').length;
+  const errorCount = results.filter((r) => r.status === 'error').length;
+
+  console.log(`  ${TEXT}✓${RESET} Migrated: ${migratedCount}`);
+  console.log(`  ${DIM}↷${RESET} Skipped: ${skippedCount}`);
+  console.log(`  ${DIM}✗${RESET} Errors: ${errorCount}`);
+
+  if (errorCount > 0) {
+    console.log();
+    console.log(`${TEXT}Skills with errors:${RESET}`);
+    results
+      .filter((r) => r.status === 'error')
+      .forEach((r) => {
+        console.log(`  ${DIM}•${RESET} ${r.skillName}: ${r.error}`);
+      });
+  }
+
+  console.log();
+  console.log(`${TEXT}Migration completed!${RESET}`);
+  console.log();
+}
+
+/**
+ * Main entry point for the merge-with-namespace command.
+ */
+export async function runMergeWithNamespace(args: string[] = []): Promise<void> {
+  console.log(`${TEXT}Migrating existing skills to namespace-based structure...${RESET}`);
+  console.log();
+
+  // Parse options
+  const global = args.includes('-g') || args.includes('--global');
+  const yes = args.includes('-y') || args.includes('--yes');
+  const dryRun = args.includes('--dry-run');
+
+  // Get canonical skills directories to scan
+  const scopes: Array<{ global: boolean; path: string }> = [];
+  if (global) {
+    // Only scan global
+    scopes.push({ global: true, path: getCanonicalSkillsDir(true) });
+  } else {
+    // Scan both project and global by default
+    const cwd = process.cwd();
+    scopes.push({ global: false, path: getCanonicalSkillsDir(false, cwd) });
+    scopes.push({ global: true, path: getCanonicalSkillsDir(true) });
+  }
+
+  // Read lock file
+  const lock = await readSkillLock();
+
+  // Process each scope and collect results
+  const results: Array<{
+    skillName: string;
+    oldPath: string;
+    newPath: string;
+    namespace: string;
+    scope: 'global' | 'project';
+    status: 'migrated' | 'skipped' | 'error';
+    error?: string;
+  }> = [];
+
+  for (const scope of scopes) {
+    const scopeResults = await processScope(scope, lock, dryRun);
+    results.push(...scopeResults);
+  }
+
+  // Update lock file if changes were made
+  if (!dryRun && results.some((r) => r.status === 'migrated')) {
+    await writeSkillLock(lock);
+    console.log(`${TEXT}✓ Lock file updated${RESET}`);
+  }
+
+  // Print summary
+  printMigrationSummary(results);
+}

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { runCli, runCliWithInput } from './test-utils.js';
+import { runCli, runCliWithInput } from './test-utils.ts';
 
 describe('remove command', () => {
   let testDir: string;

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -61,14 +61,19 @@ This is a test skill.
 
   describe('with no skills installed', () => {
     it('should show message when no skills found', () => {
-      const result = runCli(['remove', '-y'], testDir);
+      // Use testDir as HOME to isolate from user's actual skills
+      const result = runCli(['remove', '-y'], testDir, { HOME: testDir, USERPROFILE: testDir });
       expect(result.stdout).toContain('No skills found');
       expect(result.stdout).toContain('to remove');
       expect(result.exitCode).toBe(0);
     });
 
     it('should show error for non-existent skill name', () => {
-      const result = runCli(['remove', 'non-existent-skill', '-y'], testDir);
+      // Use testDir as HOME to isolate from user's actual skills
+      const result = runCli(['remove', 'non-existent-skill', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).toContain('No skills found');
       expect(result.exitCode).toBe(0);
     });
@@ -91,7 +96,10 @@ This is a test skill.
     });
 
     it('should remove specific skill by name with -y flag', () => {
-      const result = runCli(['remove', 'skill-one', '-y'], testDir);
+      const result = runCli(['remove', 'skill-one', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
 
       expect(result.stdout).toContain('Successfully removed');
       expect(result.stdout).toContain('1 skill');
@@ -105,7 +113,10 @@ This is a test skill.
     });
 
     it('should remove multiple skills by name', () => {
-      const result = runCli(['remove', 'skill-one', 'skill-two', '-y'], testDir);
+      const result = runCli(['remove', 'skill-one', 'skill-two', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
 
       expect(result.stdout).toContain('Successfully removed');
       expect(result.stdout).toContain('2 skill');
@@ -116,7 +127,10 @@ This is a test skill.
     });
 
     it('should remove all skills with --all flag', () => {
-      const result = runCli(['remove', '--all', '-y'], testDir);
+      const result = runCli(['remove', '--all', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
 
       expect(result.stdout).toContain('Successfully removed');
       expect(result.stdout).toContain('3 skill');
@@ -128,21 +142,27 @@ This is a test skill.
     });
 
     it('should show error for non-existent skill name when skills exist', () => {
-      const result = runCli(['remove', 'non-existent', '-y'], testDir);
+      const result = runCli(['remove', 'non-existent', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
 
       expect(result.stdout).toContain('No matching skills');
       expect(result.exitCode).toBe(0);
     });
 
     it('should be case-insensitive when matching skill names', () => {
-      const result = runCli(['remove', 'SKILL-ONE', '-y'], testDir);
+      const result = runCli(['remove', 'SKILL-ONE', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
 
       expect(result.stdout).toContain('Successfully removed');
       expect(existsSync(join(skillsDir, 'skill-one'))).toBe(false);
     });
 
     it('should remove only the specified skill and leave others', () => {
-      runCli(['remove', 'skill-two', '-y'], testDir);
+      runCli(['remove', 'skill-two', '-y'], testDir, { HOME: testDir, USERPROFILE: testDir });
 
       // skill-two removed
       expect(existsSync(join(skillsDir, 'skill-two'))).toBe(false);
@@ -176,7 +196,10 @@ This is a test skill.
     });
 
     it('should show error for invalid agent name', () => {
-      const result = runCli(['remove', 'test-skill', '--agent', 'invalid-agent', '-y'], testDir);
+      const result = runCli(['remove', 'test-skill', '--agent', 'invalid-agent', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
 
       expect(result.stdout).toContain('Invalid agents');
       expect(result.stdout).toContain('invalid-agent');
@@ -186,14 +209,18 @@ This is a test skill.
 
     it('should accept valid agent names', () => {
       // This should not error on agent validation
-      const result = runCli(['remove', 'test-skill', '--agent', 'claude-code', '-y'], testDir);
+      const result = runCli(['remove', 'test-skill', '--agent', 'claude-code', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).not.toContain('Invalid agents');
     });
 
     it('should accept multiple agent names', () => {
       const result = runCli(
         ['remove', 'test-skill', '--agent', 'claude-code', 'cursor', '-y'],
-        testDir
+        testDir,
+        { HOME: testDir, USERPROFILE: testDir }
       );
       expect(result.stdout).not.toContain('Invalid agents');
     });
@@ -205,7 +232,10 @@ This is a test skill.
     });
 
     it('should accept --global flag without error', () => {
-      const result = runCli(['remove', 'global-skill', '--global', '-y'], testDir);
+      const result = runCli(['remove', 'global-skill', '--global', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       // Command should run without error (skill may not be found in global scope from test dir)
       expect(result.exitCode).toBe(0);
     });
@@ -217,13 +247,19 @@ This is a test skill.
     });
 
     it('should support "rm" alias', () => {
-      const result = runCli(['rm', 'alias-test-skill', '-y'], testDir);
+      const result = runCli(['rm', 'alias-test-skill', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).toContain('Successfully removed');
       expect(result.exitCode).toBe(0);
     });
 
     it('should support "r" alias', () => {
-      const result = runCli(['r', 'alias-test-skill', '-y'], testDir);
+      const result = runCli(['r', 'alias-test-skill', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).toContain('Successfully removed');
       expect(result.exitCode).toBe(0);
     });
@@ -234,7 +270,10 @@ This is a test skill.
       createTestSkill('skill-with-dashes');
       createTestSkill('skill_with_underscores');
 
-      const result = runCli(['remove', 'skill-with-dashes', '-y'], testDir);
+      const result = runCli(['remove', 'skill-with-dashes', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).toContain('Successfully removed');
       expect(existsSync(join(skillsDir, 'skill-with-dashes'))).toBe(false);
       expect(existsSync(join(skillsDir, 'skill_with_underscores'))).toBe(true);
@@ -243,7 +282,10 @@ This is a test skill.
     it('should handle removing last remaining skill', () => {
       createTestSkill('last-skill');
 
-      const result = runCli(['remove', 'last-skill', '-y'], testDir);
+      const result = runCli(['remove', 'last-skill', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).toContain('Successfully removed');
       expect(result.stdout).toContain('1 skill');
 
@@ -260,7 +302,10 @@ This is a test skill.
 
       createTestSkill('valid-skill');
 
-      const result = runCli(['remove', 'valid-skill', '-y'], testDir);
+      const result = runCli(['remove', 'valid-skill', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).toContain('Successfully removed');
 
       // Invalid directory should still be removed
@@ -292,25 +337,35 @@ This is a test skill.
     });
 
     it('should parse -g as global', () => {
-      const result = runCli(['remove', 'parse-test-skill', '-g', '-y'], testDir);
+      const result = runCli(['remove', 'parse-test-skill', '-g', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).not.toContain('error');
       expect(result.stdout).not.toContain('unrecognized');
     });
 
     it('should parse --yes flag', () => {
-      const result = runCli(['remove', 'parse-test-skill', '--yes'], testDir);
+      const result = runCli(['remove', 'parse-test-skill', '--yes'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.exitCode).toBe(0);
     });
 
     it('should parse -a as agent', () => {
-      const result = runCli(['remove', 'parse-test-skill', '-a', 'claude-code', '-y'], testDir);
+      const result = runCli(['remove', 'parse-test-skill', '-a', 'claude-code', '-y'], testDir, {
+        HOME: testDir,
+        USERPROFILE: testDir,
+      });
       expect(result.stdout).not.toContain('Invalid agents');
     });
 
     it('should handle multiple values for --agent', () => {
       const result = runCli(
         ['remove', 'parse-test-skill', '--agent', 'claude-code', 'cursor', '-y'],
-        testDir
+        testDir,
+        { HOME: testDir, USERPROFILE: testDir }
       );
       expect(result.stdout).not.toContain('Invalid agents');
     });

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -20,6 +20,8 @@ export interface SkillLockEntry {
   sourceUrl: string;
   /** Subpath within the source repo, if applicable */
   skillPath?: string;
+  /** Namespace for organizing skills (optional) */
+  namespace?: string;
   /**
    * GitHub tree SHA for the entire skill folder.
    * This hash changes when ANY file in the skill folder changes.

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -27,7 +27,7 @@ async function hasSkillMd(dir: string): Promise<boolean> {
 
 export async function parseSkillMd(
   skillMdPath: string,
-  options?: { includeInternal?: boolean }
+  options?: { includeInternal?: boolean; basePath?: string }
 ): Promise<Skill | null> {
   try {
     const content = await readFile(skillMdPath, 'utf-8');
@@ -45,10 +45,30 @@ export async function parseSkillMd(
       return null;
     }
 
+    // Extract namespace from parent directory name relative to basePath
+    const skillDir = dirname(skillMdPath);
+    let namespace: string | undefined;
+
+    if (options?.basePath && skillDir.startsWith(options.basePath)) {
+      const relativePath = skillDir.slice(options.basePath.length).replace(/^[\\/]/, '');
+      const parts = relativePath.split(/[\\/]/).filter((p) => p && p !== 'SKILL.md');
+
+      // If skill is in a subdirectory, use the parent directory as namespace
+      // For example: basePath/skills/github/copilot/SKILL.md → namespace = "github"
+      if (parts.length >= 2) {
+        // The parent directory of the skill folder
+        namespace = parts[parts.length - 2];
+      } else if (parts.length === 1 && parts[0] !== '') {
+        // If skill is directly under a subdirectory, use that as namespace
+        namespace = parts[0];
+      }
+    }
+
     return {
       name: data.name,
       description: data.description,
-      path: dirname(skillMdPath),
+      path: skillDir,
+      namespace,
       rawContent: content,
       metadata: data.metadata,
     };
@@ -97,9 +117,12 @@ export async function discoverSkills(
   const seenNames = new Set<string>();
   const searchPath = subpath ? join(basePath, subpath) : basePath;
 
+  // Pass basePath to parseSkillMd for namespace extraction
+  const parseOptions = { ...options, basePath };
+
   // If pointing directly at a skill, add it (and return early unless fullDepth is set)
   if (await hasSkillMd(searchPath)) {
-    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
+    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), parseOptions);
     if (skill) {
       skills.push(skill);
       seenNames.add(skill.name);
@@ -155,7 +178,7 @@ export async function discoverSkills(
         if (entry.isDirectory()) {
           const skillDir = join(dir, entry.name);
           if (await hasSkillMd(skillDir)) {
-            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), parseOptions);
             if (skill && !seenNames.has(skill.name)) {
               skills.push(skill);
               seenNames.add(skill.name);
@@ -173,7 +196,7 @@ export async function discoverSkills(
     const allSkillDirs = await findSkillDirs(searchPath);
 
     for (const skillDir of allSkillDirs) {
-      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), parseOptions);
       if (skill && !seenNames.has(skill.name)) {
         skills.push(skill);
         seenNames.add(skill.name);

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -35,6 +35,423 @@ export function getOwnerRepo(parsed: ParsedSource): string | null {
 }
 
 /**
+ * Extract a short domain keyword from a hostname.
+ * e.g., "gitlab.com" -> "gitlab", "github.com" -> "github"
+ * For self-hosted instances (gitlab.company.io), extracts the organization/company name.
+ */
+function getDomainKeyword(hostname: string): string {
+  const lowerHost = hostname.toLowerCase();
+
+  // Well-known public domains - use service name as keyword
+  const knownDomains: Record<string, string> = {
+    'github.com': 'github',
+    'gitlab.com': 'gitlab',
+    'gitlab.org': 'gitlab',
+    'bitbucket.org': 'bitbucket',
+    'gitea.io': 'gitea',
+    'gitee.com': 'gitee',
+  };
+
+  if (knownDomains[lowerHost]) {
+    return knownDomains[lowerHost];
+  }
+
+  // For self-hosted instances, extract the organization/company name
+  // e.g., "gitlab.company.io" -> "company", "git.example.com" -> "example"
+  const parts = lowerHost.split('.');
+
+  // Filter out common subdomains and TLDs
+  const meaningfulParts = parts.filter(
+    (part) => !['www', 'com', 'org', 'net', 'io', 'co', 'dev'].includes(part)
+  );
+
+  // For self-hosted GitLab/GitHub/etc, skip the service name (gitlab, git, etc)
+  // and use the organization/company name
+  const serviceNames = ['gitlab', 'git', 'github', 'gitea', 'gogs', 'gitblit'];
+  const orgPart = meaningfulParts.find((part) => !serviceNames.includes(part));
+
+  if (orgPart) {
+    return orgPart;
+  }
+
+  // Fallback to first non-service part or first part
+  return meaningfulParts[0] || parts[0] || 'git';
+}
+
+/**
+ * Extract organization/company name from hostname.
+ * e.g., "gitlab.company.com.cn" -> "company"
+ * e.g., "github.com" -> "github"
+ */
+function getOrgFromHostname(hostname: string): string {
+  const lowerHost = hostname.toLowerCase();
+  const parts = lowerHost.split('.');
+
+  // Filter out common TLDs and service names
+  const excludedParts = new Set([
+    'com',
+    'org',
+    'net',
+    'io',
+    'co',
+    'dev',
+    'cn',
+    'io',
+    'gitlab',
+    'git',
+    'github',
+    'gitea',
+    'gogs',
+    'gitblit',
+    'www',
+  ]);
+
+  // Find the first meaningful part (usually the org/company name)
+  for (const part of parts) {
+    if (!excludedParts.has(part) && part.length > 1) {
+      return part;
+    }
+  }
+
+  // Fallback: return the first non-excluded part or first part
+  return parts.find((p) => !excludedParts.has(p)) || parts[0] || 'git';
+}
+
+/**
+ * Generic directory names that should be skipped when building namespace
+ * but included in the skill subpath
+ */
+const GENERIC_DIR_NAMES = new Set([
+  'skills',
+  'skill',
+  'src',
+  'lib',
+  'packages',
+  'pkg',
+  'code',
+  'repo',
+  'repos',
+  'projects',
+]);
+
+/**
+ * Build namespace from path components.
+ * Strategy:
+ * 1. For paths with 4+ segments (e.g., /tools/skills-center/skills/01-base/list-skills):
+ *    - Use org from hostname + first 2-3 meaningful path segments for namespace
+ *    - Remaining segments (excluding generic dirs like 'skills') become skill subpath
+ * 2. For simple 2-segment paths (e.g., /owner/repo): use traditional owner-repo format
+ */
+function buildNamespaceFromPath(
+  hostname: string,
+  pathSegments: string[],
+  isGitHub: boolean,
+  isGitLab: boolean
+): { namespace: string; skillSubpath?: string } | null {
+  // Remove empty segments and .git suffixes
+  const segments = pathSegments.map((s) => s.replace(/\.git$/, '')).filter((s) => s.length > 0);
+
+  if (segments.length < 2) {
+    return null;
+  }
+
+  const lowerHost = hostname.toLowerCase();
+
+  // GitHub: use traditional owner-repo format
+  if (isGitHub) {
+    const owner = segments[0]!;
+    const repo = segments[1]!;
+    if (segments.length > 2) {
+      // Has subpath: owner-repo/subpath
+      return {
+        namespace: `${owner}-${repo}`,
+        skillSubpath: segments.slice(2).join('/'),
+      };
+    }
+    return { namespace: `${owner}-${repo}` };
+  }
+
+  // GitLab.com: use gitlab-owner-repo format
+  if (isGitLab && (lowerHost === 'gitlab.com' || lowerHost === 'gitlab.org')) {
+    const owner = segments[0]!;
+    const repo = segments[1]!;
+    if (segments.length > 2) {
+      return {
+        namespace: `gitlab-${owner}-${repo}`,
+        skillSubpath: segments.slice(2).join('/'),
+      };
+    }
+    return { namespace: `gitlab-${owner}-${repo}` };
+  }
+
+  // Self-hosted GitLab or other Git hosts
+  // For self-hosted GitLab instances, use the same format as GitLab.com (hyphens)
+  // e.g., company-team-repo instead of company/team/repo
+  let orgFromHost: string;
+  const isSelfHostedGitLab =
+    lowerHost.includes('gitlab') &&
+    !['github.com', 'gitlab.com', 'gitlab.org', 'gitee.com'].includes(lowerHost);
+
+  if (isSelfHostedGitLab) {
+    // For self-hosted GitLab, extract org from hostname
+    orgFromHost = getOrgFromHostname(hostname);
+  } else if (
+    lowerHost === 'github.com' ||
+    lowerHost === 'gitlab.com' ||
+    lowerHost === 'gitlab.org' ||
+    lowerHost === 'gitee.com'
+  ) {
+    // For public git hosting services, don't add prefix
+    orgFromHost = '';
+  } else {
+    orgFromHost = getOrgFromHostname(hostname);
+  }
+
+  // For self-hosted GitLab, use the same logic as GitLab.com (hyphens)
+  // Namespace: org + all path segments (joined with hyphens)
+  // Subpath: remove only the first 'skills' directory, keep rest as-is
+  if (isSelfHostedGitLab) {
+    const namespaceParts: string[] = [];
+    if (orgFromHost.length > 0) {
+      namespaceParts.push(orgFromHost);
+    }
+
+    // Find the first occurrence of 'skills' directory
+    // Everything before it becomes namespace
+    // Everything after it (excluding 'skills') becomes subpath
+    let firstSkillsIndex = -1;
+
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]!;
+      if (firstSkillsIndex === -1 && segment.toLowerCase() === 'skills') {
+        firstSkillsIndex = i;
+      }
+    }
+
+    // Namespace: org + all segments before first 'skills'
+    const namespaceSegmentCount = firstSkillsIndex !== -1 ? firstSkillsIndex : segments.length;
+    for (let i = 0; i < namespaceSegmentCount; i++) {
+      namespaceParts.push(segments[i]!);
+    }
+
+    // Build namespace with hyphens
+    const namespace = namespaceParts.join('-');
+
+    // Subpath: all segments after first 'skills', preserving hierarchy
+    let skillSubpath: string | undefined;
+    if (firstSkillsIndex !== -1 && firstSkillsIndex < segments.length - 1) {
+      const subpathSegments = segments.slice(firstSkillsIndex + 1);
+      skillSubpath = subpathSegments.join('/');
+    }
+
+    return { namespace, skillSubpath };
+  }
+
+  // For multi-level paths from other hosts (Gitee, etc.)
+  // Separate meaningful segments from generic ones for namespace building
+  // But keep track of generic dirs for subpath calculation
+  const meaningfulSegments: string[] = [];
+  let firstGenericIndex = -1;
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]!;
+    if (!GENERIC_DIR_NAMES.has(segment.toLowerCase())) {
+      meaningfulSegments.push(segment);
+    } else if (firstGenericIndex === -1) {
+      firstGenericIndex = i;
+    }
+  }
+
+  // For multi-level paths like /tools/skills-center/skills/01-base/list-skills
+  // We want: group1-tools-skills-center/01-base/list-skills (for Gitee)
+  if (segments.length >= 4) {
+    // For public hosts (no orgFromHost), use first 2 meaningful segments as namespace
+    // For self-hosted, use org + first 2 meaningful segments
+    let namespaceParts: string[] = [];
+
+    if (orgFromHost.length > 0) {
+      namespaceParts.push(orgFromHost);
+    }
+
+    // Use first 2 meaningful segments for namespace
+    const maxNamespaceSegments = 2;
+    for (let i = 0; i < Math.min(maxNamespaceSegments, meaningfulSegments.length); i++) {
+      namespaceParts.push(meaningfulSegments[i]!);
+    }
+
+    // Calculate skill subpath - starts after the segments used for namespace
+    // We need to count which original segments are used in the namespace
+    const namespaceSegmentCount = namespaceParts.length;
+
+    const skillSubpath = segments.slice(namespaceSegmentCount).join('/');
+
+    // Remove leading generic directory names from subpath
+    const subpathParts = skillSubpath.split('/');
+    while (subpathParts.length > 0 && GENERIC_DIR_NAMES.has(subpathParts[0]!.toLowerCase())) {
+      subpathParts.shift();
+    }
+
+    return {
+      namespace: namespaceParts.join('-'),
+      skillSubpath: subpathParts.join('/') || undefined,
+    };
+  }
+
+  // For 3 segment paths with a generic middle segment like /tools/skills/my-skill
+  // We want: company-tools/my-skill (not company-tools-skills)
+  if (segments.length === 3 && GENERIC_DIR_NAMES.has(segments[1]!.toLowerCase())) {
+    if (orgFromHost.length > 0) {
+      return {
+        namespace: `${orgFromHost}-${segments[0]}`,
+        skillSubpath: segments[2],
+      };
+    } else {
+      // For public hosts, just use the first meaningful segment
+      return {
+        namespace: segments[0]!,
+        skillSubpath: segments[2],
+      };
+    }
+  }
+
+  // For 2-3 segment paths: org-segment1-segment2
+  const namespaceParts: string[] = [];
+  if (orgFromHost.length > 0) {
+    namespaceParts.push(orgFromHost);
+  }
+  for (let i = 0; i < Math.min(2, segments.length); i++) {
+    namespaceParts.push(segments[i]!);
+  }
+
+  const namespace = namespaceParts.join('-');
+  if (segments.length > 2) {
+    return {
+      namespace,
+      skillSubpath: segments.slice(2).join('/'),
+    };
+  }
+
+  return { namespace };
+}
+
+/**
+ * Infers a namespace from a parsed source.
+ * Namespace naming strategy:
+ * - GitHub: owner-repo (clean format)
+ * - GitLab: gitlab-owner-repo (prefix to distinguish from GitHub)
+ * - Other Git hosts: domain-keyword-owner-repo (with domain keyword prefix)
+ * - Direct URLs: hostname (e.g., "docs.bun.com" -> "bun.com")
+ * - Well-known: wellknown/hostname (e.g., "wellknown/mintlify.com")
+ * Returns null for local paths.
+ */
+export function inferNamespace(parsed: ParsedSource): string | null {
+  if (parsed.type === 'local') {
+    return null;
+  }
+
+  const url = parsed.url;
+
+  // Handle direct-url type (Mintlify, HuggingFace, etc.)
+  if (parsed.type === 'direct-url') {
+    try {
+      const urlObj = new URL(url);
+      return urlObj.hostname.replace(/^www\./, '');
+    } catch {
+      return null;
+    }
+  }
+
+  // Handle well-known type
+  if (parsed.type === 'well-known') {
+    try {
+      const urlObj = new URL(url);
+      return `wellknown/${urlObj.hostname.replace(/^www\./, '')}`;
+    } catch {
+      return null;
+    }
+  }
+
+  // Try to parse the URL to extract hostname and path
+  let hostname: string;
+  let pathPart: string;
+
+  try {
+    const urlObj = new URL(url);
+    hostname = urlObj.hostname;
+    pathPart = urlObj.pathname;
+  } catch {
+    // Not a valid URL, try SSH format
+    const sshMatch = url.match(/^git@([^:]+):(.+)\.git$/);
+    if (sshMatch) {
+      hostname = sshMatch[1] || '';
+      pathPart = sshMatch[2] || '';
+    } else {
+      return null;
+    }
+  }
+
+  const lowerHost = hostname.toLowerCase();
+  const isGitHub = lowerHost === 'github.com' || parsed.type === 'github';
+  const isGitLab =
+    lowerHost === 'gitlab.com' || lowerHost === 'gitlab.org' || parsed.type === 'gitlab';
+
+  // Split path into segments
+  const pathSegments = pathPart.split('/').filter((s) => s.length > 0);
+
+  // Use smart path builder for multi-level paths
+  const result = buildNamespaceFromPath(hostname, pathSegments, isGitHub, isGitLab);
+  if (result) {
+    return result.namespace;
+  }
+
+  // Fallback: use domain keyword
+  const keyword = getDomainKeyword(hostname);
+  return keyword || 'git';
+}
+
+/**
+ * Extract skill subpath from a parsed source.
+ * For multi-level paths like /tools/skills-center/skills/01-base/list-skills,
+ * returns the subpath part (e.g., "01-base/list-skills").
+ */
+export function inferSkillSubpath(parsed: ParsedSource): string | undefined {
+  if (parsed.type === 'local' || parsed.type === 'direct-url' || parsed.type === 'well-known') {
+    return parsed.subpath;
+  }
+
+  const url = parsed.url;
+
+  try {
+    const urlObj = new URL(url);
+    const pathSegments = urlObj.pathname.split('/').filter((s) => s.length > 0);
+
+    const isGitHub = urlObj.hostname.toLowerCase() === 'github.com' || parsed.type === 'github';
+    const isGitLab =
+      urlObj.hostname.toLowerCase() === 'gitlab.com' ||
+      urlObj.hostname.toLowerCase() === 'gitlab.org' ||
+      parsed.type === 'gitlab';
+
+    const result = buildNamespaceFromPath(urlObj.hostname, pathSegments, isGitHub, isGitLab);
+    return result?.skillSubpath || parsed.subpath;
+  } catch {
+    // Try SSH format
+    const sshMatch = url.match(/^git@([^:]+):(.+)\.git$/);
+    if (sshMatch) {
+      const hostname = sshMatch[1] || '';
+      const pathSegments = sshMatch[2]!.split('/').filter((s) => s.length > 0);
+      const isGitHub = hostname.toLowerCase() === 'github.com';
+      const isGitLab =
+        hostname.toLowerCase() === 'gitlab.com' || hostname.toLowerCase() === 'gitlab.org';
+
+      const result = buildNamespaceFromPath(hostname, pathSegments, isGitHub, isGitLab);
+      return result?.skillSubpath;
+    }
+  }
+
+  return parsed.subpath;
+}
+
+/**
  * Extract owner and repo from an owner/repo string.
  * Returns null if the format is invalid.
  */
@@ -134,6 +551,48 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
+  // Git SSH URL: git@github.com:owner/repo.git or git@gitlab.com:owner/repo.git
+  // This handles SSH-style Git URLs for GitHub, GitLab, and other Git hosts
+  // Keep SSH protocol for cloning to support SSH key authentication
+  const gitSshMatch = input.match(/^git@([^:]+):(.+)\.git$/i);
+  if (gitSshMatch) {
+    const [, hostname, repoPath] = gitSshMatch;
+    if (!hostname || !repoPath) {
+      return { type: 'git', url: input };
+    }
+
+    // Determine if it's GitHub or GitLab based on hostname
+    const isGitHub = hostname.toLowerCase() === 'github.com';
+    const isGitLab =
+      hostname.toLowerCase() === 'gitlab.com' || hostname.toLowerCase() === 'gitlab.org';
+
+    if (isGitHub || isGitLab) {
+      // Parse owner/repo from repoPath (e.g., "owner/repo" or "owner/repo/path/to/skill")
+      const repoPathParts = repoPath.split('/');
+      const owner = repoPathParts[0];
+      const repo = repoPathParts[1] || owner;
+
+      // Keep original SSH URL for cloning, preserving SSH protocol
+      if (isGitHub) {
+        return {
+          type: 'github',
+          url: input, // Keep SSH URL: git@github.com:owner/repo.git
+        };
+      } else if (isGitLab) {
+        return {
+          type: 'gitlab',
+          url: input, // Keep SSH URL: git@gitlab.com:owner/repo.git
+        };
+      }
+    }
+
+    // Other Git hosts with SSH - keep the original SSH URL
+    return {
+      type: 'git',
+      url: input,
+    };
+  }
+
   // Direct skill.md URL (non-GitHub/GitLab): https://docs.bun.com/docs/skill.md
   if (isDirectSkillUrl(input)) {
     return {
@@ -222,6 +681,24 @@ export function parseSource(input: string): ParsedSource {
     }
   }
 
+  // Private/self-hosted GitLab instances: detect by hostname containing 'gitlab'
+  // e.g., https://gitlab.company.com/owner/repo or https://gitlab.company.com.cn/tools/project
+  // This pattern handles both 2-level (owner/repo) and multi-level paths
+  const privateGitLabMatch = input.match(/^(https?):\/\/([^/]*gitlab[^/]*)\/(.+)$/i);
+  if (privateGitLabMatch) {
+    const [, protocol, hostname, pathPart] = privateGitLabMatch;
+    // Skip if it's github.com
+    if (hostname!.toLowerCase() !== 'github.com') {
+      // For paths without tree/blob markers, treat as repo URL
+      // Support both 2-level (owner/repo) and multi-level paths
+      const cleanPath = pathPart!.replace(/\.git$/, '');
+      return {
+        type: 'gitlab',
+        url: `${protocol}://${hostname}/${cleanPath}.git`,
+      };
+    }
+  }
+
   // GitHub shorthand: owner/repo, owner/repo/path/to/skill, or owner/repo@skill-name
   // Exclude paths that start with . or / to avoid matching local paths
   // First check for @skill syntax: owner/repo@skill-name
@@ -242,6 +719,20 @@ export function parseSource(input: string): ParsedSource {
       type: 'github',
       url: `https://github.com/${owner}/${repo}.git`,
       subpath,
+    };
+  }
+
+  // Other Git hosts (git.example.com, gitea.company.io, etc.)
+  // Detect by common service names in hostname
+  const gitHostMatch = input.match(
+    /^(https?):\/\/((?:git|gitea|gogs|gitblit)[^.]*\.[^/]+)\/(.+)$/i
+  );
+  if (gitHostMatch) {
+    const [, protocol, hostname, pathPart] = gitHostMatch;
+    const cleanPath = pathPart!.replace(/\.git$/, '');
+    return {
+      type: 'git',
+      url: `${protocol}://${hostname}/${cleanPath}.git`,
     };
   }
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -26,8 +26,10 @@ export function runCli(
   env?: Record<string, string>,
   timeout?: number
 ): { stdout: string; stderr: string; exitCode: number } {
+  const tsxPath = join(import.meta.dirname, '..', 'node_modules', '.bin', 'tsx');
+  const cmd = `${tsxPath} ${CLI_PATH} ${args.join(' ')}`;
   try {
-    const output = execSync(`node ${CLI_PATH} ${args.join(' ')}`, {
+    const output = execSync(cmd, {
       encoding: 'utf-8',
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -54,8 +56,10 @@ export function runCliWithInput(
   input: string,
   cwd?: string
 ): { stdout: string; stderr: string; exitCode: number } {
+  const tsxPath = join(import.meta.dirname, '..', 'node_modules', '.bin', 'tsx');
+  const cmd = `${tsxPath} ${CLI_PATH} ${args.join(' ')}`;
   try {
-    const output = execSync(`node ${CLI_PATH} ${args.join(' ')}`, {
+    const output = execSync(cmd, {
       encoding: 'utf-8',
       cwd,
       input: input + '\n',

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,8 +1,10 @@
 import { execSync } from 'child_process';
 import { join } from 'path';
+import { existsSync } from 'fs';
 
 // const PROJECT_ROOT = join(import.meta.dirname, '..');
-const CLI_PATH = join(import.meta.dirname, 'cli.ts');
+const CLI_PATH_SRC = join(import.meta.dirname, 'cli.ts');
+const CLI_PATH_DIST = join(import.meta.dirname, '..', 'dist', 'cli.mjs');
 
 export function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*m/g, '');
@@ -27,7 +29,17 @@ export function runCli(
   timeout?: number
 ): { stdout: string; stderr: string; exitCode: number } {
   const tsxPath = join(import.meta.dirname, '..', 'node_modules', '.bin', 'tsx');
-  const cmd = `${tsxPath} ${CLI_PATH} ${args.join(' ')}`;
+
+  // Use tsx if available, otherwise use node with compiled dist/cli.mjs
+  let cmd: string;
+  const tsxExists = existsSync(tsxPath);
+
+  if (tsxExists) {
+    cmd = `${tsxPath} ${CLI_PATH_SRC} ${args.join(' ')}`;
+  } else {
+    cmd = `node ${CLI_PATH_DIST} ${args.join(' ')}`;
+  }
+
   try {
     const output = execSync(cmd, {
       encoding: 'utf-8',
@@ -57,7 +69,17 @@ export function runCliWithInput(
   cwd?: string
 ): { stdout: string; stderr: string; exitCode: number } {
   const tsxPath = join(import.meta.dirname, '..', 'node_modules', '.bin', 'tsx');
-  const cmd = `${tsxPath} ${CLI_PATH} ${args.join(' ')}`;
+
+  // Use tsx if available, otherwise use node with compiled dist/cli.mjs
+  let cmd: string;
+  const tsxExists = existsSync(tsxPath);
+
+  if (tsxExists) {
+    cmd = `${tsxPath} ${CLI_PATH_SRC} ${args.join(' ')}`;
+  } else {
+    cmd = `node ${CLI_PATH_DIST} ${args.join(' ')}`;
+  }
+
   try {
     const output = execSync(cmd, {
       encoding: 'utf-8',

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,10 +1,19 @@
 import { execSync } from 'child_process';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { platform } from 'os';
 
 // const PROJECT_ROOT = join(import.meta.dirname, '..');
 const CLI_PATH_SRC = join(import.meta.dirname, 'cli.ts');
 const CLI_PATH_DIST = join(import.meta.dirname, '..', 'dist', 'cli.mjs');
+
+function getTsxPath(): string {
+  const isWindows = platform() === 'win32';
+  const binDir = join(import.meta.dirname, '..', 'node_modules', '.bin');
+  const tsxCmd = join(binDir, isWindows ? 'tsx.CMD' : 'tsx');
+  const tsxFallback = join(binDir, 'tsx');
+  return existsSync(tsxCmd) ? tsxCmd : tsxFallback;
+}
 
 export function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*m/g, '');
@@ -28,14 +37,14 @@ export function runCli(
   env?: Record<string, string>,
   timeout?: number
 ): { stdout: string; stderr: string; exitCode: number } {
-  const tsxPath = join(import.meta.dirname, '..', 'node_modules', '.bin', 'tsx');
+  const tsxPath = getTsxPath();
 
   // Use tsx if available, otherwise use node with compiled dist/cli.mjs
   let cmd: string;
   const tsxExists = existsSync(tsxPath);
 
   if (tsxExists) {
-    cmd = `${tsxPath} ${CLI_PATH_SRC} ${args.join(' ')}`;
+    cmd = `"${tsxPath}" ${CLI_PATH_SRC} ${args.join(' ')}`;
   } else {
     cmd = `node ${CLI_PATH_DIST} ${args.join(' ')}`;
   }
@@ -68,14 +77,14 @@ export function runCliWithInput(
   input: string,
   cwd?: string
 ): { stdout: string; stderr: string; exitCode: number } {
-  const tsxPath = join(import.meta.dirname, '..', 'node_modules', '.bin', 'tsx');
+  const tsxPath = getTsxPath();
 
   // Use tsx if available, otherwise use node with compiled dist/cli.mjs
   let cmd: string;
   const tsxExists = existsSync(tsxPath);
 
   if (tsxExists) {
-    cmd = `${tsxPath} ${CLI_PATH_SRC} ${args.join(' ')}`;
+    cmd = `"${tsxPath}" ${CLI_PATH_SRC} ${args.join(' ')}`;
   } else {
     cmd = `node ${CLI_PATH_DIST} ${args.join(' ')}`;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface Skill {
   name: string;
   description: string;
   path: string;
+  /** Namespace for organizing skills (optional, defaults to parent directory name) */
+  namespace?: string;
   /** Raw SKILL.md content for hashing */
   rawContent?: string;
   metadata?: Record<string, unknown>;
@@ -67,6 +69,8 @@ export interface ParsedSource {
   ref?: string;
   /** Skill name extracted from @skill syntax (e.g., owner/repo@skill-name) */
   skillFilter?: string;
+  /** Namespace for skill installation (optional, defaults to parent directory name) */
+  namespace?: string;
 }
 
 export interface MintlifySkill {

--- a/tests/dist.test.ts
+++ b/tests/dist.test.ts
@@ -7,7 +7,7 @@ const rootDir = join(import.meta.dirname, '..');
 describe('dist build', () => {
   it('builds and runs without errors', { timeout: 30000 }, () => {
     // Build the project
-    execSync('pnpm build', { cwd: rootDir, stdio: 'pipe' });
+    execSync('npm run build', { cwd: rootDir, stdio: 'pipe' });
 
     // Run the CLI - should exit cleanly with help output
     const result = execSync('node dist/cli.mjs --help', {

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -118,6 +118,12 @@ describe('installer symlink regression', () => {
 
   // Regression test for #293: when agent skills dir is a symlink to canonical dir
   it('handles agent skills dir being a symlink to canonical dir', async () => {
+    // Skip on Windows without symlink support (requires admin or developer mode)
+    if (!(await symlinksSupported())) {
+      console.log('Skipping test: symlinks not supported on this platform');
+      return;
+    }
+
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
     const projectDir = join(root, 'project');
     await mkdir(projectDir, { recursive: true });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    teardownTimeout: 30000,
+    // Use forks pool for better Windows compatibility
+    pool: 'forks',
+    singleFork: true,
+  },
+});


### PR DESCRIPTION
**Objective:** Implement a namespace-based skill organization system with migration support for legacy skills.

**Key Changes:**

1. **Namespace Prefix Support** - Added namespace field to skill types and lock file; refactored installer logic to handle namespaced skill paths and updated skill discovery/parsing.

2. **Migration Command** - Introduced `merge-with-namespace.ts` (438 lines) providing a dedicated CLI command for users to migrate existing skills to the namespace structure.

3. **Enhanced Source Parser** - Extended to handle namespace-aware skill sources and improved URL/path parsing logic.

4. **CLI Updates** - Modified `add`, `list`, and `remove` commands to fully support namespaced skills.

5. **Refactored Installer** - Reorganized installation logic with improved error handling and namespace path management.

**Files Modified:** 12 files (1 new: `merge-with-namespace.ts`)

**Lines Changed:** +1,238/-332 lines

**Overall Goal:** Transition the skills CLI from flat skill names to a hierarchical namespace structure, enabling better organization, avoiding naming conflicts, and providing a smooth migration path for existing users.