### PR TITLE
fix: support comma-separated values in --agent and --skill flags

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -389,6 +389,24 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse comma-separated agents', () => {
+    const result = parseAddOptions(['source', '-a', 'claude-code,cursor,codex']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.agent).toEqual(['claude-code', 'cursor', 'codex']);
+  });
+
+  it('should parse comma-separated skills', () => {
+    const result = parseAddOptions(['source', '-s', 'skill-a,skill-b']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.skill).toEqual(['skill-a', 'skill-b']);
+  });
+
+  it('should parse mixed comma-separated and space-separated agents', () => {
+    const result = parseAddOptions(['source', '-a', 'claude-code,cursor', 'codex']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.agent).toEqual(['claude-code', 'cursor', 'codex']);
+  });
 });
 
 describe('find-skills prompt with -y flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1762,7 +1762,7 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.agent.push(nextArg);
+        options.agent.push(...nextArg.split(','));
         i++;
         nextArg = args[i];
       }
@@ -1772,7 +1772,7 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.skill.push(nextArg);
+        options.skill.push(...nextArg.split(','));
         i++;
         nextArg = args[i];
       }

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -61,6 +61,16 @@ describe('list command', () => {
       expect(options.agent).toEqual(['claude-code']);
       expect(options.global).toBe(true);
     });
+
+    it('should parse comma-separated agents', () => {
+      const options = parseListOptions(['-a', 'claude-code,cursor,codex']);
+      expect(options.agent).toEqual(['claude-code', 'cursor', 'codex']);
+    });
+
+    it('should parse mixed comma-separated and space-separated agents', () => {
+      const options = parseListOptions(['-a', 'claude-code,cursor', 'codex']);
+      expect(options.agent).toEqual(['claude-code', 'cursor', 'codex']);
+    });
   });
 
   describe('CLI integration', () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -53,7 +53,7 @@ export function parseListOptions(args: string[]): ListOptions {
       options.agent = options.agent || [];
       // Collect all following arguments until next flag
       while (i + 1 < args.length && !args[i + 1]!.startsWith('-')) {
-        options.agent.push(args[++i]!);
+        options.agent.push(...args[++i]!.split(','));
       }
     }
   }

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -314,5 +314,13 @@ This is a test skill.
       );
       expect(result.stdout).not.toContain('Invalid agents');
     });
+
+    it('should handle comma-separated values for --agent', () => {
+      const result = runCli(
+        ['remove', 'parse-test-skill', '--agent', 'claude-code,cursor', '-y'],
+        testDir
+      );
+      expect(result.stdout).not.toContain('Invalid agents');
+    });
   });
 });

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -297,7 +297,7 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.agent.push(nextArg);
+        options.agent.push(...nextArg.split(','));
         i++;
         nextArg = args[i];
       }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -435,7 +435,7 @@ export function parseSyncOptions(args: string[]): { options: SyncOptions } {
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.agent.push(nextArg);
+        options.agent.push(...nextArg.split(','));
         i++;
         nextArg = args[i];
       }


### PR DESCRIPTION
## Problem
When passing comma-separated agent names to -a/--agent, the CLI treats the entire string as a single agent name:
```
npx skills add devxoul/agent-messenger -a claude-code,codex,opencode
```

■ Invalid agents: claude-code,codex,opencode
● Valid agents: claude-code, codex, opencode, ...

Each individual name is valid, but "claude-code,codex,opencode" as a single string is not.

### Root Cause
All four option parsers (parseAddOptions, parseRemoveOptions, parseSyncOptions, parseListOptions) push raw argument values without splitting on commas:
```
// Before
options.agent.push(nextArg); // "claude-code,codex,opencode" → 1 entry
```
## Changes
Split comma-separated values before pushing:

```
// After
options.agent.push(...nextArg.split(',')); // → 3 entries
```

Applied to --agent parsing in all 4 files and --skill parsing in add.ts.
Supported formats after fix:
```
skills add source -a claude-code codex opencode      # space-separated (existing)
skills add source -a claude-code,codex,opencode       # comma-separated (new)
skills add source -a claude-code,codex opencode        # mixed (new)
skills add source -s skill-a,skill-b                  # comma-separated skills (new)
```

## Tests
Added unit tests for comma-separated and mixed parsing in add.test.ts, list.test.ts, remove.test.ts. All existing tests unaffected.