### PR TITLE
fix: readme was referencing the section with an incorrect name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [35 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [35 more](#supported-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill


### PR DESCRIPTION
The markdown link was referencing #available-agents, but the section was titled #supported-agents. Updated the link.