### PR TITLE
fix(cli): add missing 'add' command in update spawnSync call

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -502,7 +502,7 @@ async function runUpdate(): Promise<void> {
     // Use skills CLI to reinstall with -g -y flags
     const result = spawnSync(
       'npx',
-      ['-y', 'skills', entry.sourceUrl, '--skill', update.name, '-g', '-y'],
+      ['-y', 'skills', 'add', entry.sourceUrl, '--skill', update.name, '-g', '-y'],
       {
         stdio: ['inherit', 'pipe', 'pipe'],
       }


### PR DESCRIPTION
## Summary

The `skills update` command was missing the `add` subcommand when spawning the reinstall process, causing updates to silently fail while reporting success.

## Problem

In [`src/cli.ts` line 505](https://github.com/vercel-labs/skills/blob/main/src/cli.ts#L505), the command was:

```javascript
['-y', 'skills', entry.sourceUrl, '--skill', update.name, '-g', '-y']
```

Which runs:
```bash
npx -y skills {sourceUrl} --skill {name} -g -y
```

Without `add`, the CLI doesn't know what operation to perform.

## Fix

Added the missing `add` command:

```javascript
['-y', 'skills', 'add', entry.sourceUrl, '--skill', update.name, '-g', '-y']
```

Fixes #254