### PR TITLE
Add universal agent type for skills management

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -385,6 +385,14 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.adal'));
     },
   },
+  universal: {
+    name: 'universal',
+    displayName: 'Universal',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(configHome, 'agents/skills'),
+    showInUniversalList: false,
+    detectInstalled: async () => false,
+  },
 };
 
 export async function detectInstalledAgents(): Promise<AgentType[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,8 @@ export type AgentType =
   | 'windsurf'
   | 'zencoder'
   | 'pochi'
-  | 'adal';
+  | 'adal'
+  | 'universal';
 
 export interface Skill {
   name: string;


### PR DESCRIPTION
## Summary
Introduces a universal agent type to streamline skills management functionality, along with cleanup of third-party notices.

## Key Changes
- Added universal agent type definition in `src/agents.ts` for managing skills across different agent implementations
- Updated type exports in `src/types.ts` to support the new agent type
- Removed obsolete `ThirdPartyNoticeText.txt` file