### PR TITLE
feat: support GitHub Enterprise custom domains in source parser

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -104,15 +104,20 @@ function isDirectSkillUrl(input: string): boolean {
 
   // Exclude GitHub and GitLab repository URLs - they have their own handling
   // (but allow raw.githubusercontent.com if someone wants to use it directly)
-  if (input.includes('github.com/') && !input.includes('raw.githubusercontent.com')) {
-    // Check if it's a blob/raw URL to SKILL.md (these should be handled by providers)
-    // vs a tree/repo URL (these should be cloned)
-    if (!input.includes('/blob/') && !input.includes('/raw/')) {
+  // Supports GitHub Enterprise domains (any hostname containing "github")
+  try {
+    const parsedUrl = new URL(input);
+    const host = parsedUrl.hostname.toLowerCase();
+    if (host.includes('github') && !host.includes('raw.githubusercontent.com')) {
+      if (!input.includes('/blob/') && !input.includes('/raw/')) {
+        return false;
+      }
+    }
+    if (host.includes('gitlab') && !input.includes('/-/raw/')) {
       return false;
     }
-  }
-  if (input.includes('gitlab.com/') && !input.includes('/-/raw/')) {
-    return false;
+  } catch {
+    // Invalid URL, continue with other checks
   }
 
   return true;
@@ -154,36 +159,45 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
-  const githubTreeWithPathMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/);
+  // Also supports GitHub Enterprise domains (any hostname containing "github")
+  const githubTreeWithPathMatch = input.match(
+    /^(https?):\/\/((?:[^/]*github[^/]*)(?::\d+)?)\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/
+  );
   if (githubTreeWithPathMatch) {
-    const [, owner, repo, ref, subpath] = githubTreeWithPathMatch;
+    const [, protocol, hostname, owner, repo, ref, subpath] = githubTreeWithPathMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      url: `${protocol}://${hostname}/${owner}/${repo}.git`,
       ref,
       subpath,
     };
   }
 
   // GitHub URL with branch only: https://github.com/owner/repo/tree/branch
-  const githubTreeMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/);
+  // Also supports GitHub Enterprise domains (any hostname containing "github")
+  const githubTreeMatch = input.match(
+    /^(https?):\/\/((?:[^/]*github[^/]*)(?::\d+)?)\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/
+  );
   if (githubTreeMatch) {
-    const [, owner, repo, ref] = githubTreeMatch;
+    const [, protocol, hostname, owner, repo, ref] = githubTreeMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      url: `${protocol}://${hostname}/${owner}/${repo}.git`,
       ref,
     };
   }
 
   // GitHub URL: https://github.com/owner/repo
-  const githubRepoMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
+  // Also supports GitHub Enterprise domains (any hostname containing "github")
+  const githubRepoMatch = input.match(
+    /^(https?):\/\/((?:[^/]*github[^/]*)(?::\d+)?)\/([^/]+)\/([^/]+)/
+  );
   if (githubRepoMatch) {
-    const [, owner, repo] = githubRepoMatch;
+    const [, protocol, hostname, owner, repo] = githubRepoMatch;
     const cleanRepo = repo!.replace(/\.git$/, '');
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${cleanRepo}.git`,
+      url: `${protocol}://${hostname}/${owner}/${cleanRepo}.git`,
     };
   }
 
@@ -286,13 +300,14 @@ function isWellKnownUrl(input: string): boolean {
     const parsed = new URL(input);
 
     // Exclude known git hosts that have their own handling
-    const excludedHosts = [
-      'github.com',
-      'gitlab.com',
-      'huggingface.co',
-      'raw.githubusercontent.com',
-    ];
-    if (excludedHosts.includes(parsed.hostname)) {
+    // Supports GitHub/GitLab Enterprise domains (any hostname containing "github" or "gitlab")
+    const host = parsed.hostname.toLowerCase();
+    if (
+      host.includes('github') ||
+      host.includes('gitlab') ||
+      host === 'huggingface.co' ||
+      host === 'raw.githubusercontent.com'
+    ) {
       return false;
     }
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -56,6 +56,57 @@ describe('parseSource', () => {
     });
   });
 
+  describe('GitHub Enterprise URL tests', () => {
+    it('GHE URL - basic repo', () => {
+      const result = parseSource('https://github.company.com/owner/repo');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.company.com/owner/repo.git');
+      expect(result.ref).toBeUndefined();
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('GHE URL - tree with branch only', () => {
+      const result = parseSource('https://github.company.com/owner/repo/tree/main');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.company.com/owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('GHE URL - tree with branch and path', () => {
+      const result = parseSource('https://github.company.com/owner/repo/tree/main/path/to/skill');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.company.com/owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('path/to/skill');
+    });
+
+    it('GHE URL - with port number', () => {
+      const result = parseSource('https://github.company.com:8443/owner/repo');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.company.com:8443/owner/repo.git');
+      expect(result.ref).toBeUndefined();
+    });
+
+    it('GHE URL - with .git suffix', () => {
+      const result = parseSource('https://github.company.com/owner/repo.git');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.company.com/owner/repo.git');
+    });
+
+    it('GHE URL - http protocol', () => {
+      const result = parseSource('http://github.internal.io/owner/repo');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('http://github.internal.io/owner/repo.git');
+    });
+
+    it('GHE URL - should not be treated as well-known', () => {
+      const result = parseSource('https://github.enterprise.corp/owner/repo');
+      expect(result.type).toBe('github');
+      expect(result.type).not.toBe('well-known');
+    });
+  });
+
   describe('GitLab URL tests', () => {
     it('GitLab URL - basic repo', () => {
       const result = parseSource('https://gitlab.com/owner/repo');


### PR DESCRIPTION
## Summary
- Recognize GitHub Enterprise (GHE) custom domain URLs (e.g., `github.company.com`) as `github` type sources instead of falling through to `well-known` or `git` types
- Use a heuristic approach: match hostnames containing `github`, dynamically capturing protocol, hostname, and port — similar to how GitLab already supports custom domains
- Apply the same heuristic to `isDirectSkillUrl()` and `isWellKnownUrl()` to prevent GHE URLs from being misclassified

### Limitations
- GHE domains without `github` in the hostname (e.g., `code.company.com`) still work via `.git` suffix fallback as `git` type
- Full GHE support would require a config-based approach, which is out of scope for this PR

Closes #418

## Test plan
- [x] All existing GitHub/GitLab/shorthand/local tests pass
- [x] 7 new GHE custom domain test cases added and passing:
  - basic repo, tree+branch, tree+branch+path, port number, `.git` suffix, http protocol, well-known exclusion