### PR TITLE
feat: add skills agents command to sync AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,11 @@ This file provides guidance to AI coding agents working on the `skills` CLI code
 | `skills init [name]` | Create a new SKILL.md template                      |
 | `skills add <pkg>`   | Install skills from git repos, URLs, or local paths |
 | `skills list`        | List installed skills (alias: `ls`)                 |
+| `skills agents`      | Sync installed skills into project AGENTS.md        |
 | `skills check`       | Check for available skill updates                   |
 | `skills update`      | Update all skills to latest versions                |
 
-Aliases: `skills a`, `skills i`, `skills install` all work for `add`. `skills ls` works for `list`.
+Aliases: `skills a`, `skills i`, `skills install` all work for `add`. `skills ls` works for `list`. `skills sync-agents` works for `agents`.
 
 ## Architecture
 
@@ -29,6 +30,8 @@ src/
 ├── add.test.ts      # Add command tests
 ├── list.ts          # List installed skills command
 ├── list.test.ts     # List command tests
+├── agents-md.ts     # Sync installed skills into AGENTS.md
+├── agents-md.test.ts # Tests for AGENTS.md sync command
 ├── agents.ts        # Agent definitions and detection
 ├── installer.ts     # Skill installation logic (symlink/copy) + listInstalledSkills
 ├── skills.ts        # Skill discovery and parsing

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ When installing interactively, you can choose:
 | Command                      | Description                                             |
 | ---------------------------- | ------------------------------------------------------- |
 | `npx skills list`            | List installed skills (alias: `ls`)                     |
+| `npx skills agents`          | Sync installed skills (name + description) into AGENTS.md |
 | `npx skills find [query]`    | Search for skills interactively or by keyword           |
 | `npx skills remove [skills]` | Remove installed skills from agents                     |
 | `npx skills check`           | Check for available skill updates                       |
@@ -113,6 +114,18 @@ npx skills ls -g
 
 # Filter by specific agents
 npx skills ls -a claude-code -a cursor
+```
+
+### `skills agents`
+
+Update or create a managed skills section in the project `AGENTS.md` file with a table of installed skills and descriptions.
+
+```bash
+# Sync project skills into AGENTS.md
+npx skills agents
+
+# Sync global skills into AGENTS.md
+npx skills agents -g
 ```
 
 ### `skills find`

--- a/src/agents-md.test.ts
+++ b/src/agents-md.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseAgentsOptions } from './agents-md.ts';
+import { runCliOutput } from './test-utils.ts';
+
+function createProjectSkill(
+  testDir: string,
+  folderName: string,
+  skillName: string,
+  description: string
+): void {
+  const skillDir = join(testDir, '.agents', 'skills', folderName);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---
+name: ${skillName}
+description: ${description}
+---
+
+# ${skillName}
+`
+  );
+}
+
+describe('agents command', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-agents-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('parseAgentsOptions', () => {
+    it('should parse --global and -g', () => {
+      expect(parseAgentsOptions(['--global'])).toEqual({ global: true });
+      expect(parseAgentsOptions(['-g'])).toEqual({ global: true });
+      expect(parseAgentsOptions([])).toEqual({});
+    });
+  });
+
+  it('should create AGENTS.md and add managed skills section', () => {
+    createProjectSkill(
+      testDir,
+      'project-skill',
+      'project-skill',
+      'A project skill description for AGENTS.md'
+    );
+
+    const output = runCliOutput(['agents'], testDir);
+    expect(output).toContain('Updated AGENTS.md with 1 project skill(s).');
+
+    const agentsMdPath = join(testDir, 'AGENTS.md');
+    expect(existsSync(agentsMdPath)).toBe(true);
+
+    const content = readFileSync(agentsMdPath, 'utf-8');
+    expect(content).toContain('# AGENTS.md');
+    expect(content).toContain('<!-- skills:agents:start -->');
+    expect(content).toContain('<!-- skills:agents:end -->');
+    expect(content).toContain('| Skill | Description |');
+    expect(content).toContain('| `project-skill` | A project skill description for AGENTS.md |');
+  });
+
+  it('should update an existing managed section without touching surrounding content', () => {
+    createProjectSkill(testDir, 'my-skill', 'my-skill', 'Fresh description');
+
+    const agentsMdPath = join(testDir, 'AGENTS.md');
+    writeFileSync(
+      agentsMdPath,
+      `# AGENTS.md
+
+Custom intro.
+
+<!-- skills:agents:start -->
+## Skills
+
+Old managed content
+<!-- skills:agents:end -->
+
+Custom footer.
+`
+    );
+
+    runCliOutput(['agents'], testDir);
+
+    const content = readFileSync(agentsMdPath, 'utf-8');
+    expect(content).toContain('Custom intro.');
+    expect(content).toContain('Custom footer.');
+    expect(content).not.toContain('Old managed content');
+    expect(content.match(/<!-- skills:agents:start -->/g)?.length).toBe(1);
+    expect(content.match(/<!-- skills:agents:end -->/g)?.length).toBe(1);
+    expect(content).toContain('| `my-skill` | Fresh description |');
+  });
+
+  it('should append a managed section when AGENTS.md exists without markers', () => {
+    createProjectSkill(testDir, 'app-skill', 'app-skill', 'App skill description');
+
+    const agentsMdPath = join(testDir, 'AGENTS.md');
+    writeFileSync(
+      agentsMdPath,
+      `# AGENTS.md
+
+Project-specific instructions.
+`
+    );
+
+    runCliOutput(['agents'], testDir);
+
+    const content = readFileSync(agentsMdPath, 'utf-8');
+    expect(content).toContain('Project-specific instructions.');
+    expect(content).toContain('<!-- skills:agents:start -->');
+    expect(content).toContain('<!-- skills:agents:end -->');
+    expect(content).toContain('| `app-skill` | App skill description |');
+  });
+});

