### PR TITLE
feat: add `skills validate` command for metadata quality checking

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
+import { runValidate } from './validate.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
 
@@ -88,6 +89,9 @@ function showBanner(): void {
   );
   console.log();
   console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills validate${RESET}              ${DIM}Validate skill metadata${RESET}`
+  );
+  console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills experimental_install${RESET} ${DIM}Restore from skills-lock.json${RESET}`
   );
   console.log(
@@ -119,9 +123,12 @@ ${BOLD}Updates:${RESET}
   check                Check for available skill updates
   update               Update all skills to latest versions
 
+${BOLD}Authoring:${RESET}
+  validate [path]      Validate skill metadata (alias: lint)
+  init [name]          Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
+
 ${BOLD}Project:${RESET}
   experimental_install Restore skills from skills-lock.json
-  init [name]          Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
   experimental_sync    Sync skills from node_modules into agent directories
 
 ${BOLD}Add Options:${RESET}
@@ -229,6 +236,10 @@ function runInit(args: string[]): void {
   const skillContent = `---
 name: ${skillName}
 description: A brief description of what this skill does
+author: your-name-or-org
+license: MIT
+# repository: https://github.com/owner/repo
+# keywords: [topic1, topic2]
 ---
 
 # ${skillName}
@@ -673,6 +684,13 @@ async function main(): Promise<void> {
       showLogo();
       const { options: syncOptions } = parseSyncOptions(restArgs);
       await runSync(restArgs, syncOptions);
+      break;
+    }
+    case 'validate':
+    case 'lint': {
+      showLogo();
+      console.log();
+      await runValidate(restArgs);
       break;
     }
     case 'list':

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -47,6 +47,10 @@ describe('init command', () => {
       "---
       name: my-test-skill
       description: A brief description of what this skill does
+      author: your-name-or-org
+      license: MIT
+      # repository: https://github.com/owner/repo
+      # keywords: [topic1, topic2]
       ---
 
       # my-test-skill

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,397 @@
+import { readFile, readdir, stat } from 'fs/promises';
+import { join, relative, basename } from 'path';
+import matter from 'gray-matter';
+import pc from 'picocolors';
+import { agents } from './agents.ts';
+
+type Severity = 'error' | 'warning' | 'info';
+
+interface ValidationResult {
+  field: string;
+  severity: Severity;
+  message: string;
+  suggestion?: string;
+}
+
+interface ValidationReport {
+  skillName: string;
+  skillPath: string;
+  results: ValidationResult[];
+  errors: number;
+  warnings: number;
+}
+
+const COMMON_SPDX = new Set([
+  'MIT',
+  'Apache-2.0',
+  'ISC',
+  'BSD-2-Clause',
+  'BSD-3-Clause',
+  'GPL-2.0',
+  'GPL-3.0',
+  'LGPL-2.1',
+  'LGPL-3.0',
+  'MPL-2.0',
+  'Unlicense',
+  'CC-BY-4.0',
+  'CC-BY-SA-4.0',
+  'CC0-1.0',
+  'AGPL-3.0',
+  'BSL-1.0',
+  'Artistic-2.0',
+]);
+
+const VALID_AGENT_NAMES = new Set(Object.values(agents).map((a) => a.displayName));
+
+/**
+ * Validate a license string against common SPDX identifiers.
+ * Supports OR expressions like "MIT OR Apache-2.0".
+ */
+export function isValidSPDX(license: string): boolean {
+  const parts = license.split(/\s+OR\s+/);
+  return parts.every((part) => COMMON_SPDX.has(part.trim()));
+}
+
+/**
+ * Validate a single SKILL.md file's frontmatter.
+ */
+export function validateFrontmatter(
+  data: Record<string, unknown>,
+  content: string
+): ValidationResult[] {
+  const results: ValidationResult[] = [];
+
+  // Required: name
+  if (!data.name) {
+    results.push({ field: 'name', severity: 'error', message: 'missing (required)' });
+  } else if (typeof data.name !== 'string') {
+    results.push({ field: 'name', severity: 'error', message: 'must be a string' });
+  } else {
+    if (data.name.length < 1 || data.name.length > 64) {
+      results.push({
+        field: 'name',
+        severity: 'error',
+        message: `length ${data.name.length} chars (must be 1-64)`,
+      });
+    }
+    if (!/^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/.test(data.name)) {
+      results.push({
+        field: 'name',
+        severity: 'warning',
+        message: 'should be kebab-case (lowercase, hyphens, dots, underscores)',
+        suggestion: data.name
+          .toLowerCase()
+          .replace(/[^a-z0-9._]+/g, '-')
+          .replace(/^-|-$/g, ''),
+      });
+    }
+  }
+
+  // Required: description
+  if (!data.description) {
+    results.push({ field: 'description', severity: 'error', message: 'missing (required)' });
+  } else if (typeof data.description !== 'string') {
+    results.push({ field: 'description', severity: 'error', message: 'must be a string' });
+  } else {
+    if (data.description.length < 20) {
+      results.push({
+        field: 'description',
+        severity: 'error',
+        message: `too short (${data.description.length} chars, minimum 20)`,
+      });
+    }
+    if (data.description.length > 500) {
+      results.push({
+        field: 'description',
+        severity: 'warning',
+        message: `very long (${data.description.length} chars, recommended max 500)`,
+      });
+    }
+  }
+
+  // Recommended: author
+  if (!data.author) {
+    results.push({
+      field: 'author',
+      severity: 'warning',
+      message: 'missing (who maintains this skill?)',
+    });
+  } else if (typeof data.author !== 'string' || data.author.trim() === '') {
+    results.push({ field: 'author', severity: 'warning', message: 'should be a non-empty string' });
+  }
+
+  // Recommended: license
+  if (!data.license) {
+    results.push({
+      field: 'license',
+      severity: 'warning',
+      message: 'missing (what are the usage terms?)',
+    });
+  } else if (typeof data.license === 'string') {
+    if (!isValidSPDX(data.license)) {
+      results.push({
+        field: 'license',
+        severity: 'info',
+        message: `"${data.license}" is not a recognized SPDX identifier`,
+        suggestion: 'Common licenses: MIT, Apache-2.0, ISC, GPL-3.0, CC-BY-4.0',
+      });
+    }
+  }
+
+  // Recommended: repository
+  if (!data.repository) {
+    results.push({
+      field: 'repository',
+      severity: 'warning',
+      message: 'missing (where is the source code?)',
+    });
+  } else if (typeof data.repository === 'string') {
+    try {
+      new URL(data.repository);
+    } catch {
+      results.push({
+        field: 'repository',
+        severity: 'warning',
+        message: 'should be a valid URL',
+      });
+    }
+  }
+
+  // Optional: keywords
+  if (!data.keywords) {
+    results.push({
+      field: 'keywords',
+      severity: 'info',
+      message: 'missing (helps with discovery)',
+    });
+  } else if (!Array.isArray(data.keywords)) {
+    results.push({ field: 'keywords', severity: 'info', message: 'should be an array of strings' });
+  }
+
+  // Conditional: product-version
+  if (data['product-version'] !== undefined) {
+    if (typeof data['product-version'] !== 'string') {
+      results.push({
+        field: 'product-version',
+        severity: 'warning',
+        message: 'should be a string (e.g., ">=18.0.0")',
+      });
+    }
+  }
+
+  // Conditional: agents
+  if (data.agents !== undefined) {
+    if (!Array.isArray(data.agents)) {
+      results.push({
+        field: 'agents',
+        severity: 'warning',
+        message: 'should be an array of strings',
+      });
+    } else {
+      for (const agent of data.agents) {
+        if (typeof agent !== 'string') {
+          results.push({
+            field: 'agents',
+            severity: 'warning',
+            message: `invalid agent entry: ${agent}`,
+          });
+        } else if (!VALID_AGENT_NAMES.has(agent) && agent !== '*') {
+          results.push({
+            field: 'agents',
+            severity: 'info',
+            message: `"${agent}" is not a recognized agent name`,
+          });
+        }
+      }
+    }
+  }
+
+  // Body content check
+  const bodyContent = content.replace(/^---[\s\S]*?---/, '').trim();
+  if (bodyContent.length < 50) {
+    results.push({
+      field: 'body',
+      severity: 'info',
+      message: 'skill body is very short (consider adding more instructions)',
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Find all SKILL.md files in a directory tree.
+ */
+async function findSkillFiles(dir: string, maxDepth = 5, depth = 0): Promise<string[]> {
+  if (depth > maxDepth) return [];
+
+  const results: string[] = [];
+
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.name === 'SKILL.md' && entry.isFile()) {
+        results.push(join(dir, entry.name));
+      } else if (entry.isDirectory() && !['node_modules', '.git', '.agents'].includes(entry.name)) {
+        const subResults = await findSkillFiles(join(dir, entry.name), maxDepth, depth + 1);
+        results.push(...subResults);
+      }
+    }
+  } catch {
+    // Directory not readable
+  }
+
+  return results;
+}
+
+/**
+ * Validate a single SKILL.md file and return a report.
+ */
+async function validateSkillFile(skillMdPath: string, cwd: string): Promise<ValidationReport> {
+  const content = await readFile(skillMdPath, 'utf-8');
+  const { data } = matter(content);
+  const skillName =
+    (typeof data.name === 'string' && data.name) || basename(join(skillMdPath, '..'));
+
+  const results = validateFrontmatter(data, content);
+  const errors = results.filter((r) => r.severity === 'error').length;
+  const warnings = results.filter((r) => r.severity === 'warning').length;
+
+  return {
+    skillName,
+    skillPath: relative(cwd, skillMdPath) || skillMdPath,
+    results,
+    errors,
+    warnings,
+  };
+}
+
+interface ValidateOptions {
+  strict?: boolean;
+}
+
+function parseValidateOptions(args: string[]): { paths: string[]; options: ValidateOptions } {
+  const options: ValidateOptions = {};
+  const paths: string[] = [];
+
+  for (const arg of args) {
+    if (arg === '--strict') {
+      options.strict = true;
+    } else if (!arg.startsWith('-')) {
+      paths.push(arg);
+    }
+  }
+
+  return { paths, options };
+}
+
+/**
+ * Run the `skills validate` command.
+ */
+export async function runValidate(args: string[]): Promise<void> {
+  const { paths, options } = parseValidateOptions(args);
+  const cwd = process.cwd();
+
+  console.log();
+  console.log(pc.bold('Validating skills...'));
+  console.log();
+
+  // Find SKILL.md files
+  let skillFiles: string[] = [];
+
+  if (paths.length > 0) {
+    for (const p of paths) {
+      const fullPath = join(cwd, p);
+      try {
+        const s = await stat(fullPath);
+        if (s.isFile() && p.endsWith('SKILL.md')) {
+          skillFiles.push(fullPath);
+        } else if (s.isDirectory()) {
+          const found = await findSkillFiles(fullPath);
+          skillFiles.push(...found);
+        }
+      } catch {
+        console.log(pc.red(`  Path not found: ${p}`));
+      }
+    }
+  } else {
+    skillFiles = await findSkillFiles(cwd);
+  }
+
+  if (skillFiles.length === 0) {
+    console.log(pc.dim('No SKILL.md files found.'));
+    console.log(pc.dim(`Create one with ${pc.cyan('npx skills init')}`));
+    return;
+  }
+
+  // Validate each file
+  const reports: ValidationReport[] = [];
+  let totalErrors = 0;
+  let totalWarnings = 0;
+
+  for (const file of skillFiles) {
+    try {
+      const report = await validateSkillFile(file, cwd);
+      reports.push(report);
+      totalErrors += report.errors;
+      totalWarnings += report.warnings;
+    } catch (error) {
+      console.log(
+        pc.red(
+          `  Failed to validate ${relative(cwd, file)}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        )
+      );
+    }
+  }
+
+  // Display results
+  const severityColors: Record<Severity, (s: string) => string> = {
+    error: pc.red,
+    warning: pc.yellow,
+    info: pc.dim,
+  };
+
+  for (const report of reports) {
+    console.log(`${pc.bold(report.skillName)} ${pc.dim(`(${report.skillPath})`)}`);
+
+    if (report.results.length === 0) {
+      console.log(`  ${pc.green('[pass]')}    All checks passed`);
+    } else {
+      for (const result of report.results) {
+        const color = severityColors[result.severity];
+        const tag = `[${result.severity}]`.padEnd(10);
+        console.log(`  ${color(tag)} ${result.field}: ${result.message}`);
+        if (result.suggestion) {
+          console.log(`  ${' '.repeat(10)} ${pc.dim(`suggestion: ${result.suggestion}`)}`);
+        }
+      }
+    }
+    console.log();
+  }
+
+  // Summary
+  const parts: string[] = [];
+  if (totalErrors > 0) parts.push(pc.red(`${totalErrors} error${totalErrors !== 1 ? 's' : ''}`));
+  if (totalWarnings > 0)
+    parts.push(pc.yellow(`${totalWarnings} warning${totalWarnings !== 1 ? 's' : ''}`));
+
+  if (parts.length > 0) {
+    console.log(
+      `Results: ${parts.join(', ')} across ${reports.length} skill${reports.length !== 1 ? 's' : ''}`
+    );
+  } else {
+    console.log(
+      pc.green(`All ${reports.length} skill${reports.length !== 1 ? 's' : ''} passed validation`)
+    );
+  }
+  console.log();
+
+  // Exit code
+  if (totalErrors > 0) {
+    process.exit(1);
+  }
+  if (options.strict && totalWarnings > 0) {
+    process.exit(1);
+  }
+}

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { validateFrontmatter, isValidSPDX } from '../src/validate.ts';
+
+const CLI_PATH = join(import.meta.dirname, '..', 'src', 'cli.ts');
+
+function runCli(args: string[], cwd: string) {
+  return spawnSync('node', [CLI_PATH, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, NODE_ENV: 'test' },
+    timeout: 30000,
+  });
+}
+
+describe('isValidSPDX', () => {
+  it('recognizes common licenses', () => {
+    expect(isValidSPDX('MIT')).toBe(true);
+    expect(isValidSPDX('Apache-2.0')).toBe(true);
+    expect(isValidSPDX('ISC')).toBe(true);
+    expect(isValidSPDX('GPL-3.0')).toBe(true);
+    expect(isValidSPDX('CC-BY-4.0')).toBe(true);
+    expect(isValidSPDX('Unlicense')).toBe(true);
+  });
+
+  it('supports OR expressions', () => {
+    expect(isValidSPDX('MIT OR Apache-2.0')).toBe(true);
+    expect(isValidSPDX('GPL-3.0 OR MIT')).toBe(true);
+  });
+
+  it('rejects unknown identifiers', () => {
+    expect(isValidSPDX('CUSTOM-LICENSE')).toBe(false);
+    expect(isValidSPDX('')).toBe(false);
+  });
+
+  it('rejects partially valid OR expressions', () => {
+    expect(isValidSPDX('MIT OR CUSTOM')).toBe(false);
+  });
+});
+
+describe('validateFrontmatter', () => {
+  it('passes a well-formed skill', () => {
+    const results = validateFrontmatter(
+      {
+        name: 'my-skill',
+        description: 'A great skill that does many wonderful things',
+        author: 'test-author',
+        license: 'MIT',
+        repository: 'https://github.com/test/repo',
+        keywords: ['testing', 'example'],
+      },
+      '---\n---\n# My Skill\n\n' + 'x'.repeat(50)
+    );
+
+    const errors = results.filter((r) => r.severity === 'error');
+    expect(errors).toHaveLength(0);
+  });
+
+  it('requires name field', () => {
+    const results = validateFrontmatter({ description: 'A valid description here enough' }, '');
+    expect(results.some((r) => r.field === 'name' && r.severity === 'error')).toBe(true);
+  });
+
+  it('requires description field', () => {
+    const results = validateFrontmatter({ name: 'test-skill' }, '');
+    expect(results.some((r) => r.field === 'description' && r.severity === 'error')).toBe(true);
+  });
+
+  it('rejects non-string name', () => {
+    const results = validateFrontmatter(
+      { name: 123, description: 'A valid description here enough' },
+      ''
+    );
+    expect(results.some((r) => r.field === 'name' && r.severity === 'error')).toBe(true);
+  });
+
+  it('rejects non-string description', () => {
+    const results = validateFrontmatter({ name: 'test', description: true }, '');
+    expect(results.some((r) => r.field === 'description' && r.severity === 'error')).toBe(true);
+  });
+
+  it('errors on too-short description', () => {
+    const results = validateFrontmatter({ name: 'test', description: 'too short' }, '');
+    expect(
+      results.some(
+        (r) =>
+          r.field === 'description' && r.severity === 'error' && r.message.includes('too short')
+      )
+    ).toBe(true);
+  });
+
+  it('warns on very long description', () => {
+    const results = validateFrontmatter({ name: 'test', description: 'x'.repeat(501) }, '');
+    expect(
+      results.some(
+        (r) =>
+          r.field === 'description' && r.severity === 'warning' && r.message.includes('very long')
+      )
+    ).toBe(true);
+  });
+
+  it('warns on name with uppercase', () => {
+    const results = validateFrontmatter(
+      { name: 'MySkill', description: 'A valid description here enough' },
+      ''
+    );
+    expect(results.some((r) => r.field === 'name' && r.severity === 'warning')).toBe(true);
+  });
+
+  it('warns on missing author', () => {
+    const results = validateFrontmatter(
+      { name: 'test', description: 'A valid description here enough' },
+      ''
+    );
+    expect(results.some((r) => r.field === 'author' && r.severity === 'warning')).toBe(true);
+  });
+
+  it('warns on missing license', () => {
+    const results = validateFrontmatter(
+      { name: 'test', description: 'A valid description here enough' },
+      ''
+    );
+    expect(results.some((r) => r.field === 'license' && r.severity === 'warning')).toBe(true);
+  });
+
+  it('warns on missing repository', () => {
+    const results = validateFrontmatter(
+      { name: 'test', description: 'A valid description here enough' },
+      ''
+    );
+    expect(results.some((r) => r.field === 'repository' && r.severity === 'warning')).toBe(true);
+  });
+
+  it('info on unrecognized SPDX license', () => {
+    const results = validateFrontmatter(
+      {
+        name: 'test',
+        description: 'A valid description here enough',
+        license: 'CUSTOM-1.0',
+      },
+      ''
+    );
+    expect(results.some((r) => r.field === 'license' && r.severity === 'info')).toBe(true);
+  });
+
+  it('warns on invalid repository URL', () => {
+    const results = validateFrontmatter(
+      {
+        name: 'test',
+        description: 'A valid description here enough',
+        repository: 'not-a-url',
+      },
+      ''
+    );
+    expect(results.some((r) => r.field === 'repository' && r.severity === 'warning')).toBe(true);
+  });
+
+  it('info on missing keywords', () => {
+    const results = validateFrontmatter(
+      { name: 'test', description: 'A valid description here enough' },
+      ''
+    );
+    expect(results.some((r) => r.field === 'keywords' && r.severity === 'info')).toBe(true);
+  });
+
+  it('info on non-array keywords', () => {
+    const results = validateFrontmatter(
+      { name: 'test', description: 'A valid description here enough', keywords: 'single' },
+      ''
+    );
+    expect(results.some((r) => r.field === 'keywords' && r.severity === 'info')).toBe(true);
+  });
+
+  it('validates agents field', () => {
+    const results = validateFrontmatter(
+      {
+        name: 'test',
+        description: 'A valid description here enough',
+        agents: ['Claude Code', 'NonExistentAgent'],
+      },
+      ''
+    );
+    // Claude Code is valid, NonExistentAgent should get info
+    expect(
+      results.some((r) => r.field === 'agents' && r.message.includes('NonExistentAgent'))
+    ).toBe(true);
+  });
+
+  it('warns on non-array agents', () => {
+    const results = validateFrontmatter(
+      {
+        name: 'test',
+        description: 'A valid description here enough',
+        agents: 'Claude Code',
+      },
+      ''
+    );
+    expect(results.some((r) => r.field === 'agents' && r.severity === 'warning')).toBe(true);
+  });
+
+  it('info on short body content', () => {
+    const results = validateFrontmatter(
+      { name: 'test', description: 'A valid description here enough' },
+      '---\nname: test\n---\nShort.'
+    );
+    expect(results.some((r) => r.field === 'body' && r.severity === 'info')).toBe(true);
+  });
+
+  it('validates product-version field type', () => {
+    const results = validateFrontmatter(
+      {
+        name: 'test',
+        description: 'A valid description here enough',
+        'product-version': 123,
+      },
+      ''
+    );
+    expect(results.some((r) => r.field === 'product-version' && r.severity === 'warning')).toBe(
+      true
+    );
+  });
+});
+
+describe('validate CLI command', () => {
+  let dir: string;
+
+  it('should be listed in help output', () => {
+    const result = runCli(['--help'], process.cwd());
+    expect(result.stdout).toContain('validate');
+    expect(result.stdout).toContain('lint');
+  });
+
+  it('should validate a valid skill and exit 0', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'validate-cli-'));
+    try {
+      const skillDir = join(dir, 'my-skill');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: my-skill
+description: A perfectly valid skill with enough description text
+author: test-author
+license: MIT
+repository: https://github.com/test/repo
+keywords: [test]
+---
+
+# My Skill
+
+This is a well-written skill with plenty of body content to pass validation checks easily.
+`,
+        'utf-8'
+      );
+
+      const result = runCli(['validate', 'my-skill'], dir);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('my-skill');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should exit 1 for skill with errors', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'validate-cli-'));
+    try {
+      const skillDir = join(dir, 'bad-skill');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: bad-skill
+description: short
+---
+# Bad
+`,
+        'utf-8'
+      );
+
+      const result = runCli(['validate', 'bad-skill'], dir);
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('error');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should exit 1 in strict mode with warnings', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'validate-cli-'));
+    try {
+      const skillDir = join(dir, 'warn-skill');
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: warn-skill
+description: A description that is long enough to pass the minimum requirement
+---
+
+# Warn Skill
+
+This skill has enough body content to avoid the short body warning message here.
+`,
+        'utf-8'
+      );
+
+      // Without --strict: should pass (only warnings, no errors)
+      const normalResult = runCli(['validate', 'warn-skill'], dir);
+      expect(normalResult.status).toBe(0);
+
+      // With --strict: should fail on warnings
+      const strictResult = runCli(['validate', 'warn-skill', '--strict'], dir);
+      expect(strictResult.status).toBe(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should handle no SKILL.md files gracefully', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'validate-cli-'));
+    try {
+      const result = runCli(['validate'], dir);
+      expect(result.stdout).toContain('No SKILL.md files found');
+      expect(result.status).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('lint alias should work', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'validate-cli-'));
+    try {
+      const result = runCli(['lint'], dir);
+      expect(result.stdout).toContain('No SKILL.md files found');
+      expect(result.status).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('init template includes recommended fields', () => {
+  it('should include author and license in init template', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'init-template-'));
+    try {
+      const result = runCli(['init', 'new-skill'], dir);
+      expect(result.status).toBe(0);
+
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(join(dir, 'new-skill', 'SKILL.md'), 'utf-8');
+      expect(content).toContain('author:');
+      expect(content).toContain('license:');
+      expect(content).toContain('# repository:');
+      expect(content).toContain('# keywords:');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `skills validate` (alias: `lint`) command for skill authors to check their SKILL.md files against quality requirements before sharing.

- **Validation rules engine** with error/warning/info severity levels:
  - Required (error): `name` (1-64 chars, kebab-case), `description` (20-500 chars)
  - Recommended (warning): `author`, `license` (SPDX), `repository` (valid URL)
  - Optional (info): `keywords` (array), body content length
  - Conditional: `product-version` (string type), `agents` (valid agent names)
- **SPDX license validation** supporting OR expressions (`MIT OR Apache-2.0`)
- **`--strict` flag** treats warnings as errors for CI pipelines
- **Enhanced `skills init` template** with `author`, `license`, commented `repository` and `keywords`
- Path argument support: validate specific files/directories or auto-discover

### Output example
```
my-skill (my-skill/SKILL.md)
  [error]    description: too short (15 chars, minimum 20)
  [warning]  author: missing (who maintains this skill?)
  [warning]  license: missing (what are the usage terms?)
  [info]     keywords: missing (helps with discovery)

Results: 1 error, 2 warnings across 1 skill
```

## Test plan

- [x] All 398 tests pass (368 existing + 30 new)
- [x] SPDX validation: common licenses, OR expressions, unknown identifiers
- [x] Frontmatter validation: required fields, types, lengths, conditional fields
- [x] CLI: valid skill exits 0, errors exit 1, `--strict` exits 1 on warnings
- [x] `lint` alias works
- [x] Init template includes recommended fields
- [x] Snapshot updated for new init template

Closes #503