### PR TITLE
feat: add Zenflow as a supported agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "trae-cn",
     "windsurf",
     "zencoder",
+    "zenflow",
     "neovate",
     "pochi",
     "adal"

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -346,6 +346,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.zencoder'));
     },
   },
+  zenflow: {
+    name: 'zenflow',
+    displayName: 'Zenflow',
+    skillsDir: '.zencoder/skills',
+    globalSkillsDir: join(home, '.zencoder/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.zencoder'));
+    },
+  },
   neovate: {
     name: 'neovate',
     displayName: 'Neovate',

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type AgentType =
   | 'trae-cn'
   | 'windsurf'
   | 'zencoder'
+  | 'zenflow'
   | 'pochi'
   | 'adal';
 


### PR DESCRIPTION
Adds **Zenflow** (part of the Zencoder ecosystem) as a supported agent.

Zenflow shares the same `.zencoder/skills/` directory for skill discovery, consistent with the [Zencoder docs](https://docs.zencoder.ai/features/skills).

### Changes
- Added `zenflow` to `AgentType` union in `src/types.ts`
- Added `zenflow` agent config in `src/agents.ts`
- Added `zenflow` keyword in `package.json`