### PR TITLE
feat: structured taxonomy / classifiers for skills

### DIFF
--- a/src/classifiers/compatibility.ts
+++ b/src/classifiers/compatibility.ts
@@ -1,0 +1,51 @@
+import type { ParsedClassifiers } from './parser.ts';
+import { agents } from '../agents.ts';
+import type { AgentType } from '../types.ts';
+
+export interface CompatibilityWarning {
+  skillName: string;
+  declaredAgents: string[];
+  targetAgent: string;
+  message: string;
+}
+
+/**
+ * Check if a skill's classifiers indicate agent compatibility issues.
+ *
+ * Rules:
+ * - No Agent classifiers → no warnings (backward compatible)
+ * - "Agent :: Universal" → compatible with all agents
+ * - Specific agents listed → warn if target agent is not in the list
+ */
+export function checkAgentCompatibility(
+  skillName: string,
+  classifiers: ParsedClassifiers | null,
+  targetAgents: AgentType[]
+): CompatibilityWarning[] {
+  if (!classifiers || classifiers.agents.length === 0) return [];
+
+  // Universal means compatible with all
+  if (classifiers.agents.includes('Universal')) return [];
+
+  const warnings: CompatibilityWarning[] = [];
+
+  for (const agentKey of targetAgents) {
+    const agent = agents[agentKey];
+    if (!agent) continue;
+
+    const isCompatible = classifiers.agents.some(
+      (declared) => declared === agent.displayName || declared.toLowerCase() === agentKey
+    );
+
+    if (!isCompatible) {
+      warnings.push({
+        skillName,
+        declaredAgents: classifiers.agents,
+        targetAgent: agent.displayName,
+        message: `"${skillName}" is classified for ${classifiers.agents.join(', ')} only. You're installing to ${agent.displayName}.`,
+      });
+    }
+  }
+
+  return warnings;
+}

--- a/src/classifiers/index.ts
+++ b/src/classifiers/index.ts
@@ -1,0 +1,11 @@
+export {
+  CLASSIFIER_VOCABULARY,
+  parseClassifier,
+  validateClassifier,
+  getAgentDisplayNames,
+  getCategories,
+  type ClassifierCategory,
+  type ParsedClassifier,
+} from './vocabulary.ts';
+export { parseClassifiers, formatClassifiers, type ParsedClassifiers } from './parser.ts';
+export { checkAgentCompatibility, type CompatibilityWarning } from './compatibility.ts';

--- a/src/classifiers/parser.ts
+++ b/src/classifiers/parser.ts
@@ -1,0 +1,67 @@
+import { parseClassifier, validateClassifier } from './vocabulary.ts';
+
+export interface ParsedClassifiers {
+  raw: string[];
+  byCategory: Record<string, string[]>;
+  agents: string[];
+  warnings: string[];
+}
+
+/**
+ * Parse classifiers from SKILL.md frontmatter.
+ * Returns null if no classifiers field is present.
+ */
+export function parseClassifiers(frontmatter: Record<string, unknown>): ParsedClassifiers | null {
+  if (!frontmatter.classifiers) return null;
+
+  if (!Array.isArray(frontmatter.classifiers)) {
+    return {
+      raw: [],
+      byCategory: {},
+      agents: [],
+      warnings: ['classifiers must be an array of strings'],
+    };
+  }
+
+  const raw = frontmatter.classifiers.filter((c): c is string => typeof c === 'string');
+  const byCategory: Record<string, string[]> = {};
+  const agents: string[] = [];
+  const warnings: string[] = [];
+
+  for (const classifier of raw) {
+    const warning = validateClassifier(classifier);
+    if (warning) {
+      warnings.push(warning);
+    }
+
+    const parsed = parseClassifier(classifier);
+    if (!parsed) continue;
+
+    if (!byCategory[parsed.category]) {
+      byCategory[parsed.category] = [];
+    }
+    const fullValue = parsed.subvalue ? `${parsed.value} :: ${parsed.subvalue}` : parsed.value;
+    byCategory[parsed.category].push(fullValue);
+
+    if (parsed.category === 'Agent') {
+      agents.push(parsed.value);
+    }
+  }
+
+  return { raw, byCategory, agents, warnings };
+}
+
+/**
+ * Format classifiers for compact display.
+ * Returns a string like "Domain: Frontend | Type: Patterns | Complexity: Intermediate"
+ */
+export function formatClassifiers(classifiers: ParsedClassifiers): string {
+  const parts: string[] = [];
+
+  for (const [category, values] of Object.entries(classifiers.byCategory)) {
+    if (category === 'Agent') continue; // Agents shown separately
+    parts.push(`${category}: ${values.join(', ')}`);
+  }
+
+  return parts.join(' | ');
+}

