### PR TITLE
fix: acknolwedge cursor as specific agent and create symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Skills can be installed to any of these agents:
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
 | Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
 | Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
-| Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
+| Cursor | `cursor` | `.cursor/skills/` | `~/.cursor/skills/` |
 | Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -142,7 +142,7 @@ export const agents: Record<AgentType, AgentConfig> = {
   cursor: {
     name: 'cursor',
     displayName: 'Cursor',
-    skillsDir: '.agents/skills',
+    skillsDir: '.cursor/skills',
     globalSkillsDir: join(home, '.cursor/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.cursor'));

--- a/tests/list-installed.test.ts
+++ b/tests/list-installed.test.ts
@@ -165,8 +165,8 @@ ${skillData.description}
   it('should find skills in agent-specific directories (issue #225)', async () => {
     vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['cursor']);
 
-    // Cursor now uses .agents/skills (universal directory)
-    const cursorSkillDir = join(testDir, '.agents', 'skills', 'cursor-skill');
+    // Cursor uses .cursor/skills (agent-specific directory)
+    const cursorSkillDir = join(testDir, '.cursor', 'skills', 'cursor-skill');
     await mkdir(cursorSkillDir, { recursive: true });
     await writeFile(
       join(cursorSkillDir, 'SKILL.md'),


### PR DESCRIPTION
## Summary

Fixes vercel-labs#421

Cursor was previously configured as a **universal** agent (`skillsDir: '.agents/skills'`), so it shared the canonical `.agents/skills` directory with Amp, Claude Code, and others. Cursor instead expects skills in its own locations: `.cursor/skills` in the repo and `~/.cursor/skills` globally.

- **Stopped treating Cursor as universal:** set Cursor’s `skillsDir` to `.cursor/skills` (and kept `globalSkillsDir` as `~/.cursor/skills`). Cursor is now a normal non-universal agent.
- **Install behavior:** the existing installer already copies to the canonical `.agents/skills` (or `~/.agents/skills`) and creates symlinks for non-universal agents. Cursor now gets symlinks in `.cursor/skills` and `~/.cursor/skills` pointing at those canonical paths.
- **Docs and tests:** README agent table and the list-installed test were updated so Cursor uses `.cursor/skills` (agent-specific) instead of `.agents/skills`.

## Test plan

- All 341 existing tests pass (`pnpm test`)
- `list-installed.test.ts`: “should find skills in agent-specific directories (issue #225)” now places the Cursor skill under `.cursor/skills/cursor-skill` and asserts it is found and attributed to Cursor
- Code formatted with `pnpm format`
