### PR TITLE
feat: add .skillignore support for filtering internal skills

### DIFF
--- a/src/skillignore.ts
+++ b/src/skillignore.ts
@@ -29,11 +29,14 @@ export function parseSkillIgnore(content: string): string[] {
  * Supports exact matches and trailing-wildcard patterns (e.g. "internal-*").
  */
 export function isSkillIgnored(skillName: string, patterns: string[]): boolean {
+  const normalizedSkillName = skillName.toLowerCase();
   return patterns.some((pattern) => {
-    if (pattern.endsWith('*')) {
-      return skillName.startsWith(pattern.slice(0, -1));
+    const normalizedPattern = pattern.toLowerCase();
+    if (normalizedPattern.endsWith('*')) {
+      const prefix = normalizedPattern.slice(0, -1);
+      return normalizedSkillName.startsWith(prefix);
     }
-    return skillName === pattern;
+    return normalizedSkillName === normalizedPattern;
   });
 }
 

--- a/src/skillignore.ts
+++ b/src/skillignore.ts
@@ -1,0 +1,51 @@
+/**
+ * .skillignore support for skill maintainers.
+ *
+ * A `.skillignore` file at the repo root lets maintainers hide internal skills
+ * from public discovery (e.g., validation scripts, prompt evals, scaffolding).
+ *
+ * Format (one pattern per line):
+ *   # comment
+ *   internal-tool        # exact match
+ *   test-*               # trailing wildcard
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+/**
+ * Parse a .skillignore file into an array of patterns.
+ * Blank lines and lines starting with # are ignored.
+ */
+export function parseSkillIgnore(content: string): string[] {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));
+}
+
+/**
+ * Check whether a skill name matches any of the ignore patterns.
+ * Supports exact matches and trailing-wildcard patterns (e.g. "internal-*").
+ */
+export function isSkillIgnored(skillName: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    if (pattern.endsWith('*')) {
+      return skillName.startsWith(pattern.slice(0, -1));
+    }
+    return skillName === pattern;
+  });
+}
+
+/**
+ * Try to read and parse a .skillignore file from the given directory.
+ * Returns an empty array if the file doesn't exist.
+ */
+export async function loadSkillIgnorePatterns(dir: string): Promise<string[]> {
+  try {
+    const content = await readFile(join(dir, '.skillignore'), 'utf-8');
+    return parseSkillIgnore(content);
+  } catch {
+    return [];
+  }
+}

--- a/src/skillignore.ts
+++ b/src/skillignore.ts
@@ -15,13 +15,16 @@ import { join } from 'path';
 
 /**
  * Parse a .skillignore file into an array of patterns.
- * Blank lines and lines starting with # are ignored.
+ * Blank lines and comments (everything from # onward) are ignored.
  */
 export function parseSkillIgnore(content: string): string[] {
   return content
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0 && !line.startsWith('#'));
+    .map((line) => {
+      const commentIndex = line.indexOf('#');
+      return (commentIndex === -1 ? line : line.slice(0, commentIndex)).trim();
+    })
+    .filter((line) => line.length > 0);
 }
 
 /**

--- a/src/skillignore.ts
+++ b/src/skillignore.ts
@@ -4,10 +4,10 @@
  * A `.skillignore` file at the repo root lets maintainers hide internal skills
  * from public discovery (e.g., validation scripts, prompt evals, scaffolding).
  *
- * Format (one pattern per line):
- *   # comment
- *   internal-tool        # exact match
- *   test-*               # trailing wildcard
+ * Format (one pattern per line, inline comments supported):
+ *   # full-line comment
+ *   internal-tool        # exact match by name
+ *   test-*               # trailing wildcard (matches any name starting with "test-")
  */
 
 import { readFile } from 'fs/promises';

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -187,10 +187,12 @@ export async function discoverSkills(
     }
   }
 
-  // Apply .skillignore filtering (read from repo root)
-  const ignorePatterns = await loadSkillIgnorePatterns(basePath);
-  if (ignorePatterns.length > 0) {
-    return skills.filter((skill) => !isSkillIgnored(skill.name, ignorePatterns));
+  // Apply .skillignore filtering (read from repo root), unless internal skills are explicitly requested
+  if (!options?.includeInternal) {
+    const ignorePatterns = await loadSkillIgnorePatterns(basePath);
+    if (ignorePatterns.length > 0) {
+      return skills.filter((skill) => !isSkillIgnored(skill.name, ignorePatterns));
+    }
   }
 
   return skills;

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -3,6 +3,7 @@ import { join, basename, dirname } from 'path';
 import matter from 'gray-matter';
 import type { Skill } from './types.ts';
 import { getPluginSkillPaths } from './plugin-manifest.ts';
+import { loadSkillIgnorePatterns, isSkillIgnored } from './skillignore.ts';
 
 const SKIP_DIRS = ['node_modules', '.git', 'dist', 'build', '__pycache__'];
 
@@ -184,6 +185,12 @@ export async function discoverSkills(
         seenNames.add(skill.name);
       }
     }