--- a/src/classifiers/vocabulary.ts
+++ b/src/classifiers/vocabulary.ts
@@ -1,0 +1,124 @@
+import { agents } from '../agents.ts';
+
+export interface ClassifierCategory {
+  name: string;
+  description: string;
+  values: string[];
+  openEnded?: boolean;
+}
+
+/**
+ * Controlled vocabulary for skill classifiers.
+ * Product and License categories are open-ended (any value accepted).
+ */
+export const CLASSIFIER_VOCABULARY: Record<string, ClassifierCategory> = {
+  Agent: {
+    name: 'Agent',
+    description: 'Compatible coding agents',
+    values: ['Universal'],
+  },
+  Domain: {
+    name: 'Domain',
+    description: 'Application domain',
+    values: [
+      'Frontend',
+      'Backend',
+      'DevOps',
+      'Mobile',
+      'Data',
+      'Security',
+      'Testing',
+      'Documentation',
+    ],
+  },
+  Product: {
+    name: 'Product',
+    description: 'Specific product or framework',
+    values: [],
+    openEnded: true,
+  },
+  Type: {
+    name: 'Type',
+    description: 'Skill type',
+    values: ['Patterns', 'Setup', 'Debugging', 'Migration', 'Review', 'Testing', 'Workflow'],
+  },
+  Complexity: {
+    name: 'Complexity',
+    description: 'Target expertise level',
+    values: ['Beginner', 'Intermediate', 'Advanced'],
+  },
+  License: {
+    name: 'License',
+    description: 'License type',
+    values: [],
+    openEnded: true,
+  },
+};
+
+export interface ParsedClassifier {
+  category: string;
+  value: string;
+  subvalue?: string;
+}
+
+/**
+ * Parse a classifier string like "Domain :: Frontend" into parts.
+ */
+export function parseClassifier(classifier: string): ParsedClassifier | null {
+  const parts = classifier.split('::').map((p) => p.trim());
+  if (parts.length < 2 || !parts[0] || !parts[1]) return null;
+  return {
+    category: parts[0],
+    value: parts[1],
+    subvalue: parts[2] || undefined,
+  };
+}
+
+/**
+ * Get all valid agent display names for use as Agent classifiers.
+ */
+export function getAgentDisplayNames(): string[] {
+  return Object.values(agents).map((a) => a.displayName);
+}
+
+/**
+ * Check if a classifier string is valid against the vocabulary.
+ * Returns a warning message if invalid, or null if valid.
+ */
+export function validateClassifier(classifier: string): string | null {
+  const parsed = parseClassifier(classifier);
+  if (!parsed) {
+    return `Invalid classifier format: "${classifier}". Expected "Category :: Value"`;
+  }
+
+  const category = CLASSIFIER_VOCABULARY[parsed.category];
+  if (!category) {
+    return `Unknown classifier category: "${parsed.category}"`;
+  }
+
+  // Open-ended categories accept any value
+  if (category.openEnded) return null;
+
+  // Agent category: check against display names + "Universal"
+  if (parsed.category === 'Agent') {
+    const validAgents = ['Universal', ...getAgentDisplayNames()];
+    if (!validAgents.includes(parsed.value)) {
+      return `Unknown agent: "${parsed.value}"`;
+    }
+    return null;
+  }
+
+  // Check value against vocabulary
+  if (category.values.length > 0 && !category.values.includes(parsed.value)) {
+    return `Unknown ${parsed.category} value: "${parsed.value}". Valid: ${category.values.join(', ')}`;
+  }
+
+  return null;
+}
+
+/**
+ * Get all valid classifier categories.
+ */
+export function getCategories(): string[] {
+  return Object.keys(CLASSIFIER_VOCABULARY);
+}

