### PR TITLE
fix: correct gemini-cli skill path configuration

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -141,7 +141,7 @@ export const agents: Record<AgentType, AgentConfig> = {
   'gemini-cli': {
     name: 'gemini-cli',
     displayName: 'Gemini CLI',
-    skillsDir: '.agents/skills',
+    skillsDir: '.gemini/skills',
     globalSkillsDir: join(home, '.gemini/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.gemini'));


### PR DESCRIPTION
## Problem
Incorrect `skillsDir` configuration for gemini-cli causes skills to be installed in the wrong location, breaking Gemini CLI integration.

The current configuration uses `.agents/skills` (shared with other agents), which incorrectly classifies gemini-cli as a universal agent. This causes skills to be installed to `.agents/skills/` instead of `.gemini/skills/`, making them inaccessible to Gemini CLI.

## Solution
Update the gemini-cli agent configuration to use the correct skill paths per the [Gemini CLI documentation](https://geminicli.com/docs/cli/skills/):
- **Workspace skills**: `.gemini/skills/` (not `.agents/skills/`)
- **Global skills**: `~/.gemini/skills/` (correct)

## Changes
- Fix `skillsDir` from `.agents/skills` to `.gemini/skills` in `src/agents.ts`
- This ensures skills are installed to the correct location recognized by Gemini CLI

## Testing
- Verify skills are installed to `.gemini/skills/` in workspace
- Confirm Gemini CLI can discover and use installed skills