### PR TITLE
feat(agents): add Lingma (通义灵码) support (#443)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Skills can be installed to any of these agents:
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
+| Lingma | `lingma` | `.lingma/skills/` | `~/.lingma/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
@@ -333,6 +334,7 @@ The CLI searches for skills in these locations within a repository:
 - `.kilocode/skills/`
 - `.kiro/skills/`
 - `.kode/skills/`
+- `.lingma/skills/`
 - `.mcpjam/skills/`
 - `.vibe/skills/`
 - `.mux/skills/`
@@ -376,12 +378,12 @@ If no skills are found in standard locations, a recursive search is performed.
 Skills are generally compatible across agents since they follow a
 shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
-| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
-| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
-| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
-| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder | Lingma |
+| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- | ------ |
+| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      | Yes    |
+| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       | Yes    |
+| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       | No     |
+| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       | No     |
 
 ## Troubleshooting
 
@@ -439,6 +441,7 @@ Telemetry is automatically disabled in CI environments.
 - [Kimi Code CLI Skills Documentation](https://moonshotai.github.io/kimi-cli/en/customization/skills.html)
 - [Kiro CLI Skills Documentation](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources)
 - [Kode Skills Documentation](https://github.com/shareAI-lab/kode/blob/main/docs/skills.md)
+- [Lingma Skills Documentation](https://help.aliyun.com/zh/lingma/user-guide/skills)
 - [OpenCode Skills Documentation](https://opencode.ai/docs/skills)
 - [Qwen Code Skills Documentation](https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/)
 - [OpenHands Skills Documentation](https://docs.openhands.ai/modules/usage/how-to/using-skills)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "kimi-cli",
     "kiro-cli",
     "kode",
+    "lingma",
     "mcpjam",
     "mistral-vibe",
     "mux",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -238,6 +238,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.kode'));
     },
   },
+  lingma: {
+    name: 'lingma',
+    displayName: 'Lingma',
+    skillsDir: '.lingma/skills',
+    globalSkillsDir: join(home, '.lingma/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.lingma'));
+    },
+  },
   mcpjam: {
     name: 'mcpjam',
     displayName: 'MCPJam',

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type AgentType =
   | 'kimi-cli'
   | 'kiro-cli'
   | 'kode'
+  | 'lingma'
   | 'mcpjam'
   | 'mistral-vibe'
   | 'mux'


### PR DESCRIPTION
## Description

Add [Lingma (通义灵码)](https://help.aliyun.com/zh/lingma/user-guide/skills) as a new supported coding agent.

Lingma is an AI-powered intelligent coding assistant developed by Alibaba Cloud, available as an IDE extension.

This PR enables users to install and manage skills for Lingma through the skills CLI.

Resolves #443

---

## Changes

| File | Changes |
|------|---------|
| `src/types.ts` | Added `'lingma'` to `AgentType` |
| `src/agents.ts` | Added Lingma agent config (`.lingma/skills/`, `~/.lingma/skills/`) |
| `README.md` | Updated supported agents table, skill discovery locations, compatibility table, and docs links |
| `package.json` | Added `lingma` keyword |

---

## Agent Configuration

| Property | Value |
|----------|-------|
| Agent Name | `lingma` |
| Display Name | `Lingma` |
| Project Skills Directory | `.lingma/skills/` |
| Global Skills Directory | `~/.lingma/skills/` |
| Detection Path | `~/.lingma` |

---

## Related Links

- [Lingma Skills Documentation](https://help.aliyun.com/zh/lingma/user-guide/skills)
- [Issue #443](https://github.com/vercel-labs/skills/issues/443)