### PR TITLE
feat: add Warp as a universal agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [37 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [38 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -214,7 +214,7 @@ Skills can be installed to any of these agents:
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline | `cline` | `.agents/skills/` | `~/.agents/skills/` |
+| Cline, Warp | `cline`, `warp` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "roo",
     "trae",
     "trae-cn",
+    "warp",
     "windsurf",
     "zencoder",
     "neovate",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -347,6 +347,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.trae-cn'));
     },
   },
+  warp: {
+    name: 'warp',
+    displayName: 'Warp',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.warp'));
+    },
+  },
   windsurf: {
     name: 'windsurf',
     displayName: 'Windsurf',

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export type AgentType =
   | 'roo'
   | 'trae'
   | 'trae-cn'
+  | 'warp'
   | 'windsurf'
   | 'zencoder'
   | 'pochi'


### PR DESCRIPTION
## Summary

Adds [Warp](https://warp.dev) to the list of compatible AI coding agents.

## About Warp

Warp is an AI-native terminal and agentic development environment. Warp's AI agent (Oz) supports the agent skills format natively, reading skills from `.agents/skills/` in the project and `~/.agents/skills/` globally.

## Changes

- Added `warp` to the `AgentType` union in `src/types.ts`
- Added the `warp` agent config in `src/agents.ts` with `skillsDir: '.agents/skills'` (universal), `globalSkillsDir: ~/.agents/skills`, and detection via `~/.warp`
- Re-ran `sync-agents.ts` to update the README supported-agents table and `package.json` keywords — Warp now appears alongside Cline in the `~/.agents/skills` row