### PR TITLE
fix: correct global install path for universal agents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,22 +209,17 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:start -->
 | Agent | `--agent` | Project Path | Global Path |
 |-------|-----------|--------------|-------------|
-| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
+| Amp, Cline, Codex, Cursor, Gemini CLI, GitHub Copilot, Kimi Code CLI, OpenCode, Replit, Universal | `amp`, `cline`, `codex`, `cursor`, `gemini-cli`, `github-copilot`, `kimi-cli`, `opencode`, `replit`, `universal` | `.agents/skills/` | `~/.agents/skills/` |
 | Antigravity | `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline | `cline` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
-| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
 | Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
 | Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
-| Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
 | Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
-| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
-| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
@@ -234,7 +229,6 @@ Skills can be installed to any of these agents:
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
-| OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -5,6 +5,8 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { agents } from '../src/agents.ts';
 
+const CANONICAL_GLOBAL_SKILLS_DIR = join(homedir(), '.agents', 'skills');
+
 const ROOT = join(import.meta.dirname, '..');
 const README_PATH = join(ROOT, 'README.md');
 const PACKAGE_PATH = join(ROOT, 'package.json');
@@ -32,13 +34,15 @@ function generateAvailableAgentsTable(): string {
   >();
 
   for (const [key, a] of Object.entries(agents)) {
-    const pathKey = `${a.skillsDir}|${a.globalSkillsDir}`;
+    const globalInstallDir =
+      a.skillsDir === '.agents/skills' ? CANONICAL_GLOBAL_SKILLS_DIR : a.globalSkillsDir;
+    const pathKey = `${a.skillsDir}|${globalInstallDir}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
         keys: [],
         displayNames: [],
         skillsDir: a.skillsDir,
-        globalSkillsDir: a.globalSkillsDir,
+        globalSkillsDir: globalInstallDir,
       });
     }
     const group = pathGroups.get(pathKey)!;


### PR DESCRIPTION
## Summary

Universal agents (those with `.agents/skills/` as their project path) all install globally to `~/.agents/skills/` via the canonical path logic in `installer.ts`. However, the README was displaying incorrect paths sourced directly from each agent's `globalSkillsDir` property — for example, `~/.cursor/skills/`, `~/.gemini/skills/`, `~/.config/agents/skills/` — which don't match where skills actually end up.

Root cause: `sync-agents.ts` used `a.globalSkillsDir` directly when generating the table, but `installer.ts` bypasses `globalSkillsDir` for universal agents and always uses `getCanonicalSkillsDir()` (`~/.agents/skills/`).

**Fix:** Updated `sync-agents.ts` to use the canonical path (`~/.agents/skills/`) for any agent where `skillsDir === '.agents/skills'`, then regenerated the README.