### PR TITLE
feat: add Apple Foundation Models skills for iOS/macOS

### DIFF
--- a/skills/apple-foundation-models-app-patterns/SKILL.md
+++ b/skills/apple-foundation-models-app-patterns/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-app-patterns
+description: Apply MVVM architecture patterns for building Foundation Models apps.
+triggers: ["afm"]
+---
+
+# App Patterns
+
+## Use when
+
+- Working with app patterns in your iOS/macOS project
+- Implementing features related to app patterns
+- Debugging issues with app patterns
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-app-patterns/agents/openai.yaml
+++ b/skills/apple-foundation-models-app-patterns/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-app-patterns
+description: MVVM architecture patterns for Foundation Models apps with SwiftUI
+tools: []

--- a/skills/apple-foundation-models-app-patterns/references/guide.md
+++ b/skills/apple-foundation-models-app-patterns/references/guide.md
@@ -1,0 +1,149 @@
+# App Patterns — Reference Guide
+
+## ViewModel pattern
+
+Every view model follows this template:
+
+```swift
+@MainActor
+@Observable
+final class SomeViewModel {
+    // Published state
+    var isLoading: Bool = false
+    var errorMessage: String?
+    var showError: Bool = false
+
+    // Private session
+    private(set) var session: LanguageModelSession
+
+    // Streaming task
+    private var streamingTask: Task<Void, Error>?
+
+    init() {
+        session = LanguageModelSession(...)
+    }
+
+    func sendMessage(_ content: String) async { ... }
+
+    func clearChat() {
+        streamingTask?.cancel()
+        streamingTask = nil
+        session = LanguageModelSession(...)
+    }
+
+    func tearDown() {
+        streamingTask?.cancel()
+        streamingTask = nil
+    }
+}
+```
+
+## Navigation architecture
+
+```
+FoundationLabApp.swift
+  └── AdaptiveNavigationView
+        ├── SidebarView (iPad/Mac)
+        │     └── TabSelection enum
+        └── ContentView
+              ├── ChatView (tab)
+              ├── ToolsView (tab)
+              ├── ExamplesView (tab)
+              └── SettingsView (tab)
+```
+
+Key types:
+- `TabSelection` enum — navigation destinations
+- `NavigationCoordinator.shared` — cross-tab sync
+- `AdaptiveNavigationView` — switches between TabView (iPhone) and NavigationSplitView (iPad/Mac)
+
+## Service layer pattern
+
+### ToolExecutor (reusable)
+
+```swift
+@MainActor
+@Observable
+final class ToolExecutor {
+    var isRunning = false
+    var result: String = ""
+    var errorMessage: String?
+
+    func execute<T: Tool>(tool: T, prompt: String, ...) async { ... }
+}
+```
+
+### LanguageService (singleton)
+
+```swift
+@MainActor
+@Observable
+final class LanguageService {
+    private(set) var supportedLanguages: [Locale.Language] = []
+    // Auto-loads on init
+}
+```
+
+### HealthDataManager (shared singleton)
+
+```swift
+class HealthDataManager {
+    static let shared = HealthDataManager()
+}
+```
+
+## Error display pattern
+
+```swift
+// In ViewModel
+var errorMessage: String?
+var showError: Bool = false
+
+// Set on error
+errorMessage = FoundationModelsErrorHandler.handleError(error)
+showError = true
+
+// Dismiss
+func dismissError() {
+    showError = false
+    errorMessage = nil
+}
+```
+
+## ExampleViewBase
+
+Consistent layout for example views:
+
+```swift
+struct MyExampleView: View {
+    var body: some View {
+        ExampleViewBase(title: "My Example", description: "...") {
+            // Content
+        }
+    }
+}
+```
+
+## SwiftLint configuration
+
+```yaml
+line_length: 140/200
+type_body_length: 200/300
+file_length: 600/800
+identifier_name: min 2/1, max 40/50
+type_name: max 50/60
+function_body_length: 60/100
+nesting: type_level 3/5
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/FoundationLabApp.swift` | App entry point |
+| `Foundation Lab/Models/NavigationCoordinator.swift` | Navigation sync |
+| `Foundation Lab/Models/TabSelection.swift` | Tab destinations |
+| `Foundation Lab/Views/AdaptiveNavigationView.swift` | Adaptive navigation |
+| `Foundation Lab/Views/Components/ExampleViewBase.swift` | Example view template |
+| `Foundation Lab/Services/ToolExecutor.swift` | Reusable tool executor |
+| `.swiftlint.yml` | SwiftLint config |

--- a/skills/apple-foundation-models-conversation-context-builder/SKILL.md
+++ b/skills/apple-foundation-models-conversation-context-builder/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-conversation-context-builder
+description: Extract context and build continuation prompts for multi-turn conversations.
+triggers: ["afm"]
+---
+
+# Conversation Context Builder
+
+## Use when
+
+- Working with conversation context builder in your iOS/macOS project
+- Implementing features related to conversation context builder
+- Debugging issues with conversation context builder
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-conversation-context-builder/agents/openai.yaml
+++ b/skills/apple-foundation-models-conversation-context-builder/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-conversation-context-builder
+description: Extract conversation text from transcripts and build continuation instructions
+tools: []

--- a/skills/apple-foundation-models-conversation-context-builder/references/guide.md
+++ b/skills/apple-foundation-models-conversation-context-builder/references/guide.md
@@ -1,0 +1,125 @@
+# Conversation Context Builder — Reference Guide
+
+## Full implementation
+
+From `ConversationContextBuilder.swift`:
+
+```swift
+enum ConversationContextBuilder {
+    static func conversationText(
+        from transcript: Transcript,
+        userLabel: String,
+        assistantLabel: String
+    ) -> String {
+        transcript.compactMap { entry in
+            switch entry {
+            case .prompt:
+                guard let text = entry.textContent() else { return nil }
+                return "\(userLabel) \(text)"
+            case .response:
+                guard let text = entry.textContent() else { return nil }
+                return "\(assistantLabel) \(text)"
+            default:
+                return nil
+            }
+        }.joined(separator: "\n\n")
+    }
+
+    static func contextInstructions(
+        baseInstructions: String,
+        summary: String,
+        keyTopics: [String],
+        userPreferences: [String],
+        continuationNote: String? = nil
+    ) -> String {
+        var contextInstructions = """
+        \(baseInstructions)
+
+        You are continuing a conversation with a user. Here's a summary of your previous conversation:
+
+        CONVERSATION SUMMARY:
+        \(summary)
+
+        KEY TOPICS DISCUSSED:
+        \(keyTopics.bulletList())
+
+        USER PREFERENCES/REQUESTS:
+        \(userPreferences.bulletList())
+        """
+
+        if let continuationNote {
+            contextInstructions += "\n\n\(continuationNote)"
+        }
+
+        return contextInstructions
+    }
+}
+```
+
+## Usage in ChatViewModel
+
+From `ChatViewModel.swift:490-543`:
+
+```swift
+// Step 1: Extract conversation text
+func createConversationText() -> String {
+    ConversationContextBuilder.conversationText(
+        from: session.transcript,
+        userLabel: "User:",
+        assistantLabel: "Assistant:"
+    )
+}
+
+// Step 2: Summarize with a dedicated session
+func generateConversationSummary() async throws -> ConversationSummary {
+    let summarySession = LanguageModelSession(
+        model: languageModel,
+        instructions: Instructions("You are an expert at summarizing conversations...")
+    )
+    let conversationText = createConversationText()
+    let summaryResponse = try await summarySession.respond(
+        to: Prompt(summaryPrompt),
+        generating: ConversationSummary.self
+    )
+    return summaryResponse.content
+}
+
+// Step 3: Build new session with context
+func createNewSessionWithContext(summary: ConversationSummary) {
+    let contextInstructions = ConversationContextBuilder.contextInstructions(
+        baseInstructions: instructions,
+        summary: summary.summary,
+        keyTopics: summary.keyTopics,
+        userPreferences: summary.userPreferences,
+        continuationNote: "Continue the conversation naturally..."
+    )
+    session = LanguageModelSession(
+        model: languageModel,
+        instructions: Instructions(contextInstructions)
+    )
+    sessionCount += 1
+    currentTokenCount = 0
+}
+```
+
+## Usage in HealthChatViewModel
+
+```swift
+// Health-specific labels
+func createConversationText() -> String {
+    ConversationContextBuilder.conversationText(
+        from: session.transcript,
+        userLabel: String(localized: "User:"),
+        assistantLabel: String(localized: "Health AI:")
+    )
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Services/ConversationContextBuilder.swift` | Builder utility |
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Chat usage |
+| `Foundation Lab/Health/ViewModels/HealthChatViewModel.swift` | Health usage |
+| `Foundation Lab/Models/DataModels.swift` | `ConversationSummary` @Generable struct |

--- a/skills/apple-foundation-models-custom-tools/SKILL.md
+++ b/skills/apple-foundation-models-custom-tools/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-custom-tools
+description: Build custom tools that the model can call to extend functionality.
+triggers: ["afm"]
+---
+
+# Custom Tools
+
+## Use when
+
+- Working with custom tools in your iOS/macOS project
+- Implementing features related to custom tools
+- Debugging issues with custom tools
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-custom-tools/agents/openai.yaml
+++ b/skills/apple-foundation-models-custom-tools/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-custom-tools
+description: Build custom tools that Foundation Models can call during generation
+tools: []

--- a/skills/apple-foundation-models-custom-tools/references/guide.md
+++ b/skills/apple-foundation-models-custom-tools/references/guide.md
@@ -1,0 +1,94 @@
+# Custom Tools — Reference Guide
+
+## Basic Tool protocol implementation
+
+From `Playgrounds/08_BasicToolUse/01_BasicToolProtocol.swift`:
+
+```swift
+struct BasicTool: Tool {
+    let name = "basicTool"
+    let description = "A simple example tool"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The input message to process")
+        var message: String
+    }
+
+    func call(arguments: Arguments) async throws -> some PromptRepresentable {
+        "Processed: \(arguments.message)"
+    }
+}
+```
+
+## Real-world tool examples
+
+### Weather Tool
+`Foundation Lab/Views/Tools/WeatherTool.swift` — OpenMeteo API, no API key required.
+
+### Contacts Tool
+`Foundation Lab/Views/Tools/ContactsTool.swift` — System contacts search via Contacts framework.
+
+### Calendar Tool
+`Foundation Lab/Views/Tools/CalendarTool.swift` — Event creation with EventKit.
+
+### Health Data Tool
+`Foundation Lab/Health/Tools/HealthDataTool.swift` — HealthKit queries.
+
+### Music Tool
+`Foundation Lab/Views/Tools/MusicTool.swift` — Apple Music catalog search.
+
+## Using tools in a session
+
+From `ToolExecutor.swift`:
+
+```swift
+func execute<T: Tool>(tool: T, prompt: String, ...) async {
+    let session = LanguageModelSession(tools: [tool])
+    let response = try await session.respond(to: Prompt(prompt))
+    return response.content
+}
+```
+
+## Multi-tool session
+
+From `HealthChatViewModel.swift`:
+
+```swift
+private let tools: [any Tool] = [
+    HealthDataTool(),
+    HealthAnalysisTool()
+]
+
+let session = LanguageModelSession(
+    tools: tools,
+    instructions: Instructions(Self.baseInstructions)
+)
+```
+
+## Handling tool errors
+
+From `FoundationModelsError.swift`:
+
+```swift
+static func handleToolCallError(_ error: LanguageModelSession.ToolCallError) -> String {
+    return "Tool '\(error.tool.name)' failed: \(error.underlyingError.localizedDescription)"
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Views/Tools/WeatherTool.swift` | Weather API tool |
+| `Foundation Lab/Views/Tools/Search1WebSearchTool.swift` | Web search tool |
+| `Foundation Lab/Views/Tools/ContactsTool.swift` | Contacts tool |
+| `Foundation Lab/Views/Tools/CalendarTool.swift` | Calendar tool |
+| `Foundation Lab/Views/Tools/RemindersTool.swift` | Reminders tool |
+| `Foundation Lab/Views/Tools/LocationTool.swift` | Location tool |
+| `Foundation Lab/Views/Tools/MusicTool.swift` | Music tool |
+| `Foundation Lab/Views/Tools/WebMetadataTool.swift` | URL metadata tool |
+| `Foundation Lab/Health/Tools/HealthDataTool.swift` | HealthKit tool |
+| `Foundation Lab/Health/Models/AI/HealthAnalysisTool.swift` | Health analysis tool |
+| `Foundation Lab/Services/ToolExecutor.swift` | Reusable tool execution helper |
+| `Foundation Lab/Playgrounds/08_BasicToolUse/` | 9 playground examples |

