### PR TITLE
feat: move Cline to universal .agents/skills directory

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -79,7 +79,7 @@ export const agents: Record<AgentType, AgentConfig> = {
   cline: {
     name: 'cline',
     displayName: 'Cline',
-    skillsDir: '.cline/skills',
+    skillsDir: '.agents/skills',
     globalSkillsDir: join(home, '.cline/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.cline'));


### PR DESCRIPTION
## Summary

Cline now natively supports `.agents/skills` as its default skill directory, as introduced in [cline/cline#9074](https://github.com/cline/cline/pull/9074).

This PR updates Cline's `skillsDir` from `.cline/skills` to `.agents/skills`, which moves it into the **Universal (.agents/skills)** section of the agent selection menu — alongside Amp, Codex, Cursor, Gemini CLI, GitHub Copilot, Kimi Code CLI, and OpenCode.