### PR TITLE
feat: add -b/--branch flag to specify branch explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ npx skills add git@github.com:vercel-labs/agent-skills.git
 
 # Local path
 npx skills add ./my-local-skills
+
+# Branch with slashes (use --branch flag)
+npx skills add owner/repo --branch feature/some-skill
 ```
 
 ### Options
@@ -41,6 +44,7 @@ npx skills add ./my-local-skills
 | `-g, --global`            | Install to user directory instead of project                                                                                                       |
 | `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Available Agents](#available-agents)<!-- agent-names:end -->                  |
 | `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
+| `-b, --branch <branch>`   | Specify branch name explicitly (useful for branches with slashes like `feature/some-skill`)                                                        |
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
@@ -72,6 +76,10 @@ npx skills add vercel-labs/agent-skills --skill '*' -a claude-code
 
 # Install specific skills to all agents
 npx skills add vercel-labs/agent-skills --agent '*' --skill frontend-design
+
+# Install from a branch with slashes in the name
+npx skills add owner/repo --branch feature/some-skill
+npx skills add https://github.com/owner/repo -b develop/some-skill
 ```
 
 ### Installation Scope

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -389,6 +389,32 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse --branch flag', () => {
+    const result = parseAddOptions(['source', '--branch', 'feature/some-skill']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('feature/some-skill');
+  });
+
+  it('should parse -b flag (branch shorthand)', () => {
+    const result = parseAddOptions(['source', '-b', 'develop']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('develop');
+  });
+
+  it('should parse branch with complex names', () => {
+    const result = parseAddOptions(['source', '-b', 'feature/my-feature/sub-task']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('feature/my-feature/sub-task');
+  });
+
+  it('should parse branch with other flags', () => {
+    const result = parseAddOptions(['source', '-b', 'main', '-g', '-y']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.branch).toBe('main');
+    expect(result.options.global).toBe(true);
+    expect(result.options.yes).toBe(true);
+  });
 });
 
 describe('find-skills prompt with -y flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -417,6 +417,7 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  branch?: string;
 }
 
 /**
@@ -922,7 +923,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const spinner = p.spinner();
 
     spinner.start('Parsing source...');
-    const parsed = parseSource(source);
+    const parsed = parseSource(source, options.branch);
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
@@ -1775,6 +1776,11 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg === '-b' || arg === '--branch') {
+      i++;
+      if (i < args.length && args[i] && !args[i]!.startsWith('-')) {
+        options.branch = args[i];
+      }
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
     } else if (arg === '--copy') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,7 @@ ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
   -s, --skill <skills>   Specify skill names to install (use '*' for all skills)
+  -b, --branch <branch>  Specify branch name (useful for branches with slashes like feature/some-skill)
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
@@ -140,7 +141,7 @@ ${BOLD}Remove Options:${RESET}
   -s, --skill <skills>   Specify skills to remove (use '*' for all skills)
   -y, --yes              Skip confirmation prompts
   --all                  Shorthand for --skill '*' --agent '*' -y
-  
+
 ${BOLD}Experimental Sync Options:${RESET}
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
   -y, --yes              Skip confirmation prompts

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -92,7 +92,11 @@ const SOURCE_ALIASES: Record<string, string> = {
   'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
 };
 
-export function parseSource(input: string): ParsedSource {
+/**
+ * @param input - The source string to parse
+ * @param explicitBranch - Optional explicit branch name (useful for branches with slashes like feature/some-skill)
+ */
+export function parseSource(input: string, explicitBranch?: string): ParsedSource {
   // Resolve source aliases before parsing
   const alias = SOURCE_ALIASES[input];
   if (alias) {
@@ -108,6 +112,38 @@ export function parseSource(input: string): ParsedSource {
       url: resolvedPath, // Store resolved path in url for consistency
       localPath: resolvedPath,
     };
+  }
+
+  // If explicitBranch is provided, handle GitHub URLs and shorthand specially
+  // Extract owner/repo and use the explicit branch, ignoring any path-like segments
+  if (explicitBranch) {
+    // Handle GitHub URLs
+    const githubMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
+    if (githubMatch) {
+      const [, owner, repo] = githubMatch;
+      const cleanRepo = repo!.replace(/\.git$/, '').replace(/\/.*$/, '');
+      return {
+        type: 'github',
+        url: `https://github.com/${owner}/${cleanRepo}.git`,
+        ref: explicitBranch,
+      };
+    }
+
+    // Handle GitHub shorthand: owner/repo
+    const shorthandMatch = input.match(/^([^/]+)\/([^/]+)(?:\/.*)?$/);
+    if (
+      shorthandMatch &&
+      !input.includes(':') &&
+      !input.startsWith('.') &&
+      !input.startsWith('/')
+    ) {
+      const [, owner, repo] = shorthandMatch;
+      return {
+        type: 'github',
+        url: `https://github.com/${owner}/${repo}.git`,
+        ref: explicitBranch,
+      };
+    }
   }
 
   // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill

--- a/tests/branch-with-slash.test.ts
+++ b/tests/branch-with-slash.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { parseSource } from '../src/source-parser.ts';
+
+describe('parseSource with branch parameter', () => {
+  it('should parse branch with slashes when explicitBranch is provided (shorthand)', () => {
+    const result = parseSource('owner/repo', 'feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should parse branch with slashes when explicitBranch is provided (full URL with tree)', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/feature', 'feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should parse branch with slashes when explicitBranch is provided (URL with tree and path)', () => {
+    const result = parseSource(
+      'https://github.com/owner/repo/tree/feature/some-skill',
+      'feature/some-skill'
+    );
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should treat path as subpath when no explicitBranch is provided', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/main/path/to/skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'main',
+      subpath: 'path/to/skill',
+    });
+  });
+
+  it('should override URL branch with explicitBranch when both are present', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/main', 'feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/some-skill',
+    });
+  });
+
+  it('should work with complex branch names', () => {
+    const result = parseSource('owner/repo', 'feature/my-feature/sub-task');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature/my-feature/sub-task',
+    });
+  });
+
+  it('should not affect normal branch parsing without explicitBranch', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/main');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'main',
+    });
+  });
+
+  it('should work with shorthand owner/repo/path when no explicitBranch', () => {
+    const result = parseSource('owner/repo/path/to/skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      subpath: 'path/to/skill',
+    });
+  });
+
+  it('should incorrectly parse branch with slashes as ref+subpath when explicitBranch is NOT provided (demonstrates the problem)', () => {
+    // This demonstrates the problem: when branch name has slashes like "feature/some-skill"
+    // and you don't provide explicitBranch, it gets incorrectly parsed as ref + subpath
+    const result = parseSource('https://github.com/owner/repo/tree/feature/some-skill');
+    expect(result).toEqual({
+      type: 'github',
+      url: 'https://github.com/owner/repo.git',
+      ref: 'feature', // Wrong: only first part is treated as branch
+      subpath: 'some-skill', // Wrong: rest is treated as path
+    });
+    // This is why you need to use --branch flag for branches with slashes
+  });
+});