--- a/skills/apple-foundation-models-dynamic-schemas/SKILL.md
+++ b/skills/apple-foundation-models-dynamic-schemas/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-dynamic-schemas
+description: Build schemas dynamically at runtime for flexible structured output.
+triggers: ["afm"]
+---
+
+# Dynamic Schemas
+
+## Use when
+
+- Working with dynamic schemas in your iOS/macOS project
+- Implementing features related to dynamic schemas
+- Debugging issues with dynamic schemas
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-dynamic-schemas/agents/openai.yaml
+++ b/skills/apple-foundation-models-dynamic-schemas/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-dynamic-schemas
+description: Build generation schemas dynamically at runtime with DynamicGenerationSchema
+tools: []

--- a/skills/apple-foundation-models-dynamic-schemas/references/guide.md
+++ b/skills/apple-foundation-models-dynamic-schemas/references/guide.md
@@ -1,0 +1,55 @@
+# Dynamic Schemas — Reference Guide
+
+## Schema example files
+
+The repo has a comprehensive set of dynamic schema examples:
+
+| File | Pattern |
+|------|---------|
+| `BasicDynamicSchemaView.swift` | Simple property schemas |
+| `ArrayDynamicSchemaView.swift` | Collection/array schemas |
+| `EnumDynamicSchemaView.swift` | Enum and union type schemas |
+| `NestedDynamicSchemaView.swift` | Nested object schemas |
+| `ReferencedSchemaView.swift` | Schema references |
+| `GuidedDynamicSchemaView.swift` | Guided constraint schemas |
+| `UnionTypesSchemaView.swift` | Union/discriminated union schemas |
+| `FormBuilderSchemaView.swift` | Multi-step form generation |
+| `InvoiceProcessingSchemaView.swift` | Complex document parsing |
+| `SchemaErrorHandlingView.swift` | Schema error patterns |
+| `GenerablePatternView.swift` | Patterns bridging @Generable and dynamic |
+
+All files are in `Foundation Lab/Views/Examples/DynamicSchemas/`.
+
+## Helper files
+
+Each view has a corresponding `*Helpers.swift` file with schema construction logic:
+
+- `DynamicSchemaHelpers.swift` — Shared utilities
+- `DynamicSchemaExecutorExtension.swift` — Execution helpers
+- `NestedSchemaFormatter.swift` — Formatting nested results
+- `InvoiceSchemas.swift` + `InvoiceSchemasHelpers.swift` — Invoice-specific schemas
+
+## Key patterns
+
+### Basic dynamic schema
+
+```swift
+// Build schema with properties
+let schema = DynamicGenerationSchema(...)
+
+// Generate
+let session = LanguageModelSession()
+let response = try await session.respond(to: prompt, generating: schema)
+// response.content is a dictionary
+```
+
+### Error handling
+
+From `SchemaErrorHandlingView.swift` and `SchemaErrorHandlingHelpers.swift`:
+
+- `decodingFailure` — Schema couldn't parse the model output
+- `unsupportedGuide` — A guide constraint isn't compatible with the schema type
+
+## Repo files
+
+All in `Foundation Lab/Views/Examples/DynamicSchemas/` — 26 files total covering every dynamic schema pattern.

--- a/skills/apple-foundation-models-error-recovery/SKILL.md
+++ b/skills/apple-foundation-models-error-recovery/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-error-recovery
+description: Handle context overflow, refusals, rate limits, and generation errors.
+triggers: ["afm"]
+---
+
+# Error Recovery
+
+## Use when
+
+- Working with error recovery in your iOS/macOS project
+- Implementing features related to error recovery
+- Debugging issues with error recovery
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-error-recovery/agents/openai.yaml
+++ b/skills/apple-foundation-models-error-recovery/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-error-recovery
+description: Handle Foundation Models errors including context overflow, refusals, and rate limits
+tools: []

--- a/skills/apple-foundation-models-error-recovery/references/guide.md
+++ b/skills/apple-foundation-models-error-recovery/references/guide.md
@@ -1,0 +1,119 @@
+# Error Recovery — Reference Guide
+
+## FoundationModelsErrorHandler
+
+From `FoundationModelsError.swift`:
+
+```swift
+struct FoundationModelsErrorHandler: Sendable {
+    static func handleGenerationError(_ error: LanguageModelSession.GenerationError) -> String {
+        switch error {
+        case .exceededContextWindowSize(let context):
+            return "Context window exceeded: \(context.debugDescription)"
+        case .assetsUnavailable(let context):
+            return "Model assets unavailable: \(context.debugDescription)"
+        case .guardrailViolation(let context):
+            return "Content policy violation: \(context.debugDescription)"
+        case .decodingFailure(let context):
+            return "Failed to decode response: \(context.debugDescription)"
+        case .unsupportedGuide(let context):
+            return "Unsupported generation guide: \(context.debugDescription)"
+        case .unsupportedLanguageOrLocale(let context):
+            return "Unsupported language/locale: \(context.debugDescription)"
+        case .rateLimited(let context):
+            return "Rate limited: \(context.debugDescription)"
+        case .concurrentRequests(let context):
+            return "Too many concurrent requests: \(context.debugDescription)"
+        case .refusal(_, let context):
+            return "Model refused to respond: \(context.debugDescription)"
+        @unknown default:
+            return "Unknown generation error"
+        }
+    }
+
+    static func handleToolCallError(_ error: LanguageModelSession.ToolCallError) -> String {
+        return "Tool '\(error.tool.name)' failed: \(error.underlyingError.localizedDescription)"
+    }
+
+    static func handleError(_ error: Error) -> String {
+        if let generationError = error as? LanguageModelSession.GenerationError {
+            return handleGenerationError(generationError)
+        } else if let toolCallError = error as? LanguageModelSession.ToolCallError {
+            return handleToolCallError(toolCallError)
+        } else if let customError = error as? FoundationModelsError {
+            return customError.localizedDescription
+        } else {
+            return "Unexpected error: \(error.localizedDescription)"
+        }
+    }
+}
+```
+
+## Custom error enum
+
+```swift
+nonisolated enum FoundationModelsError: LocalizedError, Sendable {
+    case sessionCreationFailed
+    case responseGenerationFailed(String)
+    case toolCallFailed(String)
+    case streamingFailed(String)
+    case modelUnavailable(String)
+}
+```
+
+## Context overflow recovery
+
+From `ChatViewModel.swift`:
+
+```swift
+// Catch specifically
+} catch LanguageModelSession.GenerationError.exceededContextWindowSize {
+    await handleContextWindowExceeded(userMessage: content)
+} catch {
+    errorMessage = FoundationModelsErrorHandler.handleError(error)
+    showError = true
+}
+```
+
+Recovery flow:
+1. Generate `ConversationSummary` from current transcript
+2. Create new session with summary baked into instructions
+3. Retry the failed user message on the new session
+
+## Health module fallback
+
+From `HealthChatViewModel.swift` — if summarization itself fails:
+
+```swift
+} catch {
+    isSummarizing = false
+    session = LanguageModelSession(
+        tools: tools,
+        instructions: Instructions(Self.baseInstructions)
+    )
+    currentTokenCount = 0
+    let restartMessage = "I need to start a fresh conversation. Please repeat your question."
+    await saveMessageToSession(restartMessage, isFromUser: false)
+}
+```
+
+## CancellationError handling
+
+Always catch `CancellationError` before general errors:
+
+```swift
+do {
+    try await task.value
+} catch is CancellationError {
+    return  // User-initiated, not an error
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Models/FoundationModelsError.swift` | Error types + handler |
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Context overflow recovery |
+| `Foundation Lab/Health/ViewModels/HealthChatViewModel.swift` | Health error recovery with fallback |
+| `Foundation Lab/Views/Examples/DynamicSchemas/SchemaErrorHandlingView.swift` | Schema-specific errors |

--- a/skills/apple-foundation-models-feedback-sentiment-api/SKILL.md
+++ b/skills/apple-foundation-models-feedback-sentiment-api/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-feedback-sentiment-api
+description: Collect user feedback and analyze sentiment to improve model responses.
+triggers: ["afm"]
+---
+
+# Feedback Sentiment Api
+
+## Use when
+
+- Working with feedback sentiment api in your iOS/macOS project
+- Implementing features related to feedback sentiment api
+- Debugging issues with feedback sentiment api
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-feedback-sentiment-api/agents/openai.yaml
+++ b/skills/apple-foundation-models-feedback-sentiment-api/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-feedback-sentiment-api
+description: Collect per-response feedback using the LanguageModelFeedback sentiment API
+tools: []

--- a/skills/apple-foundation-models-feedback-sentiment-api/references/guide.md
+++ b/skills/apple-foundation-models-feedback-sentiment-api/references/guide.md
@@ -1,0 +1,89 @@
+# Feedback & Sentiment API — Reference Guide
+
+## ViewModel feedback state
+
+From `ChatViewModel.swift`:
+
+```swift
+// State tracking
+private(set) var feedbackState: [Transcript.Entry.ID: LanguageModelFeedback.Sentiment] = [:]
+
+// Submit feedback
+@MainActor
+func submitFeedback(for entryID: Transcript.Entry.ID, sentiment: LanguageModelFeedback.Sentiment) {
+    feedbackState[entryID] = sentiment
+    let feedbackData = session.logFeedbackAttachment(sentiment: sentiment)
+    _ = feedbackData
+}
+
+// Query feedback
+@MainActor
+func getFeedback(for entryID: Transcript.Entry.ID) -> LanguageModelFeedback.Sentiment? {
+    return feedbackState[entryID]
+}
+```
+
+Feedback state is cleared in `clearChat()`:
+
+```swift
+func clearChat() {
+    feedbackState.removeAll()
+    // ... reset other state
+}
+```
+
+## FeedbackView UI
+
+From `FeedbackView.swift`:
+
+```swift
+struct FeedbackView: View {
+    let viewModel: ChatViewModel
+    @Binding var isPresented: Bool
+
+    // Filter to only assistant responses
+    private var assistantEntries: [Transcript.Entry] {
+        viewModel.session.transcript.filter { entry in
+            if case .response = entry { return true }
+            return false
+        }
+    }
+}
+```
+
+## FeedbackRowView
+
+```swift
+struct FeedbackRowView: View {
+    let entry: Transcript.Entry
+    let viewModel: ChatViewModel
+
+    // Extract text from response segments
+    private var responseText: String {
+        guard case .response(let response) = entry else { return "" }
+        return response.segments.compactMap { segment in
+            if case .text(let textSegment) = segment {
+                return textSegment.content
+            }
+            return nil
+        }.joined(separator: " ")
+    }
+
+    private var existingFeedback: LanguageModelFeedback.Sentiment? {
+        viewModel.getFeedback(for: entry.id)
+    }
+
+    // Thumbs up/down buttons, disabled after submission
+    Button(action: {
+        viewModel.submitFeedback(for: entry.id, sentiment: .positive)
+    }) { ... }
+    .disabled(existingFeedback != nil)
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Views/Components/FeedbackView.swift` | Feedback UI (full + row) |
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Feedback state + API calls |

