### PR TITLE
filter out the unsupported global config

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -157,11 +157,17 @@ export async function promptForAgents(
 async function selectAgentsInteractive(options: {
   global?: boolean;
 }): Promise<AgentType[] | symbol> {
-  const allAgents = Object.keys(agents) as AgentType[];
+  const allAgents = (Object.keys(agents) as AgentType[]).filter((a) => {
+    // Filter out agents that don't support global installation when --global is used
+    if (options.global && !agents[a].globalSkillsDir) {
+      return false;
+    }
+    return true;
+  });
   const agentChoices = allAgents.map((a) => ({
     value: a,
     label: agents[a].displayName,
-    hint: `${options.global ? agents[a].globalSkillsDir : agents[a].skillsDir}`,
+    hint: options.global ? agents[a].globalSkillsDir! : agents[a].skillsDir,
   }));
 
   return promptForAgents('Which agents do you want to install to?', agentChoices);


### PR DESCRIPTION
Some agent doesn't support the global config like replit when you do `add -g`, e.g.

<img width="300" height="150" alt="image" src="https://github.com/user-attachments/assets/83bf9abc-e4ce-422e-8ac0-e0c2df7c6c24" />

Hence we filter them out from the list