### PR TITLE
fix: prefer ~/.openclaw path and align OpenClaw docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Skills can be installed to any of these agents:
 | Antigravity | `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
-| OpenClaw | `openclaw` | `skills/` | `~/.moltbot/skills/` |
+| OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
 | Cline | `cline` | `.cline/skills/` | `~/.cline/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
@@ -373,7 +373,7 @@ If no skills are found in standard locations, a recursive search is performed.
 Skills are generally compatible across agents since they follow a
 shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | Clawdbot | Neovate | Pi  | Qoder | Zencoder |
+| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
 | --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
 | Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
 | `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
@@ -423,7 +423,7 @@ Telemetry is automatically disabled in CI environments.
 - [Antigravity Skills Documentation](https://antigravity.google/docs/skills)
 - [Factory AI / Droid Skills Documentation](https://docs.factory.ai/cli/configuration/skills)
 - [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)
-- [Clawdbot Skills Documentation](https://docs.clawd.bot/tools/skills)
+- [OpenClaw Skills Documentation](https://docs.openclaw.ai/tools/skills)
 - [Cline Skills Documentation](https://docs.cline.bot/features/skills)
 - [CodeBuddy Skills Documentation](https://www.codebuddy.ai/docs/ide/Features/Skills)
 - [Codex Skills Documentation](https://developers.openai.com/codex/skills)

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -10,6 +10,22 @@ const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 
+export function getOpenClawGlobalSkillsDir(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  if (pathExists(join(homeDir, '.openclaw'))) {
+    return join(homeDir, '.openclaw/skills');
+  }
+  if (pathExists(join(homeDir, '.clawdbot'))) {
+    return join(homeDir, '.clawdbot/skills');
+  }
+  if (pathExists(join(homeDir, '.moltbot'))) {
+    return join(homeDir, '.moltbot/skills');
+  }
+  return join(homeDir, '.openclaw/skills');
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   amp: {
     name: 'amp',
@@ -53,11 +69,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'openclaw',
     displayName: 'OpenClaw',
     skillsDir: 'skills',
-    globalSkillsDir: existsSync(join(home, '.openclaw'))
-      ? join(home, '.openclaw/skills')
-      : existsSync(join(home, '.clawdbot'))
-        ? join(home, '.clawdbot/skills')
-        : join(home, '.moltbot/skills'),
+    globalSkillsDir: getOpenClawGlobalSkillsDir(),
     detectInstalled: async () => {
       return (
         existsSync(join(home, '.openclaw')) ||

--- a/tests/openclaw-paths.test.ts
+++ b/tests/openclaw-paths.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { getOpenClawGlobalSkillsDir } from '../src/agents.ts';
+
+describe('openclaw global path resolution', () => {
+  const home = '/tmp/home';
+
+  it('prefers ~/.openclaw when present', () => {
+    const exists = (path: string) =>
+      path === '/tmp/home/.openclaw' ||
+      path === '/tmp/home/.clawdbot' ||
+      path === '/tmp/home/.moltbot';
+    expect(getOpenClawGlobalSkillsDir(home, exists)).toBe('/tmp/home/.openclaw/skills');
+  });
+
+  it('falls back to ~/.clawdbot when ~/.openclaw is missing', () => {
+    const exists = (path: string) =>
+      path === '/tmp/home/.clawdbot' || path === '/tmp/home/.moltbot';
+    expect(getOpenClawGlobalSkillsDir(home, exists)).toBe('/tmp/home/.clawdbot/skills');
+  });
+
+  it('falls back to ~/.moltbot when only legacy path exists', () => {
+    const exists = (path: string) => path === '/tmp/home/.moltbot';
+    expect(getOpenClawGlobalSkillsDir(home, exists)).toBe('/tmp/home/.moltbot/skills');
+  });
+
+  it('defaults to ~/.openclaw when no known path exists', () => {
+    expect(getOpenClawGlobalSkillsDir(home, () => false)).toBe('/tmp/home/.openclaw/skills');
+  });
+});


### PR DESCRIPTION
## Summary
- fix OpenClaw global skills directory resolution to prefer `~/.openclaw/skills`
- keep legacy fallback support for `~/.clawdbot/skills` then `~/.moltbot/skills`
- default to `~/.openclaw/skills` when none of the legacy directories exist
- update README OpenClaw path, naming, and docs link
- add regression tests for OpenClaw path precedence and fallback behavior

## Validation
- `pnpm test tests/openclaw-paths.test.ts tests/xdg-config-paths.test.ts`

## Notes
- preserves backward compatibility for existing users with legacy config directories
