### PR TITLE
fix(find): correctly format searched skill package-name constructs

### DIFF
--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { searchSkillsAPI, type SearchSkill } from './find.ts';
+
+// Mock the global fetch for API tests
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('find command', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('searchSkillsAPI', () => {
+    it('should return empty array when API returns no results', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ skills: [] }),
+      });
+
+      const results = await searchSkillsAPI('nonexistent');
+      expect(results).toEqual([]);
+    });
+
+    it('should return mapped skills from API response with pkg field', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            skills: [
+              {
+                id: 'owner/repo/my-skill',
+                name: 'my-skill',
+                installs: 100,
+                source: 'owner/repo',
+              },
+            ],
+          }),
+      });
+
+      const results = await searchSkillsAPI('skill');
+      expect(results).toHaveLength(1);
+      expect(results[0]).toEqual({
+        name: 'my-skill',
+        slug: 'owner/repo/my-skill',
+        source: 'owner/repo',
+        installs: 100,
+        pkg: 'owner/repo@my-skill',
+      });
+    });
+
+    it('should construct pkg from slug when source is empty', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            skills: [
+              {
+                id: 'owner/repo/my-skill',
+                name: 'my-skill',
+                installs: 50,
+                source: '',
+              },
+            ],
+          }),
+      });
+
+      const results = await searchSkillsAPI('skill');
+      expect(results).toHaveLength(1);
+      expect(results[0]!.pkg).toBe('owner/repo@my-skill');
+    });
+
+    it('should return empty array when API request fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      const results = await searchSkillsAPI('test');
+      expect(results).toEqual([]);
+    });
+
+    it('should return empty array when fetch throws', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const results = await searchSkillsAPI('test');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('pkg field usage', () => {
+    // These tests verify the pkg field is used correctly for display
+
+    it('should use pkg field for display', () => {
+      const skill: SearchSkill = {
+        name: 'my-skill',
+        slug: 'owner/repo/my-skill',
+        source: 'owner/repo',
+        installs: 100,
+        pkg: 'owner/repo@my-skill',
+      };
+
+      expect(skill.pkg).toBe('owner/repo@my-skill');
+      expect(`https://skills.sh/${skill.slug}`).toBe('https://skills.sh/owner/repo/my-skill');
+    });
+
+    it('should handle multi-word repo names in pkg', () => {
+      const skill: SearchSkill = {
+        name: 'nested-skill',
+        slug: 'owner/multi-skills/nested-skill',
+        source: 'owner/multi-skills',
+        installs: 25,
+        pkg: 'owner/multi-skills@nested-skill',
+      };
+
+      expect(skill.pkg).toBe('owner/multi-skills@nested-skill');
+    });
+
+    it('should handle complex skill names in pkg', () => {
+      const skill: SearchSkill = {
+        name: 'api-security-best-practices',
+        slug: 'owner/skills-collection/api-security-best-practices',
+        source: 'owner/skills-collection',
+        installs: 5,
+        pkg: 'owner/skills-collection@api-security-best-practices',
+      };
+
+      expect(skill.pkg).toBe('owner/skills-collection@api-security-best-practices');
+    });
+  });
+});


### PR DESCRIPTION
The find command was incorectly displaying skill package names like ower/repo/skill@skill instead of the correct format which would be owner/repo@skill.

Issue stemmed from concatenating source + name without handling what the API actually returned. This PR updates to properly use internal self-handled and owned API requests with better typing, with data-mapping at source instead of ad-hoc mapping at every possible time of use.

Added tests to verify things are working as expected, with fallbacks to how it previously was (not) working as a failsafe.

(Disclaimer; I have no idea whether this API is in the works, being developed, or changed. I used what was returned on https://skills.sh/api/search?q=security&limit=100 as the baseline for what this API actually returns)