### PR TITLE
feat: dependency groups for skill management

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -57,6 +57,7 @@ import {
   saveSelectedAgents,
 } from './skill-lock.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
+import { addSkillToGroup } from './groups.ts';
 import type { Skill, AgentType } from './types.ts';
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
@@ -418,6 +419,7 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  group?: string;
 }
 
 /**
@@ -857,6 +859,15 @@ async function handleWellKnownSkills(
         )
       );
     }
+  }
+
+  // Add successfully installed skills to group if --group was specified
+  if (options.group && successful.length > 0) {
+    const installedNames = [...new Set(successful.map((r) => r.skill))];
+    for (const name of installedNames) {
+      await addSkillToGroup(name, options.group);
+    }
+    p.log.info(`Added ${installedNames.length} skill(s) to group "${options.group}"`);
   }
 
   if (failed.length > 0) {
@@ -1621,6 +1632,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    // Add successfully installed skills to group if --group was specified
+    if (options.group && successful.length > 0) {
+      const installedNames = [...new Set(successful.map((r) => r.skill))];
+      for (const name of installedNames) {
+        await addSkillToGroup(name, options.group);
+      }
+      p.log.info(`Added ${installedNames.length} skill(s) to group "${options.group}"`);
+    }
+
     if (failed.length > 0) {
       console.log();
       p.log.error(pc.red(`Failed to install ${failed.length}`));
@@ -1781,6 +1801,11 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--group') {
+      i++;
+      if (i < args.length && args[i] && !args[i]!.startsWith('-')) {
+        options.group = args[i];
+      }
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
+import { runGroups } from './groups-command.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
 
@@ -88,6 +89,9 @@ function showBanner(): void {
   );
   console.log();
   console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills groups${RESET}              ${DIM}Manage skill groups${RESET}`
+  );
+  console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills experimental_install${RESET} ${DIM}Restore from skills-lock.json${RESET}`
   );
   console.log(
@@ -118,6 +122,14 @@ ${BOLD}Manage Skills:${RESET}
 ${BOLD}Updates:${RESET}
   check                Check for available skill updates
   update               Update all skills to latest versions
+
+${BOLD}Groups:${RESET}
+  groups               Manage skill groups
+  groups show <group>  Show group details
+  groups create <name> Create a new group (-d "description")
+  groups add <g> <s>   Add a skill to a group
+  groups remove <g> <s> Remove a skill from a group
+  groups delete <name> Delete a group
 
 ${BOLD}Project:${RESET}
   experimental_install Restore skills from skills-lock.json
@@ -678,6 +690,10 @@ async function main(): Promise<void> {
     case 'list':
     case 'ls':
       await runList(restArgs);
+      break;
+    case 'groups':
+    case 'group':
+      await runGroups(restArgs);
       break;
     case 'check':
       runCheck(restArgs);

--- a/src/groups-command.ts
+++ b/src/groups-command.ts
@@ -1,0 +1,211 @@
+import {
+  readGroupsConfig,
+  createGroup,
+  deleteGroup,
+  addSkillToGroup,
+  removeSkillFromGroup,
+  getSkillsInGroup,
+} from './groups.ts';
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[38;5;102m';
+const TEXT = '\x1b[38;5;145m';
+const CYAN = '\x1b[36m';
+const YELLOW = '\x1b[33m';
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+
+function showGroupsHelp(): void {
+  console.log(`
+${BOLD}Usage:${RESET} skills groups [subcommand] [options]
+
+${BOLD}Subcommands:${RESET}
+  ${TEXT}(none)${RESET}              List all groups and their skills
+  show <group>        Show details of a specific group
+  create <group>      Create a new empty group
+  add <group> <skill> Add a skill to a group
+  remove <group> <skill>  Remove a skill from a group (doesn't uninstall)
+  delete <group>      Delete a group (doesn't uninstall skills)
+
+${BOLD}Options:${RESET}
+  --description, -d   Description for create subcommand
+
+${BOLD}Examples:${RESET}
+  ${DIM}$${RESET} skills groups
+  ${DIM}$${RESET} skills groups show debug
+  ${DIM}$${RESET} skills groups create deploy -d "Deployment skills"
+  ${DIM}$${RESET} skills groups add debug logging-best-practices
+  ${DIM}$${RESET} skills groups remove debug logging-best-practices
+  ${DIM}$${RESET} skills groups delete deploy
+`);
+}
+
+/**
+ * Run the `skills groups` subcommand.
+ */
+export async function runGroups(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    showGroupsHelp();
+    return;
+  }
+
+  const subcommand = args[0];
+
+  if (!subcommand) {
+    await listGroups();
+    return;
+  }
+
+  switch (subcommand) {
+    case 'show':
+      await showGroup(args[1]);
+      break;
+    case 'create':
+      await handleCreate(args.slice(1));
+      break;
+    case 'add':
+      await handleAdd(args[1], args[2]);
+      break;
+    case 'remove':
+      await handleRemove(args[1], args[2]);
+      break;
+    case 'delete':
+      await handleDelete(args[1]);
+      break;
+    default:
+      console.log(`${RED}Unknown subcommand: ${subcommand}${RESET}`);
+      showGroupsHelp();
+  }
+}
+
+async function listGroups(): Promise<void> {
+  const config = await readGroupsConfig();
+  if (!config || Object.keys(config.groups).length === 0) {
+    console.log(`${DIM}No groups defined.${RESET}`);
+    console.log(`${DIM}Create one with:${RESET} ${TEXT}npx skills groups create <name>${RESET}`);
+    return;
+  }
+
+  console.log(`${BOLD}Skill Groups${RESET}`);
+  console.log();
+
+  for (const [name, group] of Object.entries(config.groups).sort(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    const desc = group.description ? ` ${DIM}— ${group.description}${RESET}` : '';
+    console.log(`${CYAN}${name}${RESET}${desc}`);
+    if (group.skills.length === 0) {
+      console.log(`  ${DIM}(empty)${RESET}`);
+    } else {
+      for (const skill of group.skills.sort()) {
+        console.log(`  ${TEXT}•${RESET} ${skill}`);
+      }
+    }
+    console.log();
+  }
+}
+
+async function showGroup(groupName?: string): Promise<void> {
+  if (!groupName) {
+    console.log(`${RED}Usage: skills groups show <group>${RESET}`);
+    return;
+  }
+
+  const config = await readGroupsConfig();
+  if (!config) {
+    console.log(`${DIM}No groups config found.${RESET}`);
+    return;
+  }
+
+  const skills = getSkillsInGroup(config, groupName);
+  if (!skills) {
+    console.log(`${YELLOW}Group "${groupName}" not found.${RESET}`);
+    return;
+  }
+
+  const group = config.groups[groupName]!;
+  console.log(`${BOLD}${groupName}${RESET}`);
+  if (group.description) {
+    console.log(`${DIM}${group.description}${RESET}`);
+  }
+  console.log();
+
+  if (skills.length === 0) {
+    console.log(`  ${DIM}(empty)${RESET}`);
+  } else {
+    for (const skill of skills.sort()) {
+      console.log(`  ${TEXT}•${RESET} ${skill}`);
+    }
+  }
+  console.log();
+}
+
+async function handleCreate(args: string[]): Promise<void> {
+  const groupName = args[0];
+  if (!groupName) {
+    console.log(`${RED}Usage: skills groups create <group> [-d "description"]${RESET}`);
+    return;
+  }
+
+  let description = '';
+  const descIdx = args.indexOf('-d');
+  const descLongIdx = args.indexOf('--description');
+  const idx = descIdx !== -1 ? descIdx : descLongIdx;
+  if (idx !== -1 && args[idx + 1]) {
+    description = args[idx + 1]!;
+  }
+
+  const created = await createGroup(groupName, description);
+  if (created) {
+    console.log(`${GREEN}✓${RESET} Created group "${groupName}"`);
+  } else {
+    console.log(`${YELLOW}Group "${groupName}" already exists.${RESET}`);
+  }
+}
+
+async function handleAdd(groupName?: string, skillName?: string): Promise<void> {
+  if (!groupName || !skillName) {
+    console.log(`${RED}Usage: skills groups add <group> <skill>${RESET}`);
+    return;
+  }
+
+  const added = await addSkillToGroup(skillName, groupName);
+  if (added) {
+    console.log(`${GREEN}✓${RESET} Added "${skillName}" to group "${groupName}"`);
+  } else {
+    console.log(`${YELLOW}"${skillName}" is already in group "${groupName}".${RESET}`);
+  }
+}
+
+async function handleRemove(groupName?: string, skillName?: string): Promise<void> {
+  if (!groupName || !skillName) {
+    console.log(`${RED}Usage: skills groups remove <group> <skill>${RESET}`);
+    return;
+  }
+
+  const removed = await removeSkillFromGroup(skillName, groupName);
+  if (removed) {
+    console.log(`${GREEN}✓${RESET} Removed "${skillName}" from group "${groupName}"`);
+  } else {
+    console.log(
+      `${YELLOW}Could not remove "${skillName}" from group "${groupName}" (not found).${RESET}`
+    );
+  }
+}
+
+async function handleDelete(groupName?: string): Promise<void> {
+  if (!groupName) {
+    console.log(`${RED}Usage: skills groups delete <group>${RESET}`);
+    return;
+  }
+
+  const deleted = await deleteGroup(groupName);
+  if (deleted) {
+    const skillCount = deleted.skills.length;
+    const note = skillCount > 0 ? ` (${skillCount} skill(s) ungrouped, not uninstalled)` : '';
+    console.log(`${GREEN}✓${RESET} Deleted group "${groupName}"${note}`);
+  } else {
+    console.log(`${YELLOW}Group "${groupName}" not found.${RESET}`);
+  }
+}

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -1,0 +1,150 @@
+import { readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+const GROUPS_FILE = 'skills.groups.json';
+
+export interface SkillGroup {
+  description: string;
+  skills: string[];
+}
+
+export interface GroupsConfig {
+  groups: Record<string, SkillGroup>;
+}
+
+/**
+ * Get the path to the groups config file.
+ */
+export function getGroupsPath(cwd?: string): string {
+  return join(cwd || process.cwd(), GROUPS_FILE);
+}
+
+/**
+ * Read the groups config file.
+ * Returns null if the file doesn't exist or is invalid.
+ */
+export async function readGroupsConfig(cwd?: string): Promise<GroupsConfig | null> {
+  try {
+    const content = await readFile(getGroupsPath(cwd), 'utf-8');
+    const parsed = JSON.parse(content) as GroupsConfig;
+    if (!parsed.groups || typeof parsed.groups !== 'object') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the groups config file.
+ * Groups are sorted alphabetically by name for deterministic output.
+ */
+export async function writeGroupsConfig(config: GroupsConfig, cwd?: string): Promise<void> {
+  const sorted: Record<string, SkillGroup> = {};
+  for (const key of Object.keys(config.groups).sort()) {
+    const group = config.groups[key]!;
+    sorted[key] = { description: group.description, skills: [...group.skills].sort() };
+  }
+  const output: GroupsConfig = { groups: sorted };
+  const content = JSON.stringify(output, null, 2) + '\n';
+  await writeFile(getGroupsPath(cwd), content, 'utf-8');
+}
+
+/**
+ * Create a new group. Returns false if the group already exists.
+ */
+export async function createGroup(
+  groupName: string,
+  description: string,
+  cwd?: string
+): Promise<boolean> {
+  const config = (await readGroupsConfig(cwd)) || { groups: {} };
+  if (config.groups[groupName]) {
+    return false;
+  }
+  config.groups[groupName] = { description, skills: [] };
+  await writeGroupsConfig(config, cwd);
+  return true;
+}
+
+/**
+ * Delete a group. Returns the removed group or null if not found.
+ */
+export async function deleteGroup(groupName: string, cwd?: string): Promise<SkillGroup | null> {
+  const config = await readGroupsConfig(cwd);
+  if (!config || !config.groups[groupName]) {
+    return null;
+  }
+  const removed = config.groups[groupName]!;
+  delete config.groups[groupName];
+  await writeGroupsConfig(config, cwd);
+  return removed;
+}
+
+/**
+ * Add a skill to a group. Creates the group if it doesn't exist.
+ * Returns false if the skill is already in the group.
+ */
+export async function addSkillToGroup(
+  skillName: string,
+  groupName: string,
+  cwd?: string
+): Promise<boolean> {
+  const config = (await readGroupsConfig(cwd)) || { groups: {} };
+  if (!config.groups[groupName]) {
+    config.groups[groupName] = { description: '', skills: [] };
+  }
+  const group = config.groups[groupName]!;
+  if (group.skills.includes(skillName)) {
+    return false;
+  }
+  group.skills.push(skillName);
+  await writeGroupsConfig(config, cwd);
+  return true;
+}
+
+/**
+ * Remove a skill from a group.
+ * Returns false if the group doesn't exist or the skill isn't in it.
+ */
+export async function removeSkillFromGroup(
+  skillName: string,
+  groupName: string,
+  cwd?: string
+): Promise<boolean> {
+  const config = await readGroupsConfig(cwd);
+  if (!config || !config.groups[groupName]) {
+    return false;
+  }
+  const group = config.groups[groupName]!;
+  const idx = group.skills.indexOf(skillName);
+  if (idx === -1) {
+    return false;
+  }
+  group.skills.splice(idx, 1);
+  await writeGroupsConfig(config, cwd);
+  return true;
+}
+
+/**
+ * Find which group a skill belongs to.
+ * Returns the group name or null.
+ */
+export function findGroupForSkill(config: GroupsConfig, skillName: string): string | null {
+  for (const [name, group] of Object.entries(config.groups)) {
+    if (group.skills.includes(skillName)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get all skill names in a group. Returns null if group doesn't exist.
+ */
+export function getSkillsInGroup(config: GroupsConfig, groupName: string): string[] | null {
+  const group = config.groups[groupName];
+  if (!group) return null;
+  return [...group.skills];
+}

--- a/src/list.ts
+++ b/src/list.ts
@@ -3,6 +3,7 @@ import type { AgentType } from './types.ts';
 import { agents } from './agents.ts';
 import { listInstalledSkills, type InstalledSkill } from './installer.ts';
 import { getAllLockedSkills } from './skill-lock.ts';
+import { readGroupsConfig } from './groups.ts';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -14,6 +15,7 @@ const YELLOW = '\x1b[33m';
 interface ListOptions {
   global?: boolean;
   agent?: string[];
+  byGroup?: boolean;
 }
 
 /**
@@ -49,6 +51,8 @@ export function parseListOptions(args: string[]): ListOptions {
     const arg = args[i];
     if (arg === '-g' || arg === '--global') {
       options.global = true;
+    } else if (arg === '--by-group') {
+      options.byGroup = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       // Collect all following arguments until next flag
@@ -116,7 +120,58 @@ export async function runList(args: string[]): Promise<void> {
   console.log(`${BOLD}${scopeLabel} Skills${RESET}`);
   console.log();
 
-  // Group skills by plugin
+  // --by-group: organize by skills.groups.json
+  if (options.byGroup) {
+    const groupsConfig = await readGroupsConfig();
+    const groupedSkills: Record<string, InstalledSkill[]> = {};
+    const ungroupedSkills: InstalledSkill[] = [];
+
+    if (groupsConfig) {
+      const skillToGroup = new Map<string, string>();
+      for (const [gName, gDef] of Object.entries(groupsConfig.groups)) {
+        for (const sName of gDef.skills) {
+          skillToGroup.set(sName, gName);
+        }
+      }
+
+      for (const skill of installedSkills) {
+        const gName = skillToGroup.get(skill.name);
+        if (gName) {
+          if (!groupedSkills[gName]) groupedSkills[gName] = [];
+          groupedSkills[gName].push(skill);
+        } else {
+          ungroupedSkills.push(skill);
+        }
+      }
+    } else {
+      ungroupedSkills.push(...installedSkills);
+    }
+
+    for (const gName of Object.keys(groupedSkills).sort()) {
+      const title = gName
+        .split('-')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+      const desc = groupsConfig?.groups[gName]?.description;
+      const suffix = desc ? ` ${DIM}— ${desc}${RESET}` : '';
+      console.log(`${BOLD}${title}${RESET}${suffix}`);
+      for (const skill of groupedSkills[gName]!) {
+        printSkill(skill, true);
+      }
+      console.log();
+    }
+
+    if (ungroupedSkills.length > 0) {
+      console.log(`${BOLD}Ungrouped${RESET}`);
+      for (const skill of ungroupedSkills) {
+        printSkill(skill, true);
+      }
+      console.log();
+    }
+    return;
+  }
+
+  // Default: group skills by plugin (existing behavior)
   const groupedSkills: Record<string, InstalledSkill[]> = {};
   const ungroupedSkills: InstalledSkill[] = [];
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -12,15 +12,36 @@ import {
   getCanonicalSkillsDir,
   sanitizeName,
 } from './installer.ts';
+import { readGroupsConfig, deleteGroup } from './groups.ts';
 
 export interface RemoveOptions {
   global?: boolean;
   agent?: string[];
   yes?: boolean;
   all?: boolean;
+  group?: string;
 }
 
 export async function removeCommand(skillNames: string[], options: RemoveOptions) {
+  // If --group specified, resolve skill names from group config
+  if (options.group) {
+    const config = await readGroupsConfig();
+    if (!config || !config.groups[options.group]) {
+      p.log.error(`Group "${options.group}" not found.`);
+      return;
+    }
+    const groupSkills = config.groups[options.group]!.skills;
+    if (groupSkills.length === 0) {
+      p.log.warn(`Group "${options.group}" has no skills.`);
+      return;
+    }
+    skillNames = [...groupSkills];
+    // Auto-confirm unless explicitly not
+    if (options.yes === undefined) {
+      options.yes = false; // still prompt for group removal
+    }
+  }
+
   const isGlobal = options.global ?? false;
   const cwd = process.cwd();
 
@@ -264,6 +285,14 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     p.log.success(pc.green(`Successfully removed ${successful.length} skill(s)`));
   }
 
+  // Clean up group entry if --group was used
+  if (options.group && successful.length > 0) {
+    const deleted = await deleteGroup(options.group);
+    if (deleted) {
+      p.log.info(`Removed group "${options.group}"`);
+    }
+  }
+
   if (failed.length > 0) {
     p.log.error(pc.red(`Failed to remove ${failed.length} skill(s)`));
     for (const r of failed) {
@@ -302,6 +331,11 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg === '--group') {
+      i++;
+      if (i < args.length && args[i] && !args[i]!.startsWith('-')) {
+        options.group = args[i];
+      }
     } else if (arg && !arg.startsWith('-')) {
       skills.push(arg);
     }

--- a/tests/groups.test.ts
+++ b/tests/groups.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  readGroupsConfig,
+  writeGroupsConfig,
+  createGroup,
+  deleteGroup,
+  addSkillToGroup,
+  removeSkillFromGroup,
+  findGroupForSkill,
+  getSkillsInGroup,
+  getGroupsPath,
+  type GroupsConfig,
+} from '../src/groups.ts';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'skills-groups-test-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('readGroupsConfig', () => {
+  it('returns null when file does not exist', async () => {
+    const result = await readGroupsConfig(tempDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for invalid JSON', async () => {
+    const { writeFile } = await import('fs/promises');
+    await writeFile(join(tempDir, 'skills.groups.json'), 'not json');
+    const result = await readGroupsConfig(tempDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when groups field is missing', async () => {
+    const { writeFile } = await import('fs/promises');
+    await writeFile(join(tempDir, 'skills.groups.json'), JSON.stringify({ version: 1 }));
+    const result = await readGroupsConfig(tempDir);
+    expect(result).toBeNull();
+  });
+
+  it('reads a valid config', async () => {
+    const config: GroupsConfig = {
+      groups: {
+        core: { description: 'Core skills', skills: ['coding-standards'] },
+      },
+    };
+    const { writeFile } = await import('fs/promises');
+    await writeFile(join(tempDir, 'skills.groups.json'), JSON.stringify(config));
+    const result = await readGroupsConfig(tempDir);
+    expect(result).toEqual(config);
+  });
+});
+
+describe('writeGroupsConfig', () => {
+  it('writes sorted groups and skills', async () => {
+    const config: GroupsConfig = {
+      groups: {
+        debug: { description: 'Debug', skills: ['logging', 'debugging'] },
+        core: { description: 'Core', skills: ['typescript', 'coding'] },
+      },
+    };
+    await writeGroupsConfig(config, tempDir);
+    const content = JSON.parse(await readFile(join(tempDir, 'skills.groups.json'), 'utf-8'));
+    const groupNames = Object.keys(content.groups);
+    expect(groupNames).toEqual(['core', 'debug']);
+    expect(content.groups.debug.skills).toEqual(['debugging', 'logging']);
+  });
+});
+
+describe('createGroup', () => {
+  it('creates a new group', async () => {
+    const created = await createGroup('deploy', 'Deployment skills', tempDir);
+    expect(created).toBe(true);
+    const config = await readGroupsConfig(tempDir);
+    expect(config?.groups.deploy).toEqual({ description: 'Deployment skills', skills: [] });
+  });
+
+  it('returns false if group already exists', async () => {
+    await createGroup('deploy', 'First', tempDir);
+    const created = await createGroup('deploy', 'Second', tempDir);
+    expect(created).toBe(false);
+    const config = await readGroupsConfig(tempDir);
+    expect(config?.groups.deploy?.description).toBe('First');
+  });
+
+  it('creates groups file if it does not exist', async () => {
+    await createGroup('core', '', tempDir);
+    const config = await readGroupsConfig(tempDir);
+    expect(config).not.toBeNull();
+    expect(config?.groups.core).toBeDefined();
+  });
+});
+
+describe('deleteGroup', () => {
+  it('deletes an existing group', async () => {
+    await createGroup('temp', 'Temporary', tempDir);
+    const deleted = await deleteGroup('temp', tempDir);
+    expect(deleted).toEqual({ description: 'Temporary', skills: [] });
+    const config = await readGroupsConfig(tempDir);
+    expect(config?.groups.temp).toBeUndefined();
+  });
+
+  it('returns null for non-existent group', async () => {
+    const deleted = await deleteGroup('missing', tempDir);
+    expect(deleted).toBeNull();
+  });
+});
+
+describe('addSkillToGroup', () => {
+  it('adds a skill to an existing group', async () => {
+    await createGroup('core', 'Core', tempDir);
+    const added = await addSkillToGroup('typescript', 'core', tempDir);
+    expect(added).toBe(true);
+    const config = await readGroupsConfig(tempDir);
+    expect(config?.groups.core?.skills).toContain('typescript');
+  });
+
+  it('creates the group if it does not exist', async () => {
+    const added = await addSkillToGroup('logging', 'debug', tempDir);
+    expect(added).toBe(true);
+    const config = await readGroupsConfig(tempDir);
+    expect(config?.groups.debug?.skills).toContain('logging');
+  });
+
+  it('returns false if skill already in group', async () => {
+    await addSkillToGroup('typescript', 'core', tempDir);
+    const added = await addSkillToGroup('typescript', 'core', tempDir);
+    expect(added).toBe(false);
+  });
+});
+
+describe('removeSkillFromGroup', () => {
+  it('removes a skill from a group', async () => {
+    await addSkillToGroup('typescript', 'core', tempDir);
+    const removed = await removeSkillFromGroup('typescript', 'core', tempDir);
+    expect(removed).toBe(true);
+    const config = await readGroupsConfig(tempDir);
+    expect(config?.groups.core?.skills).not.toContain('typescript');
+  });
+
+  it('returns false if group does not exist', async () => {
+    const removed = await removeSkillFromGroup('skill', 'missing', tempDir);
+    expect(removed).toBe(false);
+  });
+
+  it('returns false if skill not in group', async () => {
+    await createGroup('core', 'Core', tempDir);
+    const removed = await removeSkillFromGroup('missing', 'core', tempDir);
+    expect(removed).toBe(false);
+  });
+});
+
+describe('findGroupForSkill', () => {
+  it('finds the group for a skill', () => {
+    const config: GroupsConfig = {
+      groups: {
+        core: { description: '', skills: ['typescript'] },
+        debug: { description: '', skills: ['logging'] },
+      },
+    };
+    expect(findGroupForSkill(config, 'typescript')).toBe('core');
+    expect(findGroupForSkill(config, 'logging')).toBe('debug');
+  });
+
+  it('returns null for ungrouped skill', () => {
+    const config: GroupsConfig = {
+      groups: { core: { description: '', skills: ['typescript'] } },
+    };
+    expect(findGroupForSkill(config, 'unknown')).toBeNull();
+  });
+});
+
+describe('getSkillsInGroup', () => {
+  it('returns skills for an existing group', () => {
+    const config: GroupsConfig = {
+      groups: { core: { description: '', skills: ['a', 'b'] } },
+    };
+    expect(getSkillsInGroup(config, 'core')).toEqual(['a', 'b']);
+  });
+
+  it('returns null for non-existent group', () => {
+    const config: GroupsConfig = { groups: {} };
+    expect(getSkillsInGroup(config, 'missing')).toBeNull();
+  });
+});
+
+describe('getGroupsPath', () => {
+  it('returns correct path', () => {
+    expect(getGroupsPath('/my/project')).toBe('/my/project/skills.groups.json');
+  });
+});
+
+describe('parseRemoveOptions --group', () => {
+  it('parses --group flag', async () => {
+    const { parseRemoveOptions } = await import('../src/remove.ts');
+    const { skills, options } = parseRemoveOptions(['--group', 'debug']);
+    expect(options.group).toBe('debug');
+    expect(skills).toEqual([]);
+  });
+});
+
+describe('parseAddOptions --group', () => {
+  it('parses --group flag', async () => {
+    const { parseAddOptions } = await import('../src/add.ts');
+    const { source, options } = parseAddOptions([
+      'vercel-labs/skills',
+      '--group',
+      'core',
+      '--skill',
+      'typescript',
+    ]);
+    expect(options.group).toBe('core');
+    expect(source).toEqual(['vercel-labs/skills']);
+  });
+});
+
+describe('parseListOptions --by-group', () => {
+  it('parses --by-group flag', async () => {
+    const { parseListOptions } = await import('../src/list.ts');
+    const options = parseListOptions(['--by-group']);
+    expect(options.byGroup).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Dependency Groups** for skill management (Issue #502).

- New `skills.groups.json` config file for organizing skills into named groups
- `skills groups` subcommand with full CRUD: list, show, create, add, remove, delete
- `--group` flag on `skills add` to assign skills to a group at install time
- `--group` flag on `skills remove` to remove all skills in a group at once
- `--by-group` flag on `skills list` to display skills organized by group

## New Files

- `src/groups.ts` — Group config read/write, CRUD operations, skill-to-group mapping
- `src/groups-command.ts` — `skills groups` subcommand with 6 sub-operations
- `tests/groups.test.ts` — 24 tests for group operations and CLI flag parsing

## Modified Files

- `src/cli.ts` — Added `groups` command routing, updated banner and help text
- `src/add.ts` — Added `--group` flag, post-install group assignment
- `src/remove.ts` — Added `--group` flag, group-based bulk removal
- `src/list.ts` — Added `--by-group` flag, group-aware display

## Tests

- 24 new tests covering config read/write, CRUD, CLI flag parsing
- All 392 tests pass (368 existing + 24 new)

## Test plan

- [ ] Verify `skills groups create/delete/add/remove` subcommands
- [ ] Verify `skills add --group <name>` assigns skill to group
- [ ] Verify `skills remove --group <name>` removes all skills in group
- [ ] Verify `skills list --by-group` organizes output by group
- [ ] Verify projects without `skills.groups.json` behave as before
- [ ] Verify no regressions in existing test suite

Closes #502