### PR TITLE
fix: resolve default branch instead of hardcoding main/master

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,10 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "pnpm@10.17.1"
+  "packageManager": "pnpm@10.17.1",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  }
 }

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { readFileSync, mkdtempSync } from 'fs';
 import { join } from 'path';
-import { runCliOutput, stripLogo, hasLogo } from './test-utils.ts';
+import { tmpdir } from 'os';
+import { runCli, runCliOutput, stripLogo, hasLogo } from './test-utils.ts';
 
 describe('skills CLI', () => {
   describe('--help', () => {
@@ -74,15 +75,16 @@ describe('skills CLI', () => {
     });
 
     it('should not display logo for check command', () => {
-      // Note: check command makes GitHub API calls, so we just verify initial output
-      const output = runCliOutput(['check']);
-      expect(hasLogo(output)).toBe(false);
-    }, 60000);
+      // Use isolated HOME so the lock file is empty and no GitHub API calls are made
+      const isolatedHome = mkdtempSync(join(tmpdir(), 'skills-test-'));
+      const { stdout, stderr } = runCli(['check'], undefined, { HOME: isolatedHome });
+      expect(hasLogo(stdout + stderr)).toBe(false);
+    });
 
     it('should not display logo for update command', () => {
-      // Note: update command makes GitHub API calls, so we just verify initial output
-      const output = runCliOutput(['update']);
-      expect(hasLogo(output)).toBe(false);
-    }, 60000);
+      const isolatedHome = mkdtempSync(join(tmpdir(), 'skills-test-'));
+      const { stdout, stderr } = runCli(['update'], undefined, { HOME: isolatedHome });
+      expect(hasLogo(stdout + stderr)).toBe(false);
+    });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -516,8 +516,7 @@ async function runUpdate(): Promise<void> {
   for (const update of updates) {
     console.log(`${TEXT}Updating ${update.name}...${RESET}`);
 
-    // Build the URL with subpath to target the specific skill directory
-    // e.g., https://github.com/owner/repo/tree/main/skills/my-skill
+    // Build the install specifier for the specific skill directory
     let installUrl = update.entry.sourceUrl;
     if (update.entry.skillPath) {
       // Extract the skill folder path (remove /SKILL.md suffix)
@@ -531,10 +530,10 @@ async function runUpdate(): Promise<void> {
         skillFolder = skillFolder.slice(0, -1);
       }
 
-      // Convert git URL to tree URL with path
-      // https://github.com/owner/repo.git -> https://github.com/owner/repo/tree/main/path
-      installUrl = update.entry.sourceUrl.replace(/\.git$/, '').replace(/\/$/, '');
-      installUrl = `${installUrl}/tree/main/${skillFolder}`;
+      // Use GitHub shorthand (owner/repo/path) so parseSource clones the
+      // repo's default branch instead of assuming "main".
+      // entry.source is always "owner/repo" for GitHub-sourced skills.
+      installUrl = skillFolder ? `${update.source}/${skillFolder}` : update.source;
     }
 
     // Use skills CLI to reinstall with -g -y flags
@@ -615,7 +614,7 @@ async function main(): Promise<void> {
     }
     case 'remove':
     case 'rm':
-    case 'r':
+    case 'r': {
       // Check for --help or -h flag
       if (restArgs.includes('--help') || restArgs.includes('-h')) {
         showRemoveHelp();
@@ -624,6 +623,7 @@ async function main(): Promise<void> {
       const { skills, options: removeOptions } = parseRemoveOptions(restArgs);
       await removeCommand(skills, removeOptions);
       break;
+    }
     case 'experimental_sync': {
       showLogo();
       const { options: syncOptions } = parseSyncOptions(restArgs);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
-import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { fetchSkillFolderHash, getGitHubToken, normalizeSkillFolder } from './skill-lock.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -519,16 +519,7 @@ async function runUpdate(): Promise<void> {
     // Build the install specifier for the specific skill directory
     let installUrl = update.entry.sourceUrl;
     if (update.entry.skillPath) {
-      // Extract the skill folder path (remove /SKILL.md suffix)
-      let skillFolder = update.entry.skillPath;
-      if (skillFolder.endsWith('/SKILL.md')) {
-        skillFolder = skillFolder.slice(0, -9);
-      } else if (skillFolder.endsWith('SKILL.md')) {
-        skillFolder = skillFolder.slice(0, -8);
-      }
-      if (skillFolder.endsWith('/')) {
-        skillFolder = skillFolder.slice(0, -1);
-      }
+      const skillFolder = normalizeSkillFolder(update.entry.skillPath);
 
       // Use GitHub shorthand (owner/repo/path) so parseSource clones the
       // repo's default branch instead of assuming "main".
@@ -635,11 +626,11 @@ async function main(): Promise<void> {
       await runList(restArgs);
       break;
     case 'check':
-      runCheck(restArgs);
+      await runCheck(restArgs);
       break;
     case 'update':
     case 'upgrade':
-      runUpdate();
+      await runUpdate();
       break;
     case '--help':
     case '-h':

--- a/src/git.ts
+++ b/src/git.ts
@@ -87,7 +87,7 @@ export async function resolveDefaultBranch(repoUrl: string): Promise<string | nu
     GIT_TERMINAL_PROMPT: '0',
   });
   try {
-    const output = await git.listRemote(['--symref', 'HEAD', repoUrl]);
+    const output = await git.listRemote(['--symref', repoUrl, 'HEAD']);
     return parseSymrefOutput(output);
   } catch {
     return null;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,7 +1,7 @@
-import simpleGit from 'simple-git';
-import { join, normalize, resolve, sep } from 'path';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
+import { join, normalize, resolve, sep } from 'path';
+import simpleGit from 'simple-git';
 
 const CLONE_TIMEOUT_MS = 60000; // 60 seconds
 
@@ -21,9 +21,9 @@ export class GitCloneError extends Error {
 
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const git = simpleGit({
-    timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  const git = simpleGit({ timeout: { block: CLONE_TIMEOUT_MS } }).env({
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
   });
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 
@@ -67,6 +67,30 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     }
 
     throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);
+  }
+}
+
+/** Parse the branch name from `git ls-remote --symref` output. */
+export function parseSymrefOutput(output: string): string | null {
+  // Output format: "ref: refs/heads/main\tHEAD\n<sha>\tHEAD\n"
+  const match = output.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD$/m);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Resolve the default branch of a remote repository via `git ls-remote --symref`.
+ * Returns the branch name (e.g. "main"), or null if resolution fails.
+ */
+export async function resolveDefaultBranch(repoUrl: string): Promise<string | null> {
+  const git = simpleGit({ timeout: { block: 10_000 } }).env({
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+  });
+  try {
+    const output = await git.listRemote(['--symref', 'HEAD', repoUrl]);
+    return parseSymrefOutput(output);
+  } catch {
+    return null;
   }
 }
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -18,6 +18,8 @@ export interface RemoveOptions {
   agent?: string[];
   yes?: boolean;
   all?: boolean;
+  /** Override for testing — defaults to detectInstalledAgents */
+  _detectInstalledAgents?: () => Promise<AgentType[]>;
 }
 
 export async function removeCommand(skillNames: string[], options: RemoveOptions) {
@@ -191,7 +193,8 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       // Only remove the canonical path if no other installed agents are using it.
       // This prevents breaking other agents when uninstalling from a specific agent (#287).
-      const installedAgents = await detectInstalledAgents();
+      const detectFn = options._detectInstalledAgents ?? detectInstalledAgents;
+      const installedAgents = await detectFn();
       const remainingAgents = installedAgents.filter((a) => !targetAgents.includes(a));
 
       let isStillUsed = false;

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
+import { resolveDefaultBranch } from './git.ts';
 
 const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
@@ -178,7 +179,13 @@ export async function fetchSkillFolderHash(
     folderPath = folderPath.slice(0, -1);
   }
 
-  const branches = ['main', 'master'];
+  const repoUrl = `https://github.com/${ownerRepo}.git`;
+  const defaultBranch = await resolveDefaultBranch(repoUrl);
+  const branches = defaultBranch ? [defaultBranch] : ['main', 'master'];
+
+  if (!defaultBranch) {
+    console.error(`Warning: Could not resolve default branch for ${ownerRepo}, trying main/master`);
+  }
 
   for (const branch of branches) {
     try {

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -10,6 +10,20 @@ const LOCK_FILE = '.skill-lock.json';
 const CURRENT_VERSION = 3; // Bumped from 2 to 3 for folder hash support (GitHub tree SHA)
 
 /**
+ * Strip `SKILL.md` suffix and trailing slashes from a skill path to get the
+ * containing folder path. Backslashes are normalized to forward slashes.
+ *
+ * Returns `""` for root-level skills (e.g. bare `"SKILL.md"`).
+ */
+export function normalizeSkillFolder(skillPath: string): string {
+  let folder = skillPath.replace(/\\/g, '/');
+  if (folder.endsWith('/SKILL.md')) folder = folder.slice(0, -9);
+  else if (folder.endsWith('SKILL.md')) folder = folder.slice(0, -8);
+  if (folder.endsWith('/')) folder = folder.slice(0, -1);
+  return folder;
+}
+
+/**
  * Represents a single installed skill entry in the lock file.
  */
 export interface SkillLockEntry {
@@ -164,20 +178,7 @@ export async function fetchSkillFolderHash(
   skillPath: string,
   token?: string | null
 ): Promise<string | null> {
-  // Normalize to forward slashes first (for GitHub API compatibility)
-  let folderPath = skillPath.replace(/\\/g, '/');
-
-  // Remove SKILL.md suffix to get folder path
-  if (folderPath.endsWith('/SKILL.md')) {
-    folderPath = folderPath.slice(0, -9);
-  } else if (folderPath.endsWith('SKILL.md')) {
-    folderPath = folderPath.slice(0, -8);
-  }
-
-  // Remove trailing slash
-  if (folderPath.endsWith('/')) {
-    folderPath = folderPath.slice(0, -1);
-  }
+  const folderPath = normalizeSkillFolder(skillPath);
 
   const repoUrl = `https://github.com/${ownerRepo}.git`;
   const defaultBranch = await resolveDefaultBranch(repoUrl);

--- a/tests/cross-platform-paths.test.ts
+++ b/tests/cross-platform-paths.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { sep } from 'path';
+import { normalizeSkillFolder } from '../src/skill-lock.ts';
 
 /**
  * Simulates the shortenPath function from add.ts (cross-platform version)
@@ -32,27 +33,6 @@ function isValidSkillFile(file: string): boolean {
   // Files must not start with / or \ or contain .. (path traversal prevention)
   if (file.startsWith('/') || file.startsWith('\\') || file.includes('..')) return false;
   return true;
-}
-
-/**
- * Simulates the SKILL.md path normalization from skill-lock.ts
- */
-function normalizeSkillPath(skillPath: string): string {
-  let folderPath = skillPath;
-
-  // Handle both forward and backslash separators for cross-platform compatibility
-  if (folderPath.endsWith('/SKILL.md') || folderPath.endsWith('\\SKILL.md')) {
-    folderPath = folderPath.slice(0, -9);
-  } else if (folderPath.endsWith('SKILL.md')) {
-    folderPath = folderPath.slice(0, -8);
-  }
-
-  if (folderPath.endsWith('/') || folderPath.endsWith('\\')) {
-    folderPath = folderPath.slice(0, -1);
-  }
-
-  // Convert to forward slashes for GitHub API
-  return folderPath.split('\\').join('/');
 }
 
 describe('shortenPath (Unix)', () => {
@@ -209,49 +189,49 @@ describe('isValidSkillFile', () => {
   });
 });
 
-describe('normalizeSkillPath', () => {
+describe('normalizeSkillFolder', () => {
   it('removes /SKILL.md suffix (Unix)', () => {
-    const result = normalizeSkillPath('skills/my-skill/SKILL.md');
+    const result = normalizeSkillFolder('skills/my-skill/SKILL.md');
     expect(result).toBe('skills/my-skill');
   });
 
   it('removes \\SKILL.md suffix (Windows)', () => {
-    const result = normalizeSkillPath('skills\\my-skill\\SKILL.md');
+    const result = normalizeSkillFolder('skills\\my-skill\\SKILL.md');
     expect(result).toBe('skills/my-skill');
   });
 
   it('removes SKILL.md without path separator', () => {
-    const result = normalizeSkillPath('SKILL.md');
+    const result = normalizeSkillFolder('SKILL.md');
     expect(result).toBe('');
   });
 
   it('removes trailing forward slash', () => {
-    const result = normalizeSkillPath('skills/my-skill/');
+    const result = normalizeSkillFolder('skills/my-skill/');
     expect(result).toBe('skills/my-skill');
   });
 
   it('removes trailing backslash', () => {
-    const result = normalizeSkillPath('skills\\my-skill\\');
+    const result = normalizeSkillFolder('skills\\my-skill\\');
     expect(result).toBe('skills/my-skill');
   });
 
   it('converts Windows paths to forward slashes', () => {
-    const result = normalizeSkillPath('skills\\.curated\\advanced-skill\\SKILL.md');
+    const result = normalizeSkillFolder('skills\\.curated\\advanced-skill\\SKILL.md');
     expect(result).toBe('skills/.curated/advanced-skill');
   });
 
   it('handles mixed separators', () => {
-    const result = normalizeSkillPath('skills/category\\my-skill/SKILL.md');
+    const result = normalizeSkillFolder('skills/category\\my-skill/SKILL.md');
     expect(result).toBe('skills/category/my-skill');
   });
 
   it('handles root-level skill', () => {
-    const result = normalizeSkillPath('/SKILL.md');
+    const result = normalizeSkillFolder('/SKILL.md');
     expect(result).toBe('');
   });
 
   it('handles deep nested paths (Windows)', () => {
-    const result = normalizeSkillPath('a\\b\\c\\d\\e\\SKILL.md');
+    const result = normalizeSkillFolder('a\\b\\c\\d\\e\\SKILL.md');
     expect(result).toBe('a/b/c/d/e');
   });
 });

--- a/tests/remove-canonical.test.ts
+++ b/tests/remove-canonical.test.ts
@@ -1,18 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdir, rm, writeFile, lstat, symlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { removeCommand } from '../src/remove.ts';
-import * as agentsModule from '../src/agents.ts';
-
-// Mock detectInstalledAgents
-vi.mock('../src/agents.ts', async () => {
-  const actual = await vi.importActual('../src/agents.ts');
-  return {
-    ...actual,
-    detectInstalledAgents: vi.fn(),
-  };
-});
+import type { AgentType } from '../src/types.ts';
 
 describe('removeCommand canonical protection', () => {
   let tempDir: string;
@@ -63,12 +54,12 @@ describe('removeCommand canonical protection', () => {
       (await lstat(continuePath)).isSymbolicLink() || (await lstat(continuePath)).isDirectory()
     ).toBe(true);
 
-    // Mock agents: Claude and Continue are installed
-    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['claude-code', 'continue']);
-
-    // 3. Remove from Claude only
-    // -a claude-code
-    await removeCommand([skillName], { agent: ['claude-code'], yes: true });
+    // 3. Remove from Claude only, with DI override for detectInstalledAgents
+    await removeCommand([skillName], {
+      agent: ['claude-code'],
+      yes: true,
+      _detectInstalledAgents: async (): Promise<AgentType[]> => ['claude-code', 'continue'],
+    });
 
     // 4. Verify results
     // Claude path should be gone
@@ -92,11 +83,12 @@ describe('removeCommand canonical protection', () => {
     await writeFile(join(canonicalPath, 'SKILL.md'), '# Test');
     await symlink(canonicalPath, claudePath, 'junction');
 
-    // Mock agents: Only Claude is installed
-    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['claude-code']);
-
-    // Remove from Claude
-    await removeCommand([skillName], { agent: ['claude-code'], yes: true });
+    // Remove from Claude, with DI override — only Claude is installed
+    await removeCommand([skillName], {
+      agent: ['claude-code'],
+      yes: true,
+      _detectInstalledAgents: async (): Promise<AgentType[]> => ['claude-code'],
+    });
 
     // Both should be gone
     await expect(lstat(claudePath)).rejects.toThrow();

--- a/tests/resolve-default-branch.test.ts
+++ b/tests/resolve-default-branch.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { parseSymrefOutput, resolveDefaultBranch } from '../src/git.ts';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseSymrefOutput } from '../src/git.ts';
+
+const mockListRemote = vi.fn();
+
+vi.mock('simple-git', () => ({
+  default: vi.fn(() => ({
+    env: vi.fn(() => ({ listRemote: mockListRemote })),
+  })),
+}));
 
 describe('parseSymrefOutput', () => {
   it('parses "main" from standard output', () => {
@@ -42,17 +50,50 @@ describe('parseSymrefOutput', () => {
 });
 
 describe('resolveDefaultBranch', () => {
-  it('returns null for a nonexistent repo', async () => {
-    const branch = await resolveDefaultBranch(
-      'https://github.com/this-does-not-exist-12345/nope.git'
-    );
-    expect(branch).toBeNull();
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('returns a string or null (network-dependent)', async () => {
-    // This test validates the function contract without requiring network access.
-    // If network is available, it returns a branch name; otherwise null.
-    const branch = await resolveDefaultBranch('https://github.com/octocat/Hello-World.git');
-    expect(branch === null || typeof branch === 'string').toBe(true);
+  // Dynamic import required because vi.mock is hoisted
+  async function loadResolveDefaultBranch() {
+    const { resolveDefaultBranch } = await import('../src/git.ts');
+    return resolveDefaultBranch;
+  }
+
+  it('passes args to listRemote in correct order: --symref, url, HEAD', async () => {
+    const resolveDefaultBranch = await loadResolveDefaultBranch();
+    mockListRemote.mockResolvedValue('ref: refs/heads/main\tHEAD\nabc123\tHEAD\n');
+
+    await resolveDefaultBranch('https://github.com/owner/repo.git');
+
+    expect(mockListRemote).toHaveBeenCalledWith([
+      '--symref',
+      'https://github.com/owner/repo.git',
+      'HEAD',
+    ]);
+  });
+
+  it('returns parsed branch name from listRemote output', async () => {
+    const resolveDefaultBranch = await loadResolveDefaultBranch();
+    mockListRemote.mockResolvedValue('ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n');
+
+    const result = await resolveDefaultBranch('https://github.com/owner/repo.git');
+    expect(result).toBe('develop');
+  });
+
+  it('returns null when listRemote throws', async () => {
+    const resolveDefaultBranch = await loadResolveDefaultBranch();
+    mockListRemote.mockRejectedValue(new Error('fatal: repository not found'));
+
+    const result = await resolveDefaultBranch('https://github.com/bad/repo.git');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when output has no symref line', async () => {
+    const resolveDefaultBranch = await loadResolveDefaultBranch();
+    mockListRemote.mockResolvedValue('abc123\tHEAD\n');
+
+    const result = await resolveDefaultBranch('https://github.com/owner/repo.git');
+    expect(result).toBeNull();
   });
 });

--- a/tests/resolve-default-branch.test.ts
+++ b/tests/resolve-default-branch.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { parseSymrefOutput, resolveDefaultBranch } from '../src/git.ts';
+
+describe('parseSymrefOutput', () => {
+  it('parses "main" from standard output', () => {
+    const output = 'ref: refs/heads/main\tHEAD\na1b2c3d4e5f6\tHEAD\n';
+    expect(parseSymrefOutput(output)).toBe('main');
+  });
+
+  it('parses "master" from standard output', () => {
+    const output = 'ref: refs/heads/master\tHEAD\na1b2c3d4e5f6\tHEAD\n';
+    expect(parseSymrefOutput(output)).toBe('master');
+  });
+
+  it('parses non-standard branch names', () => {
+    expect(parseSymrefOutput('ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n')).toBe('develop');
+    expect(parseSymrefOutput('ref: refs/heads/trunk\tHEAD\nabc123\tHEAD\n')).toBe('trunk');
+    expect(parseSymrefOutput('ref: refs/heads/v2\tHEAD\nabc123\tHEAD\n')).toBe('v2');
+    expect(parseSymrefOutput('ref: refs/heads/release/1.0\tHEAD\nabc123\tHEAD\n')).toBe(
+      'release/1.0'
+    );
+  });
+
+  it('returns null for empty output', () => {
+    expect(parseSymrefOutput('')).toBeNull();
+  });
+
+  it('returns null for output without symref line', () => {
+    // Some servers only return the SHA line without the symref
+    expect(parseSymrefOutput('a1b2c3d4e5f6\tHEAD\n')).toBeNull();
+  });
+
+  it('returns null for malformed output', () => {
+    expect(parseSymrefOutput('garbage')).toBeNull();
+    expect(parseSymrefOutput('ref: not-a-branch\tHEAD')).toBeNull();
+  });
+
+  it('handles extra whitespace in ref line', () => {
+    const output = 'ref:  refs/heads/main\tHEAD\nabc123\tHEAD\n';
+    expect(parseSymrefOutput(output)).toBe('main');
+  });
+});
+
+describe('resolveDefaultBranch', () => {
+  it('returns null for a nonexistent repo', async () => {
+    const branch = await resolveDefaultBranch(
+      'https://github.com/this-does-not-exist-12345/nope.git'
+    );
+    expect(branch).toBeNull();
+  });
+
+  it('returns a string or null (network-dependent)', async () => {
+    // This test validates the function contract without requiring network access.
+    // If network is available, it returns a branch name; otherwise null.
+    const branch = await resolveDefaultBranch('https://github.com/octocat/Hello-World.git');
+    expect(branch === null || typeof branch === 'string').toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`skills update` failed against a real repo ([`kjanat/paperless-mcp`](https://github.com/kjanat/paperless-mcp)) because the reinstall path was rebuilt with a hardcoded `/tree/main/...`, while the repo’s default branch is `master`.

The only user-facing message was:

```console
✗ Failed to update ...
```

…which gave no actionable reason.

This PR fixes that specific failure and makes branch handling more robust across update/hash paths so repos using non-standard default branches (`master`, `develop`, `trunk`, etc.) work correctly.

Closes #373.

## Reproduction / observed behavior

- `skills check` reported an update for `paperless-ngx`
- `skills update` consistently failed with:
  - `✗ Failed to update paperless-ngx`
- Manually reproducing the generated install target surfaced the real error:
  - `fatal: Remote branch main not found in upstream origin`
- Verified repo default branch:
  - `git ls-remote --symref https://github.com/kjanat/paperless-mcp.git HEAD`
  - `ref: refs/heads/master HEAD`

## Root causes

1. `src/cli.ts` (`runUpdate`) rebuilt install URLs using a hardcoded `/tree/main/...`
2. `src/skill-lock.ts` (`fetchSkillFolderHash`) only tried `main`/`master`, which is brittle for repos with other default branches
3. Update failures did not clearly surface the underlying clone/branch error

## Changes

### `src/git.ts`
- Add `resolveDefaultBranch()` using `git ls-remote --symref <repo> HEAD` (via existing `simple-git`)
- Add `parseSymrefOutput()` as a pure parser for easier testing
- Fix `.env()` usage in `cloneRepo` (constructor env was not being applied as intended)

### `src/skill-lock.ts`
- `fetchSkillFolderHash()` now resolves the actual default branch first
- If branch resolution fails, fall back to `main`/`master` and emit a warning

### `src/cli.ts`
- `runUpdate()` now uses GitHub shorthand (`owner/repo/path`) instead of constructing `/tree/main/...`, so clone/install follows the repo’s default branch naturally
- Add block scoping braces to the `remove` switch case

### `src/remove.ts`
- Add optional `_detectInstalledAgents` DI hook in `RemoveOptions` for deterministic tests without `vi.mock()`

### Tests
- `tests/resolve-default-branch.test.ts`
  - Add coverage for standard, non-standard, malformed, and empty `symref` output
  - Add integration-level behavior tests
- `tests/remove-canonical.test.ts`
  - Refactor from `vi.mock()` to DI for better compatibility with plain Node execution

### Tooling
- `package.json`
  - Add `pnpm.onlyBuiltDependencies` for `esbuild`

## Testing

- `pnpm run exec:test` — 17/17 passing
- `pnpm test` — 346/346 passing