### PR DESCRIPTION
## Summary

Cherry-picks and rebases the work from [vercel-labs/skills#228](https://github.com/vercel-labs/skills/pull/228) by [@Zmnortal](https://github.com/Zmnortal) onto v1.4.3.

Adds a `-b` / `--branch` CLI flag to `skills add` that lets users specify a branch name explicitly, solving the long-standing ambiguity when branch names contain `/` (e.g. `feature/some-skill`, `skills/add-foo`).

### The problem

`skills add "https://github.com/org/repo/tree/feature/some-skill"` is ambiguous — the URL parser can't distinguish branch `feature` + subpath `some-skill` from branch `feature/some-skill`. GitHub resolves this server-side; a local CLI parser cannot.

### The fix

```bash
skills add owner/repo -b feature/some-skill
skills add https://github.com/owner/repo --branch skills/add-cve-lookup
```

The `--branch` flag bypasses URL-based branch extraction entirely, passing the explicit branch to `parseSource()` which constructs a clean `owner/repo.git` + `ref` result.

### Changes

- `src/add.ts` — Add `branch?: string` to `AddOptions`, parse `-b`/`--branch` in `parseAddOptions()`, pass to `parseSource()`
- `src/source-parser.ts` — Accept optional `explicitBranch` parameter, short-circuit GitHub URL/shorthand parsing when provided
- `src/cli.ts` — Add `-b, --branch` to help text
- `src/add.test.ts` — 4 new tests for flag parsing
- `tests/branch-with-slash.test.ts` — 9 new tests for source parser with explicit branch
- `README.md` — Document the new flag and examples

### Test results

All 56 tests pass (9 new branch-with-slash + 47 existing source-parser).

### Attribution

Based on [vercel-labs/skills#228](https://github.com/vercel-labs/skills/pull/228) by [@Zmnortal](https://github.com/Zmnortal). The upstream PR has been open since 2026-01-30 with no maintainer review. This fork carries the feature forward on v1.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)