### PR TITLE
feat: add Bitbucket Cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ npx skills add https://github.com/vercel-labs/agent-skills/tree/main/skills/web-
 # GitLab URL
 npx skills add https://gitlab.com/org/repo
 
+# Bitbucket URL
+npx skills add https://bitbucket.org/workspace/repo
+
 # Any git URL
 npx skills add git@github.com:vercel-labs/agent-skills.git
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -52,6 +52,8 @@ import { fetchMintlifySkill } from './mintlify.ts';
 import {
   addSkillToLock,
   fetchSkillFolderHash,
+  fetchBitbucketSkillFolderHash,
+  getBitbucketAuthHeaders,
   isPromptDismissed,
   dismissPrompt,
   getLastSelectedAgents,
@@ -694,10 +696,17 @@ async function handleRemoteSkill(
   // Add to skill lock file for update tracking (only for global installs)
   if (successful.length > 0 && installGlobally) {
     try {
-      // Try to fetch the folder hash from GitHub Trees API
+      // Try to fetch the folder hash from GitHub/Bitbucket API
       let skillFolderHash = '';
       if (remoteSkill.providerId === 'github') {
         const hash = await fetchSkillFolderHash(remoteSkill.sourceIdentifier, url);
+        if (hash) skillFolderHash = hash;
+      } else if (remoteSkill.providerId === 'bitbucket') {
+        const hash = await fetchBitbucketSkillFolderHash(
+          remoteSkill.sourceIdentifier,
+          url,
+          getBitbucketAuthHeaders()
+        );
         if (hash) skillFolderHash = hash;
       }
 
@@ -2042,11 +2051,18 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
-            // Fetch the folder hash from GitHub Trees API
+            // Fetch the folder hash from GitHub/Bitbucket API
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
               const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue);
+              if (hash) skillFolderHash = hash;
+            } else if (parsed.type === 'bitbucket' && skillPathValue) {
+              const hash = await fetchBitbucketSkillFolderHash(
+                normalizedSource,
+                skillPathValue,
+                getBitbucketAuthHeaders()
+              );
               if (hash) skillFolderHash = hash;
             }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,12 @@ import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
-import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import {
+  fetchSkillFolderHash,
+  getGitHubToken,
+  fetchBitbucketSkillFolderHash,
+  getBitbucketAuthHeaders,
+} from './skill-lock.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -111,6 +116,7 @@ ${BOLD}Manage Skills:${RESET}
   add <package>        Add a skill package (alias: a)
                        e.g. vercel-labs/agent-skills
                             https://github.com/vercel-labs/agent-skills
+                            https://bitbucket.org/workspace/repo
   remove [skills]      Remove installed skills
   list, ls             List installed skills
   find [query]         Search for skills interactively
@@ -364,10 +370,11 @@ async function runCheck(args: string[] = []): Promise<void> {
     return;
   }
 
-  // Get GitHub token from user's environment for higher rate limits
+  // Get auth tokens/headers for higher rate limits
   const token = getGitHubToken();
+  const bbAuthHeaders = getBitbucketAuthHeaders();
 
-  // Group skills by source (owner/repo) to batch GitHub API calls
+  // Group skills by source (owner/repo) to batch API calls
   const skillsBySource = new Map<string, Array<{ name: string; entry: SkillLockEntry }>>();
   let skippedCount = 0;
 
@@ -375,8 +382,12 @@ async function runCheck(args: string[] = []): Promise<void> {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check GitHub-sourced skills with folder hash
-    if (entry.sourceType !== 'github' || !entry.skillFolderHash || !entry.skillPath) {
+    // Only check GitHub/Bitbucket-sourced skills with folder hash
+    if (
+      (entry.sourceType !== 'github' && entry.sourceType !== 'bitbucket') ||
+      !entry.skillFolderHash ||
+      !entry.skillPath
+    ) {
       skippedCount++;
       continue;
     }
@@ -388,7 +399,7 @@ async function runCheck(args: string[] = []): Promise<void> {
 
   const totalSkills = skillNames.length - skippedCount;
   if (totalSkills === 0) {
-    console.log(`${DIM}No GitHub skills to check.${RESET}`);
+    console.log(`${DIM}No trackable skills to check.${RESET}`);
     return;
   }
 
@@ -401,10 +412,16 @@ async function runCheck(args: string[] = []): Promise<void> {
   for (const [source, skills] of skillsBySource) {
     for (const { name, entry } of skills) {
       try {
-        const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token);
+        let latestHash: string | null = null;
+
+        if (entry.sourceType === 'github') {
+          latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token);
+        } else if (entry.sourceType === 'bitbucket') {
+          latestHash = await fetchBitbucketSkillFolderHash(source, entry.skillPath!, bbAuthHeaders);
+        }
 
         if (!latestHash) {
-          errors.push({ name, source, error: 'Could not fetch from GitHub' });
+          errors.push({ name, source, error: `Could not fetch from ${entry.sourceType}` });
           continue;
         }
 
@@ -466,10 +483,11 @@ async function runUpdate(): Promise<void> {
     return;
   }
 
-  // Get GitHub token from user's environment for higher rate limits
+  // Get auth tokens/headers for higher rate limits
   const token = getGitHubToken();
+  const bbAuthHeaders = getBitbucketAuthHeaders();
 
-  // Find skills that need updates by checking GitHub directly
+  // Find skills that need updates by checking GitHub/Bitbucket directly
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   let checkedCount = 0;
 
@@ -477,15 +495,29 @@ async function runUpdate(): Promise<void> {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check GitHub-sourced skills with folder hash
-    if (entry.sourceType !== 'github' || !entry.skillFolderHash || !entry.skillPath) {
+    // Only check GitHub/Bitbucket-sourced skills with folder hash
+    if (
+      (entry.sourceType !== 'github' && entry.sourceType !== 'bitbucket') ||
+      !entry.skillFolderHash ||
+      !entry.skillPath
+    ) {
       continue;
     }
 
     checkedCount++;
 
     try {
-      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
+      let latestHash: string | null = null;
+
+      if (entry.sourceType === 'github') {
+        latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
+      } else if (entry.sourceType === 'bitbucket') {
+        latestHash = await fetchBitbucketSkillFolderHash(
+          entry.source,
+          entry.skillPath,
+          bbAuthHeaders
+        );
+      }
 
       if (latestHash && latestHash !== entry.skillFolderHash) {
         updates.push({ name: skillName, source: entry.source, entry });
@@ -531,10 +563,15 @@ async function runUpdate(): Promise<void> {
         skillFolder = skillFolder.slice(0, -1);
       }
 
-      // Convert git URL to tree URL with path
-      // https://github.com/owner/repo.git -> https://github.com/owner/repo/tree/main/path
+      // Convert git URL to browsable URL with path
       installUrl = update.entry.sourceUrl.replace(/\.git$/, '').replace(/\/$/, '');
-      installUrl = `${installUrl}/tree/main/${skillFolder}`;
+      if (update.entry.sourceType === 'bitbucket') {
+        // https://bitbucket.org/workspace/repo.git -> https://bitbucket.org/workspace/repo/src/main/path
+        installUrl = `${installUrl}/src/main/${skillFolder}`;
+      } else {
+        // https://github.com/owner/repo.git -> https://github.com/owner/repo/tree/main/path
+        installUrl = `${installUrl}/tree/main/${skillFolder}`;
+      }
     }
 
     // Use skills CLI to reinstall with -g -y flags

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -149,6 +149,87 @@ export function getGitHubToken(): string | null {
 }
 
 /**
+ * Get Bitbucket authentication headers from user's environment.
+ * Tries in order:
+ * 1. BITBUCKET_TOKEN environment variable → Bearer auth
+ * 2. BITBUCKET_USERNAME + BITBUCKET_APP_PASSWORD → Basic auth
+ * 3. Returns empty headers (unauthenticated, works for public repos)
+ */
+export function getBitbucketAuthHeaders(): Record<string, string> {
+  if (process.env.BITBUCKET_TOKEN) {
+    return { Authorization: `Bearer ${process.env.BITBUCKET_TOKEN}` };
+  }
+
+  if (process.env.BITBUCKET_USERNAME && process.env.BITBUCKET_APP_PASSWORD) {
+    const credentials = Buffer.from(
+      `${process.env.BITBUCKET_USERNAME}:${process.env.BITBUCKET_APP_PASSWORD}`
+    ).toString('base64');
+    return { Authorization: `Basic ${credentials}` };
+  }
+
+  return {};
+}
+
+/**
+ * Fetch the latest commit hash for a skill folder using Bitbucket's Commits API.
+ * Bitbucket doesn't have GitHub-style tree SHAs, so we use the latest commit
+ * hash affecting the skill folder path as a change-detection mechanism.
+ *
+ * @param ownerRepo - Bitbucket workspace/repo (e.g., "workspace/repo")
+ * @param skillPath - Path to skill folder or SKILL.md
+ * @param authHeaders - Optional auth headers from getBitbucketAuthHeaders()
+ * @returns The latest commit hash for the skill folder, or null if not found
+ */
+export async function fetchBitbucketSkillFolderHash(
+  ownerRepo: string,
+  skillPath: string,
+  authHeaders?: Record<string, string>
+): Promise<string | null> {
+  // Normalize to forward slashes
+  let folderPath = skillPath.replace(/\\/g, '/');
+
+  // Remove SKILL.md suffix to get folder path
+  if (folderPath.endsWith('/SKILL.md')) {
+    folderPath = folderPath.slice(0, -9);
+  } else if (folderPath.endsWith('SKILL.md')) {
+    folderPath = folderPath.slice(0, -8);
+  }
+
+  // Remove trailing slash
+  if (folderPath.endsWith('/')) {
+    folderPath = folderPath.slice(0, -1);
+  }
+
+  const branches = ['main', 'master'];
+
+  for (const branch of branches) {
+    try {
+      const url = `https://api.bitbucket.org/2.0/repositories/${ownerRepo}/commits?include=${branch}&path=${folderPath}&pagelen=1`;
+      const headers: Record<string, string> = {
+        'User-Agent': 'skills-cli',
+        ...authHeaders,
+      };
+
+      const response = await fetch(url, { headers });
+
+      if (!response.ok) continue;
+
+      const data = (await response.json()) as {
+        values?: Array<{ hash: string }>;
+      };
+
+      if (data.values && data.values.length > 0) {
+        return data.values[0]!.hash;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Fetch the tree SHA (folder hash) for a skill folder using GitHub's Trees API.
  * This makes ONE API call to get the entire repo tree, then extracts the SHA
  * for the specific skill folder.

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -114,6 +114,9 @@ function isDirectSkillUrl(input: string): boolean {
   if (input.includes('gitlab.com/') && !input.includes('/-/raw/')) {
     return false;
   }
+  if (input.includes('bitbucket.org/')) {
+    return false;
+  }
 
   return true;
 }
@@ -233,6 +236,42 @@ export function parseSource(input: string): ParsedSource {
     }
   }
 
+  // Bitbucket URL with path: https://bitbucket.org/workspace/repo/src/branch/path/to/skill
+  const bitbucketSrcWithPathMatch = input.match(
+    /bitbucket\.org\/([^/]+)\/([^/]+)\/src\/([^/]+)\/(.+)/
+  );
+  if (bitbucketSrcWithPathMatch) {
+    const [, workspace, repo, ref, subpath] = bitbucketSrcWithPathMatch;
+    return {
+      type: 'bitbucket',
+      url: `https://bitbucket.org/${workspace}/${repo}.git`,
+      ref,
+      subpath,
+    };
+  }
+
+  // Bitbucket URL with branch only: https://bitbucket.org/workspace/repo/src/branch
+  const bitbucketSrcMatch = input.match(/bitbucket\.org\/([^/]+)\/([^/]+)\/src\/([^/]+)$/);
+  if (bitbucketSrcMatch) {
+    const [, workspace, repo, ref] = bitbucketSrcMatch;
+    return {
+      type: 'bitbucket',
+      url: `https://bitbucket.org/${workspace}/${repo}.git`,
+      ref,
+    };
+  }
+
+  // Bitbucket URL: https://bitbucket.org/workspace/repo
+  const bitbucketRepoMatch = input.match(/bitbucket\.org\/([^/]+)\/([^/]+)/);
+  if (bitbucketRepoMatch) {
+    const [, workspace, repo] = bitbucketRepoMatch;
+    const cleanRepo = repo!.replace(/\.git$/, '');
+    return {
+      type: 'bitbucket',
+      url: `https://bitbucket.org/${workspace}/${cleanRepo}.git`,
+    };
+  }
+
   // GitHub shorthand: owner/repo, owner/repo/path/to/skill, or owner/repo@skill-name
   // Exclude paths that start with . or / to avoid matching local paths
   // First check for @skill syntax: owner/repo@skill-name
@@ -289,6 +328,7 @@ function isWellKnownUrl(input: string): boolean {
     const excludedHosts = [
       'github.com',
       'gitlab.com',
+      'bitbucket.org',
       'huggingface.co',
       'raw.githubusercontent.com',
     ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'direct-url' | 'well-known';
+  type: 'github' | 'gitlab' | 'bitbucket' | 'git' | 'local' | 'direct-url' | 'well-known';
   url: string;
   subpath?: string;
   localPath?: string;

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -131,6 +131,44 @@ describe('parseSource', () => {
     });
   });
 
+  describe('Bitbucket URL tests', () => {
+    it('Bitbucket URL - basic repo', () => {
+      const result = parseSource('https://bitbucket.org/workspace/repo');
+      expect(result.type).toBe('bitbucket');
+      expect(result.url).toBe('https://bitbucket.org/workspace/repo.git');
+      expect(result.ref).toBeUndefined();
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('Bitbucket URL - with .git suffix', () => {
+      const result = parseSource('https://bitbucket.org/workspace/repo.git');
+      expect(result.type).toBe('bitbucket');
+      expect(result.url).toBe('https://bitbucket.org/workspace/repo.git');
+    });
+
+    it('Bitbucket URL - with branch only', () => {
+      const result = parseSource('https://bitbucket.org/workspace/repo/src/main');
+      expect(result.type).toBe('bitbucket');
+      expect(result.url).toBe('https://bitbucket.org/workspace/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('Bitbucket URL - with branch and path', () => {
+      const result = parseSource('https://bitbucket.org/workspace/repo/src/main/skills/my-skill');
+      expect(result.type).toBe('bitbucket');
+      expect(result.url).toBe('https://bitbucket.org/workspace/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('skills/my-skill');
+    });
+
+    it('Bitbucket URL - with trailing slash', () => {
+      const result = parseSource('https://bitbucket.org/workspace/repo/');
+      expect(result.type).toBe('bitbucket');
+      expect(result.url).toBe('https://bitbucket.org/workspace/repo.git');
+    });
+  });
+
   describe('GitHub shorthand tests', () => {
     it('GitHub shorthand - owner/repo', () => {
       const result = parseSource('owner/repo');
@@ -245,6 +283,16 @@ describe('getOwnerRepo', () => {
   it('getOwnerRepo - GitLab URL with subgroup', () => {
     const parsed = parseSource('https://gitlab.com/coresofthq/ai/agent-skills');
     expect(getOwnerRepo(parsed)).toBe('coresofthq/ai/agent-skills');
+  });
+
+  it('getOwnerRepo - Bitbucket URL', () => {
+    const parsed = parseSource('https://bitbucket.org/workspace/repo');
+    expect(getOwnerRepo(parsed)).toBe('workspace/repo');
+  });
+
+  it('getOwnerRepo - Bitbucket URL with src/branch/path', () => {
+    const parsed = parseSource('https://bitbucket.org/workspace/repo/src/main/skills/my-skill');
+    expect(getOwnerRepo(parsed)).toBe('workspace/repo');
   });
 
   it('getOwnerRepo - local path returns null', () => {


### PR DESCRIPTION
## Summary

- Add full Bitbucket Cloud (bitbucket.org) support with feature parity to GitHub/GitLab
- Users can now `skills add`, `skills check`, and `skills update` for Bitbucket-hosted skills
- Supports private repos via `BITBUCKET_TOKEN` or `BITBUCKET_USERNAME` + `BITBUCKET_APP_PASSWORD` environment variables

## Changes

| File | Description |
|------|-------------|
| `src/types.ts` | Add `'bitbucket'` to `ParsedSource` type union |
| `src/source-parser.ts` | Add 3 Bitbucket URL regex patterns, exclude from `isDirectSkillUrl` / `isWellKnownUrl` |
| `src/skill-lock.ts` | Add `getBitbucketAuthHeaders()` and `fetchBitbucketSkillFolderHash()` |
| `src/cli.ts` | Update `runCheck()` / `runUpdate()` to support Bitbucket, add help text example |
| `src/add.ts` | Add Bitbucket branches to hash fetching in 2 locations |
| `README.md` | Add Bitbucket URL example to Source Formats |
| `tests/source-parser.test.ts` | Add 7 Bitbucket URL parsing + `getOwnerRepo` tests |

## Design Decisions

- **Hash detection:** Bitbucket lacks GitHub-style tree SHAs, so the latest commit hash affecting the skill folder path is used as a change-detection mechanism via `GET /2.0/repositories/{workspace}/{repo}/commits?include={branch}&path={path}&pagelen=1`
- **URL pattern:** Bitbucket uses `/src/branch/path` (vs GitHub `/tree/` and GitLab `/-/tree/`)
- **Auth:** Supports Bearer token (`BITBUCKET_TOKEN`) and Basic auth (`BITBUCKET_USERNAME` + `BITBUCKET_APP_PASSWORD`); unauthenticated access works for public repos

## Test Plan

- [x] All existing unit tests pass (64/64)
- [x] New Bitbucket URL parsing tests pass (5 parseSource + 2 getOwnerRepo)
- [x] E2E: `skills add` from private Bitbucket repo — clones and installs skill
- [x] E2E: `skills check` — detects no updates when up to date
- [x] E2E: Push change to Bitbucket → `skills check` detects update
- [x] E2E: `skills update` — applies update, verified file content reflects changes
- [x] E2E: `skills check` after update — confirms "All skills are up to date"

Closes #277