--- a/skills/apple-foundation-models-generation-tuning/SKILL.md
+++ b/skills/apple-foundation-models-generation-tuning/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-generation-tuning
+description: Tune temperature, sampling, seeds, and token limits for optimal output.
+triggers: ["afm"]
+---
+
+# Generation Tuning
+
+## Use when
+
+- Working with generation tuning in your iOS/macOS project
+- Implementing features related to generation tuning
+- Debugging issues with generation tuning
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-generation-tuning/agents/openai.yaml
+++ b/skills/apple-foundation-models-generation-tuning/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-generation-tuning
+description: Tune generation parameters like temperature, sampling, seeds, and token limits
+tools: []

--- a/skills/apple-foundation-models-generation-tuning/references/guide.md
+++ b/skills/apple-foundation-models-generation-tuning/references/guide.md
@@ -1,0 +1,74 @@
+# Generation Tuning — Reference Guide
+
+## GenerationOptions construction
+
+From `ChatViewModel.swift:72`:
+
+```swift
+var generationOptions: GenerationOptions {
+    switch samplingStrategy {
+    case .default:
+        return GenerationOptions()
+    case .greedy:
+        return GenerationOptions(sampling: .greedy)
+    case .sampling:
+        let seed: UInt64? = useFixedSeed ? (samplingSeed ?? generateAndStoreSeed()) : nil
+        return GenerationOptions(sampling: .random(top: topKSamplingValue, seed: seed))
+    }
+}
+```
+
+## Seed management
+
+From `ChatViewModel.swift:412`:
+
+```swift
+func generateAndStoreSeed() -> UInt64 {
+    let seed = UInt64.random(in: UInt64.min...UInt64.max)
+    samplingSeed = seed
+    return seed
+}
+```
+
+## UI for generation parameters
+
+From `GenerationOptionsView.swift`:
+
+```swift
+@State private var temperature: Double = 0.7
+@State private var topK: Int = 50
+@State private var topP: Double = 0.9
+@State private var maximumResponseTokens: Int = 500
+@State private var useSampling: Bool = true
+@State private var samplingMode: SamplingType = .nucleus
+```
+
+The view provides:
+- Temperature slider (0.0–1.0)
+- Sampling mode picker (greedy / top-k / nucleus)
+- Top-K value slider (1–100)
+- Top-P probability threshold slider (0.1–1.0)
+- Max response tokens slider
+
+## Passing options to generation
+
+```swift
+let options = createGenerationOptions(from: config)
+let session = LanguageModelSession()
+let response = try await session.respond(to: Prompt(prompt), options: options)
+```
+
+Or with streaming:
+
+```swift
+let responseStream = session.streamResponse(to: Prompt(content), options: generationOptions)
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | GenerationOptions construction + seed storage |
+| `Foundation Lab/Views/GenerationOptionsView.swift` | Full parameter tuning UI |
+| `Foundation Lab/Views/GenerationOptionsHelpers.swift` | Helper types for generation config |
+| `Foundation Lab/Playgrounds/03_GenerationOptions/` | 5 playground examples |

--- a/skills/apple-foundation-models-health-assistant/SKILL.md
+++ b/skills/apple-foundation-models-health-assistant/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-health-assistant
+description: Integrate HealthKit data with custom tools for health-focused AI assistants.
+triggers: ["afm"]
+---
+
+# Health Assistant
+
+## Use when
+
+- Working with health assistant in your iOS/macOS project
+- Implementing features related to health assistant
+- Debugging issues with health assistant
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-health-assistant/agents/openai.yaml
+++ b/skills/apple-foundation-models-health-assistant/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-health-assistant
+description: Build a health coaching assistant with HealthKit integration and SwiftData persistence
+tools: []

--- a/skills/apple-foundation-models-health-assistant/references/guide.md
+++ b/skills/apple-foundation-models-health-assistant/references/guide.md
@@ -1,0 +1,109 @@
+# Health Assistant — Reference Guide
+
+## Architecture
+
+```
+Health/
+├── Models/
+│   ├── HealthMetric.swift           # MetricType enum + health metric model
+│   ├── HealthInsight.swift          # SwiftData model for AI insights
+│   ├── HealthSession.swift          # SwiftData model for coaching sessions
+│   ├── HealthDataManager.swift      # Shared HealthKit data manager
+│   └── AI/
+│       ├── HealthDataTool.swift     # HealthKit query tool
+│       ├── HealthAnalysisTool.swift # Health analysis tool
+│       ├── HealthAI.swift           # AI helper types
+│       ├── HealthAnalysis.swift     # Analysis models
+│       ├── PersonalizedHealthPlan.swift # Health plan generation
+│       └── ConversationSummary.swift    # HealthConversationSummary
+├── ViewModels/
+│   └── HealthChatViewModel.swift    # Health chat view model
+└── Views/
+    ├── HealthDashboardView.swift    # AI health dashboard
+    ├── HealthChatView.swift         # Health chat UI
+    └── Components/                  # Health UI components
+```
+
+## Session initialization
+
+From `HealthChatViewModel.swift`:
+
+```swift
+private let tools: [any Tool] = [HealthDataTool(), HealthAnalysisTool()]
+
+init(healthDataManager: HealthDataManager? = nil) {
+    self.healthDataManager = healthDataManager ?? .shared
+    self.session = LanguageModelSession(
+        tools: tools,
+        instructions: Instructions(Self.baseInstructions)
+    )
+}
+
+static let baseInstructions = """
+You are a friendly and knowledgeable health coach AI assistant.
+Based on the user's health data, provide personalized, encouraging responses.
+Be supportive and celebrate small wins. Use emojis occasionally.
+"""
+```
+
+## Loading health data
+
+```swift
+func loadInitialHealthData() async {
+    try await healthDataManager.fetchTodayHealthData()
+    currentHealthMetrics = [
+        .steps: healthDataManager.todaySteps,
+        .heartRate: healthDataManager.currentHeartRate,
+        .sleep: healthDataManager.lastNightSleep,
+        .activeEnergy: healthDataManager.todayActiveEnergy,
+        .distance: healthDataManager.todayDistance
+    ]
+}
+```
+
+## SwiftData persistence
+
+Messages are saved to `HealthSession` via `ModelContext`:
+
+```swift
+func saveMessageToSession(_ content: String, isFromUser: Bool) async {
+    let sessions = try modelContext.fetch(descriptor)
+    let activeSession: HealthSession
+
+    if let existing = sessions.first,
+       existing.startDate.timeIntervalSinceNow > -sessionTimeout {
+        activeSession = existing
+    } else {
+        activeSession = HealthSession(sessionType: .coaching)
+        modelContext.insert(activeSession)
+    }
+
+    let message = BuddyMessage(content: content, isFromUser: isFromUser)
+    activeSession.messages.append(message)
+    try modelContext.save()
+}
+```
+
+## Auto-insight generation
+
+```swift
+func shouldGenerateInsight(from response: String) -> Bool {
+    let keywords = ["goal", "achieve", "progress", "improve", "recommend", "suggest", "tip", "advice"]
+    return keywords.contains { response.lowercased().contains($0) }
+}
+```
+
+## Context overflow handling
+
+Uses `HealthConversationSummary` (health-specific version) and falls back to a fresh session if summarization fails.
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Health/ViewModels/HealthChatViewModel.swift` | Main health chat VM |
+| `Foundation Lab/Health/Models/HealthDataManager.swift` | HealthKit data manager |
+| `Foundation Lab/Health/Models/AI/HealthDataTool.swift` | HealthKit tool |
+| `Foundation Lab/Health/Models/AI/HealthAnalysisTool.swift` | Analysis tool |
+| `Foundation Lab/Health/Views/HealthDashboardView.swift` | Dashboard UI |
+| `Foundation Lab/Views/Examples/HealthExampleView.swift` | Health example |

--- a/skills/apple-foundation-models-multilingual/SKILL.md
+++ b/skills/apple-foundation-models-multilingual/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-multilingual
+description: Handle multiple languages for global user bases and cross-lingual tasks.
+triggers: ["afm"]
+---
+
+# Multilingual
+
+## Use when
+
+- Working with multilingual in your iOS/macOS project
+- Implementing features related to multilingual
+- Debugging issues with multilingual
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-multilingual/agents/openai.yaml
+++ b/skills/apple-foundation-models-multilingual/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-multilingual
+description: Handle multilingual sessions and language detection with Foundation Models
+tools: []

