### PR TITLE
fix: pass auth token to fetchSkillFolderHash and fix Windows spawnSync ENOENT

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -50,6 +50,7 @@ import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
   fetchSkillFolderHash,
+  getGitHubToken,
   isPromptDismissed,
   dismissPrompt,
   getLastSelectedAgents,
@@ -1485,7 +1486,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
-              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue);
+              const token = getGitHubToken();
+              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token);
               if (hash) skillFolderHash = hash;
             }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -584,6 +584,7 @@ async function runUpdate(): Promise<void> {
     // Use skills CLI to reinstall with -g -y flags
     const result = spawnSync('npx', ['-y', 'skills', 'add', installUrl, '-g', '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
     });
 
     if (result.status === 0) {


### PR DESCRIPTION
## Summary

Two small bug fixes:

- **#454**: `fetchSkillFolderHash()` in `add.ts` was called without an auth token, meaning authenticated users hit unauthenticated GitHub API rate limits (60 req/hr instead of 5,000) during `skills add`. Now passes `getGitHubToken()`.
- **#477**: `spawnSync('npx', ...)` in the `update` command fails with `ENOENT` on Windows because `npx` is a `.cmd` script. Added `shell: true` when `process.platform === 'win32'`.

## Changes

- `src/add.ts`: Import `getGitHubToken` and pass the token to `fetchSkillFolderHash()` at the install lock-file step
- `src/cli.ts`: Add `shell: process.platform === 'win32'` to the `spawnSync` call in `runUpdate()`

## Testing

All 347 tests pass. Both changes are minimal and low-risk.

Fixes #454
Fixes #477