### PR TITLE
feat: add AstrBot agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [37 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [38 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -209,44 +209,45 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:start -->
 | Agent | `--agent` | Project Path | Global Path |
 |-------|-----------|--------------|-------------|
-| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
-| Antigravity | `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
-| Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
-| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
-| OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline | `cline` | `.agents/skills/` | `~/.agents/skills/` |
-| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
-| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
-| Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
-| Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
-| Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
-| Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
-| Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
-| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
-| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
-| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
-| Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
-| Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
-| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
-| Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
-| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
-| Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
-| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
-| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
-| Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
-| OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
-| OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
-| Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
-| Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
-| Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
-| Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
-| Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
-| Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
-| Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
-| Zencoder | `zencoder` | `.zencoder/skills/` | `~/.zencoder/skills/` |
-| Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
-| Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
-| AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
+| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~\.config\agents\skills/` |
+| AstrBot | `astrbot` | `data/skills/` | `~\.astrbot\data\skills/` |
+| Antigravity | `antigravity` | `.agent/skills/` | `~\.gemini\antigravity\skills/` |
+| Augment | `augment` | `.augment/skills/` | `~\.augment\skills/` |
+| Claude Code | `claude-code` | `.claude/skills/` | `~\.claude\skills/` |
+| OpenClaw | `openclaw` | `skills/` | `~\.openclaw\skills/` |
+| Cline | `cline` | `.agents/skills/` | `~\.agents\skills/` |
+| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~\.codebuddy\skills/` |
+| Codex | `codex` | `.agents/skills/` | `~\.codex\skills/` |
+| Command Code | `command-code` | `.commandcode/skills/` | `~\.commandcode\skills/` |
+| Continue | `continue` | `.continue/skills/` | `~\.continue\skills/` |
+| Cortex Code | `cortex` | `.cortex/skills/` | `~\.snowflake\cortex\skills/` |
+| Crush | `crush` | `.crush/skills/` | `~\.config\crush\skills/` |
+| Cursor | `cursor` | `.agents/skills/` | `~\.cursor\skills/` |
+| Droid | `droid` | `.factory/skills/` | `~\.factory\skills/` |
+| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~\.gemini\skills/` |
+| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~\.copilot\skills/` |
+| Goose | `goose` | `.goose/skills/` | `~\.config\goose\skills/` |
+| Junie | `junie` | `.junie/skills/` | `~\.junie\skills/` |
+| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~\.iflow\skills/` |
+| Kilo Code | `kilo` | `.kilocode/skills/` | `~\.kilocode\skills/` |
+| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~\.kiro\skills/` |
+| Kode | `kode` | `.kode/skills/` | `~\.kode\skills/` |
+| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~\.mcpjam\skills/` |
+| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~\.vibe\skills/` |
+| Mux | `mux` | `.mux/skills/` | `~\.mux\skills/` |
+| OpenCode | `opencode` | `.agents/skills/` | `~\.config\opencode\skills/` |
+| OpenHands | `openhands` | `.openhands/skills/` | `~\.openhands\skills/` |
+| Pi | `pi` | `.pi/skills/` | `~\.pi\agent\skills/` |
+| Qoder | `qoder` | `.qoder/skills/` | `~\.qoder\skills/` |
+| Qwen Code | `qwen-code` | `.qwen/skills/` | `~\.qwen\skills/` |
+| Roo Code | `roo` | `.roo/skills/` | `~\.roo\skills/` |
+| Trae | `trae` | `.trae/skills/` | `~\.trae\skills/` |
+| Trae CN | `trae-cn` | `.trae/skills/` | `~\.trae-cn\skills/` |
+| Windsurf | `windsurf` | `.windsurf/skills/` | `~\.codeium\windsurf\skills/` |
+| Zencoder | `zencoder` | `.zencoder/skills/` | `~\.zencoder\skills/` |
+| Neovate | `neovate` | `.neovate/skills/` | `~\.neovate\skills/` |
+| Pochi | `pochi` | `.pochi/skills/` | `~\.pochi\skills/` |
+| AdaL | `adal` | `.adal/skills/` | `~\.adal\skills/` |
 <!-- supported-agents:end -->
 
 > [!NOTE]
@@ -317,6 +318,7 @@ The CLI searches for skills in these locations within a repository:
 - `skills/.experimental/`
 - `skills/.system/`
 - `.agents/skills/`
+- `./data/skills/`
 - `.agent/skills/`
 - `.augment/skills/`
 - `.claude/skills/`

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "skills",
     "ai-agents",
     "amp",
+    "astrbot",
     "antigravity",
     "augment",
     "claude-code",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -36,6 +36,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(configHome, 'amp'));
     },
   },
+  astrbot: {
+    name: 'astrbot',
+    displayName: 'AstrBot',
+    skillsDir: 'data/skills',
+    globalSkillsDir: join(home, '.astrbot/data/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), 'data/skills')) || existsSync(join(home, '.astrbot'));
+    },
+  },
   antigravity: {
     name: 'antigravity',
     displayName: 'Antigravity',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type AgentType =
   | 'amp'
   | 'antigravity'
+  | 'astrbot'
   | 'augment'
   | 'claude-code'
   | 'openclaw'


### PR DESCRIPTION
## Summary
Adds support for [AstrBot](https://github.com/AstrBotDevs/AstrBot) as a target agent.

- **Local install dir**: \data/skills\
- **Global install dir**: \~/.astrbot/data/skills\

Closes #460