### PR TITLE
fix: prevent namespace squatting via name-directory binding in skill discovery

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -401,24 +401,24 @@ describe('find-skills prompt with -y flag', () => {
   });
 
   it('should skip find-skills prompt when -y flag is passed', () => {
-    // Create a test skill
+    // Create a test skill (name must match directory to pass name-directory binding)
     const skillDir = join(testDir, 'test-skill');
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(
       join(skillDir, 'SKILL.md'),
       `---
-name: yes-flag-test-skill
+name: test-skill
 description: A test skill for -y flag testing
 ---
 
-# Yes Flag Test Skill
+# Test Skill
 
 This is a test skill for -y flag mode testing.
 `
     );
 
     // Run with -y flag - should complete without hanging
-    const result = runCli(['add', testDir, '-g', '-y', '--skill', 'yes-flag-test-skill'], testDir);
+    const result = runCli(['add', testDir, '-g', '-y', '--skill', 'test-skill'], testDir);
 
     // Should not contain the find-skills prompt
     expect(result.stdout).not.toContain('Install the find-skills skill');

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -402,23 +402,23 @@ describe('find-skills prompt with -y flag', () => {
 
   it('should skip find-skills prompt when -y flag is passed', () => {
     // Create a test skill (name must match directory to pass name-directory binding)
-    const skillDir = join(testDir, 'test-skill');
+    const skillDir = join(testDir, 'yes-flag-test-skill');
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(
       join(skillDir, 'SKILL.md'),
       `---
-name: test-skill
+name: yes-flag-test-skill
 description: A test skill for -y flag testing
 ---
 
-# Test Skill
+# Yes FlagTest Skill
 
 This is a test skill for -y flag mode testing.
 `
     );
 
     // Run with -y flag - should complete without hanging
-    const result = runCli(['add', testDir, '-g', '-y', '--skill', 'test-skill'], testDir);
+    const result = runCli(['add', testDir, '-g', '-y', '--skill', 'yes-flag-test-skill'], testDir);
 
     // Should not contain the find-skills prompt
     expect(result.stdout).not.toContain('Install the find-skills skill');

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -18,6 +18,9 @@ import type { WellKnownSkill } from './providers/wellknown.ts';
 import { agents, detectInstalledAgents, isUniversalAgent } from './agents.ts';
 import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
 import { parseSkillMd } from './skills.ts';
+import { sanitizeName } from './sanitize.ts';
+
+export { sanitizeName };
 
 export type InstallMode = 'symlink' | 'copy';
 
@@ -28,29 +31,6 @@ interface InstallResult {
   mode: InstallMode;
   symlinkFailed?: boolean;
   error?: string;
-}
-
-/**
- * Sanitizes a filename/directory name to prevent path traversal attacks
- * and ensures it follows kebab-case convention
- * @param name - The name to sanitize
- * @returns Sanitized name safe for use in file paths
- */
-export function sanitizeName(name: string): string {
-  const sanitized = name
-    .toLowerCase()
-    // Replace any sequence of characters that are NOT lowercase letters (a-z),
-    // digits (0-9), dots (.), or underscores (_) with a single hyphen.
-    // This converts spaces, special chars, and path traversal attempts (../) into hyphens.
-    .replace(/[^a-z0-9._]+/g, '-')
-    // Remove leading/trailing dots and hyphens to prevent hidden files (.) and
-    // ensure clean directory names. The pattern matches:
-    // - ^[.\-]+ : one or more dots or hyphens at the start
-    // - [.\-]+$ : one or more dots or hyphens at the end
-    .replace(/^[.\-]+|[.\-]+$/g, '');
-
-  // Limit to 255 chars (common filesystem limit), fallback to 'unnamed-skill' if empty
-  return sanitized.substring(0, 255) || 'unnamed-skill';
 }
 
 /**

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,22 @@
+/**
+ * Sanitizes a filename/directory name to prevent path traversal attacks
+ * and ensures it follows kebab-case convention
+ * @param name - The name to sanitize
+ * @returns Sanitized name safe for use in file paths
+ */
+export function sanitizeName(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    // Replace any sequence of characters that are NOT lowercase letters (a-z),
+    // digits (0-9), dots (.), or underscores (_) with a single hyphen.
+    // This converts spaces, special chars, and path traversal attempts (../) into hyphens.
+    .replace(/[^a-z0-9._]+/g, '-')
+    // Remove leading/trailing dots and hyphens to prevent hidden files (.) and
+    // ensure clean directory names. The pattern matches:
+    // - ^[.\-]+ : one or more dots or hyphens at the start
+    // - [.\-]+$ : one or more dots or hyphens at the end
+    .replace(/^[.\-]+|[.\-]+$/g, '');
+
+  // Limit to 255 chars (common filesystem limit), fallback to 'unnamed-skill' if empty
+  return sanitized.substring(0, 255) || 'unnamed-skill';
+}

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,8 +1,9 @@
 import { readdir, readFile, stat } from 'fs/promises';
-import { join, basename, dirname } from 'path';
+import { join, basename, dirname, resolve } from 'path';
 import matter from 'gray-matter';
 import type { Skill } from './types.ts';
 import { getPluginSkillPaths } from './plugin-manifest.ts';
+import { sanitizeName } from './sanitize.ts';
 
 const SKIP_DIRS = ['node_modules', '.git', 'dist', 'build', '__pycache__'];
 
@@ -27,7 +28,7 @@ async function hasSkillMd(dir: string): Promise<boolean> {
 
 export async function parseSkillMd(
   skillMdPath: string,
-  options?: { includeInternal?: boolean }
+  options?: { includeInternal?: boolean; basePath?: string }
 ): Promise<Skill | null> {
   try {
     const content = await readFile(skillMdPath, 'utf-8');
@@ -48,6 +49,22 @@ export async function parseSkillMd(
     const isInternal = data.metadata?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
+    }
+
+    // Validate name-directory binding to prevent namespace squatting.
+    // Only applies when basePath is provided (i.e., called from discoverSkills).
+    // Skip for root-level SKILL.md (where dirname is a temp clone directory).
+    if (options?.basePath) {
+      const dirName = basename(dirname(skillMdPath));
+      const isRootSkill = resolve(dirname(skillMdPath)) === resolve(options.basePath);
+
+      if (!isRootSkill && sanitizeName(data.name) !== sanitizeName(dirName)) {
+        console.warn(
+          `[skills] Warning: Skill at "${skillMdPath}" claims name "${data.name}" ` +
+            `but is in directory "${dirName}". Using directory name to prevent namespace squatting.`
+        );
+        data.name = dirName;
+      }
     }
 
     return {
@@ -99,15 +116,16 @@ export async function discoverSkills(
   options?: DiscoverSkillsOptions
 ): Promise<Skill[]> {
   const skills: Skill[] = [];
-  const seenNames = new Set<string>();
+  const seenNames = new Map<string, string>(); // name → path (for duplicate warnings)
   const searchPath = subpath ? join(basePath, subpath) : basePath;
+  const parseOptions = { ...options, basePath: searchPath };
 
   // If pointing directly at a skill, add it (and return early unless fullDepth is set)
   if (await hasSkillMd(searchPath)) {
-    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
+    const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), parseOptions);
     if (skill) {
       skills.push(skill);
-      seenNames.add(skill.name);
+      seenNames.set(skill.name, skill.path);
       // Only return early if fullDepth is not set
       if (!options?.fullDepth) {
         return skills;
@@ -160,10 +178,18 @@ export async function discoverSkills(
         if (entry.isDirectory()) {
           const skillDir = join(dir, entry.name);
           if (await hasSkillMd(skillDir)) {
-            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
-            if (skill && !seenNames.has(skill.name)) {
-              skills.push(skill);
-              seenNames.add(skill.name);
+            const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), parseOptions);
+            if (skill) {
+              if (seenNames.has(skill.name)) {
+                console.warn(
+                  `[skills] Warning: Duplicate skill name "${skill.name}".\n` +
+                    `  Accepted: ${seenNames.get(skill.name)}\n` +
+                    `  Skipped:  ${skill.path}`
+                );
+              } else {
+                skills.push(skill);
+                seenNames.set(skill.name, skill.path);
+              }
             }
           }
         }
@@ -178,10 +204,18 @@ export async function discoverSkills(
     const allSkillDirs = await findSkillDirs(searchPath);
 
     for (const skillDir of allSkillDirs) {
-      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
-      if (skill && !seenNames.has(skill.name)) {
-        skills.push(skill);
-        seenNames.add(skill.name);
+      const skill = await parseSkillMd(join(skillDir, 'SKILL.md'), parseOptions);
+      if (skill) {
+        if (seenNames.has(skill.name)) {
+          console.warn(
+            `[skills] Warning: Duplicate skill name "${skill.name}".\n` +
+              `  Accepted: ${seenNames.get(skill.name)}\n` +
+              `  Skipped:  ${skill.path}`
+          );
+        } else {
+          skills.push(skill);
+          seenNames.set(skill.name, skill.path);
+        }
       }
     }
   }
@@ -196,14 +230,29 @@ export function getSkillDisplayName(skill: Skill): string {
 /**
  * Filter skills based on user input (case-insensitive direct matching).
  * Multi-word skill names must be quoted on the command line.
+ * When multiple skills match, prefer those whose directory name matches the filter
+ * (defense-in-depth against namespace squatting).
  */
 export function filterSkills(skills: Skill[], inputNames: string[]): Skill[] {
   const normalizedInputs = inputNames.map((n) => n.toLowerCase());
 
-  return skills.filter((skill) => {
+  const matches = skills.filter((skill) => {
     const name = skill.name.toLowerCase();
     const displayName = getSkillDisplayName(skill).toLowerCase();
 
     return normalizedInputs.some((input) => input === name || input === displayName);
   });
+
+  // When multiple skills match, prefer those whose directory name matches the filter
+  if (matches.length > 1) {
+    const dirMatches = matches.filter((skill) => {
+      const dirName = sanitizeName(basename(skill.path));
+      return normalizedInputs.some((input) => sanitizeName(input) === dirName);
+    });
+    if (dirMatches.length > 0) {
+      return dirMatches;
+    }
+  }
+
+  return matches;
 }

--- a/tests/namespace-squatting.test.ts
+++ b/tests/namespace-squatting.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Security tests for namespace squatting vulnerability fix.
+ *
+ * These tests verify the mitigations against the namespace squatting attack
+ * where an attacker's SKILL.md claims a different skill name via YAML frontmatter
+ * to shadow a legitimate skill.
+ *
+ * See: github-issue-draft-namespace-squatting-vuln-long.md
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseSkillMd, discoverSkills, filterSkills } from '../src/skills.ts';
+import type { Skill } from '../src/types.ts';
+
+// Helper to create a SKILL.md with given frontmatter
+function createSkillMd(dir: string, name: string, description: string = 'A test skill'): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+Content here
+`
+  );
+}
+
+// Helper factory for Skill objects
+function makeSkill(name: string, path: string): Skill {
+  return { name, description: 'desc', path };
+}
+
+// ─── parseSkillMd: name-directory binding ─────────────────────────────────────
+
+describe('parseSkillMd name-directory validation', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-ns-squatting-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should override name when frontmatter name does not match directory', async () => {
+    // Attacker scenario: directory is "aaa-bird-fake" but claims name "bird"
+    createSkillMd(join(testDir, 'aaa-bird-fake'), 'bird');
+
+    const result = await parseSkillMd(join(testDir, 'aaa-bird-fake', 'SKILL.md'), {
+      basePath: testDir,
+    });
+    expect(result).not.toBeNull();
+    // After fix: name should be overridden to match the directory
+    expect(result!.name).toBe('aaa-bird-fake');
+  });
+
+  it('should keep name when frontmatter name matches directory exactly', async () => {
+    createSkillMd(join(testDir, 'bird'), 'bird');
+
+    const result = await parseSkillMd(join(testDir, 'bird', 'SKILL.md'), {
+      basePath: testDir,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('bird');
+  });
+
+  it('should keep original name when match after sanitization (case/spaces)', async () => {
+    // Legitimate case: directory is "my-skill" but frontmatter says "My Skill"
+    // sanitizeName("My Skill") === "my-skill" === sanitizeName("my-skill")
+    createSkillMd(join(testDir, 'my-skill'), 'My Skill');
+
+    const result = await parseSkillMd(join(testDir, 'my-skill', 'SKILL.md'), {
+      basePath: testDir,
+    });
+    expect(result).not.toBeNull();
+    // Original frontmatter name preserved since sanitized forms match
+    expect(result!.name).toBe('My Skill');
+  });
+
+  it('should skip name validation for root-level SKILL.md when basePath is provided', async () => {
+    // Root SKILL.md: dirname is the temp dir itself (e.g., /tmp/skills-xyz)
+    // which doesn't match the skill name — validation must be skipped
+    writeFileSync(
+      join(testDir, 'SKILL.md'),
+      `---
+name: my-awesome-skill
+description: Root level skill
+---
+
+# Root Skill
+`
+    );
+
+    const result = await parseSkillMd(join(testDir, 'SKILL.md'), { basePath: testDir });
+    expect(result).not.toBeNull();
+    // Name should be preserved since this is a root skill
+    expect(result!.name).toBe('my-awesome-skill');
+  });
+
+  it('should not validate name when basePath is not provided (backward compat)', async () => {
+    // Direct callers of parseSkillMd (e.g., listInstalledSkills) don't provide basePath
+    createSkillMd(join(testDir, 'some-dir'), 'different-name');
+
+    const result = await parseSkillMd(join(testDir, 'some-dir', 'SKILL.md'));
+    expect(result).not.toBeNull();
+    // Without basePath, original frontmatter name is kept
+    expect(result!.name).toBe('different-name');
+  });
+
+  it('should still validate name when basePath is provided but skill is not at root', async () => {
+    // Skill is in a subdirectory, not at basePath root
+    createSkillMd(join(testDir, 'skills', 'fake-bird'), 'bird');
+
+    const result = await parseSkillMd(join(testDir, 'skills', 'fake-bird', 'SKILL.md'), {
+      basePath: testDir,
+    });
+    expect(result).not.toBeNull();
+    // Should be overridden because fake-bird != bird
+    expect(result!.name).toBe('fake-bird');
+  });
+});
+
+// ─── discoverSkills: namespace squatting prevention ───────────────────────────
+
+describe('discoverSkills namespace squatting prevention', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-ns-discover-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should prevent attacker from shadowing legitimate skill', async () => {
+    // Attacker: directory "aaa-attacker-bird" claims name: bird
+    // Legitimate: directory "bird" claims name: bird
+    // After fix: attacker's skill name overridden to "aaa-attacker-bird"
+    createSkillMd(join(testDir, 'skills', 'aaa-attacker-bird'), 'bird', 'MALICIOUS');
+    createSkillMd(join(testDir, 'skills', 'bird'), 'bird', 'Legitimate bird skill');
+
+    const skills = await discoverSkills(testDir);
+
+    // Both skills should be present with distinct names
+    expect(skills).toHaveLength(2);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(['aaa-attacker-bird', 'bird']);
+
+    // The legitimate bird skill should have the correct description
+    const bird = skills.find((s) => s.name === 'bird');
+    expect(bird).toBeDefined();
+    expect(bird!.description).toBe('Legitimate bird skill');
+  });
+
+  it('should warn about duplicate skill names from different directories', async () => {
+    // Two skills in different priority directories with the same name
+    createSkillMd(join(testDir, 'skills', 'my-skill'), 'my-skill', 'First');
+    createSkillMd(join(testDir, '.claude', 'skills', 'my-skill'), 'my-skill', 'Second');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const skills = await discoverSkills(testDir);
+
+    // Only one should be included (deduplicated)
+    const mySkills = skills.filter((s) => s.name === 'my-skill');
+    expect(mySkills).toHaveLength(1);
+
+    // A warning should have been emitted
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate skill name'));
+
+    warnSpy.mockRestore();
+  });
+});
+
+// ─── filterSkills: directory name preference ──────────────────────────────────
+
+describe('filterSkills directory name preference', () => {
+  it('should prefer skill whose directory matches the filter when multiple share a name', () => {
+    // Two skills both named "bird" but in different directories
+    const skills: Skill[] = [
+      makeSkill('bird', '/repo/skills/aaa-fake-bird'),
+      makeSkill('bird', '/repo/skills/bird'),
+    ];
+
+    const result = filterSkills(skills, ['bird']);
+
+    // Should prefer the one whose directory is "bird"
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('/repo/skills/bird');
+  });
+
+  it('should return all matches when no directory matches the filter', () => {
+    const skills: Skill[] = [
+      makeSkill('bird', '/repo/skills/dir-a'),
+      makeSkill('bird', '/repo/skills/dir-b'),
+    ];
+
+    const result = filterSkills(skills, ['bird']);
+
+    // No directory matches "bird", so return all
+    expect(result).toHaveLength(2);
+  });
+
+  it('should work normally for single-match scenarios', () => {
+    const skills: Skill[] = [
+      makeSkill('bird', '/repo/skills/bird'),
+      makeSkill('cat', '/repo/skills/cat'),
+    ];
+
+    const result = filterSkills(skills, ['bird']);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('bird');
+  });
+
+  it('should not regress: case-insensitive matching still works', () => {
+    const skills: Skill[] = [makeSkill('Bird', '/repo/skills/bird')];
+
+    const result = filterSkills(skills, ['bird']);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Bird');
+  });
+});

--- a/tests/namespace-squatting.test.ts
+++ b/tests/namespace-squatting.test.ts
@@ -5,7 +5,7 @@
  * where an attacker's SKILL.md claims a different skill name via YAML frontmatter
  * to shadow a legitimate skill.
  *
- * See: github-issue-draft-namespace-squatting-vuln-long.md
+ * See: https://github.com/vercel-labs/skills/issues/353
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -35,8 +35,6 @@ Content here
 function makeSkill(name: string, path: string): Skill {
   return { name, description: 'desc', path };
 }
-
-// ─── parseSkillMd: name-directory binding ─────────────────────────────────────
 
 describe('parseSkillMd name-directory validation', () => {
   let testDir: string;
@@ -160,8 +158,6 @@ Content here
   });
 });
 
-// ─── discoverSkills: namespace squatting prevention ───────────────────────────
-
 describe('discoverSkills namespace squatting prevention', () => {
   let testDir: string;
 
@@ -236,8 +232,6 @@ describe('discoverSkills namespace squatting prevention', () => {
     warnSpy.mockRestore();
   });
 });
-
-// ─── filterSkills: directory name preference ──────────────────────────────────
 
 describe('filterSkills directory name preference', () => {
   it('should prefer skill whose directory matches the filter when multiple share a name', () => {

--- a/tests/plugin-manifest-discovery.test.ts
+++ b/tests/plugin-manifest-discovery.test.ts
@@ -37,12 +37,12 @@ describe('discoverSkills with plugin manifests', () => {
       })
     );
 
-    // Create the skill
+    // Create the skill (name must match directory for name-directory binding)
     mkdirSync(join(testDir, 'plugins/test-plugin/skills/test-skill'), { recursive: true });
     writeFileSync(
       join(testDir, 'plugins/test-plugin/skills/test-skill/SKILL.md'),
       `---
-name: manifest-skill
+name: test-skill
 description: Skill discovered via manifest
 ---
 # Test
@@ -51,7 +51,7 @@ description: Skill discovered via manifest
 
     const skills = await discoverSkills(testDir);
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe('manifest-skill');
+    expect(skills[0].name).toBe('test-skill');
   });
 
   it('should respect metadata.pluginRoot', async () => {
@@ -74,7 +74,7 @@ description: Skill discovered via manifest
     writeFileSync(
       join(testDir, 'plugins/my-plugin/skills/my-skill/SKILL.md'),
       `---
-name: pluginroot-skill
+name: my-skill
 description: Test
 ---
 `
@@ -82,7 +82,7 @@ description: Test
 
     const skills = await discoverSkills(testDir);
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe('pluginroot-skill');
+    expect(skills[0].name).toBe('my-skill');
   });
 
   it('should discover skills from plugin.json', async () => {
@@ -99,7 +99,7 @@ description: Test
     writeFileSync(
       join(testDir, 'skills/single-skill/SKILL.md'),
       `---
-name: single-plugin-skill
+name: single-skill
 description: Test
 ---
 `
@@ -107,7 +107,7 @@ description: Test
 
     const skills = await discoverSkills(testDir);
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe('single-plugin-skill');
+    expect(skills[0].name).toBe('single-skill');
   });
 
   it('should skip remote source objects', async () => {
@@ -521,7 +521,7 @@ description: Should not be found
     writeFileSync(
       join(testDir, 'valid-plugin/skills/skill2/SKILL.md'),
       `---
-name: valid-skill
+name: skill2
 description: Should be found
 ---
 `
@@ -529,7 +529,7 @@ description: Should be found
 
     const skills = await discoverSkills(testDir);
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe('valid-skill');
+    expect(skills[0].name).toBe('skill2');
   });
 
   it('should reject skill paths without ./ prefix', async () => {
@@ -571,7 +571,7 @@ description: Should be found - path has ./
     writeFileSync(
       join(testDir, 'skills/standard/SKILL.md'),
       `---
-name: standard-skill
+name: standard
 description: Standard location
 ---
 `
@@ -579,8 +579,8 @@ description: Standard location
 
     const skills = await discoverSkills(testDir);
     const names = skills.map((s) => s.name).sort();
-    // Should find: valid-skill (via valid manifest path) and standard-skill (via convention)
+    // Should find: valid-skill (via valid manifest path) and standard (via convention)
     // Should NOT find: bare-skill (manifest path lacks ./)
-    expect(names).toEqual(['standard-skill', 'valid-skill']);
+    expect(names).toEqual(['standard', 'valid-skill']);
   });
 });

--- a/tests/plugin-manifest-discovery.test.ts
+++ b/tests/plugin-manifest-discovery.test.ts
@@ -38,11 +38,11 @@ describe('discoverSkills with plugin manifests', () => {
     );
 
     // Create the skill (name must match directory for name-directory binding)
-    mkdirSync(join(testDir, 'plugins/test-plugin/skills/test-skill'), { recursive: true });
+    mkdirSync(join(testDir, 'plugins/test-plugin/skills/manifest-skill'), { recursive: true });
     writeFileSync(
-      join(testDir, 'plugins/test-plugin/skills/test-skill/SKILL.md'),
+      join(testDir, 'plugins/test-plugin/skills/manifest-skill/SKILL.md'),
       `---
-name: test-skill
+name: manifest-skill
 description: Skill discovered via manifest
 ---
 # Test
@@ -51,7 +51,7 @@ description: Skill discovered via manifest
 
     const skills = await discoverSkills(testDir);
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe('test-skill');
+    expect(skills[0].name).toBe('manifest-skill');
   });
 
   it('should respect metadata.pluginRoot', async () => {
@@ -70,9 +70,9 @@ description: Skill discovered via manifest
       })
     );
 
-    mkdirSync(join(testDir, 'plugins/my-plugin/skills/my-skill'), { recursive: true });
+    mkdirSync(join(testDir, 'plugins/my-plugin/skills/pluginroot-skill'), { recursive: true });
     writeFileSync(
-      join(testDir, 'plugins/my-plugin/skills/my-skill/SKILL.md'),
+      join(testDir, 'plugins/my-plugin/skills/pluginroot-skill/SKILL.md'),
       `---
 name: my-skill
 description: Test
@@ -82,7 +82,7 @@ description: Test
 
     const skills = await discoverSkills(testDir);
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe('my-skill');
+    expect(skills[0].name).toBe('pluginroot-skill');
   });
 
   it('should discover skills from plugin.json', async () => {
@@ -95,11 +95,11 @@ description: Test
       })
     );
 
-    mkdirSync(join(testDir, 'skills/single-skill'), { recursive: true });
+    mkdirSync(join(testDir, 'skills/single-plugin-skill'), { recursive: true });
     writeFileSync(
-      join(testDir, 'skills/single-skill/SKILL.md'),
+      join(testDir, 'skills/single-plugin-skill/SKILL.md'),
       `---
-name: single-skill
+name: single-plugin-skill
 description: Test
 ---
 `
@@ -107,7 +107,7 @@ description: Test
 
     const skills = await discoverSkills(testDir);
     expect(skills).toHaveLength(1);
-    expect(skills[0].name).toBe('single-skill');
+    expect(skills[0].name).toBe('single-plugin-skill');
   });
 
   it('should skip remote source objects', async () => {


### PR DESCRIPTION
## Summary

Fixes a critical namespace squatting vulnerability in skill discovery that allows attackers to shadow legitimate skills with malicious ones in community skill repositories.

- Enforces name-directory binding in `parseSkillMd()` — overrides YAML frontmatter `name:` when it doesn't match the containing directory name (after sanitization)
- Adds duplicate name detection with warnings in `discoverSkills()` — replaces silent first-match-wins dedup
- Adds directory-name preference in `filterSkills()` as defense-in-depth — when multiple skills match a filter, prefers skills whose directory matches the requested name
- Extracts `sanitizeName()` to `src/sanitize.ts` to avoid circular dependency between `skills.ts` and `installer.ts`

Resolve https://github.com/vercel-labs/skills/issues/353

## Motivation

The `npx skills add` command is vulnerable to a **namespace squatting attack** where:

1. An attacker submits a skill in a directory like `aaa-attacker/bird-fake/` with YAML frontmatter `name: bird` (matching a legitimate skill at `steipete/bird/`)
2. `discoverSkills()` deduplicates by frontmatter `name:` with first-match-wins, and filesystem traversal order (`readdir()`) typically processes alphabetically-earlier directories first
3. The attacker's skill silently shadows the legitimate one — the user sees no warning

**This vulnerability is being actively exploited in the wild.** As [reported on Reddit](https://www.reddit.com/r/openclaw/comments/1r2enjm/psa_openclaws_skills_are_compromised/), the `openclaw/skills` community repository contains 100+ malicious skill submissions from accounts including `sakaen736jih`, `gitgoodordietrying`, `dongsjoa-byte`, and others. Reported payloads include C2 callbacks, SSH key injection, and binary downloads.

### Root cause

Two design flaws combine to enable the attack:

| Flaw | Location | Description |
|------|----------|-------------|
| No name-directory binding | `parseSkillMd()` | YAML frontmatter `name:` is trusted without validation against the directory name |
| Silent first-match-wins dedup | `discoverSkills()` | Duplicate names are silently dropped based on filesystem traversal order |

## Changes

### 1. `parseSkillMd()` — name-directory binding (`src/skills.ts`)

Added an optional `basePath` parameter. When provided (from `discoverSkills`), compares `sanitizeName(data.name)` against `sanitizeName(basename(dirname(skillMdPath)))`. On mismatch, emits a warning and overrides the name to match the directory.

**Exceptions** (no false positives):
- **Root-level SKILL.md**: When `dirname(skillMdPath) === basePath` (e.g., a single-skill repo clone), validation is skipped since the dirname is a temp directory, not a skill identity
- **Legitimate case-mismatch**: `sanitizeName("My Skill") === "my-skill"` — the original frontmatter name is preserved when sanitized forms match
- **Direct callers without basePath**: `listInstalledSkills()` and other existing callers that don't pass `basePath` are unaffected (backward compatible)

### 2. `discoverSkills()` — duplicate detection (`src/skills.ts`)

- Changed `seenNames` from `Set<string>` to `Map<string, string>` (name → path) for tracking
- When a duplicate name is detected, emits a warning showing the accepted and skipped paths
- Passes `basePath: searchPath` to all `parseSkillMd()` calls to activate name-directory validation

This applies at all three dedup sites: root skill, priority directory search, and fallback recursive search.

### 3. `filterSkills()` — directory-name preference (`src/skills.ts`)

When multiple skills match a user's filter input, prefers those whose `basename(skill.path)` matches the input after sanitization. This is a defense-in-depth layer that resolves ambiguity in favor of the skill at the expected directory path.

### 4. `sanitizeName()` extraction (`src/sanitize.ts`)

Extracted `sanitizeName()` from `src/installer.ts` to a new `src/sanitize.ts` module. Both `skills.ts` and `installer.ts` now import from `sanitize.ts`. The original export from `installer.ts` is preserved via re-export for backward compatibility.

## How the fix neutralizes the attack

```
Before fix:
  aaa-attacker/bird-fake/SKILL.md  →  name: "bird"     ← attacker claims "bird"
  steipete/bird/SKILL.md           →  name: "bird"     ← legitimate, silently dropped
  User gets: attacker's skill installed as "bird"

After fix:
  aaa-attacker/bird-fake/SKILL.md  →  name: "bird-fake" ← overridden to match directory
  steipete/bird/SKILL.md           →  name: "bird"      ← accepted as legitimate
  User gets: legitimate skill installed as "bird"
```

## Test plan

Added `tests/namespace-squatting.test.ts` with 12 test cases across 3 describe blocks:

**`parseSkillMd` name-directory validation (6 tests)**
- [x] Overrides name when frontmatter name doesn't match directory
- [x] Keeps name when frontmatter matches directory exactly
- [x] Keeps original name when match after sanitization (case/spaces)
- [x] Skips validation for root-level SKILL.md (basePath)
- [x] No validation when basePath not provided (backward compat)
- [x] Validates non-root skill even when basePath is provided

**`discoverSkills` namespace squatting prevention (2 tests)**
- [x] Prevents attacker from shadowing legitimate skill (end-to-end)
- [x] Warns about duplicate skill names from different directories

**`filterSkills` directory name preference (4 tests)**
- [x] Prefers directory-matching skill when multiple share a name
- [x] Returns all matches when no directory matches the filter
- [x] Works normally for single-match scenarios
- [x] Case-insensitive matching regression test

Updated existing tests that relied on name-directory mismatches:
- `tests/plugin-manifest-discovery.test.ts` — 5 test cases updated to use consistent name-directory bindings
- `src/add.test.ts` — 1 test case updated for consistent naming

**All 299 applicable tests pass.**

## Files changed

| File | Lines | Description |
|------|-------|-------------|
| `src/sanitize.ts` | +22 | New module: extracted `sanitizeName()` |
| `src/skills.ts` | +77 −17 | Core fix: name-directory binding, duplicate detection, dir preference |
| `src/installer.ts` | +3 −26 | Import + re-export `sanitizeName` from `sanitize.ts` |
| `tests/namespace-squatting.test.ts` | +233 | New: security fix test suite |
| `tests/plugin-manifest-discovery.test.ts` | +12 −12 | Updated for name-directory consistency |
| `src/add.test.ts` | +4 −4 | Updated for name-directory consistency |

## Security considerations

- **No breaking changes for legitimate skills**: Skills where `name` matches the directory (or matches after sanitization) are unaffected
- **Backward compatible**: Callers of `parseSkillMd()` that don't pass `basePath` (e.g., `listInstalledSkills()`) retain original behavior
- **Defense-in-depth**: Three independent layers — name binding, duplicate warnings, and filter preference — each individually breaks the exploit chain
- **Warning, not rejection**: Mismatched skills are still installed (under the directory name) rather than silently dropped, maintaining availability while removing the attacker's ability to impersonate

## Related

- Reddit disclosure: [PSA: OpenClaw's skills are compromised!](https://www.reddit.com/r/openclaw/comments/1r2enjm/psa_openclaws_skills_are_compromised/)
- Affected community repository: [`openclaw/skills`](https://github.com/openclaw/skills)