### PR TITLE
Fix discovery of nested skills inside container directories

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -96,16 +96,19 @@ export async function discoverSkills(
   const seenNames = new Set<string>();
   const searchPath = subpath ? join(basePath, subpath) : basePath;
 
-  // If pointing directly at a skill, add it (and return early unless fullDepth is set)
-  if (await hasSkillMd(searchPath)) {
-    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
-    if (skill) {
+  async function collectSkill(skillDir: string) {
+    const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+    if (skill && !seenNames.has(skill.name)) {
       skills.push(skill);
       seenNames.add(skill.name);
-      // Only return early if fullDepth is not set
-      if (!options?.fullDepth) {
-        return skills;
-      }
+    }
+  }
+
+  // If pointing directly at a skill, add it (and return early unless fullDepth is set)
+  if (await hasSkillMd(searchPath)) {
+    await collectSkill(searchPath);
+    if (!options?.fullDepth) {
+      return skills;
     }
   }
 
@@ -149,14 +152,15 @@ export async function discoverSkills(
       const entries = await readdir(dir, { withFileTypes: true });
 
       for (const entry of entries) {
-        if (entry.isDirectory()) {
-          const skillDir = join(dir, entry.name);
-          if (await hasSkillMd(skillDir)) {
-            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
-            if (skill && !seenNames.has(skill.name)) {
-              skills.push(skill);
-              seenNames.add(skill.name);
-            }
+        if (!entry.isDirectory()) continue;
+
+        const skillDir = join(dir, entry.name);
+        if (await hasSkillMd(skillDir)) {
+          await collectSkill(skillDir);
+        } else {
+          const nestedDirs = await findSkillDirs(skillDir, 0, 3);
+          for (const nestedDir of nestedDirs) {
+            await collectSkill(nestedDir);
           }
         }
       }
@@ -168,13 +172,8 @@ export async function discoverSkills(
   // Fall back to recursive search if nothing found
   if (skills.length === 0) {
     const allSkillDirs = await findSkillDirs(searchPath);
-
     for (const skillDir of allSkillDirs) {
-      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
-      if (skill && !seenNames.has(skill.name)) {
-        skills.push(skill);
-        seenNames.add(skill.name);
-      }
+      await collectSkill(skillDir);
     }
   }
 

--- a/tests/full-depth-discovery.test.ts
+++ b/tests/full-depth-discovery.test.ts
@@ -169,6 +169,56 @@ description: Skill 2
     expect(skillsFullDepth).toHaveLength(2);
   });
 
+  it('should discover nested skills inside container directories without --full-depth', async () => {
+    // No root SKILL.md — simulates a repo like wix-private/skills
+    // Structure:
+    //   skills/flat-skill/SKILL.md
+    //   skills/container/nested-a/SKILL.md   (container has no SKILL.md)
+    //   skills/container/nested-b/SKILL.md
+
+    mkdirSync(join(testDir, 'skills', 'flat-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'flat-skill', 'SKILL.md'),
+      `---
+name: flat-skill
+description: A flat skill
+---
+
+# Flat Skill
+`
+    );
+
+    mkdirSync(join(testDir, 'skills', 'container', 'nested-a'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'container', 'nested-a', 'SKILL.md'),
+      `---
+name: nested-a
+description: Nested skill A
+---
+
+# Nested A
+`
+    );
+
+    mkdirSync(join(testDir, 'skills', 'container', 'nested-b'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'container', 'nested-b', 'SKILL.md'),
+      `---
+name: nested-b
+description: Nested skill B
+---
+
+# Nested B
+`
+    );
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(3);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(['flat-skill', 'nested-a', 'nested-b']);
+  });
+
   it('should not duplicate skills when root and nested have the same name', async () => {
     // Edge case: root SKILL.md and a nested skill with the same name
     writeFileSync(


### PR DESCRIPTION
`discoverSkills()` now finds skills nested inside container directories (folders without their own `SKILL.md`).

Previously, the priority search loop only checked immediate children of priority directories. Container directories (folders grouping related skills without their own `SKILL.md`) were silently skipped.

- When a subdirectory lacks `SKILL.md`, recurse into it via `findSkillDirs()` with `maxDepth=3`
- Extract `collectSkill()` helper to deduplicate the parse+dedupe pattern (was repeated 3 times)
- Add test case for container directory discovery

<details>
<summary>AI Session Context</summary>

**Problem:** `discoverSkills()` only checked immediate children of priority directories for `SKILL.md`, missing skills nested inside container directories that group related skills.

**Approach:** In the priority loop, when a subdirectory doesn't have `SKILL.md`, recurse into it using the existing `findSkillDirs()` function to discover nested skills.

**Key Decisions:**
- Reuse `findSkillDirs` with `maxDepth=3`: Avoids new traversal logic; container -> category -> skill depth is sufficient
- Only recurse into dirs without `SKILL.md`: No behavior change for existing flat layouts
- Extract `collectSkill()` helper: The parse+dedupe pattern was duplicated 3 times, consolidating reduces maintenance surface

</details>