### PR TITLE
Move Goose to universal agent directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Skills can be installed to any of these agents:
 | Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
-| Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Goose | `goose` | `.agents/skills/` | `~/.config/goose/skills/` |
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -159,7 +159,7 @@ export const agents: Record<AgentType, AgentConfig> = {
   goose: {
     name: 'goose',
     displayName: 'Goose',
-    skillsDir: '.goose/skills',
+    skillsDir: '.agents/skills',
     globalSkillsDir: join(configHome, 'goose/skills'),
     detectInstalled: async () => {
       return existsSync(join(configHome, 'goose'));


### PR DESCRIPTION
This PR updates Goose to use the universal `.agents/skills` directory so it appears in the **Universal agents** group in `npx skills add`.

Goose already supports the shared universal skills directory, so this change aligns its configuration with other universal agents like Amp, Codex, and Copilot.

Also updates the README to keep documentation consistent with the CLI behavior.

### Reference
- https://block.github.io/goose/docs/guides/context-engineering/using-skills/#skill-locations
