### PR TITLE
Add PromptScript as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [37 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [38 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -246,6 +246,7 @@ Skills can be installed to any of these agents:
 | Zencoder | `zencoder` | `.zencoder/skills/` | `~/.zencoder/skills/` |
 | Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
+| PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
 <!-- supported-agents:end -->
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "zencoder",
     "neovate",
     "pochi",
+    "promptscript",
     "adal",
     "universal"
   ],

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -383,6 +383,18 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.pochi'));
     },
   },
+  promptscript: {
+    name: 'promptscript',
+    displayName: 'PromptScript',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: undefined,
+    detectInstalled: async () => {
+      return (
+        existsSync(join(process.cwd(), '.promptscript')) ||
+        existsSync(join(process.cwd(), 'promptscript.yaml'))
+      );
+    },
+  },
   adal: {
     name: 'adal',
     displayName: 'AdaL',

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export type AgentType =
   | 'windsurf'
   | 'zencoder'
   | 'pochi'
+  | 'promptscript'
   | 'adal'
   | 'universal';
 


### PR DESCRIPTION
## Summary

Adds [PromptScript](https://getpromptscript.dev) as a supported target agent.

I'm the creator of PromptScript - a language and toolchain for standardizing AI instructions across organizations. You write `.prs` files once and compile them to native formats for multiple AI coding agents simultaneously (Claude Code, Cursor, GitHub Copilot, Gemini CLI, OpenCode, Factory AI, and others).

### Why PromptScript as a universal agent?

PromptScript reads skills from `.agents/skills/` (universal directory), so `npx skills add` works out of the box - no `-a` flag needed. During compilation, discovered skills (including all resource files like CSV data, Python scripts, configs) are automatically distributed to every configured target:

```bash
# Install a skill - goes to .agents/skills/ by default
npx skills add anthropics/skills --skill frontend-design

# PromptScript picks it up and compiles to all targets at once
prs compile
# → .claude/skills/frontend-design/SKILL.md
# → .factory/skills/frontend-design/SKILL.md
# → .gemini/skills/frontend-design/skill.md
# → .opencode/skills/frontend-design/SKILL.md
# → .github/skills/frontend-design/SKILL.md