+  }
+
+  // Apply .skillignore filtering (read from repo root)
+  const ignorePatterns = await loadSkillIgnorePatterns(basePath);
+  if (ignorePatterns.length > 0) {
+    return skills.filter((skill) => !isSkillIgnored(skill.name, ignorePatterns));
   }
 
   return skills;

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -103,6 +103,9 @@ export async function discoverSkills(
   const seenNames = new Set<string>();
   const searchPath = subpath ? join(basePath, subpath) : basePath;
 
+  // Load .skillignore patterns once (used by early return and final filter)
+  const ignorePatterns = !options?.includeInternal ? await loadSkillIgnorePatterns(basePath) : [];
+
   // If pointing directly at a skill, add it (and return early unless fullDepth is set)
   if (await hasSkillMd(searchPath)) {
     const skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
@@ -111,6 +114,9 @@ export async function discoverSkills(
       seenNames.add(skill.name);
       // Only return early if fullDepth is not set
       if (!options?.fullDepth) {
+        if (ignorePatterns.length > 0) {
+          return skills.filter((s) => !isSkillIgnored(s.name, ignorePatterns));
+        }
         return skills;
       }
     }
@@ -187,12 +193,9 @@ export async function discoverSkills(
     }
   }
 
-  // Apply .skillignore filtering (read from repo root), unless internal skills are explicitly requested
-  if (!options?.includeInternal) {
-    const ignorePatterns = await loadSkillIgnorePatterns(basePath);
-    if (ignorePatterns.length > 0) {
-      return skills.filter((skill) => !isSkillIgnored(skill.name, ignorePatterns));
-    }
+  // Apply .skillignore filtering
+  if (ignorePatterns.length > 0) {
+    return skills.filter((skill) => !isSkillIgnored(skill.name, ignorePatterns));
   }
 
   return skills;

--- a/tests/skillignore.test.ts
+++ b/tests/skillignore.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for .skillignore support.
+ *
+ * Tests the parsing of .skillignore files and the pattern matching logic
+ * that hides internal skills from public discovery.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseSkillIgnore, isSkillIgnored, loadSkillIgnorePatterns } from '../src/skillignore.ts';
+
+describe('parseSkillIgnore', () => {
+  it('parses simple skill names', () => {
+    const result = parseSkillIgnore('internal-tool\ntest-runner');
+    expect(result).toEqual(['internal-tool', 'test-runner']);
+  });
+
+  it('ignores empty lines', () => {
+    const result = parseSkillIgnore('foo\n\nbar\n\n');
+    expect(result).toEqual(['foo', 'bar']);
+  });
+
+  it('ignores comment lines', () => {
+    const result = parseSkillIgnore('# This is a comment\nfoo\n# Another comment\nbar');
+    expect(result).toEqual(['foo', 'bar']);
+  });
+
+  it('trims whitespace from lines', () => {
+    const result = parseSkillIgnore('  foo  \n  bar  ');
+    expect(result).toEqual(['foo', 'bar']);
+  });
+
+  it('handles wildcard patterns', () => {
+    const result = parseSkillIgnore('internal-*\ntest-*');
+    expect(result).toEqual(['internal-*', 'test-*']);
+  });
+
+  it('returns empty array for empty content', () => {
+    expect(parseSkillIgnore('')).toEqual([]);
+  });
+
+  it('returns empty array for comments-only content', () => {
+    expect(parseSkillIgnore('# just comments\n# nothing else')).toEqual([]);
+  });
+});
+
+describe('isSkillIgnored', () => {
+  it('matches exact skill name', () => {
+    expect(isSkillIgnored('internal-tool', ['internal-tool'])).toBe(true);
+  });
+
+  it('does not match different skill name', () => {
+    expect(isSkillIgnored('public-skill', ['internal-tool'])).toBe(false);
+  });
+
+  it('matches trailing wildcard pattern', () => {
+    expect(isSkillIgnored('internal-tool', ['internal-*'])).toBe(true);
+    expect(isSkillIgnored('internal-eval', ['internal-*'])).toBe(true);
+  });
+
+  it('does not match wildcard when prefix differs', () => {
+    expect(isSkillIgnored('public-tool', ['internal-*'])).toBe(false);
+  });
+
+  it('matches against multiple patterns', () => {
+    const patterns = ['internal-*', 'test-*', 'scaffold'];
+    expect(isSkillIgnored('internal-tool', patterns)).toBe(true);
+    expect(isSkillIgnored('test-runner', patterns)).toBe(true);
+    expect(isSkillIgnored('scaffold', patterns)).toBe(true);
+    expect(isSkillIgnored('public-skill', patterns)).toBe(false);
+  });
+
+  it('returns false for empty patterns', () => {
+    expect(isSkillIgnored('any-skill', [])).toBe(false);
+  });
+
+  it('wildcard with empty prefix matches everything', () => {
+    expect(isSkillIgnored('anything', ['*'])).toBe(true);
+  });
+});
+
+describe('loadSkillIgnorePatterns', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skillignore-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('reads and parses .skillignore file', async () => {
+    writeFileSync(join(testDir, '.skillignore'), '# Internal tools\ninternal-*\ntest-runner\n');
+    const patterns = await loadSkillIgnorePatterns(testDir);
+    expect(patterns).toEqual(['internal-*', 'test-runner']);
+  });
+
+  it('returns empty array when file does not exist', async () => {
+    const patterns = await loadSkillIgnorePatterns(testDir);
+    expect(patterns).toEqual([]);
+  });
+
+  it('returns empty array for empty file', async () => {
+    writeFileSync(join(testDir, '.skillignore'), '');
+    const patterns = await loadSkillIgnorePatterns(testDir);
+    expect(patterns).toEqual([]);
+  });
+});