--- a/skills/apple-foundation-models-multilingual/references/guide.md
+++ b/skills/apple-foundation-models-multilingual/references/guide.md
@@ -1,0 +1,78 @@
+# Multilingual — Reference Guide
+
+## LanguageService
+
+From `LanguageService.swift`:
+
+```swift
+@MainActor
+@Observable
+final class LanguageService {
+    private(set) var supportedLanguages: [Locale.Language] = []
+    private(set) var isLoading = false
+
+    func loadSupportedLanguages() async {
+        isLoading = true
+        let model = SystemLanguageModel.default
+        supportedLanguages = Array(model.supportedLanguages)
+        isLoading = false
+    }
+
+    func getDisplayName(for language: Locale.Language) -> String {
+        let code = language.languageCode?.identifier ?? ""
+        let region = language.region?.identifier ?? ""
+        let languageName = Locale.current.localizedString(forLanguageCode: code) ?? code
+        if !region.isEmpty {
+            return "\(languageName) (\(code)-\(region))"
+        } else {
+            return languageName
+        }
+    }
+
+    func getCurrentUserLanguage() -> String {
+        return getCurrentUserLanguageDisplayName()
+    }
+
+    func getSupportedLanguageNames() -> [String] {
+        return supportedLanguages.map { getDisplayName(for: $0) }.sorted()
+    }
+}
+```
+
+## Using language-specific instructions
+
+For a session that responds in a specific language:
+
+```swift
+let session = LanguageModelSession(
+    instructions: Instructions("""
+        You are a helpful assistant.
+        Always respond in Japanese. Do not switch languages.
+    """)
+)
+```
+
+## Production language example
+
+The repo includes a production-quality multilingual example:
+
+- `Foundation Lab/Views/Languages/ProductionLanguageExampleView.swift` — Nutrition analysis in multiple languages
+- `Foundation Lab/Views/Languages/LanguagesView.swift` — Language selection UI
+
+## Playground examples
+
+`Foundation Lab/Playgrounds/13_Languages/` contains 7 playground examples covering:
+- Language detection
+- Multi-language sessions
+- Code-switching prevention
+- Locale-aware generation
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Services/LanguageService.swift` | Language detection and display |
+| `Foundation Lab/Views/Languages/LanguagesView.swift` | Language selection UI |
+| `Foundation Lab/Views/Languages/ProductionLanguageExampleView.swift` | Production multilingual example |
+| `Foundation Lab/Playgrounds/13_Languages/` | 7 language playground examples |
+| `Localizable.xcstrings` | App translations (10 languages) |

--- a/skills/apple-foundation-models-playground-learning/SKILL.md
+++ b/skills/apple-foundation-models-playground-learning/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-playground-learning
+description: Interactive learning examples and playground experiments for Foundation Models.
+triggers: ["afm"]
+---
+
+# Playground Learning
+
+## Use when
+
+- Working with playground learning in your iOS/macOS project
+- Implementing features related to playground learning
+- Debugging issues with playground learning
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-playground-learning/agents/openai.yaml
+++ b/skills/apple-foundation-models-playground-learning/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-playground-learning
+description: Use the #Playground directive for runnable Foundation Models learning examples
+tools: []

--- a/skills/apple-foundation-models-playground-learning/references/guide.md
+++ b/skills/apple-foundation-models-playground-learning/references/guide.md
@@ -1,0 +1,113 @@
+# Playground Learning — Reference Guide
+
+## Basic playground structure
+
+```swift
+import FoundationModels
+import Playgrounds
+
+#Playground {
+    let session = LanguageModelSession()
+    let response = try await session.respond(to: "What is Swift?")
+    print("Response: \(response.content)")
+}
+```
+
+## Prewarming example
+
+From `Playgrounds/02_GettingStartedWithSessions/11_BasicPrewarming.swift`:
+
+```swift
+#Playground {
+    let session = LanguageModelSession()
+    session.prewarm()
+    let response = try await session.respond(to: "What is the capital of France?")
+    print("Response: \(response.content)")
+}
+```
+
+## Prewarming with prompt prefix
+
+From `Playgrounds/02_GettingStartedWithSessions/12_PrewarmingWithPromptPrefix.swift`:
+
+```swift
+#Playground {
+    let session = LanguageModelSession()
+    let commonPrefix = Prompt("You are a helpful writing assistant. The user is asking about:")
+    session.prewarm(promptPrefix: commonPrefix)
+
+    let fullPrompt = "You are a helpful writing assistant. The user is asking about: grammar rules"
+    let response = try await session.respond(to: Prompt(fullPrompt))
+    print("Response: \(response.content)")
+}
+```
+
+## Tool defined at file scope + used in playground
+
+From `Playgrounds/08_BasicToolUse/01_BasicToolProtocol.swift`:
+
+```swift
+struct BasicTool: Tool {
+    let name = "basicTool"
+    let description = "A simple example tool"
+
+    @Generable
+    struct Arguments {
+        @Guide(description: "The input message to process")
+        var message: String
+    }
+
+    func call(arguments: Arguments) async throws -> some PromptRepresentable {
+        "Processed: \(arguments.message)"
+    }
+}
+
+#Playground {
+    let tool = BasicTool()
+    let arguments = BasicTool.Arguments(message: "Hello, tool!")
+    let result = try await tool.call(arguments: arguments)
+    debugPrint("Tool result: \(result)")
+}
+```
+
+## Transcript inspection
+
+From `Playgrounds/08_BasicToolUse/06_MultiToolCoordinationDemo.swift`:
+
+```swift
+for (index, entry) in session.transcript.enumerated() {
+    switch entry {
+    case .instructions:
+        print("\(index): Instructions")
+    case .prompt(let prompt):
+        let text = prompt.segments.compactMap { segment -> String? in
+            if case .text(let t) = segment { return t.content }
+            return nil
+        }.joined(separator: " ")
+        print("\(index): Prompt: \(text)")
+    case .toolCalls(let calls):
+        print("\(index): Tool calls: \(calls.map { $0.toolName })")
+    case .toolOutput(let output):
+        print("\(index): Tool output: \(output.toolName)")
+    case .response(let response):
+        let text = response.segments.compactMap { segment -> String? in
+            if case .text(let t) = segment { return t.content }
+            return nil
+        }.joined(separator: " ")
+        print("\(index): Response: \(text.prefix(100))...")
+    @unknown default:
+        print("\(index): Unknown")
+    }
+}
+```
+
+## Available playground chapters
+
+| Chapter | Folder | Count | Topics |
+|---------|--------|-------|--------|
+| 2 | `02_GettingStartedWithSessions/` | 16 | Availability, single/multi-turn, instructions, streaming, prewarming, context window |
+| 3 | `03_GenerationOptionsAndSamplingControl/` | 5 | Temperature, token limits, fitness, parameter combos, sampling strategies |
+| 8 | `08_BasicToolUse/` | 9 | Tool protocol, search/calculator/weather/location tools, multi-tool, error handling |
+| 13 | `13_SupportedLanguagesAndInternationalization/` | 7 | Language queries, display, multilingual gen, sessions, code-switching, production detection |
+
+**Total: 37 runnable playground examples.**

--- a/skills/apple-foundation-models-prompt-builder-patterns/SKILL.md
+++ b/skills/apple-foundation-models-prompt-builder-patterns/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-prompt-builder-patterns
+description: Compose prompts using @PromptBuilder for complex multi-part requests.
+triggers: ["afm"]
+---
+
+# Prompt Builder Patterns
+
+## Use when
+
+- Working with prompt builder patterns in your iOS/macOS project
+- Implementing features related to prompt builder patterns
+- Debugging issues with prompt builder patterns
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-prompt-builder-patterns/agents/openai.yaml
+++ b/skills/apple-foundation-models-prompt-builder-patterns/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-prompt-builder-patterns
+description: Compose prompts with @PromptBuilder, Prompt, and PromptRepresentable
+tools: []

--- a/skills/apple-foundation-models-prompt-builder-patterns/references/guide.md
+++ b/skills/apple-foundation-models-prompt-builder-patterns/references/guide.md
@@ -1,0 +1,117 @@
+# Prompt Builder Patterns — Reference Guide
+
+## Basic Prompt and Instructions
+
+```swift
+// Simple prompt
+let response = try await session.respond(to: Prompt("What is Swift?"))
+
+// Session with instructions
+let session = LanguageModelSession(
+    instructions: Instructions("You are a helpful assistant.")
+)
+```
+
+## @PromptBuilder in ToolExecutor
+
+From `ToolExecutor.swift`:
+
+```swift
+func executeWithPromptBuilder<T: Tool>(
+    tool: T,
+    successMessage: String? = nil,
+    clearForm: (@MainActor () -> Void)? = nil,
+    @PromptBuilder promptBuilder: () -> Prompt
+) async {
+    let session = LanguageModelSession(tools: [tool])
+    let response = try await session.respond(to: promptBuilder())
+    return response.content
+}
+```
+
+## PromptRepresentable for tool returns
+
+From `Playgrounds/08_BasicToolUse/01_BasicToolProtocol.swift`:
+
+```swift
+struct BasicTool: Tool {
+    func call(arguments: Arguments) async throws -> some PromptRepresentable {
+        "Processed: \(arguments.message)"  // String conforms to PromptRepresentable
+    }
+}
+```
+
+## ExampleExecutor
+
+From `ExampleExecutor.swift` — reusable executor with prompt history:
+
+### Basic execution
+
+```swift
+func executeBasic(
+    prompt: String,
+    instructions: String? = nil,
+    successMessage: String? = nil,
+    guardrails: SystemLanguageModel.Guardrails = .default
+) async {
+    let model = SystemLanguageModel(useCase: .general, guardrails: guardrails)
+    let session = instructions != nil
+        ? LanguageModelSession(model: model, instructions: Instructions(instructions!))
+        : LanguageModelSession(model: model)
+
+    let response = try await session.respond(to: Prompt(prompt))
+    result = response.content
+    lastTokenCount = await session.transcript.tokenCount(using: model)
+}
+```
+
+### Structured execution
+
+```swift
+func executeStructured<T: Generable>(
+    prompt: String,
+    type: T.Type,
+    instructions: String? = nil,
+    formatter: @escaping (T) -> String
+) async {
+    let response = try await session.respond(to: Prompt(prompt), generating: type)
+    result = formatter(response.content)
+}
+```
+
+### Streaming execution
+
+```swift
+func executeStreaming(
+    prompt: String,
+    instructions: String? = nil,
+    onPartialResult: @escaping (String) -> Void
+) async {
+    let stream = session.streamResponse(to: Prompt(prompt))
+    for try await partialResponse in stream {
+        result = partialResponse.content
+        onPartialResult(partialResponse.content)
+    }
+}
+```
+
+### Prompt history
+
+```swift
+private func addToHistory(_ prompt: String) {
+    promptHistory.removeAll { $0 == prompt }
+    promptHistory.insert(prompt, at: 0)
+    if promptHistory.count > 10 {
+        promptHistory = Array(promptHistory.prefix(10))
+    }
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Services/ToolExecutor.swift` | @PromptBuilder execution |
+| `Foundation Lab/Views/Examples/Components/ExampleExecutor.swift` | Basic/structured/streaming execution + history |
+| `Foundation Lab/Views/Examples/Components/PromptField.swift` | Prompt input component |
+| `Foundation Lab/Playgrounds/08_BasicToolUse/01_BasicToolProtocol.swift` | PromptRepresentable example |

--- a/skills/apple-foundation-models-rag-pipeline/SKILL.md
+++ b/skills/apple-foundation-models-rag-pipeline/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-rag-pipeline
+description: Implement retrieval-augmented generation with document indexing and search.
+triggers: ["afm"]
+---
+
+# Rag Pipeline
+
+## Use when
+
+- Working with rag pipeline in your iOS/macOS project
+- Implementing features related to rag pipeline
+- Debugging issues with rag pipeline
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-rag-pipeline/agents/openai.yaml
+++ b/skills/apple-foundation-models-rag-pipeline/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-rag-pipeline
+description: Build RAG with document indexing and semantic search using LumoKit/VecturaKit
+tools: []

--- a/skills/apple-foundation-models-rag-pipeline/references/guide.md
+++ b/skills/apple-foundation-models-rag-pipeline/references/guide.md
@@ -1,0 +1,100 @@
+# RAG Pipeline — Reference Guide
+
+## Configuration
+
+From `RAGService.swift`:
+
+```swift
+struct RAGConfig {
+    static func makeDefault() throws -> RAGConfig {
+        let options = VecturaConfig.SearchOptions(defaultNumResults: 5, minThreshold: 0.5)
+        let chunking = try ChunkingConfig(
+            chunkSize: 500,
+            overlapPercentage: 0.15,
+            strategy: .semantic,
+            contentType: .prose
+        )
+        return RAGConfig(searchOptions: options, chunkingConfig: chunking)
+    }
+}
+```
+
+## RAGService
+
+From `RAGService.swift`:
+
+```swift
+@MainActor
+final class RAGService {
+    private let lumoKit: LumoKit
+
+    func indexDocument(url: URL) async throws -> [UUID] {
+        let accessing = url.startAccessingSecurityScopedResource()
+        defer { if accessing { url.stopAccessingSecurityScopedResource() } }
+        return try await lumoKit.parseAndIndex(url: url, chunkingConfig: chunkingConfig)
+    }
+
+    func indexText(_ text: String) async throws -> [UUID] {
+        let chunks = try lumoKit.chunkText(text, config: chunkingConfig)
+        return try await lumoKit.addDocuments(texts: chunks.map { $0.text })
+    }
+
+    func search(query: String) async throws -> [VecturaSearchResult] {
+        try await lumoKit.semanticSearch(query: query, numResults: 5, threshold: 0.5)
+    }
+}
+```
+
+## LumoKit initialization
+
+From `RAGChatViewModel.swift`:
+
+```swift
+let lumoKit = try await LumoKit(
+    config: VecturaConfig(name: "foundation-lab-rag", searchOptions: config.searchOptions),
+    chunkingConfig: config.chunkingConfig
+)
+service = RAGService(lumoKit: lumoKit, chunkingConfig: config.chunkingConfig)
+```
+
+## RAG prompt composition
+
+From `RAGChatViewModel.swift`:
+
+```swift
+let systemPrompt = """
+You are a helpful assistant. Answer using only the sources provided.
+Cite sources with [1], [2]. If the sources do not contain the answer, say you don't know.
+"""
+
+let contextText = chunks.enumerated()
+    .map { index, chunk in "[\(index + 1)] \(chunk.content)" }
+    .joined(separator: "\n\n")
+
+let prompt = "SOURCES:\n\(contextText)\n\nQUESTION:\n\(query)"
+
+let session = LanguageModelSession(
+    model: SystemLanguageModel(useCase: .general),
+    instructions: Instructions(systemPrompt)
+)
+```
+
+## State persistence
+
+Indexed URLs, source titles, and chunk-to-title mappings are persisted via `UserDefaults`:
+
+```swift
+private let indexedURLsKey = "ragIndexedURLs"
+private let sourceTitlesKey = "ragSourceTitles"
+private let chunkTitlesKey = "ragChunkTitles"
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Services/RAGService.swift` | RAG service + config |
+| `Foundation Lab/ViewModels/RAGChatViewModel.swift` | RAG chat view model |
+| `Foundation Lab/Views/Examples/RAGChatView.swift` | RAG chat UI |
+| `Foundation Lab/Views/Examples/RAGChatView+Types.swift` | RAG entry/chunk types |
+| `Foundation Lab/Views/Chat/RAGDocumentPickerView.swift` | Document picker |

--- a/skills/apple-foundation-models-session-patterns/SKILL.md
+++ b/skills/apple-foundation-models-session-patterns/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-session-patterns
+description: Create and configure LanguageModelSession for single-turn and multi-turn conversations.
+triggers: ["afm"]
+---
+
+# Session Patterns
+
+## Use when
+
+- Working with session patterns in your iOS/macOS project
+- Implementing features related to session patterns
+- Debugging issues with session patterns
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-session-patterns/agents/openai.yaml
+++ b/skills/apple-foundation-models-session-patterns/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-session-patterns
+description: Create and configure LanguageModelSession for single-turn and multi-turn conversations
+tools: []

--- a/skills/apple-foundation-models-session-patterns/references/guide.md
+++ b/skills/apple-foundation-models-session-patterns/references/guide.md
@@ -1,0 +1,90 @@
+# Session Patterns — Reference Guide
+
+## Basic single-turn session
+
+```swift
+let session = LanguageModelSession()
+let response = try await session.respond(to: Prompt("What is Swift?"))
+print(response.content) // String
+```
+
+## Session with instructions
+
+From `ChatViewModel.swift`:
+
+```swift
+let session = LanguageModelSession(
+    model: languageModel,
+    instructions: Instructions("""
+        You are a helpful, friendly AI assistant. Engage in natural conversation
+        and provide thoughtful, detailed responses.
+    """)
+)
+```
+
+## Session with model + tools
+
+From `HealthChatViewModel.swift`:
+
+```swift
+let tools: [any Tool] = [HealthDataTool(), HealthAnalysisTool()]
+
+let session = LanguageModelSession(
+    tools: tools,
+    instructions: Instructions(Self.baseInstructions)
+)
+```
+
+## Updating instructions mid-conversation
+
+From `ChatViewModel.swift:180`:
+
+```swift
+func updateInstructions(_ newInstructions: String) {
+    instructions = newInstructions
+    languageModel = createLanguageModel()
+    session = LanguageModelSession(
+        model: languageModel,
+        instructions: Instructions(instructions)
+    )
+    currentTokenCount = 0
+}
+```
+
+This creates a fresh session — all previous transcript is discarded.
+
+## Accessing the transcript
+
+```swift
+// Iterate transcript entries
+for entry in session.transcript {
+    switch entry {
+    case .instructions: ...
+    case .prompt: ...
+    case .response: ...
+    default: ...
+    }
+}
+
+// Token counting
+let count = await session.transcript.tokenCount(using: languageModel)
+```
+
+## Session from existing transcript (sliding window)
+
+From `ChatViewModel.swift:450`:
+
+```swift
+let windowedTranscript = Transcript(entries: finalEntries)
+session = LanguageModelSession(model: model, transcript: windowedTranscript)
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Multi-turn session management |
+| `Foundation Lab/Health/ViewModels/HealthChatViewModel.swift` | Session with tools |
+| `Foundation Lab/Services/ToolExecutor.swift` | Single-turn tool sessions |
+| `Foundation Lab/ViewModels/RAGChatViewModel.swift` | Session with custom instructions |
+| `Foundation Lab/Playgrounds/02_GettingStartedWithSessions/` | 16 playground examples |

--- a/skills/apple-foundation-models-setup-availability/SKILL.md
+++ b/skills/apple-foundation-models-setup-availability/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-setup-availability
+description: Set up Apple Foundation Models and check model availability on-device.
+triggers: ["afm"]
+---
+
+# Setup Availability
+
+## Use when
+
+- Working with setup availability in your iOS/macOS project
+- Implementing features related to setup availability
+- Debugging issues with setup availability
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-setup-availability/agents/openai.yaml
+++ b/skills/apple-foundation-models-setup-availability/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-setup-availability
+description: Set up Apple Foundation Models and check model availability on-device
+tools: []

--- a/skills/apple-foundation-models-setup-availability/references/guide.md
+++ b/skills/apple-foundation-models-setup-availability/references/guide.md
@@ -1,0 +1,71 @@
+# Setup & Availability — Reference Guide
+
+## Key imports
+
+```swift
+import FoundationModels
+```
+
+## Creating a language model
+
+```swift
+// Default model
+let model = SystemLanguageModel.default
+
+// With use case
+let model = SystemLanguageModel(useCase: .general)
+
+// With custom guardrails
+let model = SystemLanguageModel(useCase: .general, guardrails: .permissiveContentTransformations)
+```
+
+## Querying context size
+
+From `Foundation Lab/Models/AppConfiguration.swift`:
+
+```swift
+enum AppConfiguration {
+    enum TokenManagement {
+        static let defaultMaxTokens = 4096
+
+        static func contextSize(for model: SystemLanguageModel = .default) async -> Int {
+            #if compiler(>=6.3)
+            if let size = try? await model.contextSize {
+                return size
+            }
+            #endif
+            return defaultMaxTokens
+        }
+    }
+}
+```
+
+Always fall back to a safe default when the runtime context size is unavailable.
+
+## Prewarming
+
+Call `session.prewarm()` before the first generation to reduce latency:
+
+```swift
+// From ChatViewModel.swift — called during voice mode setup
+session.prewarm()
+```
+
+## Supported languages
+
+Query at runtime via `SystemLanguageModel.default.supportedLanguages`:
+
+```swift
+let model = SystemLanguageModel.default
+let languages = Array(model.supportedLanguages)
+```
+
+See `Foundation Lab/Services/LanguageService.swift` for the full pattern.
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Models/AppConfiguration.swift` | Context size + token constants |
+| `Foundation Lab/Services/LanguageService.swift` | Language availability checks |
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Model creation with guardrails |

--- a/skills/apple-foundation-models-siri-shortcuts-integration/SKILL.md
+++ b/skills/apple-foundation-models-siri-shortcuts-integration/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-siri-shortcuts-integration
+description: Integrate with Siri Shortcuts and App Intents for system voice commands.
+triggers: ["afm"]
+---
+
+# Siri Shortcuts Integration
+
+## Use when
+
+- Working with siri shortcuts integration in your iOS/macOS project
+- Implementing features related to siri shortcuts integration
+- Debugging issues with siri shortcuts integration
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-siri-shortcuts-integration/agents/openai.yaml
+++ b/skills/apple-foundation-models-siri-shortcuts-integration/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-siri-shortcuts-integration
+description: Add Siri Shortcuts and App Intents for voice-activated navigation
+tools: []

--- a/skills/apple-foundation-models-siri-shortcuts-integration/references/guide.md
+++ b/skills/apple-foundation-models-siri-shortcuts-integration/references/guide.md
@@ -1,0 +1,103 @@
+# Siri Shortcuts Integration — Reference Guide
+
+## AppShortcutsProvider
+
+From `FoundationLabAppShortcuts.swift`:
+
+```swift
+nonisolated struct FoundationLabAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenChatIntent(),
+            phrases: [
+                "Open \(.applicationName) chat",
+                "Start chatting in \(.applicationName)",
+                "Open chat in \(.applicationName)"
+            ],
+            shortTitle: "Open Chat",
+            systemImageName: "message.fill"
+        )
+        AppShortcut(
+            intent: OpenExampleIntent(),
+            phrases: [
+                "Open \(\.$example) in \(.applicationName)",
+                "Show \(\.$example) in \(.applicationName)"
+            ],
+            shortTitle: "Open Example",
+            systemImageName: "sparkles"
+        )
+        // ... more shortcuts for tools, schemas, languages
+    }
+}
+```
+
+## AppIntent with parameter
+
+From `OpenExampleIntent.swift`:
+
+```swift
+struct OpenExampleIntent: AppIntent {
+    static let title: LocalizedStringResource = "Open Example"
+    static let description = IntentDescription("Opens a specific Foundation Lab example")
+    static let supportedModes: IntentModes = .foreground
+
+    @Parameter(title: "Example")
+    var example: ExampleDestination
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Open \(\.$example)")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        NavigationCoordinator.shared.navigateToExample(example.exampleType)
+        return .result()
+    }
+}
+```
+
+## AppEnum destinations
+
+From `AppIntentDestinations.swift`:
+
+```swift
+enum ExampleDestination: String, AppEnum, CaseIterable {
+    case basicChat, journaling, creativeWriting, structuredData
+    case streamingResponse, modelAvailability, generationGuides
+    case generationOptions, health, rag
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Example")
+
+    static var caseDisplayRepresentations: [ExampleDestination: DisplayRepresentation] = [
+        .basicChat: DisplayRepresentation(title: "One-shot"),
+        .journaling: DisplayRepresentation(title: "Journaling"),
+        // ...
+    ]
+
+    var exampleType: ExampleType {
+        switch self {
+        case .basicChat: return .basicChat
+        // ...
+        }
+    }
+}
+```
+
+Four destination enums:
+- `ExampleDestination` — 10 cases (examples)
+- `ToolDestination` — 9 cases (system tools)
+- `SchemaDestination` — 11 cases (dynamic schema examples)
+- `LanguageDestination` — 4 cases (language features)
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/AppIntents/FoundationLabAppShortcuts.swift` | Shortcut provider |
+| `Foundation Lab/AppIntents/AppIntentDestinations.swift` | All 4 destination enums |
+| `Foundation Lab/AppIntents/OpenChatIntent.swift` | Chat intent |
+| `Foundation Lab/AppIntents/OpenExampleIntent.swift` | Example intent |
+| `Foundation Lab/AppIntents/OpenToolIntent.swift` | Tool intent |
+| `Foundation Lab/AppIntents/OpenSchemaIntent.swift` | Schema intent |
+| `Foundation Lab/AppIntents/OpenLanguageIntent.swift` | Language intent |
+| `Foundation Lab/Models/NavigationCoordinator.swift` | Navigation target |

