### PR TITLE
feat: support agent home env overrides

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -10,6 +10,7 @@ const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
+const piHome = process.env.PI_CODING_AGENT_DIR?.trim() || join(home, '.pi/agent');
 
 export function getOpenClawGlobalSkillsDir(
   homeDir = home,
@@ -378,9 +379,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'pi',
     displayName: 'Pi',
     skillsDir: '.pi/skills',
-    globalSkillsDir: join(home, '.pi/agent/skills'),
+    globalSkillsDir: join(piHome, 'skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.pi/agent'));
+      return existsSync(piHome);
     },
   },
   qoder: {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -11,6 +11,7 @@ const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const piHome = process.env.PI_CODING_AGENT_DIR?.trim() || join(home, '.pi/agent');
+const copilotHome = process.env.COPILOT_HOME?.trim() || join(home, '.copilot');
 const geminiCliHome = join(process.env.GEMINI_CLI_HOME?.trim() || home, '.gemini');
 const kimiShareDir = process.env.KIMI_SHARE_DIR?.trim() || join(home, '.kimi');
 
@@ -264,9 +265,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'github-copilot',
     displayName: 'GitHub Copilot',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.copilot/skills'),
+    globalSkillsDir: join(copilotHome, 'skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.copilot'));
+      return existsSync(copilotHome);
     },
   },
   goose: {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -11,6 +11,7 @@ const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const piHome = process.env.PI_CODING_AGENT_DIR?.trim() || join(home, '.pi/agent');
+const geminiCliHome = join(process.env.GEMINI_CLI_HOME?.trim() || home, '.gemini');
 const kimiShareDir = process.env.KIMI_SHARE_DIR?.trim() || join(home, '.kimi');
 
 export function getOpenClawGlobalSkillsDir(
@@ -254,9 +255,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'gemini-cli',
     displayName: 'Gemini CLI',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/skills'),
+    globalSkillsDir: join(geminiCliHome, 'skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.gemini'));
+      return existsSync(geminiCliHome);
     },
   },
   'github-copilot': {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -11,6 +11,7 @@ const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const piHome = process.env.PI_CODING_AGENT_DIR?.trim() || join(home, '.pi/agent');
+const kimiShareDir = process.env.KIMI_SHARE_DIR?.trim() || join(home, '.kimi');
 
 export function getOpenClawGlobalSkillsDir(
   homeDir = home,
@@ -309,7 +310,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     skillsDir: '.agents/skills',
     globalSkillsDir: join(home, '.config/agents/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.kimi'));
+      return existsSync(kimiShareDir);
     },
   },
   'kiro-cli': {

--- a/tests/copilot-paths.test.ts
+++ b/tests/copilot-paths.test.ts
@@ -1,0 +1,64 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function loadAgentsModule() {
+  vi.resetModules();
+  return import('../src/agents.ts');
+}
+
+describe('github-copilot path resolution', () => {
+  const originalCopilotHome = process.env.COPILOT_HOME;
+  const originalHome = process.env.HOME;
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (originalCopilotHome === undefined) {
+      delete process.env.COPILOT_HOME;
+    } else {
+      process.env.COPILOT_HOME = originalCopilotHome;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    vi.resetModules();
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('uses COPILOT_HOME for install detection', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'copilot-home-'));
+    process.env.COPILOT_HOME = tempDir;
+    const { agents } = await loadAgentsModule();
+
+    await expect(agents['github-copilot'].detectInstalled()).resolves.toBe(true);
+    expect(agents['github-copilot'].globalSkillsDir).toBe(join(tempDir, 'skills'));
+  });
+
+  it('trims COPILOT_HOME values', async () => {
+    process.env.COPILOT_HOME = '  /tmp/copilot-home  ';
+    const { agents } = await loadAgentsModule();
+
+    expect(agents['github-copilot'].globalSkillsDir).toBe('/tmp/copilot-home/skills');
+  });
+
+  it('falls back to ~/.copilot when COPILOT_HOME is empty', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'copilot-home-'));
+    process.env.HOME = tempDir;
+    process.env.COPILOT_HOME = '   ';
+    const { agents } = await loadAgentsModule();
+    await mkdir(join(tempDir, '.copilot'), { recursive: true });
+
+    await expect(agents['github-copilot'].detectInstalled()).resolves.toBe(true);
+
+    expect(agents['github-copilot'].globalSkillsDir).toBe(join(tempDir, '.copilot', 'skills'));
+  });
+});

--- a/tests/gemini-cli-paths.test.ts
+++ b/tests/gemini-cli-paths.test.ts
@@ -1,0 +1,64 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function loadAgentsModule() {
+  vi.resetModules();
+  return import('../src/agents.ts');
+}
+
+describe('gemini-cli path resolution', () => {
+  const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
+  const originalHome = process.env.HOME;
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (originalGeminiCliHome === undefined) {
+      delete process.env.GEMINI_CLI_HOME;
+    } else {
+      process.env.GEMINI_CLI_HOME = originalGeminiCliHome;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    vi.resetModules();
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('uses GEMINI_CLI_HOME for install detection', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'gemini-cli-home-'));
+    process.env.GEMINI_CLI_HOME = tempDir;
+    const { agents } = await loadAgentsModule();
+    await mkdir(join(tempDir, '.gemini'), { recursive: true });
+
+    await expect(agents['gemini-cli'].detectInstalled()).resolves.toBe(true);
+    expect(agents['gemini-cli'].globalSkillsDir).toBe(join(tempDir, '.gemini', 'skills'));
+  });
+
+  it('trims GEMINI_CLI_HOME values', () => {
+    process.env.GEMINI_CLI_HOME = '  /tmp/gemini-home  ';
+    return loadAgentsModule().then(({ agents }) => {
+      expect(agents['gemini-cli'].globalSkillsDir).toBe('/tmp/gemini-home/.gemini/skills');
+    });
+  });
+
+  it('falls back to ~/.gemini when GEMINI_CLI_HOME is empty', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'gemini-cli-home-'));
+    process.env.HOME = tempDir;
+    process.env.GEMINI_CLI_HOME = '   ';
+    const { agents } = await loadAgentsModule();
+    await mkdir(join(tempDir, '.gemini'), { recursive: true });
+
+    await expect(agents['gemini-cli'].detectInstalled()).resolves.toBe(true);
+    expect(agents['gemini-cli'].globalSkillsDir).toBe(join(tempDir, '.gemini', 'skills'));
+  });
+});

