### PR TITLE
feat: add --method flag to control installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ npx skills add ./my-local-skills
 | `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
+| `-m, --method <method>`   | Installation method: `symlink` (default) or `copy`                                                                                                 |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
 
 ### Examples
@@ -62,6 +63,9 @@ npx skills add vercel-labs/agent-skills -a claude-code -a opencode
 
 # Non-interactive installation (CI/CD friendly)
 npx skills add vercel-labs/agent-skills --skill frontend-design -g -a claude-code -y
+
+# Non-interactive installation with copy method
+npx skills add vercel-labs/agent-skills --skill frontend-design -g -a claude-code -y --method copy
 
 # Install all skills from a repo to all agents
 npx skills add vercel-labs/agent-skills --all

--- a/src/add.ts
+++ b/src/add.ts
@@ -325,6 +325,7 @@ export interface AddOptions {
   list?: boolean;
   all?: boolean;
   fullDepth?: boolean;
+  method?: 'symlink' | 'copy';
 }
 
 /**
@@ -483,9 +484,9 @@ async function handleRemoteSkill(
   }
 
   // Prompt for install mode (symlink vs copy)
-  let installMode: InstallMode = 'symlink';
+  let installMode: InstallMode = options.method ?? 'symlink';
 
-  if (!options.yes) {
+  if (!options.method && !options.yes) {
     const modeChoice = await p.select({
       message: 'Installation method',
       options: [
@@ -883,9 +884,9 @@ async function handleWellKnownSkills(
   }
 
   // Prompt for install mode (symlink vs copy)
-  let installMode: InstallMode = 'symlink';
+  let installMode: InstallMode = options.method ?? 'symlink';
 
-  if (!options.yes) {
+  if (!options.method && !options.yes) {
     const modeChoice = await p.select({
       message: 'Installation method',
       options: [
@@ -1257,7 +1258,7 @@ async function handleDirectUrlSkillLegacy(
   }
 
   // Use symlink mode by default for direct URL skills
-  const installMode: InstallMode = 'symlink';
+  const installMode: InstallMode = options.method ?? 'symlink';
   const cwd = process.cwd();
 
   // Check for overwrites (parallel)
@@ -1691,9 +1692,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Prompt for install mode (symlink vs copy)
-    let installMode: InstallMode = 'symlink';
+    let installMode: InstallMode = options.method ?? 'symlink';
 
-    if (!options.yes) {
+    if (!options.method && !options.yes) {
       const modeChoice = await p.select({
         message: 'Installation method',
         options: [
@@ -2103,6 +2104,12 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       i--; // Back up one since the loop will increment
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
+    } else if (arg === '-m' || arg === '--method') {
+      i++;
+      const value = args[i];
+      if (value === 'symlink' || value === 'copy') {
+        options.method = value;
+      }
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/add.ts
+++ b/src/add.ts
@@ -2105,10 +2105,12 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
     } else if (arg === '-m' || arg === '--method') {
-      i++;
-      const value = args[i];
-      if (value === 'symlink' || value === 'copy') {
-        options.method = value;
+      const nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith('-')) {
+        i++;
+        if (nextArg === 'symlink' || nextArg === 'copy') {
+          options.method = nextArg;
+        }
       }
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,7 @@ ${BOLD}Add Options:${RESET}
   -s, --skill <skills>   Specify skill names to install (use '*' for all skills)
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
+  -m, --method <method>  Installation method: 'symlink' (default) or 'copy'
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 


### PR DESCRIPTION
Adds a -m/--method flag that accepts 'symlink' or 'copy', allowing users to specify the installation method non-interactively.