### PR TITLE
feat: support SSH git URL with optional ref

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -254,6 +254,17 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
+  // SSH git URL with optional ref: git@host:path#branch.git or git@host:path#branch or git@host:path
+  const sshGitMatch = input.match(/^git@([^:]+):([^#]+?)(?:\.git)?(?:#(.+?))?(?:\.git)?$/);
+  if (sshGitMatch) {
+    const [, host, repoPath, ref] = sshGitMatch;
+    return {
+      type: 'git',
+      url: `git@${host}:${repoPath}.git`,
+      ...(ref && { ref }),
+    };
+  }
+
   // Fallback: treat as direct git URL
   return {
     type: 'git',

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -198,6 +198,48 @@ describe('parseSource', () => {
       expect(result.url).toBe('git@github.com:owner/repo.git');
     });
 
+    it('Git URL - SSH format with ref', () => {
+      const result = parseSource('git@host:path#branch.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@host:path.git');
+      expect(result.ref).toBe('branch');
+    });
+
+    it('Git URL - SSH format with ref containing slashes', () => {
+      const result = parseSource('git@host:path#feature/branch.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@host:path.git');
+      expect(result.ref).toBe('feature/branch');
+    });
+
+    it('Git URL - SSH format without ref', () => {
+      const result = parseSource('git@host:path.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@host:path.git');
+      expect(result.ref).toBeUndefined();
+    });
+
+    it('Git URL - SSH format with ref after .git', () => {
+      const result = parseSource('git@host:path.git#branch');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@host:path.git');
+      expect(result.ref).toBe('branch');
+    });
+
+    it('Git URL - SSH format without .git suffix', () => {
+      const result = parseSource('git@host:path');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@host:path.git');
+      expect(result.ref).toBeUndefined();
+    });
+
+    it('Git URL - SSH format without .git suffix with ref', () => {
+      const result = parseSource('git@host:path#branch');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@host:path.git');
+      expect(result.ref).toBe('branch');
+    });
+
     it('Git URL - custom host', () => {
       const result = parseSource('https://git.example.com/owner/repo.git');
       expect(result.type).toBe('git');


### PR DESCRIPTION
This PR adds support for parsing SSH git URLs with optional branch/ref specification. Previously, SSH URLs like git@host:path#branch.git were not properly parsed to extract the ref.