### PR TITLE
feat: add Letta Code agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [35 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [36 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -229,6 +229,7 @@ Skills can be installed to any of these agents:
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
+| Letta Code | `letta-code` | `.skills/` | `~/.letta/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
@@ -336,6 +337,7 @@ The CLI searches for skills in these locations within a repository:
 - `.kilocode/skills/`
 - `.kiro/skills/`
 - `.kode/skills/`
+- `.skills/`
 - `.mcpjam/skills/`
 - `.vibe/skills/`
 - `.mux/skills/`

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "kimi-cli",
     "kiro-cli",
     "kode",
+    "letta-code",
     "mcpjam",
     "mistral-vibe",
     "mux",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -219,6 +219,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.kode'));
     },
   },
+  'letta-code': {
+    name: 'letta-code',
+    displayName: 'Letta Code',
+    skillsDir: '.skills',
+    globalSkillsDir: join(home, '.letta/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.letta'));
+    },
+  },
   mcpjam: {
     name: 'mcpjam',
     displayName: 'MCPJam',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -132,6 +132,7 @@ export async function discoverSkills(
     join(searchPath, '.junie/skills'),
     join(searchPath, '.kilocode/skills'),
     join(searchPath, '.kiro/skills'),
+    join(searchPath, '.letta/skills'),
     join(searchPath, '.mux/skills'),
     join(searchPath, '.neovate/skills'),
     join(searchPath, '.opencode/skills'),
@@ -142,6 +143,8 @@ export async function discoverSkills(
     join(searchPath, '.trae/skills'),
     join(searchPath, '.windsurf/skills'),
     join(searchPath, '.zencoder/skills'),
+    // Letta Code uses .skills at project root
+    join(searchPath, '.skills'),
   ];
 
   // Add skill paths declared in plugin manifests

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type AgentType =
   | 'kimi-cli'
   | 'kiro-cli'
   | 'kode'
+  | 'letta-code'
   | 'mcpjam'
   | 'mistral-vibe'
   | 'mux'


### PR DESCRIPTION
## Summary

- Adds [Letta Code](https://github.com/letta-ai/letta-code) to the list of supported agents
- Project path: `.skills/`
- Global path: `~/.letta/skills/`
- Detection: checks for `~/.letta` directory

## What It Looks Like After This PR

### Agent Selection
```
◆  Select agents to install skills to (space to toggle)
│  □ Kode
│  □ Letta Code    <-- NEW
│  □ MCPJam
```

### CLI Usage
```bash
npx skills add vercel-labs/agent-skills -a letta-code -g
```

👾 Generated with [Letta Code](https://letta.com)