### PR TITLE
fix(check): print individual skill names that couldn't be checked

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -400,8 +400,11 @@ async function runCheck(args: string[] = []): Promise<void> {
     if (data.errors && data.errors.length > 0) {
       console.log();
       console.log(
-        `${DIM}Could not check ${data.errors.length} skill(s) (may need reinstall)${RESET}`
+        `${DIM}Could not check ${data.errors.length} skill(s) (may need reinstall):${RESET}`
       );
+      for (const err of data.errors) {
+        console.log(`  ${DIM}• ${err.name}${RESET}`);
+      }
     }
 
     // Track telemetry


### PR DESCRIPTION
## Summary
When running `skills check`, the CLI shows "Could not check N skill(s)" but doesn't indicate which skills failed. This makes debugging difficult.

## Changes
- Print individual skill names in the error list, similar to how updates are displayed

## Before
```
Could not check 10 skill(s) (may need reinstall)
```

## After
```
Could not check 10 skill(s) (may need reinstall):
  • skill-name-1
  • skill-name-2
  ...
```