### PR TITLE
feat: add support for git branch via ssh and shorthand URLs

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1995,7 +1995,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
-              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue);
+              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, parsed.ref);
               if (hash) skillFolderHash = hash;
             }
 

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -155,12 +155,14 @@ export function getGitHubToken(): string | null {
  *
  * @param ownerRepo - GitHub owner/repo (e.g., "vercel-labs/agent-skills")
  * @param skillPath - Path to skill folder or SKILL.md (e.g., "skills/react-best-practices/SKILL.md")
+ * @param ref - Optional git ref (branch/tag/commit)
  * @param token - Optional GitHub token for authenticated requests (higher rate limits)
  * @returns The tree SHA for the skill folder, or null if not found
  */
 export async function fetchSkillFolderHash(
   ownerRepo: string,
   skillPath: string,
+  ref?: string | null,
   token?: string | null
 ): Promise<string | null> {
   // Normalize to forward slashes first (for GitHub API compatibility)
@@ -178,7 +180,8 @@ export async function fetchSkillFolderHash(
     folderPath = folderPath.slice(0, -1);
   }
 
-  const branches = ['main', 'master'];
+  // Try the provided ref first, then fallback to common defaults
+  const branches = ref ? [ref, 'main', 'master'] : ['main', 'master'];
 
   for (const branch of branches) {
     try {

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -153,37 +153,59 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
+  // Handle SSH URLs or git URLs with #branch suffix
+  let fragmentRef: string | undefined;
+  if (input.includes('#')) {
+    const parts = input.split('#');
+    fragmentRef = parts.pop();
+    input = parts.join('#');
+  }
+
+  // Handle SSH URLs explicitly to avoid false positives in broad regexes
+  if (input.startsWith('git@') || input.startsWith('ssh://')) {
+    return {
+      type: 'git',
+      url: input,
+      ref: fragmentRef,
+    };
+  }
+
   // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
-  const githubTreeWithPathMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/);
+  const githubTreeWithPathMatch = input.match(
+    /^(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/
+  );
   if (githubTreeWithPathMatch) {
-    const [, owner, repo, ref, subpath] = githubTreeWithPathMatch;
+    const [, owner, repo, matchedRef, subpath] = githubTreeWithPathMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
-      ref,
+      url: `https://github.com/${owner}/${repo!.replace(/\.git$/, '')}.git`,
+      ref: fragmentRef || matchedRef,
       subpath,
     };
   }
 
   // GitHub URL with branch only: https://github.com/owner/repo/tree/branch
-  const githubTreeMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/);
+  const githubTreeMatch = input.match(
+    /^(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/
+  );
   if (githubTreeMatch) {
-    const [, owner, repo, ref] = githubTreeMatch;
+    const [, owner, repo, matchedRef] = githubTreeMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
-      ref,
+      url: `https://github.com/${owner}/${repo!.replace(/\.git$/, '')}.git`,
+      ref: fragmentRef || matchedRef,
     };
   }
 
   // GitHub URL: https://github.com/owner/repo
-  const githubRepoMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
+  const githubRepoMatch = input.match(/^(?:https?:\/\/)?github\.com\/([^/]+)\/([^/]+)/);
   if (githubRepoMatch) {
     const [, owner, repo] = githubRepoMatch;
     const cleanRepo = repo!.replace(/\.git$/, '');
     return {
       type: 'github',
       url: `https://github.com/${owner}/${cleanRepo}.git`,
+      ref: fragmentRef,
     };
   }
 
@@ -194,12 +216,12 @@ export function parseSource(input: string): ParsedSource {
     /^(https?):\/\/([^/]+)\/(.+?)\/-\/tree\/([^/]+)\/(.+)/
   );
   if (gitlabTreeWithPathMatch) {
-    const [, protocol, hostname, repoPath, ref, subpath] = gitlabTreeWithPathMatch;
+    const [, protocol, hostname, repoPath, matchedRef, subpath] = gitlabTreeWithPathMatch;
     if (hostname !== 'github.com' && repoPath) {
       return {
         type: 'gitlab',
         url: `${protocol}://${hostname}/${repoPath.replace(/\.git$/, '')}.git`,
-        ref,
+        ref: fragmentRef || matchedRef,
         subpath,
       };
     }
@@ -208,12 +230,12 @@ export function parseSource(input: string): ParsedSource {
   // GitLab URL with branch only (any GitLab instance): https://gitlab.com/owner/repo/-/tree/branch
   const gitlabTreeMatch = input.match(/^(https?):\/\/([^/]+)\/(.+?)\/-\/tree\/([^/]+)$/);
   if (gitlabTreeMatch) {
-    const [, protocol, hostname, repoPath, ref] = gitlabTreeMatch;
+    const [, protocol, hostname, repoPath, matchedRef] = gitlabTreeMatch;
     if (hostname !== 'github.com' && repoPath) {
       return {
         type: 'gitlab',
         url: `${protocol}://${hostname}/${repoPath.replace(/\.git$/, '')}.git`,
-        ref,
+        ref: fragmentRef || matchedRef,
       };
     }
   }
@@ -221,7 +243,7 @@ export function parseSource(input: string): ParsedSource {
   // GitLab.com URL: https://gitlab.com/owner/repo or https://gitlab.com/group/subgroup/repo
   // Only for the official gitlab.com domain for user convenience.
   // Supports nested subgroups (e.g., gitlab.com/group/subgroup1/subgroup2/repo).
-  const gitlabRepoMatch = input.match(/gitlab\.com\/(.+?)(?:\.git)?\/?$/);
+  const gitlabRepoMatch = input.match(/^(?:https?:\/\/)?gitlab\.com\/(.+?)(?:\.git)?\/?$/);
   if (gitlabRepoMatch) {
     const repoPath = gitlabRepoMatch[1]!;
     // Must have at least owner/repo (one slash)
@@ -229,6 +251,7 @@ export function parseSource(input: string): ParsedSource {
       return {
         type: 'gitlab',
         url: `https://gitlab.com/${repoPath}.git`,
+        ref: fragmentRef,
       };
     }
   }
@@ -243,6 +266,7 @@ export function parseSource(input: string): ParsedSource {
       type: 'github',
       url: `https://github.com/${owner}/${repo}.git`,
       skillFilter,
+      ref: fragmentRef,
     };
   }
 
@@ -253,6 +277,7 @@ export function parseSource(input: string): ParsedSource {
       type: 'github',
       url: `https://github.com/${owner}/${repo}.git`,
       subpath,
+      ref: fragmentRef,
     };
   }
 
@@ -269,6 +294,7 @@ export function parseSource(input: string): ParsedSource {
   return {
     type: 'git',
     url: input,
+    ref: fragmentRef,
   };
 }
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -161,6 +161,13 @@ describe('parseSource', () => {
       expect(result.url).toBe('https://github.com/vercel-labs/agent-skills.git');
       expect(result.skillFilter).toBe('find-skills');
     });
+
+    it('GitHub shorthand - owner/repo#branch', () => {
+      const result = parseSource('owner/repo#feature-branch');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.com/owner/repo.git');
+      expect(result.ref).toBe('feature-branch');
+    });
   });
 
   describe('Local path tests', () => {
@@ -196,6 +203,20 @@ describe('parseSource', () => {
       const result = parseSource('git@github.com:owner/repo.git');
       expect(result.type).toBe('git');
       expect(result.url).toBe('git@github.com:owner/repo.git');
+    });
+
+    it('Git URL - SSH format with branch', () => {
+      const result = parseSource('git@github.com:owner/repo.git#feature-branch');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@github.com:owner/repo.git');
+      expect(result.ref).toBe('feature-branch');
+    });
+
+    it('Git URL - SSH protocol with branch', () => {
+      const result = parseSource('ssh://git@github.com/owner/repo.git#feature-branch');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('ssh://git@github.com/owner/repo.git');
+      expect(result.ref).toBe('feature-branch');
     });
 
     it('Git URL - custom host', () => {


### PR DESCRIPTION
## Summary
Added support for pulling from specific git branches using the `#branch` suffix in SSH URLs and GitHub shorthand.

## Problem/Background
The CLI previously only supported branch selection for GitHub/GitLab HTTPS URLs formatted like `.../tree/branch`. Users could not specify a branch when using SSH URLs or shorthand syntax, which is essential for private repositories or specific development branches.

## Solution
- Updated `parseSource` to recognize the `#` fragment as a git ref (branch/tag/commit).
- Handled SSH and shorthand URLs to preserve the branch information.
- Updated `fetchSkillFolderHash` to use the specified branch when checking for updates on GitHub.
- Added comprehensive tests for SSH branch formats and shorthand branch formats.

## Testing
- [x] Added unit tests in `tests/source-parser.test.ts`
- [x] Verified with manual test script for various URL formats
- [x] Ran full test suite to ensure no regressions