### PR TITLE
feat: add GitCode support

### DIFF
--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -92,4 +92,41 @@ describe('source-parser', () => {
       });
     });
   });
+
+  describe('GitCode Support', () => {
+    it('parses gitcode basic repository URL', () => {
+      const result = parseSource('https://gitcode.com/owner/repo');
+      expect(result).toEqual({
+        type: 'gitcode',
+        url: 'https://gitcode.com/owner/repo.git',
+      });
+    });
+
+    it('parses gitcode URL with .git suffix', () => {
+      const result = parseSource('https://gitcode.com/owner/repo.git');
+      expect(result).toEqual({
+        type: 'gitcode',
+        url: 'https://gitcode.com/owner/repo.git',
+      });
+    });
+
+    it('parses gitcode URL with branch only', () => {
+      const result = parseSource('https://gitcode.com/owner/repo/tree/main');
+      expect(result).toEqual({
+        type: 'gitcode',
+        url: 'https://gitcode.com/owner/repo.git',
+        ref: 'main',
+      });
+    });
+
+    it('parses gitcode URL with path', () => {
+      const result = parseSource('https://gitcode.com/owner/repo/tree/main/path/to/skill');
+      expect(result).toEqual({
+        type: 'gitcode',
+        url: 'https://gitcode.com/owner/repo.git',
+        ref: 'main',
+        subpath: 'path/to/skill',
+      });
+    });
+  });
 });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -176,6 +176,42 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
+  // GitCode URL with path: https://gitcode.com/owner/repo/tree/branch/path/to/skill
+  const gitcodeTreeWithPathMatch = input.match(
+    /gitcode\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/
+  );
+  if (gitcodeTreeWithPathMatch) {
+    const [, owner, repo, ref, subpath] = gitcodeTreeWithPathMatch;
+    return {
+      type: 'gitcode',
+      url: `https://gitcode.com/${owner}/${repo}.git`,
+      ref,
+      subpath,
+    };
+  }
+
+  // GitCode URL with branch only: https://gitcode.com/owner/repo/tree/branch
+  const gitcodeTreeMatch = input.match(/gitcode\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/);
+  if (gitcodeTreeMatch) {
+    const [, owner, repo, ref] = gitcodeTreeMatch;
+    return {
+      type: 'gitcode',
+      url: `https://gitcode.com/${owner}/${repo}.git`,
+      ref,
+    };
+  }
+
+  // GitCode URL: https://gitcode.com/owner/repo
+  const gitcodeRepoMatch = input.match(/gitcode\.com\/([^/]+)\/([^/]+)/);
+  if (gitcodeRepoMatch) {
+    const [, owner, repo] = gitcodeRepoMatch;
+    const cleanRepo = repo!.replace(/\.git$/, '');
+    return {
+      type: 'gitcode',
+      url: `https://gitcode.com/${owner}/${cleanRepo}.git`,
+    };
+  }
+
   // GitLab URL with path (any GitLab instance): https://gitlab.com/owner/repo/-/tree/branch/path
   // Key identifier is the "/-/tree/" path pattern unique to GitLab.
   // Supports subgroups by using a non-greedy match for the repository path.
@@ -278,6 +314,7 @@ function isWellKnownUrl(input: string): boolean {
     const excludedHosts = [
       'github.com',
       'gitlab.com',
+      'gitcode.com',
       'huggingface.co',
       'raw.githubusercontent.com',
     ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'direct-url' | 'well-known';
+  type: 'github' | 'gitlab' | 'gitcode' | 'git' | 'local' | 'direct-url' | 'well-known';
   url: string;
   subpath?: string;
   localPath?: string;


### PR DESCRIPTION
Add support for GitCode repositories as a source for skills, enabling users to discover and install skills from gitcode.com.