### PR TITLE
fix: create agent globalSkillsDir before installing for global installs

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -261,6 +261,10 @@ export async function installSkillForAgent(
   }
 
   try {
+    if (isGlobal && agent.globalSkillsDir) {
+      await mkdir(agentBase, { recursive: true });
+    }
+
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
@@ -485,6 +489,10 @@ export async function installRemoteSkillForAgent(
   }
 
   try {
+    if (isGlobal && agent.globalSkillsDir) {
+      await mkdir(agentBase, { recursive: true });
+    }
+
     // For copy mode, write directly to agent location
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
@@ -603,28 +611,32 @@ export async function installWellKnownSkillForAgent(
     };
   }
 
-  /**
-   * Write all skill files to a directory (assumes directory already exists)
-   */
-  async function writeSkillFiles(targetDir: string): Promise<void> {
-    for (const [filePath, content] of skill.files) {
-      // Validate file path doesn't escape the target directory
-      const fullPath = join(targetDir, filePath);
-      if (!isPathSafe(targetDir, fullPath)) {
-        continue; // Skip files that would escape the directory
-      }
-
-      // Create parent directories if needed
-      const parentDir = dirname(fullPath);
-      if (parentDir !== targetDir) {
-        await mkdir(parentDir, { recursive: true });
-      }
-
-      await writeFile(fullPath, content, 'utf-8');
-    }
-  }
-
   try {
+    if (isGlobal && agent.globalSkillsDir) {
+      await mkdir(agentBase, { recursive: true });
+    }
+
+    /**
+     * Write all skill files to a directory (assumes directory already exists)
+     */
+    async function writeSkillFiles(targetDir: string): Promise<void> {
+      for (const [filePath, content] of skill.files) {
+        // Validate file path doesn't escape the target directory
+        const fullPath = join(targetDir, filePath);
+        if (!isPathSafe(targetDir, fullPath)) {
+          continue; // Skip files that would escape the directory
+        }
+
+        // Create parent directories if needed
+        const parentDir = dirname(fullPath);
+        if (parentDir !== targetDir) {
+          await mkdir(parentDir, { recursive: true });
+        }
+
+        await writeFile(fullPath, content, 'utf-8');
+      }
+    }
+
     // For copy mode, write directly to agent location
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);


### PR DESCRIPTION
Fixes #537

This solution ensures the selected agent's global skills directory (from `agents.ts` metadata) exists before installing when doing a global install. This prevents the broken state where the skill is in `~/.agents/skills` but the agent-facing dir (e.g. `~/.cursor/skills`) is missing and the skill shows as "not linked".

- Only touches installer.ts; no changes to agents.ts.
- Uses existing agent.globalSkillsDir from agents.ts (generic, not hardcoded).
- Keeps canonical store at `~/.agents/skills`; fix only ensures agent dir is created before symlink/copy.