### PR TITLE
feat: add --token flag for Bearer token auth with private URL sources

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -389,6 +389,26 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse --token flag', () => {
+    const result = parseAddOptions(['https://example.com', '--token', 'my-secret-token']);
+    expect(result.source).toEqual(['https://example.com']);
+    expect(result.options.token).toBe('my-secret-token');
+  });
+
+  it('should parse --token with other flags', () => {
+    const result = parseAddOptions([
+      'https://example.com',
+      '--token',
+      'my-secret-token',
+      '-g',
+      '-y',
+    ]);
+    expect(result.source).toEqual(['https://example.com']);
+    expect(result.options.token).toBe('my-secret-token');
+    expect(result.options.global).toBe(true);
+    expect(result.options.yes).toBe(true);
+  });
 });
 
 describe('find-skills prompt with -y flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -418,6 +418,7 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  token?: string;
 }
 
 /**
@@ -433,7 +434,7 @@ async function handleWellKnownSkills(
   spinner.start('Discovering skills from well-known endpoint...');
 
   // Fetch all skills from the well-known endpoint
-  const skills = await wellKnownProvider.fetchAllSkills(url);
+  const skills = await wellKnownProvider.fetchAllSkills(url, options.token);
 
   if (skills.length === 0) {
     spinner.stop(pc.red('No skills found'));
@@ -1781,6 +1782,9 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--token') {
+      i++;
+      options.token = args[i];
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -82,11 +82,20 @@ export class WellKnownProvider implements HostProvider {
   }
 
   /**
+   * Build fetch init options with optional Bearer token authorization.
+   */
+  private buildFetchOptions(token?: string): RequestInit {
+    if (!token) return {};
+    return { headers: { Authorization: `Bearer ${token}` } };
+  }
+
+  /**
    * Fetch the skills index from a well-known endpoint.
    * Tries both the path-relative .well-known and the root .well-known.
    */
   async fetchIndex(
-    baseUrl: string
+    baseUrl: string,
+    token?: string
   ): Promise<{ index: WellKnownIndex; resolvedBaseUrl: string } | null> {
     try {
       const parsed = new URL(baseUrl);
@@ -110,9 +119,11 @@ export class WellKnownProvider implements HostProvider {
         });
       }
 
