### PR TITLE
feat: add fuzzy search to skill selection prompts

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -181,24 +181,6 @@ function buildResultLines(
 }
 
 /**
- * Wrapper around p.multiselect that adds a hint for keyboard usage.
- * Accepts options with required labels (matching our usage pattern).
- */
-function multiselect<Value>(opts: {
-  message: string;
-  options: Array<{ value: Value; label: string; hint?: string }>;
-  initialValues?: Value[];
-  required?: boolean;
-}) {
-  return p.multiselect({
-    ...opts,
-    // Cast is safe: our options always have labels, which satisfies p.Option requirements
-    options: opts.options as p.Option<Value>[],
-    message: `${opts.message} ${pc.dim('(space to toggle)')}`,
-  }) as Promise<Value[] | symbol>;
-}
-
-/**
  * Prompts the user to select agents using interactive search.
  * Pre-selects the last used agents if available.
  * Saves the selection for future use.
@@ -767,13 +749,13 @@ async function handleWellKnownSkills(
       hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
     }));
 
-    const selected = await multiselect({
+    const selected = await searchMultiselect({
       message: 'Select skills to install',
-      options: skillChoices,
+      items: skillChoices,
       required: true,
     });
 
-    if (p.isCancel(selected)) {
+    if (isCancelled(selected)) {
       p.cancel('Installation cancelled');
       process.exit(0);
     }
@@ -1571,13 +1553,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
       }));
 
-      const selected = await multiselect({
+      const selected = await searchMultiselect({
         message: 'Select skills to install',
-        options: skillChoices,
+        items: skillChoices,
         required: true,
       });
 
-      if (p.isCancel(selected)) {
+      if (isCancelled(selected)) {
         p.cancel('Installation cancelled');
         await cleanup(tempDir);
         process.exit(0);


### PR DESCRIPTION
Resolves #310.

Replace multiselect() with searchMultiselect() for skill selection, matching the existing agent selection UX. 