### PR TITLE
feat: lazy fetch & update support for well-known skills

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -46,7 +46,11 @@ import {
   type SkillAuditData,
   type PartnerAudit,
 } from './telemetry.ts';
-import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
+import {
+  wellKnownProvider,
+  type WellKnownSkill,
+  type WellKnownSkillEntry,
+} from './providers/index.ts';
 import {
   addSkillToLock,
   fetchSkillFolderHash,
@@ -431,10 +435,11 @@ async function handleWellKnownSkills(
 ): Promise<void> {
   spinner.start('Discovering skills from well-known endpoint...');
 
-  // Fetch all skills from the well-known endpoint
-  const skills = await wellKnownProvider.fetchAllSkills(url);
+  // Fetch only the index to get skill metadata for selection
+  const indexResult = await wellKnownProvider.fetchIndex(url);
+  const entries = indexResult?.index.skills ?? [];
 
-  if (skills.length === 0) {
+  if (entries.length === 0) {
     spinner.stop(pc.red('No skills found'));
     p.outro(
       pc.red(
@@ -444,25 +449,25 @@ async function handleWellKnownSkills(
     process.exit(1);
   }
 
-  spinner.stop(`Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
+  spinner.stop(`Found ${pc.green(entries.length)} skill${entries.length > 1 ? 's' : ''}`);
 
   // Log discovered skills
-  for (const skill of skills) {
-    p.log.info(`Skill: ${pc.cyan(skill.installName)}`);
-    p.log.message(pc.dim(skill.description));
-    if (skill.files.size > 1) {
-      p.log.message(pc.dim(`  Files: ${Array.from(skill.files.keys()).join(', ')}`));
+  for (const entry of entries) {
+    p.log.info(`Skill: ${pc.cyan(entry.name)}`);
+    p.log.message(pc.dim(entry.description));
+    if (entry.files.length > 1) {
+      p.log.message(pc.dim(`  Files: ${entry.files.join(', ')}`));
     }
   }
 
   if (options.list) {
     console.log();
     p.log.step(pc.bold('Available Skills'));
-    for (const skill of skills) {
-      p.log.message(`  ${pc.cyan(skill.installName)}`);
-      p.log.message(`    ${pc.dim(skill.description)}`);
-      if (skill.files.size > 1) {
-        p.log.message(`    ${pc.dim(`Files: ${skill.files.size}`)}`);
+    for (const entry of entries) {
+      p.log.message(`  ${pc.cyan(entry.name)}`);
+      p.log.message(`    ${pc.dim(entry.description)}`);
+      if (entry.files.length > 1) {
+        p.log.message(`    ${pc.dim(`Files: ${entry.files.length}`)}`);
       }
     }
     console.log();
@@ -470,43 +475,38 @@ async function handleWellKnownSkills(
     process.exit(0);
   }
 
-  // Filter skills if --skill option is provided
-  let selectedSkills: WellKnownSkill[];
+  // Filter or select entries before downloading any files
+  let selectedEntries: WellKnownSkillEntry[];
 
   if (options.skill?.includes('*')) {
     // --skill '*' selects all skills
-    selectedSkills = skills;
-    p.log.info(`Installing all ${skills.length} skills`);
+    selectedEntries = entries;
+    p.log.info(`Installing all ${entries.length} skills`);
   } else if (options.skill && options.skill.length > 0) {
-    selectedSkills = skills.filter((s) =>
-      options.skill!.some(
-        (name) =>
-          s.installName.toLowerCase() === name.toLowerCase() ||
-          s.name.toLowerCase() === name.toLowerCase()
-      )
+    selectedEntries = entries.filter((e) =>
+      options.skill!.some((name) => e.name.toLowerCase() === name.toLowerCase())
     );
 
-    if (selectedSkills.length === 0) {
+    if (selectedEntries.length === 0) {
       p.log.error(`No matching skills found for: ${options.skill.join(', ')}`);
       p.log.info('Available skills:');
-      for (const s of skills) {
-        p.log.message(`  - ${s.installName}`);
+      for (const e of entries) {
+        p.log.message(`  - ${e.name}`);
       }
       process.exit(1);
     }
-  } else if (skills.length === 1) {
-    selectedSkills = skills;
-    const firstSkill = skills[0]!;
-    p.log.info(`Skill: ${pc.cyan(firstSkill.installName)}`);
+  } else if (entries.length === 1) {
+    selectedEntries = entries;
+    p.log.info(`Skill: ${pc.cyan(entries[0]!.name)}`);
   } else if (options.yes) {
-    selectedSkills = skills;
-    p.log.info(`Installing all ${skills.length} skills`);
+    selectedEntries = entries;
+    p.log.info(`Installing all ${entries.length} skills`);
   } else {
     // Prompt user to select skills
-    const skillChoices = skills.map((s) => ({
-      value: s,
-      label: s.installName,
-      hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
+    const skillChoices = entries.map((e) => ({
+      value: e,
+      label: e.name,
+      hint: e.description.length > 60 ? e.description.slice(0, 57) + '...' : e.description,
     }));
 
     const selected = await multiselect({
@@ -520,7 +520,33 @@ async function handleWellKnownSkills(
       process.exit(0);
     }
 
-    selectedSkills = selected as WellKnownSkill[];
+    selectedEntries = selected as WellKnownSkillEntry[];
+  }
+
+  // Download files for selected skills only
+  const { resolvedBaseUrl } = indexResult!;
+  spinner.start(
+    `Downloading ${selectedEntries.length} skill${selectedEntries.length > 1 ? 's' : ''}...`
+  );
+  const downloadResults = await Promise.all(
+    selectedEntries.map((e) => wellKnownProvider.fetchSkillByEntry(resolvedBaseUrl, e))
+  );
+  spinner.stop('Download complete');
+
+  const selectedSkills: WellKnownSkill[] = downloadResults.filter(
+    (s): s is WellKnownSkill => s !== null
+  );
+
+  if (selectedSkills.length === 0) {
+    p.outro(pc.red('Failed to download selected skills. Please check the server and try again.'));
+    process.exit(1);
+  }
+
+  if (selectedSkills.length < selectedEntries.length) {
+    const failed = selectedEntries
+      .filter((e) => !selectedSkills.some((s) => s.installName === e.name))
+      .map((e) => e.name);
+    p.log.warn(`Could not download: ${failed.join(', ')}. Continuing with remaining skills.`);
   }
 
   // Detect agents

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -367,28 +367,29 @@ async function runCheck(args: string[] = []): Promise<void> {
   // Get GitHub token from user's environment for higher rate limits
   const token = getGitHubToken();
 
-  // Group skills by source (owner/repo) to batch GitHub API calls
+  // Group GitHub skills by source (owner/repo) to batch API calls
   const skillsBySource = new Map<string, Array<{ name: string; entry: SkillLockEntry }>>();
-  let skippedCount = 0;
+  const wellKnownSkillNames: string[] = [];
 
   for (const skillName of skillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check GitHub-sourced skills with folder hash
-    if (entry.sourceType !== 'github' || !entry.skillFolderHash || !entry.skillPath) {
-      skippedCount++;
-      continue;
+    if (entry.sourceType === 'well-known' && entry.sourceUrl) {
+      wellKnownSkillNames.push(skillName);
+    } else if (entry.sourceType === 'github' && entry.skillFolderHash && entry.skillPath) {
+      const existing = skillsBySource.get(entry.source) || [];
+      existing.push({ name: skillName, entry });
+      skillsBySource.set(entry.source, existing);
     }
-
-    const existing = skillsBySource.get(entry.source) || [];
-    existing.push({ name: skillName, entry });
-    skillsBySource.set(entry.source, existing);
   }
 
-  const totalSkills = skillNames.length - skippedCount;
+  const totalSkills =
+    [...skillsBySource.values()].reduce((sum, arr) => sum + arr.length, 0) +
+    wellKnownSkillNames.length;
+
   if (totalSkills === 0) {
-    console.log(`${DIM}No GitHub skills to check.${RESET}`);
+    console.log(`${DIM}No skills to check.${RESET}`);
     return;
   }
 
@@ -397,7 +398,7 @@ async function runCheck(args: string[] = []): Promise<void> {
   const updates: Array<{ name: string; source: string }> = [];
   const errors: Array<{ name: string; source: string; error: string }> = [];
 
-  // Check each source (one API call per repo)
+  // Check GitHub skills
   for (const [source, skills] of skillsBySource) {
     for (const { name, entry } of skills) {
       try {
@@ -418,6 +419,42 @@ async function runCheck(args: string[] = []): Promise<void> {
           error: err instanceof Error ? err.message : 'Unknown error',
         });
       }
+    }
+  }
+
+  // Check well-known skills by comparing remote SKILL.md content hash
+  for (const skillName of wellKnownSkillNames) {
+    const entry = lock.skills[skillName]!;
+    try {
+      const response = await fetch(entry.sourceUrl);
+      if (!response.ok) {
+        errors.push({
+          name: skillName,
+          source: entry.source,
+          error: 'Could not fetch from server',
+        });
+        continue;
+      }
+      const remoteContent = await response.text();
+      const remoteHash = createHash('sha256').update(remoteContent).digest('hex');
+
+      const localPath = join(homedir(), AGENTS_DIR, 'skills', skillName, 'SKILL.md');
+      if (!existsSync(localPath)) {
+        errors.push({ name: skillName, source: entry.source, error: 'Local skill not found' });
+        continue;
+      }
+      const localContent = readFileSync(localPath, 'utf-8');
+      const localHash = createHash('sha256').update(localContent).digest('hex');
+
+      if (remoteHash !== localHash) {
+        updates.push({ name: skillName, source: entry.source });
+      }
+    } catch (err) {
+      errors.push({
+        name: skillName,
+        source: entry.source,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
     }
   }
 
@@ -469,7 +506,7 @@ async function runUpdate(): Promise<void> {
   // Get GitHub token from user's environment for higher rate limits
   const token = getGitHubToken();
 
-  // Find skills that need updates by checking GitHub directly
+  // Find skills that need updates
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   let checkedCount = 0;
 
@@ -477,21 +514,36 @@ async function runUpdate(): Promise<void> {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check GitHub-sourced skills with folder hash
-    if (entry.sourceType !== 'github' || !entry.skillFolderHash || !entry.skillPath) {
-      continue;
-    }
-
-    checkedCount++;
-
-    try {
-      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
-
-      if (latestHash && latestHash !== entry.skillFolderHash) {
-        updates.push({ name: skillName, source: entry.source, entry });
+    if (entry.sourceType === 'github' && entry.skillFolderHash && entry.skillPath) {
+      checkedCount++;
+      try {
+        const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
+        if (latestHash && latestHash !== entry.skillFolderHash) {
+          updates.push({ name: skillName, source: entry.source, entry });
+        }
+      } catch {
+        // Skip skills that fail to check
       }
-    } catch {
-      // Skip skills that fail to check
+    } else if (entry.sourceType === 'well-known' && entry.sourceUrl) {
+      checkedCount++;
+      try {
+        const response = await fetch(entry.sourceUrl);
+        if (response.ok) {
+          const remoteContent = await response.text();
+          const remoteHash = createHash('sha256').update(remoteContent).digest('hex');
+          const localPath = join(homedir(), AGENTS_DIR, 'skills', skillName, 'SKILL.md');
+          if (existsSync(localPath)) {
+            const localHash = createHash('sha256')
+              .update(readFileSync(localPath, 'utf-8'))
+              .digest('hex');
+            if (remoteHash !== localHash) {
+              updates.push({ name: skillName, source: entry.source, entry });
+            }
+          }
+        }
+      } catch {
+        // Skip skills that fail to check
+      }
     }
   }
 
@@ -516,29 +568,33 @@ async function runUpdate(): Promise<void> {
   for (const update of updates) {
     console.log(`${TEXT}Updating ${update.name}...${RESET}`);
 
-    // Build the URL with subpath to target the specific skill directory
-    // e.g., https://github.com/owner/repo/tree/main/skills/my-skill
-    let installUrl = update.entry.sourceUrl;
-    if (update.entry.skillPath) {
-      // Extract the skill folder path (remove /SKILL.md suffix)
-      let skillFolder = update.entry.skillPath;
-      if (skillFolder.endsWith('/SKILL.md')) {
-        skillFolder = skillFolder.slice(0, -9);
-      } else if (skillFolder.endsWith('SKILL.md')) {
-        skillFolder = skillFolder.slice(0, -8);
-      }
-      if (skillFolder.endsWith('/')) {
-        skillFolder = skillFolder.slice(0, -1);
-      }
+    let installArgs: string[];
 
-      // Convert git URL to tree URL with path
-      // https://github.com/owner/repo.git -> https://github.com/owner/repo/tree/main/path
-      installUrl = update.entry.sourceUrl.replace(/\.git$/, '').replace(/\/$/, '');
-      installUrl = `${installUrl}/tree/main/${skillFolder}`;
+    if (update.entry.sourceType === 'well-known') {
+      // Strip /.well-known/skills/... suffix to get the base URL
+      const baseUrl = update.entry.sourceUrl.replace(/\/.well-known\/skills\/.*$/, '');
+      installArgs = ['-y', 'skills', 'add', baseUrl, '--skill', update.name, '-g', '-y'];
+    } else {
+      // Build the GitHub tree URL with subpath to target the specific skill directory
+      let installUrl = update.entry.sourceUrl;
+      if (update.entry.skillPath) {
+        let skillFolder = update.entry.skillPath;
+        if (skillFolder.endsWith('/SKILL.md')) {
+          skillFolder = skillFolder.slice(0, -9);
+        } else if (skillFolder.endsWith('SKILL.md')) {
+          skillFolder = skillFolder.slice(0, -8);
+        }
+        if (skillFolder.endsWith('/')) {
+          skillFolder = skillFolder.slice(0, -1);
+        }
+        installUrl = update.entry.sourceUrl.replace(/\.git$/, '').replace(/\/$/, '');
+        installUrl = `${installUrl}/tree/main/${skillFolder}`;
+      }
+      installArgs = ['-y', 'skills', 'add', installUrl, '-g', '-y'];
     }
 
     // Use skills CLI to reinstall with -g -y flags
-    const result = spawnSync('npx', ['-y', 'skills', 'add', installUrl, '-g', '-y'], {
+    const result = spawnSync('npx', installArgs, {
       stdio: ['inherit', 'pipe', 'pipe'],
     });
 


### PR DESCRIPTION
Description:                       
                
Summary

This PR improves the well-known skills workflow in two areas:

1. Lazy file fetching during add

Previously, skills add <url> called fetchAllSkills() which downloaded the full file contents of every skill on the server before presenting the selection UI. This was wasteful — the user might select only one out of ten skills, but all ten were fetched upfront.

Now only index.json is fetched first. File contents are downloaded in parallel only for the skills the user actually selects.

2. check and update support for well-known skills

check and update previously hard-filtered on sourceType === 'github', silently skipping any skill installed from a well-known endpoint. Users had no way to detect or apply updates without manually re-running skills add.

Now both commands handle sourceType === 'well-known' entries:
- check: fetches the remote SKILL.md and compares its SHA-256 hash against the locally installed copy
- update: reinstalls stale skills via skills add <baseUrl> --skill <name> -g -y

No new lock file fields are required — sourceUrl (already stored) contains enough information to reconstruct the base URL and skill name.

Test plan

- skills add <well-known-url> — only index.json is fetched before the selection prompt appears; selected skills are downloaded after confirmation
- skills check — well-known skills are included in the check output, not silently skipped
- skills update — stale well-known skills are reinstalled correctly
- skills check / skills update with GitHub-only skills — existing behaviour unchanged