+      const fetchOptions = this.buildFetchOptions(token);
+
       for (const { indexUrl, baseUrl: resolvedBase } of urlsToTry) {
         try {
-          const response = await fetch(indexUrl);
+          const response = await fetch(indexUrl, fetchOptions);
 
           if (!response.ok) {
             continue;
@@ -188,12 +199,12 @@ export class WellKnownProvider implements HostProvider {
   /**
    * Fetch a single skill and all its files from a well-known endpoint.
    */
-  async fetchSkill(url: string): Promise<RemoteSkill | null> {
+  async fetchSkill(url: string, token?: string): Promise<RemoteSkill | null> {
     try {
       const parsed = new URL(url);
 
       // First, fetch the index to get skill metadata
-      const result = await this.fetchIndex(url);
+      const result = await this.fetchIndex(url, token);
       if (!result) {
         return null;
       }
@@ -223,7 +234,7 @@ export class WellKnownProvider implements HostProvider {
         return null;
       }
 
-      return this.fetchSkillByEntry(resolvedBaseUrl, skillEntry);
+      return this.fetchSkillByEntry(resolvedBaseUrl, skillEntry, token);
     } catch {
       return null;
     }
@@ -233,18 +244,22 @@ export class WellKnownProvider implements HostProvider {
    * Fetch a skill by its index entry.
    * @param baseUrl - The base URL (e.g., https://example.com or https://example.com/docs)
    * @param entry - The skill entry from index.json
+   * @param token - Optional Bearer token for authentication
    */
   async fetchSkillByEntry(
     baseUrl: string,
-    entry: WellKnownSkillEntry
+    entry: WellKnownSkillEntry,
+    token?: string
   ): Promise<WellKnownSkill | null> {
     try {
       // Build the skill base URL: {baseUrl}/.well-known/skills/{skill-name}
       const skillBaseUrl = `${baseUrl.replace(/\/$/, '')}/${this.WELL_KNOWN_PATH}/${entry.name}`;
 
+      const fetchOptions = this.buildFetchOptions(token);
+
       // Fetch SKILL.md first (required)
       const skillMdUrl = `${skillBaseUrl}/SKILL.md`;
-      const response = await fetch(skillMdUrl);
+      const response = await fetch(skillMdUrl, fetchOptions);
 
       if (!response.ok) {
         return null;
@@ -267,7 +282,7 @@ export class WellKnownProvider implements HostProvider {
       const filePromises = otherFiles.map(async (filePath) => {
         try {
           const fileUrl = `${skillBaseUrl}/${filePath}`;
-          const fileResponse = await fetch(fileUrl);
+          const fileResponse = await fetch(fileUrl, fetchOptions);
           if (fileResponse.ok) {
             const fileContent = await fileResponse.text();
             return { path: filePath, content: fileContent };
@@ -303,9 +318,9 @@ export class WellKnownProvider implements HostProvider {
   /**
    * Fetch all skills from a well-known endpoint.
    */
-  async fetchAllSkills(url: string): Promise<WellKnownSkill[]> {
+  async fetchAllSkills(url: string, token?: string): Promise<WellKnownSkill[]> {
     try {
-      const result = await this.fetchIndex(url);
+      const result = await this.fetchIndex(url, token);
       if (!result) {
         return [];
       }
@@ -314,7 +329,7 @@ export class WellKnownProvider implements HostProvider {
 
       // Fetch all skills in parallel
       const skillPromises = index.skills.map((entry: WellKnownSkillEntry) =>
-        this.fetchSkillByEntry(resolvedBaseUrl, entry)
+        this.fetchSkillByEntry(resolvedBaseUrl, entry, token)
       );
       const results = await Promise.all(skillPromises);
 
@@ -372,8 +387,8 @@ export class WellKnownProvider implements HostProvider {
   /**
    * Check if a URL has a well-known skills index.
    */
-  async hasSkillsIndex(url: string): Promise<boolean> {
-    const result = await this.fetchIndex(url);
+  async hasSkillsIndex(url: string, token?: string): Promise<boolean> {
+    const result = await this.fetchIndex(url, token);
     return result !== null;
   }
 }

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WellKnownProvider } from '../src/providers/wellknown.ts';
 
 describe('WellKnownProvider', () => {
@@ -94,6 +94,55 @@ describe('WellKnownProvider', () => {
     it('provider should have display name "Well-Known Skills"', () => {
       expect(provider.displayName).toBe('Well-Known Skills');
     });
+  });
+});
+
+describe('WellKnownProvider token authentication', () => {
+  const provider = new WellKnownProvider();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetchIndex should send Authorization header when token is provided', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          skills: [{ name: 'test-skill', description: 'A test skill', files: ['SKILL.md'] }],
+        }),
+        { status: 200 }
+      )
+    );
+
+    await provider.fetchIndex('https://example.com', 'my-secret-token');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer my-secret-token' }),
+      })
+    );
+  });
+
+  it('fetchIndex should not send Authorization header when no token is provided', async () => {
+    const mockFetch = vi.mocked(fetch);
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          skills: [{ name: 'test-skill', description: 'A test skill', files: ['SKILL.md'] }],
+        }),
+        { status: 200 }
+      )
+    );
+
+    await provider.fetchIndex('https://example.com');
+
+    expect(mockFetch).toHaveBeenCalledWith(expect.any(String), {});
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `--token <token>` flag to `skills add` command that injects an `Authorization: Bearer <token>` header into all fetch requests made by `WellKnownProvider`
- Propagates the token through the full call chain: `parseAddOptions` → `AddOptions.token` → `handleWellKnownSkills` → `fetchAllSkills` → `fetchIndex` / `fetchSkillByEntry` → individual `fetch()` calls
- All `token` parameters are optional — fully backward-compatible

## Motivation

Private skills servers hosted at well-known endpoints (`/.well-known/skills/`) silently return "No skills found." when they require authentication. This PR enables users to pass a Bearer token to authenticate those requests.

Closes #472

## Changes

- **`src/providers/wellknown.ts`**: Added `buildFetchOptions(token?)` helper and `token?` parameter to `fetchIndex`, `fetchSkill`, `fetchSkillByEntry`, `fetchAllSkills`, `hasSkillsIndex`
- **`src/add.ts`**: Added `token?: string` to `AddOptions`; parse `--token` in `parseAddOptions`; pass token to `fetchAllSkills`
- **`src/cli.ts`**: No visible help text added — the flag works silently since well-known support is not yet officially documented
- **Tests**: Added `--token` parsing tests in `src/add.test.ts` and `Authorization` header tests in `tests/wellknown-provider.test.ts`

## Test plan

- [x] `pnpm test` passes (existing suite + new token tests)
- [ ] `skills add https://private-skills-host.example.com --token <token>` authenticates and installs skills
- [ ] `skills add https://public-skills-host.example.com` (no `--token`) continues to work as before
