### PR TITLE
fix: explicitly allow __init__.py in skill copy filter

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -299,6 +299,8 @@ const EXCLUDE_DIRS = new Set(['.git']);
 
 const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
   if (EXCLUDE_FILES.has(name)) return true;
+  // Explicitly allow __init__.py (Python package marker)
+  if (name === '__init__.py') return false;
   if (name.startsWith('_')) return true;
   if (isDirectory && EXCLUDE_DIRS.has(name)) return true;
   return false;


### PR DESCRIPTION
Fixes #292 

The isExcluded function was filtering out all files starting with '_' (underscore),

which incorrectly excluded Python __init__.py package marker files.