### PR TITLE
fix: update project-local skills from skills-lock

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,10 +10,12 @@ import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
 import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
+import { readLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { getUniversalAgents } from './agents.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -390,9 +392,125 @@ function printSkippedSkills(skipped: SkippedSkill[]): void {
   }
 }
 
+interface LocalProjectSkillUpdate {
+  name: string;
+  source: string;
+  currentHash: string;
+  latestHash: string;
+}
+
+async function getLocalProjectSkillUpdates(): Promise<LocalProjectSkillUpdate[] | null> {
+  const cwd = process.cwd();
+  const localLock = await readLocalLock(cwd);
+  const localSkills = Object.entries(localLock.skills).filter(
+    ([, entry]) => entry.sourceType === 'local'
+  );
+
+  if (localSkills.length === 0) {
+    return null;
+  }
+
+  const updates: LocalProjectSkillUpdate[] = [];
+
+  for (const [skillName, entry] of localSkills) {
+    if (!existsSync(entry.source)) {
+      continue;
+    }
+
+    const latestHash = await computeSkillFolderHash(entry.source);
+    if (latestHash !== entry.computedHash) {
+      updates.push({
+        name: skillName,
+        source: entry.source,
+        currentHash: entry.computedHash,
+        latestHash,
+      });
+    }
+  }
+
+  return updates;
+}
+
+async function runCheckLocalProject(): Promise<boolean> {
+  const updates = await getLocalProjectSkillUpdates();
+  if (updates === null) {
+    return false;
+  }
+
+  console.log(`${DIM}Checking local project skills...${RESET}`);
+
+  if (updates.length === 0) {
+    console.log(`${TEXT}✓ All local skills are up to date${RESET}`);
+    console.log();
+    return true;
+  }
+
+  console.log();
+  console.log(`${TEXT}Updates available for ${updates.length} local skill(s):${RESET}`);
+  for (const update of updates) {
+    console.log(`  ${TEXT}•${RESET} ${update.name}`);
+    console.log(`    ${DIM}${update.source}${RESET}`);
+  }
+  console.log();
+
+  return true;
+}
+
+async function runUpdateLocalProject(): Promise<boolean> {
+  const updates = await getLocalProjectSkillUpdates();
+  if (updates === null) {
+    return false;
+  }
+
+  if (updates.length === 0) {
+    console.log(`${TEXT}✓ All local skills are up to date${RESET}`);
+    console.log();
+    return true;
+  }
+
+  console.log(`${TEXT}Found ${updates.length} local update(s)${RESET}`);
+  console.log();
+
+  const universalAgents = getUniversalAgents();
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const update of updates) {
+    console.log(`${TEXT}Updating ${update.name}...${RESET}`);
+
+    try {
+      await runAdd([update.source], {
+        skill: [update.name],
+        agent: universalAgents,
+        yes: true,
+      });
+      successCount++;
+      console.log(`  ${TEXT}✓${RESET} Updated ${update.name}`);
+    } catch {
+      failCount++;
+      console.log(`  ${DIM}✗ Failed to update ${update.name}${RESET}`);
+    }
+  }
+
+  console.log();
+  if (successCount > 0) {
+    console.log(`${TEXT}✓ Updated ${successCount} local skill(s)${RESET}`);
+  }
+  if (failCount > 0) {
+    console.log(`${DIM}Failed to update ${failCount} local skill(s)${RESET}`);
+  }
+  console.log();
+
+  return true;
+}
+
 async function runCheck(args: string[] = []): Promise<void> {
   console.log(`${TEXT}Checking for skill updates...${RESET}`);
   console.log();
+
+  if (await runCheckLocalProject()) {
+    return;
+  }
 
   const lock = readSkillLock();
   const skillNames = Object.keys(lock.skills);
@@ -498,6 +616,10 @@ async function runCheck(args: string[] = []): Promise<void> {
 async function runUpdate(): Promise<void> {
   console.log(`${TEXT}Checking for skill updates...${RESET}`);
   console.log();
+
+  if (await runUpdateLocalProject()) {
+    return;
+  }
 
   const lock = readSkillLock();
   const skillNames = Object.keys(lock.skills);

--- a/tests/local-skill-check-update.test.ts
+++ b/tests/local-skill-check-update.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCli } from '../src/test-utils.ts';
+
+describe('check/update for project-local skills', () => {
+  let rootDir: string;
+  let projectDir: string;
+  let sourceSkillDir: string;
+
+  beforeEach(() => {
+    rootDir = join(tmpdir(), `skills-local-update-${Date.now()}`);
+    projectDir = join(rootDir, 'project');
+    sourceSkillDir = join(rootDir, 'local-skill');
+
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(sourceSkillDir, { recursive: true });
+
+    writeFileSync(
+      join(sourceSkillDir, 'SKILL.md'),
+      `---
+name: local-update-skill
+description: test local update flow
+---
+
+# Local Update Skill
+`
+    );
+    writeFileSync(join(sourceSkillDir, 'prompt.txt'), 'version one\n');
+  });
+
+  afterEach(() => {
+    if (existsSync(rootDir)) {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('detects and reapplies project-local skill changes from skills-lock.json', () => {
+    const addResult = runCli(
+      ['add', sourceSkillDir, '-y', '-a', 'github-copilot'],
+      projectDir
+    );
+    expect(addResult.exitCode).toBe(0);
+
+    const installedPromptPath = join(
+      projectDir,
+      '.agents',
+      'skills',
+      'local-update-skill',
+      'prompt.txt'
+    );
+    expect(readFileSync(installedPromptPath, 'utf-8')).toBe('version one\n');
+
+    writeFileSync(join(sourceSkillDir, 'prompt.txt'), 'version two\n');
+
+    const checkResult = runCli(['check'], projectDir);
+    expect(checkResult.exitCode).toBe(0);
+    expect(checkResult.stdout).toContain('Updates available for 1 local skill');
+    expect(checkResult.stdout).toContain('local-update-skill');
+
+    const updateResult = runCli(['update'], projectDir);
+    expect(updateResult.exitCode).toBe(0);
+    expect(updateResult.stdout).toContain('Updated 1 local skill');
+    expect(readFileSync(installedPromptPath, 'utf-8')).toBe('version two\n');
+
+    const lock = JSON.parse(readFileSync(join(projectDir, 'skills-lock.json'), 'utf-8'));
+    expect(lock.skills['local-update-skill']).toBeDefined();
+    expect(lock.skills['local-update-skill'].sourceType).toBe('local');
+  });
+});


### PR DESCRIPTION
## Summary
- make `skills check` prefer project-local `skills-lock.json` entries when local skills are tracked
- make `skills update` recompute hashes for those local sources and reinstall changed skills into `.agents/skills`
- add a regression test covering local add -> modify source -> check/update flow

## Testing
- `corepack pnpm vitest run tests/local-skill-check-update.test.ts tests/local-lock.test.ts`
- `git diff --check`
