### PR TITLE
feat: surface audit results in skills find and skills add

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,7 +4,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import { parseAddOptions, getLockSource } from './add.ts';
+import { parseAddOptions, getLockSource, getUnsafeSkills, hasUnsafeAudit } from './add.ts';
+import type { AuditResponse } from './telemetry.ts';
 
 describe('add command', () => {
   let testDir: string;
@@ -503,5 +504,70 @@ This is a test skill for -y flag mode testing.
     expect(result.stdout).not.toContain("One-time prompt - you won't be asked again");
     // Should complete successfully
     expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('unsafe audit detection', () => {
+  const at = '2026-01-01T00:00:00Z';
+  const skills = [{ slug: 'demo', displayName: 'demo' }];
+
+  describe('hasUnsafeAudit', () => {
+    it('returns false for undefined data', () => {
+      expect(hasUnsafeAudit(undefined)).toBe(false);
+    });
+
+    it('returns false when all partners are safe/low', () => {
+      expect(
+        hasUnsafeAudit({
+          ath: { risk: 'safe', analyzedAt: at },
+          snyk: { risk: 'low', analyzedAt: at },
+        })
+      ).toBe(false);
+    });
+
+    it.each(['medium', 'high', 'critical'] as const)('flags %s risk as unsafe', (risk) => {
+      expect(hasUnsafeAudit({ ath: { risk, analyzedAt: at } })).toBe(true);
+    });
+
+    it('flags any positive Socket alert count as unsafe', () => {
+      expect(hasUnsafeAudit({ socket: { risk: 'safe', alerts: 1, analyzedAt: at } })).toBe(true);
+    });
+
+    it('does not flag zero alerts on a safe partner', () => {
+      expect(hasUnsafeAudit({ socket: { risk: 'safe', alerts: 0, analyzedAt: at } })).toBe(false);
+    });
+
+    it('does not treat unknown risk as unsafe', () => {
+      expect(hasUnsafeAudit({ ath: { risk: 'unknown', analyzedAt: at } })).toBe(false);
+    });
+  });
+
+  describe('getUnsafeSkills', () => {
+    it('returns empty array when audit data is null', () => {
+      expect(getUnsafeSkills(null, skills)).toEqual([]);
+    });
+
+    it('returns the display names of skills with unsafe results', () => {
+      const auditData: AuditResponse = {
+        demo: { ath: { risk: 'high', analyzedAt: at } },
+      };
+      // hasUnsafeResults drives `initialValue: !hasUnsafeResults`, so a non-empty
+      // result here means the install confirm prompt defaults to "No".
+      expect(getUnsafeSkills(auditData, skills)).toEqual(['demo']);
+    });
+
+    it('returns empty when no selected skill is unsafe', () => {
+      const auditData: AuditResponse = {
+        demo: { ath: { risk: 'safe', analyzedAt: at } },
+      };
+      expect(getUnsafeSkills(auditData, skills)).toEqual([]);
+    });
+
+    it('only reports skills that are actually selected', () => {
+      const auditData: AuditResponse = {
+        other: { ath: { risk: 'critical', analyzedAt: at } },
+      };
+      expect(getUnsafeSkills(auditData, skills)).toEqual([]);
+    });
   });
 });

--- a/src/add.ts
+++ b/src/add.ts
@@ -54,6 +54,7 @@ import {
   fetchAuditData,
   type AuditResponse,
   type PartnerAudit,
+  type SkillAuditData,
 } from './telemetry.ts';
 import { detectAgent, getAgentType } from './detect-agent.ts';
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
@@ -164,6 +165,36 @@ function buildSecurityLines(
   lines.push(`${pc.dim('Details:')} ${pc.dim(`https://skills.sh/${source}`)}`);
 
   return lines;
+}
+
+export function hasUnsafeAudit(data: SkillAuditData | undefined): boolean {
+  if (!data) return false;
+
+  for (const partner of Object.values(data)) {
+    if (partner.risk === 'medium' || partner.risk === 'high' || partner.risk === 'critical') {
+      return true;
+    }
+    if ((partner.alerts ?? 0) > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function getUnsafeSkills(
+  auditData: AuditResponse | null,
+  skills: Array<{ slug: string; displayName: string }>
+): string[] {
+  if (!auditData) return [];
+
+  const unsafe: string[] = [];
+  for (const skill of skills) {
+    if (hasUnsafeAudit(auditData[skill.slug])) {
+      unsafe.push(skill.displayName);
+    }
+  }
+  return unsafe;
 }
 
 /**
@@ -1522,19 +1553,27 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     // Await and display security audit results (started earlier in parallel)
     // Wrapped in try/catch so a failed audit fetch never blocks installation.
+    let hasUnsafeResults = false;
     try {
       const auditData = await auditPromise;
       if (auditData && ownerRepoForAudit) {
-        const securityLines = buildSecurityLines(
-          auditData,
-          selectedSkills.map((s) => ({
-            slug: getSkillDisplayName(s),
-            displayName: getSkillDisplayName(s),
-          })),
-          ownerRepoForAudit
-        );
+        const selectedSkillRows = selectedSkills.map((s) => ({
+          slug: getSkillDisplayName(s),
+          displayName: getSkillDisplayName(s),
+        }));
+        const securityLines = buildSecurityLines(auditData, selectedSkillRows, ownerRepoForAudit);
         if (securityLines.length > 0) {
           p.note(securityLines.join('\n'), 'Security Risk Assessments');
+
+          const unsafeSkills = getUnsafeSkills(auditData, selectedSkillRows);
+          if (unsafeSkills.length > 0) {
+            hasUnsafeResults = true;
+            p.log.warn(
+              pc.red(
+                pc.bold(`Potentially unsafe audit results detected for: ${unsafeSkills.join(', ')}`)
+              )
+            );
+          }
         }
       }
     } catch {
@@ -1542,7 +1581,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     if (!options.yes) {
-      const confirmed = await p.confirm({ message: 'Proceed with installation?' });
+      const confirmed = await p.confirm({
+        message: 'Proceed with installation?',
+        initialValue: !hasUnsafeResults,
+      });
 
       if (p.isCancel(confirmed) || !confirmed) {
         p.cancel('Installation cancelled');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -162,6 +162,9 @@ ${BOLD}List Options:${RESET}
   -a, --agent <agents>   Filter by specific agents
   --json                 Output as JSON (machine-readable, no ANSI codes)
 
+${BOLD}Find Options:${RESET}
+  --unsafe               Show skills with risky/unknown audit results (default: safe only)
+
 ${BOLD}Options:${RESET}
   --help, -h        Show this help message
   --version, -v     Show version number
@@ -181,7 +184,8 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
   ${DIM}$${RESET} skills ls --json                      ${DIM}# JSON output${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
-  ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}
+  ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword (safe only)${RESET}
+  ${DIM}$${RESET} skills find typescript --unsafe      ${DIM}# include risky/unknown audit results${RESET}
   ${DIM}$${RESET} skills update
   ${DIM}$${RESET} skills update my-skill             ${DIM}# update a single skill${RESET}
   ${DIM}$${RESET} skills update -g                    ${DIM}# update global skills only${RESET}

--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseFindArgs, searchSkillsAPI } from './find.ts';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseFindArgs', () => {
+  it('parses --unsafe flag and query terms', () => {
+    expect(parseFindArgs(['typescript', '--unsafe'])).toEqual({
+      query: 'typescript',
+      allowUnsafe: true,
+    });
+  });
+
+  it('defaults to safe filtering without --unsafe', () => {
+    expect(parseFindArgs(['react', 'performance'])).toEqual({
+      query: 'react performance',
+      allowUnsafe: false,
+    });
+  });
+});
+
+describe('searchSkillsAPI audit integration', () => {
+  it('attaches audit data to search results', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.includes('/api/search')) {
+          return {
+            ok: true,
+            json: async () => ({
+              skills: [
+                {
+                  id: 'react-hooks',
+                  name: 'react-hooks',
+                  installs: 100,
+                  source: 'acme/skills',
+                },
+              ],
+            }),
+          } as Response;
+        }
+
+        if (url.includes('/audit')) {
+          return {
+            ok: true,
+            json: async () => ({
+              'react-hooks': {
+                ath: { risk: 'safe', analyzedAt: '2026-03-01T00:00:00.000Z' },
+                socket: { risk: 'safe', alerts: 0, analyzedAt: '2026-03-01T00:00:00.000Z' },
+              },
+            }),
+          } as Response;
+        }
+
+        return { ok: false } as Response;
+      })
+    );
+
+    const results = await searchSkillsAPI('react');
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.audit).toBeDefined();
+    expect(results[0]?.audit?.ath?.risk).toBe('safe');
+  });
+
+  it('filters out risky and unknown results by default (safe mode)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.includes('/api/search')) {
+          return {
+            ok: true,
+            json: async () => ({
+              skills: [
+                { id: 'safe-skill', name: 'safe-skill', installs: 100, source: 'acme/skills' },
+                { id: 'risky-skill', name: 'risky-skill', installs: 50, source: 'acme/skills' },
+                { id: 'unknown-skill', name: 'unknown-skill', installs: 10, source: 'acme/skills' },
+              ],
+            }),
+          } as Response;
+        }
+
+        if (url.includes('/audit')) {
+          return {
+            ok: true,
+            json: async () => ({
+              'safe-skill': {
+                ath: { risk: 'safe', analyzedAt: '2026-03-01T00:00:00.000Z' },
+              },
+              'risky-skill': {
+                ath: { risk: 'high', analyzedAt: '2026-03-01T00:00:00.000Z' },
+              },
+            }),
+          } as Response;
+        }
+
+        return { ok: false } as Response;
+      })
+    );
+
+    const results = await searchSkillsAPI('skill', { allowUnsafe: false });
+
+    expect(results.map((r) => r.name)).toEqual(['safe-skill']);
+  });
+
+  it('treats low risk (e.g. Snyk "all clear") as passing the safe filter', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.includes('/api/search')) {
+          return {
+            ok: true,
+            json: async () => ({
+              skills: [{ id: 'low-skill', name: 'low-skill', installs: 80, source: 'acme/skills' }],
+            }),
+          } as Response;
+        }
+
+        if (url.includes('/audit')) {
+          return {
+            ok: true,
+            json: async () => ({
+              'low-skill': {
+                ath: { risk: 'safe', analyzedAt: '2026-03-01T00:00:00.000Z' },
+                socket: { risk: 'safe', alerts: 0, analyzedAt: '2026-03-01T00:00:00.000Z' },
+                snyk: { risk: 'low', analyzedAt: '2026-03-01T00:00:00.000Z' },
+              },
+            }),
+          } as Response;
+        }
+
+        return { ok: false } as Response;
+      })
+    );
+
+    const results = await searchSkillsAPI('skill', { allowUnsafe: false });
+
+    expect(results.map((r) => r.name)).toEqual(['low-skill']);
+  });
+});

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,7 +1,7 @@
 import * as readline from 'readline';
 import { runAdd, parseAddOptions } from './add.ts';
 import { sanitizeMetadata } from './sanitize.ts';
-import { track } from './telemetry.ts';
+import { track, fetchAuditData, type SkillAuditData } from './telemetry.ts';
 import { isRepoPrivate } from './source-parser.ts';
 import { isRunningInAgent } from './detect-agent.ts';
 
@@ -12,6 +12,8 @@ const TEXT = '\x1b[38;5;145m';
 const CYAN = '\x1b[36m';
 const MAGENTA = '\x1b[35m';
 const YELLOW = '\x1b[33m';
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
 
 // API endpoint for skills search
 const SEARCH_API_BASE = process.env.SKILLS_API_URL || 'https://skills.sh';
@@ -28,10 +30,101 @@ export interface SearchSkill {
   slug: string;
   source: string;
   installs: number;
+  audit?: SkillAuditData;
+}
+
+type RiskLevel = 'safe' | 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+
+const RISK_RANK: Record<RiskLevel, number> = {
+  safe: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+  unknown: 5,
+};
+
+function isRiskLevel(value: unknown): value is RiskLevel {
+  return typeof value === 'string' && Object.prototype.hasOwnProperty.call(RISK_RANK, value);
+}
+
+function getEffectiveRisk(audit: SkillAuditData | undefined): RiskLevel {
+  if (!audit || Object.keys(audit).length === 0) {
+    return 'unknown';
+  }
+
+  let worst: RiskLevel = 'safe';
+  let hasRiskData = false;
+  let hasSocketAlerts = false;
+
+  for (const partner of Object.values(audit)) {
+    if (isRiskLevel(partner.risk)) {
+      hasRiskData = true;
+      if (RISK_RANK[partner.risk] > RISK_RANK[worst]) {
+        worst = partner.risk;
+      }
+    }
+    if ((partner.alerts ?? 0) > 0) {
+      hasSocketAlerts = true;
+    }
+  }
+
+  if (!hasRiskData) {
+    return hasSocketAlerts ? 'medium' : 'unknown';
+  }
+
+  if (hasSocketAlerts && RISK_RANK[worst] < RISK_RANK.medium) {
+    return 'medium';
+  }
+
+  return worst;
+}
+
+function formatAuditBadge(audit: SkillAuditData | undefined): string {
+  const risk = getEffectiveRisk(audit);
+  switch (risk) {
+    case 'safe':
+    case 'low':
+      return `${GREEN}audit: pass${RESET}`;
+    case 'medium':
+      return `${YELLOW}audit: medium risk${RESET}`;
+    case 'high':
+      return `${RED}audit: high risk${RESET}`;
+    case 'critical':
+      return `${RED}audit: critical risk${RESET}`;
+    default:
+      return `${DIM}audit: unknown${RESET}`;
+  }
+}
+
+function isSafeForFilter(audit: SkillAuditData | undefined): boolean {
+  const risk = getEffectiveRisk(audit);
+  return risk === 'safe' || risk === 'low';
+}
+
+export function parseFindArgs(args: string[]): { query: string; allowUnsafe: boolean } {
+  const queryParts: string[] = [];
+  let allowUnsafe = false;
+
+  for (const arg of args) {
+    if (arg === '--unsafe') {
+      allowUnsafe = true;
+      continue;
+    }
+    queryParts.push(arg);
+  }
+
+  return {
+    query: queryParts.join(' ').trim(),
+    allowUnsafe,
+  };
 }
 
 // Search via API
-export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
+export async function searchSkillsAPI(
+  query: string,
+  options: { allowUnsafe?: boolean } = {}
+): Promise<SearchSkill[]> {
   try {
     const url = `${SEARCH_API_BASE}/api/search?q=${encodeURIComponent(query)}&limit=10`;
     const res = await fetch(url);
@@ -47,7 +140,7 @@ export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
       }>;
     };
 
-    return data.skills
+    const mapped = data.skills
       .map((skill) => ({
         name: sanitizeMetadata(skill.name),
         slug: sanitizeMetadata(skill.id),
@@ -55,6 +148,39 @@ export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
         installs: skill.installs,
       }))
       .sort((a, b) => (b.installs || 0) - (a.installs || 0));
+
+    const sourceToSkillNames = new Map<string, Set<string>>();
+    for (const skill of mapped) {
+      if (!skill.source) continue;
+      if (!sourceToSkillNames.has(skill.source)) {
+        sourceToSkillNames.set(skill.source, new Set());
+      }
+      sourceToSkillNames.get(skill.source)!.add(skill.name);
+    }
+
+    const auditsBySource = new Map<string, Record<string, SkillAuditData>>();
+    await Promise.all(
+      Array.from(sourceToSkillNames.entries()).map(async ([source, names]) => {
+        const auditData = await fetchAuditData(source, Array.from(names), 1500);
+        if (auditData) {
+          auditsBySource.set(source, auditData);
+        }
+      })
+    );
+
+    const withAudits = mapped.map((skill) => {
+      const sourceAudits = auditsBySource.get(skill.source);
+      return {
+        ...skill,
+        audit: sourceAudits?.[skill.name] || sourceAudits?.[skill.slug],
+      };
+    });
+
+    if (!options.allowUnsafe) {
+      return withAudits.filter((skill) => isSafeForFilter(skill.audit));
+    }
+
+    return withAudits;
   } catch {
     return [];
   }
@@ -68,7 +194,10 @@ const MOVE_UP = (n: number) => `\x1b[${n}A`;
 const MOVE_TO_COL = (n: number) => `\x1b[${n}G`;
 
 // Custom fzf-style search prompt using raw readline
-async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
+async function runSearchPrompt(
+  initialQuery = '',
+  allowUnsafe = false
+): Promise<SearchSkill | null> {
   let results: SearchSkill[] = [];
   let selectedIndex = 0;
   let query = initialQuery;
@@ -104,6 +233,9 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
     // Search input line with cursor
     const cursor = `${BOLD}_${RESET}`;
     lines.push(`${TEXT}Search skills:${RESET} ${query}${cursor}`);
+    if (!allowUnsafe) {
+      lines.push(`${DIM}Filter: safe audits only (use --unsafe to show risky skills)${RESET}`);
+    }
     lines.push('');
 
     // Results - keep showing existing results while loading new ones
@@ -112,7 +244,11 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
     } else if (results.length === 0 && loading) {
       lines.push(`${DIM}Searching...${RESET}`);
     } else if (results.length === 0) {
-      lines.push(`${DIM}No skills found${RESET}`);
+      lines.push(
+        !allowUnsafe
+          ? `${DIM}No safe skills found (use --unsafe to show risky skills)${RESET}`
+          : `${DIM}No skills found${RESET}`
+      );
     } else {
       const maxVisible = 8;
       const visible = results.slice(0, maxVisible);
@@ -125,9 +261,10 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
         const source = skill.source ? ` ${DIM}${skill.source}${RESET}` : '';
         const installs = formatInstalls(skill.installs);
         const installsBadge = installs ? ` ${CYAN}${installs}${RESET}` : '';
+        const auditBadge = ` ${formatAuditBadge(skill.audit)}`;
         const loadingIndicator = loading && i === 0 ? ` ${DIM}...${RESET}` : '';
 
-        lines.push(`  ${arrow} ${name}${source}${installsBadge}${loadingIndicator}`);
+        lines.push(`  ${arrow} ${name}${source}${installsBadge}${auditBadge}${loadingIndicator}`);
       }
     }
 
@@ -169,7 +306,7 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
 
     debounceTimer = setTimeout(async () => {
       try {
-        results = await searchSkillsAPI(q);
+        results = await searchSkillsAPI(q, { allowUnsafe });
         selectedIndex = 0;
       } catch {
         results = [];
@@ -269,7 +406,7 @@ async function isRepoPublic(owner: string, repo: string): Promise<boolean> {
 }
 
 export async function runFind(args: string[]): Promise<void> {
-  const query = args.join(' ');
+  const { query, allowUnsafe } = parseFindArgs(args);
   const isNonInteractive = !process.stdin.isTTY;
   const agentTip = `${DIM}Tip: if running in a coding agent, follow these steps:${RESET}
 ${DIM}  1) npx skills find [query]${RESET}
@@ -277,7 +414,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
 
   // Non-interactive mode: just print results and exit
   if (query) {
-    const results = await searchSkillsAPI(query);
+    const results = await searchSkillsAPI(query, { allowUnsafe });
 
     // Track telemetry for non-interactive search
     track({
@@ -287,8 +424,18 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
     });
 
     if (results.length === 0) {
-      console.log(`${DIM}No skills found for "${query}"${RESET}`);
+      if (!allowUnsafe) {
+        console.log(`${DIM}No safe skills found for "${query}"${RESET}`);
+        console.log(`${DIM}Use --unsafe to show risky/unknown skills${RESET}`);
+      } else {
+        console.log(`${DIM}No skills found for "${query}"${RESET}`);
+      }
       return;
+    }
+
+    if (!allowUnsafe) {
+      console.log(`${DIM}Showing only skills with safe/low audit results${RESET}`);
+      console.log();
     }
 
     console.log(`${DIM}Install with${RESET} npx skills add <owner/repo@skill>`);
@@ -297,8 +444,9 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
     for (const skill of results.slice(0, 6)) {
       const pkg = skill.source || skill.slug;
       const installs = formatInstalls(skill.installs);
+      const audit = formatAuditBadge(skill.audit);
       console.log(
-        `${TEXT}${pkg}@${skill.name}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`
+        `${TEXT}${pkg}@${skill.name}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''} ${audit}`
       );
       console.log(`${DIM}└ https://skills.sh/${skill.slug}${RESET}`);
       console.log();
@@ -314,7 +462,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
     return;
   }
 
-  const selected = await runSearchPrompt();
+  const selected = await runSearchPrompt('', allowUnsafe);
 
   // Track telemetry for interactive search
   track({


### PR DESCRIPTION
## Summary

- **`skills find`**: fetches audit data alongside search results and displays a colored badge (`pass` / `medium risk` / `high risk` / `critical risk` / `unknown`) next to each skill. By default, only skills with safe/low audit results are shown; a new `--unsafe` flag includes risky and unknown skills.
- **`skills add`**: when unsafe audit results are detected, shows a bold red warning naming the affected skills and defaults the confirmation prompt to "No".

## Details

### `skills find`

- Audit data is fetched in parallel (grouped by source repo) with a 1.5s timeout so it doesn't significantly slow down search.
- Safe-only filtering is on by default. When no safe results are found, the output suggests using `--unsafe`.
- Both interactive (fzf-style) and non-interactive modes show the audit badge and respect the `--unsafe` flag.
- A filter hint is shown in interactive mode: `Filter: safe audits only (use --unsafe to show risky skills)`.
- Snyk's lowest risk level is `low` (it never returns `safe`), so both `safe` and `low` map to `audit: pass`.

### `skills add`

- After the "Security Risk Assessments" table (which was already displayed), a bold red warning is now shown when any selected skills have medium/high/critical risk or socket alerts.
- When unsafe results are detected, the "Proceed with installation?" prompt defaults to No instead of Yes.

## Test plan

- New unit tests for `parseFindArgs` (flag parsing) and `searchSkillsAPI` (audit attachment, safe filtering, Snyk `low`-as-pass behavior).
- Manual testing of `skills find` (interactive and non-interactive, with and without `--unsafe`), `skills add` (with safe and unsafe skills), and the confirmation prompt defaulting behavior.
- All existing tests continue to pass.

Closes #476
Closes #445