### PR TITLE
feat(agents): add loaf agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Skills can be installed to any of these agents:
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
-| Loaf | `loaf` | `.agents/skills/` | `~/.loaf/skills/` |
+| Loaf | `loaf` | `.agents/skills/` | `~/.agents/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [37 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [38 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -231,6 +231,7 @@ Skills can be installed to any of these agents:
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
+| Loaf | `loaf` | `.agents/skills/` | `~/.loaf/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "kimi-cli",
     "kiro-cli",
     "kode",
+    "loaf",
     "mcpjam",
     "mistral-vibe",
     "mux",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -238,6 +238,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.kode'));
     },
   },
+  loaf: {
+    name: 'loaf',
+    displayName: 'Loaf',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.loaf/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.loaf'));
+    },
+  },
   mcpjam: {
     name: 'mcpjam',
     displayName: 'MCPJam',

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -242,7 +242,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'loaf',
     displayName: 'Loaf',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.loaf/skills'),
+    globalSkillsDir: join(home, '.agents/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.loaf'));
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type AgentType =
   | 'kimi-cli'
   | 'kiro-cli'
   | 'kode'
+  | 'loaf'
   | 'mcpjam'
   | 'mistral-vibe'
   | 'mux'


### PR DESCRIPTION
## Summary
Add `loaf` as a supported agent in the Skills CLI installer.

## Changes
- add `loaf` to `AgentType`
- add Loaf agent config:
  - project path: `.agents/skills`
  - global path: `~/.loaf/skills`
  - detection: `~/.loaf` exists
- regenerate README/package metadata via sync script

## Notes
- Loaf also supports the universal path `~/.agents/skills` for skill discovery.
- This registry entry keeps `~/.loaf/skills` as the explicit global install target for `--agent loaf`.

## Validation
- `node scripts/validate-agents.ts`
- `node scripts/sync-agents.ts`
- `pnpm format`
- `pnpm type-check`
- `pnpm test`