--- a/skills/apple-foundation-models-streaming-chat-context/SKILL.md
+++ b/skills/apple-foundation-models-streaming-chat-context/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-streaming-chat-context
+description: Stream responses and manage context window with progressive rendering.
+triggers: ["afm"]
+---
+
+# Streaming Chat Context
+
+## Use when
+
+- Working with streaming chat context in your iOS/macOS project
+- Implementing features related to streaming chat context
+- Debugging issues with streaming chat context
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-streaming-chat-context/agents/openai.yaml
+++ b/skills/apple-foundation-models-streaming-chat-context/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-streaming-chat-context
+description: Stream responses in real-time and manage conversation context window
+tools: []

--- a/skills/apple-foundation-models-streaming-chat-context/references/guide.md
+++ b/skills/apple-foundation-models-streaming-chat-context/references/guide.md
@@ -1,0 +1,105 @@
+# Streaming & Context Management — Reference Guide
+
+## Basic streaming
+
+From `ChatViewModel.swift:119`:
+
+```swift
+let responseStream = session.streamResponse(to: Prompt(content), options: generationOptions)
+
+streamingTask?.cancel()
+let task = Task { @MainActor in
+    for try await _ in responseStream {
+        // The streaming automatically updates the session transcript
+    }
+}
+streamingTask = task
+defer { streamingTask = nil }
+do {
+    try await task.value
+} catch is CancellationError {
+    return // User-initiated cancellation
+}
+```
+
+## Token usage tracking
+
+From `ChatViewModel.swift:318`:
+
+```swift
+func updateTokenCount() async {
+    currentTokenCount = await session.transcript.tokenCount(using: languageModel)
+}
+
+var tokenUsageFraction: Double {
+    guard maxContextSize > 0 else { return 0 }
+    return min(1.0, Double(currentTokenCount) / Double(maxContextSize))
+}
+```
+
+## Sliding window implementation
+
+Configuration from `AppConfiguration.swift`:
+
+```swift
+static let windowThreshold = 0.75     // Start window at 75% usage
+static let targetWindowSize = 2000    // Target tokens after windowing
+```
+
+From `ChatViewModel.swift:422`:
+
+```swift
+func shouldApplyWindow() async -> Bool {
+    await session.transcript.isApproachingLimit(
+        threshold: windowThreshold,
+        maxTokens: maxContextSize,
+        using: languageModel
+    )
+}
+
+func applySlidingWindow() async {
+    let windowEntries = await session.transcript.entriesWithinTokenBudget(
+        targetWindowSize, using: model
+    )
+
+    // Preserve instructions entry
+    var finalEntries = windowEntries
+    if let instructions = session.transcript.first(where: {
+        if case .instructions = $0 { return true }; return false
+    }) {
+        if !finalEntries.contains(where: { $0.id == instructions.id }) {
+            finalEntries.insert(instructions, at: 0)
+        }
+    }
+
+    let windowedTranscript = Transcript(entries: finalEntries)
+    session = LanguageModelSession(model: model, transcript: windowedTranscript)
+    sessionCount += 1
+}
+```
+
+## Context overflow recovery via summarization
+
+From `ChatViewModel.swift:464`:
+
+```swift
+func handleContextWindowExceeded(userMessage: String) async {
+    isSummarizing = true
+    let summary = try await generateConversationSummary()
+    createNewSessionWithContext(summary: summary)
+    isSummarizing = false
+    try await respondWithNewSession(to: userMessage)
+}
+```
+
+The `ConversationSummary` is a `@Generable` struct with `summary`, `keyTopics`, and `userPreferences` fields.
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Full streaming + sliding window + summarization |
+| `Foundation Lab/Health/ViewModels/HealthChatViewModel.swift` | Health-specific context rollover |
+| `Foundation Lab/ViewModels/RAGChatViewModel.swift` | Streaming in RAG context |
+| `Foundation Lab/Services/ConversationContextBuilder.swift` | Builds context instructions from summaries |
+| `Foundation Lab/Extensions/Transcript+TokenCounting.swift` | Token counting + windowing extensions |