--- a/src/agents-md.ts
+++ b/src/agents-md.ts
@@ -1,0 +1,116 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { listInstalledSkills, type InstalledSkill } from './installer.ts';
+
+const RESET = '\x1b[0m';
+const DIM = '\x1b[38;5;102m';
+const TEXT = '\x1b[38;5;145m';
+
+const MANAGED_SECTION_START = '<!-- skills:agents:start -->';
+const MANAGED_SECTION_END = '<!-- skills:agents:end -->';
+
+interface AgentsOptions {
+  global?: boolean;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|').trim();
+}
+
+function renderSkillTable(skills: InstalledSkill[]): string[] {
+  const sorted = [...skills].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  );
+
+  const lines = ['| Skill | Description |', '| --- | --- |'];
+
+  for (const skill of sorted) {
+    const skillName = escapeTableCell(skill.name).replace(/`/g, '\\`');
+    const description = escapeTableCell(skill.description);
+    lines.push(`| \`${skillName}\` | ${description} |`);
+  }
+
+  return lines;
+}
+
+function renderManagedSection(skills: InstalledSkill[], global: boolean): string {
+  const scopeLabel = global ? 'global' : 'project';
+  const lines = [
+    '## Skills',
+    '',
+    `This section is managed by \`npx skills agents\`. It lists installed ${scopeLabel} skills and descriptions.`,
+    '',
+  ];
+
+  if (skills.length === 0) {
+    lines.push(
+      `No installed ${scopeLabel} skills found. Install one with \`npx skills add <package>\` and re-run this command.`
+    );
+    lines.push('');
+  } else {
+    lines.push(...renderSkillTable(skills));
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function upsertManagedSection(content: string, sectionBody: string): string {
+  const managedBlock = `${MANAGED_SECTION_START}\n${sectionBody}\n${MANAGED_SECTION_END}`;
+  const sectionRegex = new RegExp(
+    `${escapeRegExp(MANAGED_SECTION_START)}[\\s\\S]*?${escapeRegExp(MANAGED_SECTION_END)}`,
+    'm'
+  );
+
+  if (sectionRegex.test(content)) {
+    return content.replace(sectionRegex, managedBlock);
+  }
+
+  const trimmed = content.trimEnd();
+  if (trimmed.length === 0) {
+    return `${managedBlock}\n`;
+  }
+
+  return `${trimmed}\n\n${managedBlock}\n`;
+}
+
+export function parseAgentsOptions(args: string[]): AgentsOptions {
+  const options: AgentsOptions = {};
+
+  for (const arg of args) {
+    if (arg === '-g' || arg === '--global') {
+      options.global = true;
+    }
+  }
+
+  return options;
+}
+
+export async function runAgents(args: string[]): Promise<void> {
+  const options = parseAgentsOptions(args);
+  const global = options.global === true;
+  const cwd = process.cwd();
+  const agentsMdPath = join(cwd, 'AGENTS.md');
+
+  const installedSkills = await listInstalledSkills({ global, cwd });
+  const managedSection = renderManagedSection(installedSkills, global);
+
+  const currentContent = existsSync(agentsMdPath)
+    ? readFileSync(agentsMdPath, 'utf-8')
+    : '# AGENTS.md\n';
+  const nextContent = upsertManagedSection(currentContent, managedSection);
+
+  writeFileSync(agentsMdPath, nextContent, 'utf-8');
+
+  const scopeLabel = global ? 'global' : 'project';
+  console.log(
+    `${TEXT}Updated AGENTS.md with ${installedSkills.length} ${scopeLabel} skill(s).${RESET}`
+  );
+  console.log(
+    `${DIM}Run this again after installing/removing skills to refresh the section.${RESET}`
+  );
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { runCliOutput, stripLogo, hasLogo } from './test-utils.ts';
 
 describe('skills CLI', () => {
@@ -11,6 +12,7 @@ describe('skills CLI', () => {
       expect(output).toContain('Commands:');
       expect(output).toContain('init [name]');
       expect(output).toContain('add <package>');
+      expect(output).toContain('agents');
       expect(output).toContain('check');
       expect(output).toContain('update');
       expect(output).toContain('Add Options:');
@@ -49,6 +51,7 @@ describe('skills CLI', () => {
       const output = stripLogo(runCliOutput([]));
       expect(output).toContain('The open agent skills ecosystem');
       expect(output).toContain('npx skills add');
+      expect(output).toContain('npx skills agents');
       expect(output).toContain('npx skills check');
       expect(output).toContain('npx skills update');
       expect(output).toContain('npx skills init');
@@ -84,5 +87,15 @@ describe('skills CLI', () => {
       const output = runCliOutput(['update']);
       expect(hasLogo(output)).toBe(false);
     }, 60000);
+
+    it('should not display logo for agents command', () => {
+      const testDir = mkdtempSync(join(tmpdir(), 'skills-cli-agents-logo-test-'));
+      try {
+        const output = runCliOutput(['agents'], testDir);
+        expect(hasLogo(output)).toBe(false);
+      } finally {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url';
 import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
 import { runFind } from './find.ts';
 import { runList } from './list.ts';
+import { runAgents } from './agents-md.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
@@ -72,6 +73,9 @@ function showBanner(): void {
     `  ${DIM}$${RESET} ${TEXT}npx skills list${RESET}            ${DIM}List installed skills${RESET}`
   );
   console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills agents${RESET}          ${DIM}Sync installed skills to AGENTS.md${RESET}`
+  );
+  console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills find ${DIM}[query]${RESET}    ${DIM}Search for skills${RESET}`
   );
   console.log(
@@ -103,6 +107,7 @@ ${BOLD}Commands:${RESET}
                          https://github.com/vercel-labs/agent-skills
   remove [skills]   Remove installed skills
   list, ls          List installed skills
+  agents            Sync installed skills to AGENTS.md
   find [query]      Search for skills interactively
   init [name]       Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
   check             Check for available skill updates
@@ -128,6 +133,9 @@ ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
   -a, --agent <agents>   Filter by specific agents
 
+${BOLD}Agents Options:${RESET}
+  -g, --global           Use global skills instead of project skills
+
 ${BOLD}Options:${RESET}
   --help, -h        Show this help message
   --version, -v     Show version number
@@ -143,6 +151,8 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills list                     ${DIM}# list all installed skills${RESET}
   ${DIM}$${RESET} skills ls -g                    ${DIM}# list global skills only${RESET}
   ${DIM}$${RESET} skills ls -a claude-code        ${DIM}# filter by agent${RESET}
+  ${DIM}$${RESET} skills agents                   ${DIM}# sync project skills into AGENTS.md${RESET}
+  ${DIM}$${RESET} skills agents -g                ${DIM}# sync global skills into AGENTS.md${RESET}
   ${DIM}$${RESET} skills find                     ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript          ${DIM}# search by keyword${RESET}
   ${DIM}$${RESET} skills init my-skill
@@ -598,6 +608,10 @@ async function main(): Promise<void> {
     case 'list':
     case 'ls':
       await runList(restArgs);
+      break;
+    case 'agents':
+    case 'sync-agents':
+      await runAgents(restArgs);
       break;
     case 'check':
       runCheck(restArgs);


### PR DESCRIPTION
## Summary
Purpose: emphasize available skills in `AGENTS.md`, since models are not yet good enough to pick up skills when they truly need them, but they are good at following `AGENTS.md` instructions; this can be removed once newer models are better trained at using skills.
- add a new `skills agents` command (alias: `skills sync-agents`) to sync installed skills into project `AGENTS.md`
- upsert a managed block in `AGENTS.md` containing a skills table (name + description)
- support `-g, --global` to sync global skills instead of project skills
- add command docs in `README.md` and project `AGENTS.md`
- add tests for create/update/upsert behavior and CLI help/banner coverage

## Testing
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `node scripts/validate-agents.ts`