--- a/tests/classifiers-compatibility.test.ts
+++ b/tests/classifiers-compatibility.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { checkAgentCompatibility } from '../src/classifiers/compatibility.ts';
+import { parseClassifiers } from '../src/classifiers/parser.ts';
+import type { AgentType } from '../src/types.ts';
+
+describe('checkAgentCompatibility', () => {
+  it('returns no warnings when no classifiers', () => {
+    const warnings = checkAgentCompatibility('my-skill', null, ['claude-code' as AgentType]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns no warnings when no Agent classifiers', () => {
+    const classifiers = parseClassifiers({
+      classifiers: ['Domain :: Frontend'],
+    });
+    const warnings = checkAgentCompatibility('my-skill', classifiers, ['claude-code' as AgentType]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns no warnings for Universal', () => {
+    const classifiers = parseClassifiers({
+      classifiers: ['Agent :: Universal'],
+    });
+    const warnings = checkAgentCompatibility('my-skill', classifiers, ['claude-code' as AgentType]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns no warnings when target agent matches', () => {
+    const classifiers = parseClassifiers({
+      classifiers: ['Agent :: Claude Code'],
+    });
+    const warnings = checkAgentCompatibility('my-skill', classifiers, ['claude-code' as AgentType]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns when target agent does not match', () => {
+    const classifiers = parseClassifiers({
+      classifiers: ['Agent :: Cursor'],
+    });
+    const warnings = checkAgentCompatibility('my-skill', classifiers, ['claude-code' as AgentType]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.targetAgent).toBe('Claude Code');
+    expect(warnings[0]!.declaredAgents).toEqual(['Cursor']);
+    expect(warnings[0]!.message).toContain('Cursor');
+    expect(warnings[0]!.message).toContain('Claude Code');
+  });
+
+  it('warns for each incompatible target agent', () => {
+    const classifiers = parseClassifiers({
+      classifiers: ['Agent :: Cursor'],
+    });
+    const warnings = checkAgentCompatibility('my-skill', classifiers, [
+      'claude-code' as AgentType,
+      'cursor' as AgentType,
+    ]);
+    // Should warn about Claude Code but not Cursor
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.targetAgent).toBe('Claude Code');
+  });
+
+  it('handles multiple declared agents', () => {
+    const classifiers = parseClassifiers({
+      classifiers: ['Agent :: Claude Code', 'Agent :: Cursor'],
+    });
+    const warnings = checkAgentCompatibility('my-skill', classifiers, ['claude-code' as AgentType]);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/tests/classifiers-parser.test.ts
+++ b/tests/classifiers-parser.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { parseClassifiers, formatClassifiers } from '../src/classifiers/parser.ts';
+
+describe('parseClassifiers', () => {
+  it('returns null when no classifiers field', () => {
+    expect(parseClassifiers({ name: 'test' })).toBeNull();
+  });
+
+  it('returns warnings when classifiers is not an array', () => {
+    const result = parseClassifiers({ classifiers: 'invalid' });
+    expect(result).not.toBeNull();
+    expect(result!.warnings).toHaveLength(1);
+    expect(result!.raw).toEqual([]);
+  });
+
+  it('parses valid classifiers', () => {
+    const result = parseClassifiers({
+      classifiers: [
+        'Agent :: Claude Code',
+        'Domain :: Frontend',
+        'Type :: Patterns',
+        'Product :: Next.js :: 15',
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.raw).toHaveLength(4);
+    expect(result!.byCategory.Agent).toEqual(['Claude Code']);
+    expect(result!.byCategory.Domain).toEqual(['Frontend']);
+    expect(result!.byCategory.Type).toEqual(['Patterns']);
+    expect(result!.byCategory.Product).toEqual(['Next.js :: 15']);
+  });
+
+  it('extracts agent names', () => {
+    const result = parseClassifiers({
+      classifiers: ['Agent :: Claude Code', 'Agent :: Cursor'],
+    });
+    expect(result!.agents).toEqual(['Claude Code', 'Cursor']);
+  });
+
+  it('handles Universal agent', () => {
+    const result = parseClassifiers({
+      classifiers: ['Agent :: Universal'],
+    });
+    expect(result!.agents).toEqual(['Universal']);
+  });
+
+  it('collects warnings for invalid classifiers', () => {
+    const result = parseClassifiers({
+      classifiers: ['Domain :: Frontend', 'Unknown :: Thing'],
+    });
+    expect(result!.warnings.length).toBeGreaterThan(0);
+    expect(result!.warnings[0]).toContain('Unknown classifier category');
+  });
+
+  it('filters non-string values', () => {
+    const result = parseClassifiers({
+      classifiers: ['Domain :: Frontend', 42, null, 'Type :: Patterns'],
+    });
+    expect(result!.raw).toEqual(['Domain :: Frontend', 'Type :: Patterns']);
+  });
+
+  it('groups multiple values in same category', () => {
+    const result = parseClassifiers({
+      classifiers: ['Domain :: Frontend', 'Domain :: Backend'],
+    });
+    expect(result!.byCategory.Domain).toEqual(['Frontend', 'Backend']);
+  });
+});
+
+describe('formatClassifiers', () => {
+  it('formats classifiers for display (excluding Agent)', () => {
+    const result = parseClassifiers({
+      classifiers: [
+        'Agent :: Claude Code',
+        'Domain :: Frontend',
+        'Type :: Patterns',
+        'Complexity :: Intermediate',
+      ],
+    })!;
+    const formatted = formatClassifiers(result);
+    expect(formatted).toBe('Domain: Frontend | Type: Patterns | Complexity: Intermediate');
+    expect(formatted).not.toContain('Agent');
+  });
+
+  it('handles multiple values in a category', () => {
+    const result = parseClassifiers({
+      classifiers: ['Domain :: Frontend', 'Domain :: Backend'],
+    })!;
+    const formatted = formatClassifiers(result);
+    expect(formatted).toBe('Domain: Frontend, Backend');
+  });
+
+  it('returns empty string when only Agent classifiers', () => {
+    const result = parseClassifiers({
+      classifiers: ['Agent :: Universal'],
+    })!;
+    expect(formatClassifiers(result)).toBe('');
+  });
+});

--- a/tests/classifiers-vocabulary.test.ts
+++ b/tests/classifiers-vocabulary.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseClassifier,
+  validateClassifier,
+  getAgentDisplayNames,
+  getCategories,
+  CLASSIFIER_VOCABULARY,
+} from '../src/classifiers/vocabulary.ts';
+
+describe('parseClassifier', () => {
+  it('parses a simple classifier', () => {
+    const result = parseClassifier('Domain :: Frontend');
+    expect(result).toEqual({ category: 'Domain', value: 'Frontend', subvalue: undefined });
+  });
+
+  it('parses a classifier with subvalue', () => {
+    const result = parseClassifier('Product :: Next.js :: 15');
+    expect(result).toEqual({ category: 'Product', value: 'Next.js', subvalue: '15' });
+  });
+
+  it('returns null for invalid format', () => {
+    expect(parseClassifier('just-a-string')).toBeNull();
+    expect(parseClassifier('')).toBeNull();
+  });
+
+  it('trims whitespace', () => {
+    const result = parseClassifier('  Domain  ::  Frontend  ');
+    expect(result).toEqual({ category: 'Domain', value: 'Frontend', subvalue: undefined });
+  });
+});
+
+describe('validateClassifier', () => {
+  it('validates a known classifier', () => {
+    expect(validateClassifier('Domain :: Frontend')).toBeNull();
+    expect(validateClassifier('Type :: Patterns')).toBeNull();
+    expect(validateClassifier('Complexity :: Intermediate')).toBeNull();
+  });
+
+  it('validates Agent :: Universal', () => {
+    expect(validateClassifier('Agent :: Universal')).toBeNull();
+  });
+
+  it('validates Agent :: Claude Code', () => {
+    expect(validateClassifier('Agent :: Claude Code')).toBeNull();
+  });
+
+  it('validates open-ended categories', () => {
+    expect(validateClassifier('Product :: React :: 19')).toBeNull();
+    expect(validateClassifier('License :: MIT')).toBeNull();
+    expect(validateClassifier('Product :: Anything')).toBeNull();
+  });
+
+  it('warns on unknown category', () => {
+    const warning = validateClassifier('Unknown :: Value');
+    expect(warning).toContain('Unknown classifier category');
+  });
+
+  it('warns on unknown domain value', () => {
+    const warning = validateClassifier('Domain :: Quantum');
+    expect(warning).toContain('Unknown Domain value');
+  });
+
+  it('warns on unknown agent', () => {
+    const warning = validateClassifier('Agent :: NonExistentAgent');
+    expect(warning).toContain('Unknown agent');
+  });
+
+  it('warns on invalid format', () => {
+    const warning = validateClassifier('no-separator');
+    expect(warning).toContain('Invalid classifier format');
+  });
+});
+
+describe('getAgentDisplayNames', () => {
+  it('returns an array of agent names', () => {
+    const names = getAgentDisplayNames();
+    expect(names.length).toBeGreaterThan(0);
+    expect(names).toContain('Claude Code');
+    expect(names).toContain('Cursor');
+  });
+});
+
+describe('getCategories', () => {
+  it('returns all category names', () => {
+    const cats = getCategories();
+    expect(cats).toContain('Agent');
+    expect(cats).toContain('Domain');
+    expect(cats).toContain('Product');
+    expect(cats).toContain('Type');
+    expect(cats).toContain('Complexity');
+    expect(cats).toContain('License');
+  });
+});
+
+describe('CLASSIFIER_VOCABULARY', () => {
+  it('has expected structure', () => {
+    expect(CLASSIFIER_VOCABULARY.Domain.values).toContain('Frontend');
+    expect(CLASSIFIER_VOCABULARY.Type.values).toContain('Patterns');
+    expect(CLASSIFIER_VOCABULARY.Product.openEnded).toBe(true);
+    expect(CLASSIFIER_VOCABULARY.License.openEnded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Structured Taxonomy / Classifiers** for skill discovery (Issue #505).

Adds a controlled classification vocabulary (similar to PyPI classifiers) for structured filtering, discovery, and agent compatibility warnings.

## New Modules (`src/classifiers/`)

- `vocabulary.ts` — Controlled vocabulary with 6 categories (Agent, Domain, Product, Type, Complexity, License). Agent classifiers auto-generated from 41 agents in agents.ts. Product and License are open-ended.
- `parser.ts` — Parse `classifiers` array from frontmatter, group by category, extract agent compatibility, collect validation warnings
- `compatibility.ts` — Check if a skill's Agent classifiers match the target install agents (warns on mismatch, respects "Universal")
- `index.ts` — Barrel exports

## Classifier Format

```yaml
classifiers:
  - "Agent :: Claude Code"
  - "Domain :: Frontend"
  - "Product :: Next.js :: 15"
  - "Type :: Patterns"
  - "Complexity :: Intermediate"
```

## Tests

- 15 vocabulary tests (parsing, validation, agent names, categories)
- 11 parser tests (frontmatter parsing, grouping, warnings, filtering)
- 7 compatibility tests (matching, mismatched, Universal, no classifiers)
- All 401 tests pass (368 existing + 33 new)

## Test plan

- [ ] Verify `parseClassifier()` handles all format variations
- [ ] Verify `validateClassifier()` catches invalid categories/values
- [ ] Verify `parseClassifiers()` groups by category and extracts agents
- [ ] Verify `checkAgentCompatibility()` warns correctly
- [ ] Verify open-ended categories accept any value
- [ ] Verify no regressions in existing test suite

Closes #505