### PR TITLE
fix: use process.execPath instead of npx in update command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -537,10 +537,13 @@ async function runUpdate(): Promise<void> {
       installUrl = `${installUrl}/tree/main/${skillFolder}`;
     }
 
-    // Use skills CLI to reinstall with -g -y flags
-    const result = spawnSync('npx', ['-y', 'skills', 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-    });
+    // Reinstall using the current CLI entrypoint directly instead of nested npx,
+    // which fails on Windows and non-npm package managers (see #362, #371)
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(import.meta.url), 'add', installUrl, '-g', '-y'],
+      { stdio: ['inherit', 'pipe', 'pipe'], encoding: 'utf-8' }
+    );
 
     if (result.status === 0) {
       successCount++;
@@ -548,6 +551,9 @@ async function runUpdate(): Promise<void> {
     } else {
       failCount++;
       console.log(`  ${DIM}✗ Failed to update ${update.name}${RESET}`);
+      if (result.stderr) {
+        console.log(`  ${DIM}  ${result.stderr.trim()}${RESET}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

`skills update` silently fails for every skill on Windows (and for non-npm package managers on all platforms).

The `runUpdate()` function spawns a child process via:

```ts
spawnSync('npx', ['-y', 'skills', 'add', installUrl, '-g', '-y'], {
  stdio: ['inherit', 'pipe', 'pipe'],
});
```

On Windows, `spawnSync('npx', ...)` fails with `ENOENT` because Node's `spawnSync` cannot resolve `npx.cmd` without `shell: true`. The exit status is `null` (not `0`), so every skill reports `✗ Failed to update` with no error details — stderr is captured but never printed.

**Reproduction** (Windows, Node v24):

```js
> require('child_process').spawnSync('npx', ['--version']).error
Error: spawnSync npx ENOENT { errno: -4058, code: 'ENOENT', syscall: 'spawnSync npx' }
```

This also affects users who installed `skills` globally via `pnpm` or other non-npm package managers, where the nested `npx` call may resolve to a different or missing installation.

## Fix

Replace the nested `npx` invocation with a direct call to the current CLI entrypoint:

```ts
spawnSync(
  process.execPath,
  [fileURLToPath(import.meta.url), 'add', installUrl, '-g', '-y'],
  { stdio: ['inherit', 'pipe', 'pipe'], encoding: 'utf-8' }
);
```

This uses the running Node binary (`process.execPath`) to re-invoke the current CLI file directly, bypassing npx resolution entirely. Works cross-platform and regardless of package manager.

Also surfaces stderr on failure so users get actionable error output instead of a silent failure message.

## Diff

The change is minimal — only the `spawnSync` call arguments and error logging:

- `spawnSync('npx', ['-y', 'skills', 'add', ...])` → `spawnSync(process.execPath, [fileURLToPath(import.meta.url), 'add', ...])`
- Added `encoding: 'utf-8'` to get string stderr
- Added stderr output on failure

No other code was modified.

Fixes #362
Fixes #371