### PR TITLE
support github enterprise server urls

### DIFF
--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -92,4 +92,154 @@ describe('source-parser', () => {
       });
     });
   });
+
+  describe('Custom GitHub Enterprise URLs (*.github.com and github.*.*)', () => {
+    it('parses shorthand without protocol: mycompany.github.com/org/repo', () => {
+      const result = parseSource('mycompany.github.com/org/repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://mycompany.github.com/org/repo.git',
+        ref: undefined,
+        subpath: undefined,
+      });
+    });
+
+    it('parses full URL: https://mycompany.github.com/org/repo', () => {
+      const result = parseSource('https://mycompany.github.com/org/repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://mycompany.github.com/org/repo.git',
+        ref: undefined,
+        subpath: undefined,
+      });
+    });
+
+    it('parses with tree/branch: mycompany.github.com/org/repo/tree/main', () => {
+      const result = parseSource('mycompany.github.com/org/repo/tree/main');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://mycompany.github.com/org/repo.git',
+        ref: 'main',
+        subpath: undefined,
+      });
+    });
+
+    it('parses with tree/branch/path: mycompany.github.com/org/repo/tree/main/skills', () => {
+      const result = parseSource('mycompany.github.com/org/repo/tree/main/skills');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://mycompany.github.com/org/repo.git',
+        ref: 'main',
+        subpath: 'skills',
+      });
+    });
+
+    it('parses with subpath (no tree): mycompany.github.com/org/repo/skills/my-skill', () => {
+      const result = parseSource('mycompany.github.com/org/repo/skills/my-skill');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://mycompany.github.com/org/repo.git',
+        subpath: 'skills/my-skill',
+      });
+    });
+
+    it('parses with @skill syntax: mycompany.github.com/org/repo@my-skill', () => {
+      const result = parseSource('mycompany.github.com/org/repo@my-skill');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://mycompany.github.com/org/repo.git',
+        skillFilter: 'my-skill',
+      });
+    });
+
+    it('parses with .git suffix: mycompany.github.com/org/repo.git', () => {
+      const result = parseSource('mycompany.github.com/org/repo.git');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://mycompany.github.com/org/repo.git',
+        ref: undefined,
+        subpath: undefined,
+      });
+    });
+
+    it('parses various subdomains: enterprise.github.com/team/project', () => {
+      const result = parseSource('enterprise.github.com/team/project');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://enterprise.github.com/team/project.git',
+        ref: undefined,
+        subpath: undefined,
+      });
+    });
+
+    it('does not match standard github.com as custom host', () => {
+      // Standard github.com should still work via the existing github.com patterns
+      const result = parseSource('github.com/owner/repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.com/owner/repo.git',
+      });
+    });
+
+    // GitHub Enterprise Server format: github.COMPANY.com
+    it('parses GHE Server URL: https://github.mycompany.com/org/repo', () => {
+      const result = parseSource('https://github.mycompany.com/org/repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.mycompany.com/org/repo.git',
+      });
+    });
+
+    it('parses GHE Server shorthand: github.mycompany.com/org/repo', () => {
+      const result = parseSource('github.mycompany.com/org/repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.mycompany.com/org/repo.git',
+      });
+    });
+
+    it('parses GHE Server with tree/branch/path: github.mycompany.com/org/repo/tree/main/skills', () => {
+      const result = parseSource('https://github.mycompany.com/org/repo/tree/main/skills');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.mycompany.com/org/repo.git',
+        ref: 'main',
+        subpath: 'skills',
+      });
+    });
+
+    it('parses GHE Server with @skill syntax: github.mycompany.com/org/repo@my-skill', () => {
+      const result = parseSource('github.mycompany.com/org/repo@my-skill');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.mycompany.com/org/repo.git',
+        skillFilter: 'my-skill',
+      });
+    });
+
+    it('parses GHE Server with subpath: github.mycompany.com/org/repo/path/to/skill', () => {
+      const result = parseSource('https://github.mycompany.com/org/repo/path/to/skill');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.mycompany.com/org/repo.git',
+        subpath: 'path/to/skill',
+      });
+    });
+
+    it('parses GHE Server with .git suffix: github.mycompany.com/org/repo.git', () => {
+      const result = parseSource('github.mycompany.com/org/repo.git');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.mycompany.com/org/repo.git',
+      });
+    });
+
+    it('parses GHE Server with different company domain: github.acme.com/team/project', () => {
+      const result = parseSource('https://github.acme.com/team/project');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.acme.com/team/project.git',
+      });
+    });
+  });
 });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -2,6 +2,19 @@ import { isAbsolute, resolve } from 'path';
 import type { ParsedSource } from './types.ts';
 
 /**
+ * Check if a hostname is a GitHub-like host.
+ * Matches: github.com, *.github.com (e.g., mycompany.github.com),
+ * and github.*.* (e.g., github.mycompany.com) for GitHub Enterprise Server.
+ */
+function isGitHubHost(hostname: string): boolean {
+  return (
+    hostname === 'github.com' ||
+    hostname.endsWith('.github.com') ||
+    (hostname.startsWith('github.') && hostname !== 'github.com')
+  );
+}
+
+/**
  * Extract owner/repo (or group/subgroup/repo for GitLab) from a parsed source
  * for lockfile tracking and telemetry.
  * Returns null for local paths or unparseable sources.
@@ -102,16 +115,22 @@ function isDirectSkillUrl(input: string): boolean {
     return false;
   }
 
-  // Exclude GitHub and GitLab repository URLs - they have their own handling
-  // (but allow raw.githubusercontent.com if someone wants to use it directly)
-  if (input.includes('github.com/') && !input.includes('raw.githubusercontent.com')) {
-    // Check if it's a blob/raw URL to SKILL.md (these should be handled by providers)
-    // vs a tree/repo URL (these should be cloned)
-    if (!input.includes('/blob/') && !input.includes('/raw/')) {
+  try {
+    const parsed = new URL(input);
+
+    // Exclude GitHub and GitLab repository URLs - they have their own handling
+    // (but allow raw.githubusercontent.com if someone wants to use it directly)
+    if (isGitHubHost(parsed.hostname) && !input.includes('raw.githubusercontent.com')) {
+      // Check if it's a blob/raw URL to SKILL.md (these should be handled by providers)
+      // vs a tree/repo URL (these should be cloned)
+      if (!input.includes('/blob/') && !input.includes('/raw/')) {
+        return false;
+      }
+    }
+    if (parsed.hostname === 'gitlab.com' && !input.includes('/-/raw/')) {
       return false;
     }
-  }
-  if (input.includes('gitlab.com/') && !input.includes('/-/raw/')) {
+  } catch {
     return false;
   }
 
@@ -139,6 +158,69 @@ export function parseSource(input: string): ParsedSource {
     return {
       type: 'direct-url',
       url: input,
+    };
+  }
+
+  // Custom GitHub Enterprise URLs
+  // Supports two hostname formats:
+  //   - *.github.com (e.g., mycompany.github.com)
+  //   - github.*.* (e.g., github.mycompany.com) - GitHub Enterprise Server
+  // Supports both full URLs (https://github.mycompany.com/...) and shorthand (github.mycompany.com/...)
+  // Must be checked BEFORE standard github.com patterns
+
+  // Custom GitHub host with @skill syntax: github.mycompany.com/org/repo@skill-name
+  // Must be checked FIRST before other custom GitHub patterns
+  const customGitHubAtSkillMatch = input.match(
+    /^(?:https?:\/\/)?([a-z0-9-]+\.github\.com|github\.[a-z0-9-]+\.[a-z]+)\/([^/]+)\/([^/@]+)@(.+)$/i
+  );
+  if (customGitHubAtSkillMatch) {
+    const [, hostname, owner, repo, skillFilter] = customGitHubAtSkillMatch;
+    return {
+      type: 'github',
+      url: `https://${hostname}/${owner}/${repo}.git`,
+      skillFilter,
+    };
+  }
+
+  // Custom GitHub host with tree/branch/path: github.mycompany.com/org/repo/tree/main/skills
+  const customGitHubTreeMatch = input.match(
+    /^(?:https?:\/\/)?([a-z0-9-]+\.github\.com|github\.[a-z0-9-]+\.[a-z]+)\/([^/]+)\/([^/]+)\/tree\/([^/]+)(?:\/(.+))?$/i
+  );
+  if (customGitHubTreeMatch) {
+    const [, hostname, owner, repoWithGit, ref, subpath] = customGitHubTreeMatch;
+    const repo = repoWithGit!.replace(/\.git$/, '');
+    return {
+      type: 'github',
+      url: `https://${hostname}/${owner}/${repo}.git`,
+      ref,
+      subpath,
+    };
+  }
+
+  // Custom GitHub host with subpath: github.mycompany.com/org/repo/path/to/skill
+  const customGitHubSubpathMatch = input.match(
+    /^(?:https?:\/\/)?([a-z0-9-]+\.github\.com|github\.[a-z0-9-]+\.[a-z]+)\/([^/]+)\/([^/]+)\/(.+)$/i
+  );
+  if (customGitHubSubpathMatch) {
+    const [, hostname, owner, repoWithGit, subpath] = customGitHubSubpathMatch;
+    const repo = repoWithGit!.replace(/\.git$/, '');
+    return {
+      type: 'github',
+      url: `https://${hostname}/${owner}/${repo}.git`,
+      subpath,
+    };
+  }
+
+  // Basic custom GitHub host: github.mycompany.com/org/repo
+  const customGitHubMatch = input.match(
+    /^(?:https?:\/\/)?([a-z0-9-]+\.github\.com|github\.[a-z0-9-]+\.[a-z]+)\/([^/]+)\/([^/]+)$/i
+  );
+  if (customGitHubMatch) {
+    const [, hostname, owner, repoWithGit] = customGitHubMatch;
+    const repo = repoWithGit!.replace(/\.git$/, '');
+    return {
+      type: 'github',
+      url: `https://${hostname}/${owner}/${repo}.git`,
     };
   }
 
@@ -282,6 +364,11 @@ function isWellKnownUrl(input: string): boolean {
       'raw.githubusercontent.com',
     ];
     if (excludedHosts.includes(parsed.hostname)) {
+      return false;
+    }
+
+    // Exclude custom GitHub hosts (*.github.com)
+    if (isGitHubHost(parsed.hostname)) {
       return false;
     }
 


### PR DESCRIPTION
## Support GitHub Enterprise Server URLs

Adds support for installing skills from GitHub Enterprise (GHE) instances, covering both hostname formats used in the wild:

- **`*.github.com`** — GitHub Enterprise Cloud with custom subdomain (e.g., `mycompany.github.com/org/repo`)
- **`github.*.*`** — GitHub Enterprise Server (e.g., `github.mycompany.com/org/repo`)

### Changes

**`src/source-parser.ts`**
- Added `isGitHubHost()` helper that recognizes `github.com`, `*.github.com`, and `github.*.*` hostnames
- Added 4 new URL parsing patterns in `parseSource()` for custom GitHub hosts — handling basic repos, tree/branch/path, subpaths, and `@skill` syntax
- Updated `isDirectSkillUrl()` to use proper URL parsing with `isGitHubHost()` instead of string matching, so GHE URLs aren't misclassified as direct skill URLs
- Updated `isWellKnownUrl()` to exclude GHE hosts from the well-known fallback path

**`src/source-parser.test.ts`**
- Added 17 tests covering both hostname formats: shorthand, full URLs, tree paths, subpaths, `@skill` syntax, `.git` suffix, and various company domains

### Example usage

```bash
# GitHub Enterprise Server (github.COMPANY.com)
npx skills add https://github.mycompany.com/org/repo
npx skills add github.mycompany.com/org/repo --skill my-skill

# GitHub Enterprise Cloud subdomain (COMPANY.github.com)
npx skills add https://mycompany.github.com/org/repo
npx skills add mycompany.github.com/org/repo/tree/main/skills
```