--- a/skills/apple-foundation-models-structured-generation/SKILL.md
+++ b/skills/apple-foundation-models-structured-generation/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-structured-generation
+description: Generate type-safe Swift structs using @Generable and @Guide.
+triggers: ["afm"]
+---
+
+# Structured Generation
+
+## Use when
+
+- Working with structured generation in your iOS/macOS project
+- Implementing features related to structured generation
+- Debugging issues with structured generation
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-structured-generation/agents/openai.yaml
+++ b/skills/apple-foundation-models-structured-generation/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-structured-generation
+description: Generate type-safe structured data using @Generable and @Guide
+tools: []

--- a/skills/apple-foundation-models-structured-generation/references/guide.md
+++ b/skills/apple-foundation-models-structured-generation/references/guide.md
@@ -1,0 +1,75 @@
+# Structured Generation — Reference Guide
+
+## Basic @Generable struct
+
+From `DataModels.swift`:
+
+```swift
+@Generable
+struct ConversationSummary {
+    @Guide(
+        description: "A comprehensive summary of the entire conversation"
+    )
+    let summary: String
+
+    @Guide(description: "The main topics or themes discussed")
+    let keyTopics: [String]
+
+    @Guide(description: "Any specific requests or preferences the user mentioned")
+    let userPreferences: [String]
+}
+```
+
+## Using structured generation
+
+From `ChatViewModel.swift:516`:
+
+```swift
+let summarySession = LanguageModelSession(
+    model: languageModel,
+    instructions: Instructions("You are an expert at summarizing conversations.")
+)
+
+let summaryResponse = try await summarySession.respond(
+    to: Prompt(summaryPrompt),
+    generating: ConversationSummary.self
+)
+
+let summary = summaryResponse.content // ConversationSummary instance
+```
+
+## Health-specific @Generable
+
+From `Health/Models/AI/ConversationSummary.swift`:
+
+```swift
+@Generable
+struct HealthConversationSummary {
+    @Guide(description: "Summary preserving health metrics, goals, and advice")
+    let summary: String
+
+    @Guide(description: "Key health topics discussed")
+    let keyTopics: [String]
+
+    @Guide(description: "User's health preferences and concerns")
+    let userPreferences: [String]
+}
+```
+
+## Nested and complex types
+
+The dynamic schemas module demonstrates nested `@Generable` types:
+
+- `FormBuilderSchemaView.swift` — Multi-step form generation
+- `InvoiceSchemas.swift` — Complex invoice parsing with nested line items
+- `GenerablePatternView.swift` — Patterns for generable types
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Models/DataModels.swift` | Core `@Generable` models |
+| `Foundation Lab/Health/Models/AI/` | Health-specific generable models |
+| `Foundation Lab/Views/Examples/StructuredDataView.swift` | Structured generation example UI |
+| `Foundation Lab/Views/Examples/DynamicSchemas/GenerablePatternView.swift` | @Generable pattern examples |
+| `Foundation Lab/Playgrounds/` | Various playground examples |

--- a/skills/apple-foundation-models-swiftdata-persistence/SKILL.md
+++ b/skills/apple-foundation-models-swiftdata-persistence/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-swiftdata-persistence
+description: Persist conversations with SwiftData for long-term memory and context.
+triggers: ["afm"]
+---
+
+# Swiftdata Persistence
+
+## Use when
+
+- Working with swiftdata persistence in your iOS/macOS project
+- Implementing features related to swiftdata persistence
+- Debugging issues with swiftdata persistence
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-swiftdata-persistence/agents/openai.yaml
+++ b/skills/apple-foundation-models-swiftdata-persistence/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-swiftdata-persistence
+description: Persist AI conversations and insights with SwiftData @Model classes
+tools: []

--- a/skills/apple-foundation-models-swiftdata-persistence/references/guide.md
+++ b/skills/apple-foundation-models-swiftdata-persistence/references/guide.md
@@ -1,0 +1,142 @@
+# SwiftData Persistence — Reference Guide
+
+## HealthSession model
+
+From `HealthSession.swift`:
+
+```swift
+@Model
+final class HealthSession {
+    var id: UUID
+    var startDate: Date
+    var endDate: Date?
+    var messages: [BuddyMessage]
+    var sessionType: SessionType
+    var summary: String?
+
+    init(sessionType: SessionType = .general) {
+        self.id = UUID()
+        self.startDate = Date()
+        self.sessionType = sessionType
+        self.messages = []
+    }
+
+    func addMessage(_ message: BuddyMessage) {
+        messages.append(message)
+    }
+
+    func endSession(withSummary summary: String? = nil) {
+        self.endDate = Date()
+        self.summary = summary
+    }
+}
+
+@Model
+final class BuddyMessage {
+    var id: UUID
+    var content: String
+    var isFromUser: Bool
+    var timestamp: Date
+    var relatedMetricTypes: [MetricType]
+}
+```
+
+## Codable enums for @Model
+
+```swift
+enum SessionType: String, Codable, CaseIterable {
+    case general = "General Chat"
+    case healthCheck = "Health Check-in"
+    case goalSetting = "Goal Setting"
+    case analysis = "Health Analysis"
+    case coaching = "Coaching Session"
+
+    var icon: String { ... }
+}
+```
+
+## HealthInsight model
+
+From `HealthInsight.swift`:
+
+```swift
+@Model
+final class HealthInsight {
+    var id: UUID
+    var title: String
+    var content: String
+    var category: InsightCategory
+    var priority: InsightPriority
+    var relatedMetrics: [MetricType]
+    var generatedAt: Date
+    var isRead: Bool
+    var actionItems: [String]
+}
+
+enum InsightCategory: String, Codable, CaseIterable {
+    case trend, achievement, recommendation, warning, goal, comparison
+    var icon: String { ... }
+}
+
+enum InsightPriority: String, Codable, CaseIterable {
+    case low, medium, high, urgent
+    var color: String { ... }
+}
+```
+
+## Saving messages to active session
+
+From `HealthChatViewModel.swift`:
+
+```swift
+func saveMessageToSession(_ content: String, isFromUser: Bool) async {
+    guard let modelContext = modelContext else { return }
+
+    let descriptor = FetchDescriptor<HealthSession>(
+        sortBy: [SortDescriptor<HealthSession>(\.startDate, order: .reverse)]
+    )
+
+    let sessions = try modelContext.fetch(descriptor)
+    let activeSession: HealthSession
+
+    if let existingSession = sessions.first,
+       existingSession.startDate.timeIntervalSinceNow > -sessionTimeout {
+        activeSession = existingSession
+    } else {
+        activeSession = HealthSession(sessionType: .coaching)
+        modelContext.insert(activeSession)
+    }
+
+    let message = BuddyMessage(content: content, isFromUser: isFromUser)
+    activeSession.messages.append(message)
+    try modelContext.save()
+}
+```
+
+## Auto-insight generation
+
+```swift
+func generateHealthInsight(from response: String) async {
+    guard let modelContext = modelContext else { return }
+
+    let insight = HealthInsight(
+        title: "AI Health Tip",
+        content: response,
+        category: .recommendation,
+        priority: .medium,
+        relatedMetrics: []
+    )
+
+    modelContext.insert(insight)
+    try modelContext.save()
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Health/Models/HealthSession.swift` | Session + message models |
+| `Foundation Lab/Health/Models/HealthInsight.swift` | Insight model + enums |
+| `Foundation Lab/Health/Models/HealthMetric.swift` | MetricType enum |
+| `Foundation Lab/Health/ViewModels/HealthChatViewModel.swift` | Persistence logic |

--- a/skills/apple-foundation-models-system-tools/SKILL.md
+++ b/skills/apple-foundation-models-system-tools/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-system-tools
+description: Use built-in system tools for weather, contacts, calendar, and more.
+triggers: ["afm"]
+---
+
+# System Tools
+
+## Use when
+
+- Working with system tools in your iOS/macOS project
+- Implementing features related to system tools
+- Debugging issues with system tools
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-system-tools/agents/openai.yaml
+++ b/skills/apple-foundation-models-system-tools/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-system-tools
+description: Integrate Apple's built-in system tools for weather, contacts, calendar, and more
+tools: []

--- a/skills/apple-foundation-models-system-tools/references/guide.md
+++ b/skills/apple-foundation-models-system-tools/references/guide.md
@@ -1,0 +1,83 @@
+# System Tools — Reference Guide
+
+## Available system tools
+
+| Tool | File | API | Auth |
+|------|------|-----|------|
+| Weather | `WeatherTool.swift` | OpenMeteo | None |
+| Web Search | `Search1WebSearchTool.swift` | Search1API | None |
+| Contacts | `ContactsTool.swift` | Contacts framework | Runtime permission |
+| Calendar | `CalendarTool.swift` | EventKit | Runtime permission |
+| Reminders | `RemindersTool.swift` | EventKit | Runtime permission |
+| Location | `LocationTool.swift` | CoreLocation | Runtime permission |
+| Music | `MusicTool.swift` | MusicKit | Runtime permission |
+| Web Metadata | `WebMetadataTool.swift` | LinkPresentation | None |
+
+All tool files are in `Foundation Lab/Views/Tools/`.
+
+## ToolExecutor pattern
+
+From `ToolExecutor.swift`:
+
+```swift
+@MainActor
+@Observable
+final class ToolExecutor {
+    var isRunning = false
+    var result: String = ""
+    var errorMessage: String?
+    var successMessage: String?
+
+    func execute<T: Tool>(
+        tool: T,
+        prompt: String,
+        successMessage: String? = nil,
+        clearForm: (@MainActor () -> Void)? = nil
+    ) async {
+        // Creates LanguageModelSession(tools: [tool])
+        // Calls session.respond(to: Prompt(prompt))
+        // Manages isRunning, result, errorMessage state
+    }
+}
+```
+
+## Using ToolExecutor with PromptBuilder
+
+```swift
+func executeWithPromptBuilder<T: Tool>(
+    tool: T,
+    @PromptBuilder promptBuilder: () -> Prompt
+) async {
+    let session = LanguageModelSession(tools: [tool])
+    let response = try await session.respond(to: promptBuilder())
+    return response.content
+}
+```
+
+## Using ToolExecutor with custom session
+
+```swift
+func executeWithCustomSession(
+    sessionBuilder: () -> LanguageModelSession,
+    prompt: String,
+    ...
+) async {
+    let session = sessionBuilder()
+    let response = try await session.respond(to: Prompt(prompt))
+    return response.content
+}
+```
+
+## Tool views
+
+Each tool has a corresponding view in `Foundation Lab/Views/Tools/`:
+- `ToolsView.swift` — Main tool listing and navigation
+- `HealthToolView.swift` — Health-specific tool view
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Services/ToolExecutor.swift` | Reusable tool execution with state management |
+| `Foundation Lab/Views/Tools/ToolsView.swift` | Tool listing UI |
+| `Foundation Lab/Views/Tools/*.swift` | Individual tool implementations |

--- a/skills/apple-foundation-models-token-budget-management/SKILL.md
+++ b/skills/apple-foundation-models-token-budget-management/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-token-budget-management
+description: Count tokens and manage context budgets to optimize API usage.
+triggers: ["afm"]
+---
+
+# Token Budget Management
+
+## Use when
+
+- Working with token budget management in your iOS/macOS project
+- Implementing features related to token budget management
+- Debugging issues with token budget management
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-token-budget-management/agents/openai.yaml
+++ b/skills/apple-foundation-models-token-budget-management/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-token-budget-management
+description: Count tokens, manage budgets, and build efficient context windows
+tools: []

--- a/skills/apple-foundation-models-token-budget-management/references/guide.md
+++ b/skills/apple-foundation-models-token-budget-management/references/guide.md
@@ -1,0 +1,152 @@
+# Token Budget Management — Reference Guide
+
+## Estimated token counting (fallback)
+
+From `Transcript+TokenCounting.swift`:
+
+```swift
+/// ~4.5 characters per token heuristic
+func estimateTokensAdvanced(_ text: String) -> Int {
+    guard !text.isEmpty else { return 0 }
+    return max(1, Int(ceil(Double(text.count) / 4.5)))
+}
+
+/// For structured JSON content
+func estimateTokensForStructuredContent(_ content: GeneratedContent) -> Int {
+    let count = content.jsonString.count
+    return max(1, Int(ceil(Double(count) / 4.5)))
+}
+```
+
+Per-entry estimation handles all entry types:
+
+```swift
+extension Transcript.Entry {
+    var estimatedTokenCount: Int {
+        switch self {
+        case .instructions(let instructions):
+            return instructions.segments.reduce(0) { $0 + $1.estimatedTokenCount }
+        case .prompt(let prompt):
+            return prompt.segments.reduce(0) { $0 + $1.estimatedTokenCount }
+        case .response(let response):
+            return response.segments.reduce(0) { $0 + $1.estimatedTokenCount }
+        case .toolCalls(let toolCalls):
+            return toolCalls.reduce(0) { total, call in
+                total + estimateTokensAdvanced(call.toolName) +
+                estimateTokensForStructuredContent(call.arguments) + 5
+            }
+        case .toolOutput(let output):
+            return output.segments.reduce(0) { $0 + $1.estimatedTokenCount } + 3
+        @unknown default:
+            return 0
+        }
+    }
+}
+```
+
+## Real token counting (iOS 26.4+)
+
+```swift
+@available(iOS 26.4, macOS 26.4, visionOS 26.4, *)
+extension Transcript {
+    func realTokenCount(using model: SystemLanguageModel = .default) async throws -> Int {
+        try await model.tokenUsage(for: Array(self)).tokenCount
+    }
+}
+```
+
+## Unified counting (best available)
+
+```swift
+extension Transcript {
+    func tokenCount(using model: SystemLanguageModel = .default) async -> Int {
+        #if compiler(>=6.3)
+        if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *) {
+            if let real = try? await realTokenCount(using: model) {
+                return real
+            }
+        }
+        #endif
+        return estimatedTokenCount
+    }
+}
+```
+
+## Safety buffers
+
+```swift
+func safeTokenCount(using model: SystemLanguageModel = .default) async -> Int {
+    // Real: 5% buffer
+    // Estimated: 25% buffer + 100 overhead
+    #if compiler(>=6.3)
+    if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *) {
+        if let realTokens = try? await realTokenCount(using: model) {
+            let buffer = Int(Double(realTokens) * 0.05)
+            return realTokens + buffer
+        }
+    }
+    #endif
+    let baseTokens = estimatedTokenCount
+    let buffer = Int(Double(baseTokens) * 0.25)
+    return baseTokens + buffer + 100
+}
+```
+
+## Binary search token budget window (iOS 26.4+)
+
+```swift
+@available(iOS 26.4, macOS 26.4, visionOS 26.4, *)
+func realTokenBudgetWindow(
+    instructions: Transcript.Entry?,
+    conversation: [Transcript.Entry],
+    budget: Int,
+    model: SystemLanguageModel
+) async -> [Transcript.Entry]? {
+    let base: [Transcript.Entry] = instructions.map { [$0] } ?? []
+
+    guard let baseTokens = base.isEmpty
+        ? 0 : try? await model.tokenUsage(for: base).tokenCount
+    else { return nil }
+
+    if baseTokens > budget { return base }
+
+    var low = 0
+    var high = conversation.count
+
+    while low < high {
+        let mid = (low + high + 1) / 2
+        let recentEntries = Array(conversation.suffix(mid))
+        let candidate = base + recentEntries
+
+        guard let tokens = try? await model.tokenUsage(for: candidate).tokenCount
+        else { return nil }
+
+        if tokens <= budget { low = mid }
+        else { high = mid - 1 }
+    }
+
+    return base + Array(conversation.suffix(low))
+}
+```
+
+## Limit checking
+
+```swift
+func isApproachingLimit(
+    threshold: Double = 0.70,
+    maxTokens: Int = 4096,
+    using model: SystemLanguageModel = .default
+) async -> Bool {
+    let currentTokens = await safeTokenCount(using: model)
+    return currentTokens > Int(Double(maxTokens) * threshold)
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Extensions/Transcript+TokenCounting.swift` | All token counting + windowing logic |
+| `Foundation Lab/Models/AppConfiguration.swift` | Context size constants |
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Token usage in chat |
+| `Foundation Lab/Views/Components/TokenUsageBar.swift` | Token usage UI component |

--- a/skills/apple-foundation-models-ui-design-system/SKILL.md
+++ b/skills/apple-foundation-models-ui-design-system/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-ui-design-system
+description: Create reusable UI components for Foundation Models interactions.
+triggers: ["afm"]
+---
+
+# Ui Design System
+
+## Use when
+
+- Working with ui design system in your iOS/macOS project
+- Implementing features related to ui design system
+- Debugging issues with ui design system
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-ui-design-system/agents/openai.yaml
+++ b/skills/apple-foundation-models-ui-design-system/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-ui-design-system
+description: Reusable UI components, spacing system, and design patterns for Foundation Models apps
+tools: []

--- a/skills/apple-foundation-models-ui-design-system/references/guide.md
+++ b/skills/apple-foundation-models-ui-design-system/references/guide.md
@@ -1,0 +1,138 @@
+# UI Design System — Reference Guide
+
+## Spacing & CornerRadius
+
+From `Spacing.swift`:
+
+```swift
+enum Spacing {
+    static let xSmall: CGFloat = 4
+    static let small: CGFloat = 8
+    static let medium: CGFloat = 12
+    static let large: CGFloat = 16
+    static let xLarge: CGFloat = 24
+    static let xxLarge: CGFloat = 32
+}
+
+enum CornerRadius {
+    static let small: CGFloat = 8
+    static let medium: CGFloat = 12
+    static let large: CGFloat = 16
+    static let xLarge: CGFloat = 20
+}
+```
+
+## ExampleViewBase
+
+From `ExampleViewBase.swift`:
+
+```swift
+struct ExampleViewBase<Content: View>: View {
+    let title: String
+    let description: String
+    let defaultPrompt: String
+    @Binding var currentPrompt: String
+    let isRunning: Bool
+    let errorMessage: String?
+    let codeExample: String?
+    let onRun: () -> Void
+    let onReset: () -> Void
+    let content: Content
+}
+```
+
+Provides: prompt editor, run/clear buttons, error display, optional `CodeDisclosure`.
+
+## ToolViewBase
+
+From `ToolViewBase.swift`:
+
+```swift
+struct ToolViewBase<Content: View>: View {
+    let title: String
+    let icon: String
+    let description: String
+    let isRunning: Bool
+    let errorMessage: String?
+    let content: Content
+}
+```
+
+Provides: navigation title, subtitle, error banner, scrollable content.
+
+## CodeViewer & CodeDisclosure
+
+From `CodeViewer.swift`:
+
+```swift
+// Inline syntax-highlighted code with copy button
+CodeViewer(code: "let x = 42", language: "swift")
+
+// Collapsible code section
+CodeDisclosure(code: "let x = 42")
+```
+
+Uses `HighlightSwift` with Xcode theme (light/dark adaptive).
+
+## TokenUsageBar
+
+From `TokenUsageBar.swift`:
+
+```swift
+TokenUsageBar(
+    currentTokenCount: 1500,
+    maxContextSize: 4096,
+    tokenUsageFraction: 0.37
+)
+```
+
+Color thresholds:
+- Green: 0–50%
+- Yellow: 50–75%
+- Orange: 75–90%
+- Red: 90%+
+
+## PromptSuggestions
+
+```swift
+PromptSuggestions(suggestions: ["Tell a joke", "Write a poem"]) { selected in
+    prompt = selected
+}
+```
+
+## Button styles (LiquidGlasKit)
+
+```swift
+// Standard glass button
+Button("Action") { }.buttonStyle(.glass)
+
+// Prominent glass button
+Button("Primary") { }.buttonStyle(.glassProminent)
+
+// Material background
+.background(.thinMaterial, in: .rect(cornerRadius: CornerRadius.small))
+```
+
+## All reusable components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `ExampleViewBase` | `Examples/Components/ExampleViewBase.swift` | Standard example layout |
+| `ToolViewBase` | `Components/ToolViewBase.swift` | Standard tool layout |
+| `CodeViewer` | `Examples/Components/CodeViewer.swift` | Syntax-highlighted code |
+| `CodeDisclosure` | `Examples/Components/CodeViewer.swift` | Collapsible code |
+| `ExampleExecutor` | `Examples/Components/ExampleExecutor.swift` | Execution helper |
+| `PromptField` | `Examples/Components/PromptField.swift` | Prompt input |
+| `Spacing` / `CornerRadius` | `Examples/Components/Spacing.swift` | Design constants |
+| `TokenUsageBar` | `Components/TokenUsageBar.swift` | Token usage display |
+| `FeedbackView` | `Components/FeedbackView.swift` | Response feedback |
+| `MessageBubbleView` | `Components/MessageBubbleView.swift` | Chat bubbles |
+| `ChatInputView` | `Components/ChatInputView.swift` | Chat input |
+| `ResponseDisplayView` | `Components/ResponseDisplayView.swift` | Response rendering |
+| `ResultDisplay` | `Components/ResultDisplay.swift` | Success/error result |
+| `GenericCardView` | `Components/GenericCardView.swift` | Card layout |
+| `ToolBanners` | `Components/ToolBanners.swift` | Tool status banners |
+| `ToolInputs` | `Components/ToolInputs.swift` | Tool input fields |
+| `PermissiveGuardrailsToggle` | `Components/PermissiveGuardrailsToggle.swift` | Guardrails toggle |
+| `HealthColors` | `Health/Views/Components/HealthColors.swift` | Health color palette |
+| `HealthEffects` | `Health/Views/Components/HealthEffects.swift` | Health visual effects |

--- a/skills/apple-foundation-models-voice-assistant/SKILL.md
+++ b/skills/apple-foundation-models-voice-assistant/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: apple-foundation-models-voice-assistant
+description: Build voice interfaces with speech recognition and text-to-speech integration.
+triggers: ["afm"]
+---
+
+# Voice Assistant
+
+## Use when
+
+- Working with voice assistant in your iOS/macOS project
+- Implementing features related to voice assistant
+- Debugging issues with voice assistant
+
+## Don't use when
+
+- Just doing basic chat (use apple-foundation-models-session-patterns)
+- Need structured output specifically (use apple-foundation-models-structured-generation)
+
+## Workflow
+
+1. Review the skill documentation
+2. Check references/guide.md for code examples
+3. Implement according to your use case
+4. Test with actual model interactions
+
+## Hard rules
+
+- Follow Apple platform guidelines
+- Handle errors gracefully
+- Respect user privacy and data handling
+
+## References
+
+See [references/guide.md](references/guide.md) for code examples and repo file paths.

--- a/skills/apple-foundation-models-voice-assistant/agents/openai.yaml
+++ b/skills/apple-foundation-models-voice-assistant/agents/openai.yaml
@@ -1,0 +1,3 @@
+name: apple-foundation-models-voice-assistant
+description: Build a voice interface with speech recognition and text-to-speech synthesis
+tools: []

--- a/skills/apple-foundation-models-voice-assistant/references/guide.md
+++ b/skills/apple-foundation-models-voice-assistant/references/guide.md
@@ -1,0 +1,126 @@
+# Voice Assistant — Reference Guide
+
+## Architecture
+
+```
+Voice/
+├── VoiceView.swift                    # Main voice interface UI
+├── VoiceViewModel.swift               # Voice-specific view model
+├── Services/
+│   ├── InferenceService.swift         # AI text processing protocol
+│   ├── SpeechRecognizer.swift         # Speech recognition wrapper
+│   ├── SpeechSynthesizer.swift        # Text-to-speech wrapper
+│   └── PermissionManager.swift        # Microphone/speech permissions
+├── State/
+│   └── SpeechRecognitionStateMachine.swift  # Full workflow state machine
+└── Views/
+    └── PermissionRequestView.swift    # Permission request UI
+```
+
+## State machine states
+
+From `SpeechRecognitionStateMachine.swift`:
+
+```swift
+enum State {
+    case idle
+    case requestingPermission
+    case permissionGranted
+    case permissionDenied
+    case initializingRecognition
+    case listening
+    case processingSpeech(String)      // Contains recognized text
+    case synthesizingResponse(String)  // Contains response text
+    case completed
+    case error(SpeechRecognitionStateMachineError)
+}
+```
+
+## Voice mode in ChatViewModel
+
+From `ChatViewModel.swift:212`:
+
+```swift
+func startVoiceMode() async {
+    // Check permissions
+    if !permissionManager.allPermissionsGranted {
+        let granted = await permissionManager.requestAllPermissions()
+        if !granted { return }
+    }
+
+    voiceState = .preparing
+    session.prewarm()  // Reduce first-response latency
+
+    let didStart = await initializeSpeechRecognizer()
+    guard didStart else { return }
+
+    voiceState = .listening(partialText: "")
+    startSpeechObservation()
+}
+```
+
+## Voice conversation loop
+
+From `ChatViewModel.swift:267`:
+
+```swift
+func stopVoiceModeAndSend() async {
+    guard case .listening(let text) = voiceState else { return }
+    let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedText.isEmpty else { cancelVoiceMode(); return }
+
+    recognizer.stopRecognition()
+    voiceState = .processing
+
+    let response = try await session.respond(to: Prompt(trimmedText))
+    voiceState = .speaking(response: response.content)
+
+    try await speechSynthesizer.synthesizeAndSpeak(text: response.content)
+
+    // Auto-return to listening for multi-turn
+    restartListening()
+}
+```
+
+## Speech observation
+
+```swift
+func observeSpeechState() async {
+    guard let recognizer = speechRecognizer else { return }
+    for await state in recognizer.stateValues {
+        switch state {
+        case .listening(let partialText):
+            voiceState = .listening(partialText: partialText)
+        case .completed(let finalText):
+            voiceState = .listening(partialText: finalText)
+        case .error(let speechError):
+            handleVoiceError(speechError.localizedDescription)
+        case .idle: break
+        }
+    }
+}
+```
+
+## Cleanup
+
+```swift
+func tearDown() {
+    streamingTask?.cancel()
+    stopSpeechObservation()
+    speechRecognizer?.stopRecognition()
+    speechRecognizer = nil
+}
+```
+
+## Repo files
+
+| File | Purpose |
+|------|---------|
+| `Foundation Lab/Voice/State/SpeechRecognitionStateMachine.swift` | Full state machine |
+| `Foundation Lab/Voice/VoiceViewModel.swift` | Voice view model |
+| `Foundation Lab/Voice/VoiceView.swift` | Voice UI |
+| `Foundation Lab/Voice/Services/SpeechRecognizer.swift` | Recognition wrapper |
+| `Foundation Lab/Voice/Services/SpeechSynthesizer.swift` | Synthesis wrapper |
+| `Foundation Lab/Voice/Services/PermissionManager.swift` | Permission handling |
+| `Foundation Lab/Voice/Services/InferenceService.swift` | AI processing protocol |
+| `Foundation Lab/ViewModels/ChatViewModel.swift` | Voice integration in chat |


### PR DESCRIPTION
## Summary

- Add **22 skills** for building iOS/macOS apps with Apple's [Foundation Models](https://developer.apple.com/documentation/foundationmodels) framework (Apple Intelligence)
- Covers on-device AI: session management, structured generation, custom tools, RAG pipelines, voice assistants, SwiftData persistence, HealthKit integration, and more
- Requires iOS/macOS 26.0+ with Apple Silicon and Apple Intelligence enabled

## What these skills do

| Category | Skills |
|---|---|
| Core Session | `setup-availability`, `session-patterns`, `streaming-chat-context`, `token-budget-management` |
| Structured Generation | `structured-generation`, `dynamic-schemas` |
| Tools & Integration | `custom-tools`, `system-tools`, `health-assistant` |
| Context & Conversation | `conversation-context-builder`, `swiftdata-persistence` |
| Error Handling & Tuning | `error-recovery`, `generation-tuning` |
| Multimodal & Specialized | `voice-assistant`, `multilingual`, `rag-pipeline` |
| Integration & UX | `app-patterns`, `ui-design-system`, `siri-shortcuts-integration`, `feedback-sentiment-api` |
| Learning & Dev | `playground-learning`, `prompt-builder-patterns` |

## Skill structure

```
skills/apple-foundation-models-xxx/
├── SKILL.md          - Agent instructions with YAML frontmatter
├── agents/
│   └── openai.yaml   - OpenAI agent configuration
└── references/
    └── guide.md      - Code examples and implementation details
```

## Source repository

https://github.com/sambitcreate/Swift-Foundation-Models-Skills

Also installable directly via:
```bash
npx skills add sambitcreate/Swift-Foundation-Models-Skills
```

## Inspiration

Directly inspired by [@rudrankriyam](https://github.com/rudrankriyam)'s [Foundation-Models-Framework-Example](https://github.com/rudrankriyam/Foundation-Models-Framework-Example) and Apple's official [Foundation Models documentation](https://developer.apple.com/documentation/FoundationModels).