### PR TITLE
feat: switch droid to universal .agents/skills configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Skills can be installed to any of these agents:
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
 | Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
 | Cursor | `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |
-| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
+| Droid | `droid` | `.agents/skills/` | `~/.agents/skills/` |
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
@@ -325,7 +325,7 @@ The CLI searches for skills in these locations within a repository:
 - `.continue/skills/`
 - `.crush/skills/`
 - `.cursor/skills/`
-- `.factory/skills/`
+
 - `.goose/skills/`
 - `.junie/skills/`
 - `.iflow/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -132,10 +132,10 @@ export const agents: Record<AgentType, AgentConfig> = {
   droid: {
     name: 'droid',
     displayName: 'Droid',
-    skillsDir: '.factory/skills',
-    globalSkillsDir: join(home, '.factory/skills'),
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.factory'));
+      return existsSync(join(home, '.factory')) || existsSync(join(home, '.agents'));
     },
   },
   'gemini-cli': {


### PR DESCRIPTION
This PR changes factory droid from using its unique `.factory/skills` directory to the universal `.agents/skills` configuration.

## Changes
- `skillsDir`: `.factory/skills` → `.agents/skills`
- `globalSkillsDir`: `~/.factory/skills` → `~/.agents/skills`
- `detectInstalled`: Now checks for both `~/.factory` (backward compatibility) and `~/.agents`
- Updated README documentation

Droid will now join other universal agents (Codex, GitHub Copilot, Gemini CLI, etc.) that share the common skill location.

cc @enoreyes