### PR TITLE
fix: typo available-agents -> supported-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [35 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [35 more](#supported-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill


### PR DESCRIPTION
The correct anchor is #supported-agents, so I have changed the link from available-agents -> supported-agents