### PR TITLE
feat: add Jazz agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [35 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [36 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -212,7 +212,7 @@ Skills can be installed to any of these agents:
 | Antigravity | `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
-| OpenClaw | `openclaw` | `skills/` | `~/.moltbot/skills/` |
+| OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
 | Cline | `cline` | `.cline/skills/` | `~/.cline/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
@@ -227,6 +227,7 @@ Skills can be installed to any of these agents:
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
+| Jazz | `jazz` | `.jazz/skills/` | `~/.jazz/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
@@ -330,6 +331,7 @@ The CLI searches for skills in these locations within a repository:
 - `.junie/skills/`
 - `.iflow/skills/`
 - `.kilocode/skills/`
+- `.jazz/skills/`
 - `.kiro/skills/`
 - `.kode/skills/`
 - `.mcpjam/skills/`

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "iflow-cli",
     "kilo",
     "kimi-cli",
+    "jazz",
     "kiro-cli",
     "kode",
     "mcpjam",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -201,6 +201,16 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.kimi'));
     },
   },
+  jazz: {
+    name: 'jazz',
+    displayName: 'Jazz',
+    skillsDir: '.jazz/skills',
+    globalSkillsDir: join(home, '.jazz/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.jazz')) || existsSync(join(process.cwd(), '.jazz'));
+    },
+  },
+
   'kiro-cli': {
     name: 'kiro-cli',
     displayName: 'Kiro CLI',

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export type AgentType =
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'
+  | 'jazz'
   | 'iflow-cli'
   | 'junie'
   | 'kilo'


### PR DESCRIPTION
## Summary

Jazz: https://github.com/lvndry/jazz

- add Jazz agent config (project + global skills paths)
- include Jazz in supported agents table and skill discovery list
- add Jazz keyword for CLI discovery

## Testing
- pnpm test
- pnpm format
- node scripts/validate-agents.ts
- node scripts/sync-agents.ts