### PR TITLE
Account for special coinbase case

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -122,7 +122,18 @@ function isDirectSkillUrl(input: string): boolean {
  * Parse a source string into a structured format
  * Supports: local paths, GitHub URLs, GitLab URLs, GitHub shorthand, direct skill.md URLs, and direct git URLs
  */
+// Source aliases: map common shorthand to canonical source
+const SOURCE_ALIASES: Record<string, string> = {
+  'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
+};
+
 export function parseSource(input: string): ParsedSource {
+  // Resolve source aliases before parsing
+  const alias = SOURCE_ALIASES[input];
+  if (alias) {
+    input = alias;
+  }
+
   // Local path: absolute, relative, or current directory
   if (isLocalPath(input)) {
     const resolvedPath = resolve(input);

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -315,3 +315,11 @@ describe('getOwnerRepo', () => {
     expect(getOwnerRepo(parsed)).toBe('division/team/repo');
   });
 });
+
+describe('Source aliases', () => {
+  it('resolves coinbase/agentWallet to coinbase/agentic-wallet-skills', () => {
+    const result = parseSource('coinbase/agentWallet');
+    expect(result.type).toBe('github');
+    expect(result.url).toBe('https://github.com/coinbase/agentic-wallet-skills.git');
+  });
+});


### PR DESCRIPTION
typo in this tweet: https://x.com/coinbasedev/status/2021647661871640726?s=46

should be coinbase/agentic-wallet-skills