--- a/tests/skillignore.test.ts
+++ b/tests/skillignore.test.ts
@@ -10,6 +10,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { parseSkillIgnore, isSkillIgnored, loadSkillIgnorePatterns } from '../src/skillignore.ts';
+import { discoverSkills } from '../src/skills.ts';
 
 describe('parseSkillIgnore', () => {
   it('parses simple skill names', () => {
@@ -113,5 +114,74 @@ describe('loadSkillIgnorePatterns', () => {
     writeFileSync(join(testDir, '.skillignore'), '');
     const patterns = await loadSkillIgnorePatterns(testDir);
     expect(patterns).toEqual([]);
+  });
+});
+
+// Helper to create a skill directory with a SKILL.md
+function createSkill(baseDir: string, name: string): void {
+  const dir = join(baseDir, 'skills', name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${name} description\n---\n\n# ${name}\n`
+  );
+}
+
+describe('discoverSkills with .skillignore', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skillignore-discover-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('filters out skills matching .skillignore patterns', async () => {
+    createSkill(testDir, 'public-skill');
+    createSkill(testDir, 'internal-tool');
+    createSkill(testDir, 'internal-eval');
+    writeFileSync(join(testDir, '.skillignore'), 'internal-*\n');
+
+    const skills = await discoverSkills(testDir);
+    const names = skills.map((s) => s.name);
+
+    expect(names).toEqual(['public-skill']);
+    expect(names).not.toContain('internal-tool');
+    expect(names).not.toContain('internal-eval');
+  });
+
+  it('returns all skills when no .skillignore exists', async () => {
+    createSkill(testDir, 'skill-a');
+    createSkill(testDir, 'skill-b');
+
+    const skills = await discoverSkills(testDir);
+    expect(skills).toHaveLength(2);
+  });
+
+  it('filters a directly-pointed skill via early return path', async () => {
+    // Root SKILL.md (triggers early return in discoverSkills)
+    writeFileSync(
+      join(testDir, 'SKILL.md'),
+      `---\nname: ignored-root\ndescription: Should be ignored\n---\n\n# Ignored\n`
+    );
+    writeFileSync(join(testDir, '.skillignore'), 'ignored-root\n');
+
+    const skills = await discoverSkills(testDir);
+    expect(skills).toHaveLength(0);
+  });
+
+  it('does not filter when includeInternal is set', async () => {
+    createSkill(testDir, 'public-skill');
+    createSkill(testDir, 'internal-tool');
+    writeFileSync(join(testDir, '.skillignore'), 'internal-tool\n');
+
+    const skills = await discoverSkills(testDir, undefined, { includeInternal: true });
+    const names = skills.map((s) => s.name);
+
+    expect(names).toContain('internal-tool');
+    expect(names).toContain('public-skill');
   });
 });

--- a/tests/skillignore.test.ts
+++ b/tests/skillignore.test.ts
@@ -79,6 +79,11 @@ describe('isSkillIgnored', () => {
   it('wildcard with empty prefix matches everything', () => {
     expect(isSkillIgnored('anything', ['*'])).toBe(true);
   });
+
+  it('handles case differences between pattern and skill name', () => {
+    // Pattern has different casing than the skill name
+    expect(isSkillIgnored('internal-tool', ['Internal-Tool'])).toBe(true);
+  });
 });
 
 describe('loadSkillIgnorePatterns', () => {


### PR DESCRIPTION
Added .skillignore support plus test coverage (17 tests)

How it works:

1) discoverSkills() reads .skillignore from the repo root (basePath)
2) If patterns exist, skills matching those patterns are filtered out before returning
3) Supports exact names (internal-tool) and trailing wildcards (test-*)
4) Missing .skillignore is silently ignored — zero impact on repos without one
5) Works for --all, --list, interactive selection, and --skill '*' since filtering happens at discovery time

Example .skillignore:
```
# Hide internal tooling from public discovery
validation-scripts
prompt-eval-*
scaffold-template
```