--- a/tests/kimi-paths.test.ts
+++ b/tests/kimi-paths.test.ts
@@ -1,0 +1,62 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function loadAgentsModule() {
+  vi.resetModules();
+  return import('../src/agents.ts');
+}
+
+describe('kimi-cli path resolution', () => {
+  const originalKimiShareDir = process.env.KIMI_SHARE_DIR;
+  const originalHome = process.env.HOME;
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (originalKimiShareDir === undefined) {
+      delete process.env.KIMI_SHARE_DIR;
+    } else {
+      process.env.KIMI_SHARE_DIR = originalKimiShareDir;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    vi.resetModules();
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('uses KIMI_SHARE_DIR for install detection', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kimi-share-'));
+    process.env.KIMI_SHARE_DIR = tempDir;
+    const { agents } = await loadAgentsModule();
+
+    await expect(agents['kimi-cli'].detectInstalled()).resolves.toBe(true);
+  });
+
+  it('trims KIMI_SHARE_DIR values', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kimi-share-'));
+    process.env.KIMI_SHARE_DIR = `  ${tempDir}  `;
+    const { agents } = await loadAgentsModule();
+
+    await expect(agents['kimi-cli'].detectInstalled()).resolves.toBe(true);
+  });
+
+  it('falls back to ~/.kimi when KIMI_SHARE_DIR is empty', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'kimi-home-'));
+    process.env.HOME = tempDir;
+    process.env.KIMI_SHARE_DIR = '   ';
+    const { agents } = await loadAgentsModule();
+    await mkdir(join(tempDir, '.kimi'), { recursive: true });
+
+    await expect(agents['kimi-cli'].detectInstalled()).resolves.toBe(true);
+  });
+});

--- a/tests/pi-paths.test.ts
+++ b/tests/pi-paths.test.ts
@@ -1,0 +1,63 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function loadAgentsModule() {
+  vi.resetModules();
+  return import('../src/agents.ts');
+}
+
+describe('pi path resolution', () => {
+  const originalPiCodingAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const originalHome = process.env.HOME;
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (originalPiCodingAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalPiCodingAgentDir;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    vi.resetModules();
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('uses PI_CODING_AGENT_DIR for install detection', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'pi-coding-agent-'));
+    process.env.PI_CODING_AGENT_DIR = tempDir;
+    const { agents } = await loadAgentsModule();
+
+    await expect(agents.pi.detectInstalled()).resolves.toBe(true);
+    expect(agents.pi.globalSkillsDir).toBe(join(tempDir, 'skills'));
+  });
+
+  it('trims PI_CODING_AGENT_DIR values', async () => {
+    process.env.PI_CODING_AGENT_DIR = '  /tmp/pi-coding-agent  ';
+    const { agents } = await loadAgentsModule();
+
+    expect(agents.pi.globalSkillsDir).toBe('/tmp/pi-coding-agent/skills');
+  });
+
+  it('falls back to ~/.pi/agent when PI_CODING_AGENT_DIR is empty', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'pi-home-'));
+    process.env.HOME = tempDir;
+    process.env.PI_CODING_AGENT_DIR = '   ';
+    const { agents } = await loadAgentsModule();
+    await mkdir(join(tempDir, '.pi/agent'), { recursive: true });
+
+    await expect(agents.pi.detectInstalled()).resolves.toBe(true);
+    expect(agents.pi.globalSkillsDir).toBe(join(tempDir, '.pi/agent', 'skills'));
+  });
+});


### PR DESCRIPTION
## Summary
- support `PI_CODING_AGENT_DIR` for Pi path detection and global skills resolution
- support `GEMINI_CLI_HOME` for Gemini CLI path detection and global skills resolution
- support `COPILOT_HOME` for GitHub Copilot path detection and global skills resolution
- support `KIMI_SHARE_DIR` for Kimi install detection while keeping the shared skills location unchanged
- add regression tests covering env override, trimming, and default fallback behavior for all four agents

## Details
- `PI_CODING_AGENT_DIR` now overrides the default `~/.pi/agent` base directory
- `GEMINI_CLI_HOME` now resolves Gemini CLI globals from `<GEMINI_CLI_HOME>/.gemini`
- `COPILOT_HOME` now replaces the entire `~/.copilot` directory, matching Copilot CLI docs
- `KIMI_SHARE_DIR` is used only for Kimi runtime/share-dir detection; Kimi skills still live in the shared agent skills directory

## Validation
- `pnpm exec prettier --check src/agents.ts tests/gemini-cli-paths.test.ts tests/kimi-paths.test.ts tests/copilot-paths.test.ts tests/pi-paths.test.ts`
- `pnpm test tests/gemini-cli-paths.test.ts tests/kimi-paths.test.ts tests/copilot-paths.test.ts tests/pi-paths.test.ts`
