### PR TITLE
fix: gitlab subgroup URLs, universal-only global symlinks, and symlinked agent dirs

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -207,16 +207,19 @@ export function parseSource(input: string): ParsedSource {
     }
   }
 
-  // GitLab.com URL: https://gitlab.com/owner/repo
+  // GitLab.com URL: https://gitlab.com/owner/repo or https://gitlab.com/group/subgroup/repo
   // Only for the official gitlab.com domain for user convenience.
-  const gitlabRepoMatch = input.match(/gitlab\.com\/([^/]+)\/([^/]+)/);
+  // Supports nested subgroups (e.g., gitlab.com/group/subgroup1/subgroup2/repo).
+  const gitlabRepoMatch = input.match(/gitlab\.com\/(.+?)(?:\.git)?\/?$/);
   if (gitlabRepoMatch) {
-    const [, owner, repo] = gitlabRepoMatch;
-    const cleanRepo = repo!.replace(/\.git$/, '');
-    return {
-      type: 'gitlab',
-      url: `https://gitlab.com/${owner}/${cleanRepo}.git`,
-    };
+    const repoPath = gitlabRepoMatch[1]!;
+    // Must have at least owner/repo (one slash)
+    if (repoPath.includes('/')) {
+      return {
+        type: 'gitlab',
+        url: `https://gitlab.com/${repoPath}.git`,
+      };
+    }
   }
 
   // GitHub shorthand: owner/repo, owner/repo/path/to/skill, or owner/repo@skill-name

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -3,7 +3,17 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile, lstat, readFile, symlink } from 'node:fs/promises';
+import {
+  mkdtemp,
+  mkdir,
+  rm,
+  writeFile,
+  lstat,
+  readFile,
+  readlink,
+  symlink,
+  readdir,
+} from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
@@ -73,6 +83,106 @@ describe('installer symlink regression', () => {
       const postStats = await lstat(canonicalDir);
       expect(postStats.isSymbolicLink()).toBe(false);
       expect(postStats.isDirectory()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // Regression test for #293: when agent skills dir is a symlink to canonical dir
+  it('handles agent skills dir being a symlink to canonical dir', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'symlinked-dir-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    // Create canonical dir: .agents/skills
+    const canonicalBase = join(projectDir, '.agents', 'skills');
+    await mkdir(canonicalBase, { recursive: true });
+
+    // Create .claude directory and symlink .claude/skills -> .agents/skills
+    const claudeDir = join(projectDir, '.claude');
+    await mkdir(claudeDir, { recursive: true });
+    const claudeSkillsDir = join(claudeDir, 'skills');
+    await symlink(canonicalBase, claudeSkillsDir);
+
+    try {
+      // Install for claude-code, which has skillsDir: '.claude/skills'
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBeUndefined();
+
+      // The skill should exist in the canonical location
+      const canonicalSkillDir = join(canonicalBase, skillName);
+      const stats = await lstat(canonicalSkillDir);
+      expect(stats.isDirectory()).toBe(true);
+
+      // It should NOT be a broken symlink - it should be a real directory
+      const contents = await readFile(join(canonicalSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+
+      // The skill should also be accessible via the symlinked path
+      const claudeSkillDir = join(claudeSkillsDir, skillName);
+      const claudeContents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
+      expect(claudeContents).toContain(`name: ${skillName}`);
+
+      // There should be no broken symlinks in canonical dir
+      const canonicalEntries = await readdir(canonicalBase, { withFileTypes: true });
+      for (const entry of canonicalEntries) {
+        if (entry.name === skillName) {
+          const entryPath = join(canonicalBase, entry.name);
+          const entryStats = await lstat(entryPath);
+          // Should be a real directory, not a symlink
+          expect(entryStats.isDirectory()).toBe(true);
+        }
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // Regression test for #294: universal-only global install should not create agent-specific symlinks
+  it('does not create agent-specific symlinks for universal agents on global install', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+
+    const skillName = 'universal-only-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    // We test with 'github-copilot', a universal agent (skillsDir: '.agents/skills')
+    // whose globalSkillsDir is different from canonical (~/.copilot/skills vs ~/.agents/skills)
+    // For testing, we use a project-level install to avoid writing to actual home dir.
+    // But the bug only manifests with global: true.
+    // We can't safely test with global: true in unit tests (it would write to ~/.copilot/skills).
+    // Instead, we verify that the installSkillForAgent function returns the canonical path
+    // as both path and canonicalPath for universal agents with global install.
+
+    // For a project-level install, universal agents have matching canonical and agent dirs,
+    // so we just verify the function works correctly.
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'github-copilot', // Universal agent
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBeUndefined();
+
+      // For a project-level universal agent, canonical and agent dir are the same
+      // (.agents/skills), so no symlink should be created
+      const installedPath = join(projectDir, '.agents/skills', skillName);
+      const stats = await lstat(installedPath);
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -79,6 +79,56 @@ describe('parseSource', () => {
       expect(result.ref).toBe('main');
       expect(result.subpath).toBe('src/skills');
     });
+
+    it('GitLab URL - with .git suffix', () => {
+      const result = parseSource('https://gitlab.com/owner/repo.git');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/owner/repo.git');
+    });
+
+    it('GitLab URL - subgroup (2 levels)', () => {
+      const result = parseSource('https://gitlab.com/group/subgroup/repo');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
+      expect(result.ref).toBeUndefined();
+    });
+
+    it('GitLab URL - subgroup (3 levels)', () => {
+      const result = parseSource('https://gitlab.com/coresofthq/ai/agent-skills');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/coresofthq/ai/agent-skills.git');
+      expect(result.ref).toBeUndefined();
+    });
+
+    it('GitLab URL - deep subgroup with .git suffix', () => {
+      const result = parseSource('https://gitlab.com/org/team/project/repo.git');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/org/team/project/repo.git');
+    });
+
+    it('GitLab URL - subgroup with tree/branch', () => {
+      const result = parseSource('https://gitlab.com/group/subgroup/repo/-/tree/main');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('GitLab URL - subgroup with tree/branch/path', () => {
+      const result = parseSource(
+        'https://gitlab.com/group/subgroup/repo/-/tree/main/path/to/skill'
+      );
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('path/to/skill');
+    });
+
+    it('GitLab URL - trailing slash', () => {
+      const result = parseSource('https://gitlab.com/group/subgroup/repo/');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
+    });
   });
 
   describe('GitHub shorthand tests', () => {
@@ -190,6 +240,11 @@ describe('getOwnerRepo', () => {
   it('getOwnerRepo - GitLab URL with tree', () => {
     const parsed = parseSource('https://gitlab.com/owner/repo/-/tree/main/skills');
     expect(getOwnerRepo(parsed)).toBe('owner/repo');
+  });
+
+  it('getOwnerRepo - GitLab URL with subgroup', () => {
+    const parsed = parseSource('https://gitlab.com/coresofthq/ai/agent-skills');
+    expect(getOwnerRepo(parsed)).toBe('coresofthq/ai/agent-skills');
   });
 
   it('getOwnerRepo - local path returns null', () => {


### PR DESCRIPTION
## Summary

Fixes three bugs:

**1. GitLab URLs with nested subgroups fail to clone**
`src/source-parser.ts:212` — The regex only captured two path segments (`owner/repo`), so `https://gitlab.com/coresofthq/ai/agent-skills` was parsed as `https://gitlab.com/coresofthq/ai.git`, dropping `agent-skills`. Fixed the regex to capture the full path, supporting arbitrarily deep GitLab subgroups.

**2. Universal-only global install creates duplicate symlinks (#294)**
`src/installer.ts` (all 4 install functions) — When only universal agents were selected for a global install, the installer still created symlinks to agent-specific global dirs (e.g., `~/.copilot/skills`), causing skills to appear twice in GitHub Copilot. Fixed by skipping the agent-specific symlink for universal agents on global installs, since the skill is already in the canonical `~/.agents/skills`.

**3. Installation fails when `~/.claude/skills` is a symlink (#293)**
`src/installer.ts` (`createSymlink`) — When `~/.claude/skills` was symlinked to `~/.agents/skills`, the installer computed relative paths from the symlink path rather than the real filesystem path, producing broken symlinks like `../../.agents/skills`. Fixed by resolving symlinks in parent directories via `fs.realpath` before comparing paths and computing relative targets.