### PR TITLE
feat: add `skills doctor` command for agent diagnostics

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { homedir } from 'os';
 import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
+import { runDoctor } from './doctor.ts';
 import { runFind } from './find.ts';
 import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
@@ -86,6 +87,9 @@ function showBanner(): void {
   console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills init ${DIM}[name]${RESET}     ${DIM}Create a new skill${RESET}`
   );
+  console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills doctor${RESET}          ${DIM}Diagnose agent setup${RESET}`
+  );
   console.log();
   console.log(`${DIM}try:${RESET} npx skills add vercel-labs/agent-skills`);
   console.log();
@@ -107,6 +111,7 @@ ${BOLD}Commands:${RESET}
   init [name]       Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
   check             Check for available skill updates
   update            Update all skills to latest versions
+  doctor            Diagnose agent detection and paths
 
 ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
@@ -605,6 +610,9 @@ async function main(): Promise<void> {
     case 'update':
     case 'upgrade':
       runUpdate();
+      break;
+    case 'doctor':
+      await runDoctor(VERSION);
       break;
     case '--help':
     case '-h':

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,54 @@
+import os from 'node:os';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { agents, detectInstalledAgents } from './agents.ts';
+import type { AgentType } from './types.ts';
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[38;5;102m';
+const TEXT = '\x1b[38;5;145m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+
+export async function runDoctor(version: string): Promise<void> {
+  console.log(`\n${BOLD}Skills CLI Doctor${RESET}\n`);
+
+  // System environment
+  console.log(`${BOLD}System:${RESET}`);
+  console.log(`  OS:      ${TEXT}${os.type()} ${os.release()} (${os.arch()})${RESET}`);
+  console.log(`  Node:    ${TEXT}${process.version}${RESET}`);
+  console.log(`  Version: ${TEXT}${version}${RESET}`);
+  console.log();
+
+  // Agent detection
+  console.log(`${BOLD}Detected Agents:${RESET}`);
+  const detected = await detectInstalledAgents();
+
+  if (detected.length === 0) {
+    console.log(`  ${YELLOW}No supported agents detected on this system.${RESET}`);
+  } else {
+    for (const agentType of detected) {
+      const config = agents[agentType];
+      const projectPath = join(process.cwd(), config.skillsDir);
+      const globalPath = config.globalSkillsDir;
+      const hasProject = existsSync(projectPath);
+      const hasGlobal = globalPath ? existsSync(globalPath) : false;
+
+      console.log(`  ${GREEN}*${RESET} ${BOLD}${config.displayName}${RESET}`);
+      console.log(
+        `      Project: ${hasProject ? TEXT : DIM}${projectPath}${hasProject ? '' : ' (not found)'}${RESET}`
+      );
+      if (globalPath) {
+        console.log(
+          `      Global:  ${hasGlobal ? TEXT : DIM}${globalPath}${hasGlobal ? '' : ' (not found)'}${RESET}`
+        );
+      }
+    }
+  }
+
+  const totalAgents = Object.keys(agents).length;
+  console.log(
+    `\n${DIM}${detected.length}/${totalAgents} agents detected. Run 'skills list' to see installed skills.${RESET}\n`
+  );
+}

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for the `skills doctor` command.
+ *
+ * Verifies system info output and agent detection diagnostics.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runCliOutput, runCli } from '../src/test-utils.ts';
+
+describe('doctor command', () => {
+  it('should output system information', () => {
+    const output = runCliOutput(['doctor']);
+    expect(output).toContain('Skills CLI Doctor');
+    expect(output).toContain('System:');
+    expect(output).toContain('OS:');
+    expect(output).toContain('Node:');
+    expect(output).toContain('Version:');
+  });
+
+  it('should output agent detection section', () => {
+    const output = runCliOutput(['doctor']);
+    expect(output).toContain('Detected Agents:');
+    expect(output).toContain('agents detected');
+  });
+
+  it('should exit with code 0', () => {
+    const result = runCli(['doctor']);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('should not display the logo', () => {
+    const output = runCliOutput(['doctor']);
+    expect(output).not.toContain('███');
+  });
+
+  it('should show the current node version', () => {
+    const output = runCliOutput(['doctor']);
+    expect(output).toContain(process.version);
+  });
+});


### PR DESCRIPTION
Adds a diagnostic command that outputs system info (OS, Node, CLI version) and lists all detected agents with their resolved project/global paths. Helps users and maintainers quickly triage "skill not loading" issues.