### PR TITLE
feat: add Witsy agent support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -392,6 +392,18 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.adal'));
     },
   },
+  witsy: {
+    name: 'witsy',
+    displayName: 'Witsy',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
+    detectInstalled: async () => {
+      return (
+        existsSync(join(home, 'Library/Application Support/Witsy')) ||
+        existsSync(join(configHome, 'Witsy'))
+      );
+    },
+  },
   universal: {
     name: 'universal',
     displayName: 'Universal',

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type AgentType =
   | 'zencoder'
   | 'pochi'
   | 'adal'
+  | 'witsy'
   | 'universal';
 
 export interface Skill {


### PR DESCRIPTION
## Summary

Adds [Witsy](https://github.com/nbonamy/witsy) as a supported agent.

Witsy is a cross-platform Electron-based desktop AI assistant that serves as a universal MCP client. It already supports Claude-style SKILL.md skills with the same frontmatter format and uses the `.agents/skills` directory convention (universal agent).

### Changes

- Added `'witsy'` to the `AgentType` union in `src/types.ts`
- Added `witsy` agent config in `src/agents.ts` with:
  - `skillsDir: '.agents/skills'` (universal)
  - `globalSkillsDir: ~/.agents/skills`
  - Detection via Electron userData directory (macOS: `~/Library/Application Support/Witsy`, Linux/Windows: `~/.config/Witsy`)

### Testing

All 368 existing tests pass with no modifications needed.