### PR TITLE
chore: add common IDE and tool directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,22 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+*.log
+package-lock.json
+.codebuddy/
+.agent/
+.agents/
+.claude/
+.cursor/
+.gemini/
+.github/skills/
+.opencode/
+.qoder/
+.qwen/
+.trae/
+.vscode/
+
+bin/_chunks/
+bin/cli-wrapper.mjs
+bin/cli.d.mts


### PR DESCRIPTION
Add ignore patterns for:

- Log files (*.log)

- npm lock file (package-lock.json)

- AI coding assistants (.agent, .agents, .claude, etc.)

- IDE configs (.vscode, .cursor, etc.)