### PR TITLE
feat: Add QoderWork support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [37 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [38 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -238,6 +238,7 @@ Skills can be installed to any of these agents:
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
+| QoderWork | `qoderwork` | `.qoderwork/skills/` | `~/.qoderwork/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
@@ -339,6 +340,7 @@ The CLI searches for skills in these locations within a repository:
 - `.openhands/skills/`
 - `.pi/skills/`
 - `.qoder/skills/`
+- `.qoderwork/skills/`
 - `.qwen/skills/`
 - `.roo/skills/`
 - `.trae/skills/`
@@ -376,12 +378,12 @@ If no skills are found in standard locations, a recursive search is performed.
 Skills are generally compatible across agents since they follow a
 shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
-| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
-| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
-| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
-| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | QoderWork | Zencoder |
+| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | --------- | -------- |
+| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes       | Yes      |
+| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes       | No       |
+| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No        | No       |
+| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No        | No       |
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "openhands",
     "pi",
     "qoder",
+    "qoderwork",
     "qwen-code",
     "replit",
     "roo",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -301,6 +301,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.qoder'));
     },
   },
+  qoderwork: {
+    name: 'qoderwork',
+    displayName: 'QoderWork',
+    skillsDir: '.qoderwork/skills',
+    globalSkillsDir: join(home, '.qoderwork/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.qoderwork'));
+    },
+  },
   'qwen-code': {
     name: 'qwen-code',
     displayName: 'Qwen Code',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -177,6 +177,7 @@ export async function discoverSkills(
     join(searchPath, '.openhands/skills'),
     join(searchPath, '.pi/skills'),
     join(searchPath, '.qoder/skills'),
+    join(searchPath, '.qoderwork/skills'),
     join(searchPath, '.roo/skills'),
     join(searchPath, '.trae/skills'),
     join(searchPath, '.windsurf/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type AgentType =
   | 'openhands'
   | 'pi'
   | 'qoder'
+  | 'qoderwork'
   | 'qwen-code'
   | 'replit'
   | 'roo'

--- a/tests/qoderwork-agent.test.ts
+++ b/tests/qoderwork-agent.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for QoderWork agent support.
+ *
+ * Verifies that the QoderWork agent is correctly defined with:
+ * - Correct skillsDir (.qoderwork/skills)
+ * - Correct globalSkillsDir (~/.qoderwork/skills)
+ * - Correct detection logic (checks ~/.qoderwork existence)
+ * - Correct display name and type
+ * - Correct skill installation behavior
+ */
+
+import { describe, it, expect } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+import { mkdtemp, mkdir, rm, writeFile, lstat, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { agents } from '../src/agents.ts';
+import { installSkillForAgent } from '../src/installer.ts';
+import type { AgentType } from '../src/types.ts';
+
+const home = homedir();
+
+describe('QoderWork agent definition', () => {
+  it('is defined in agents registry', () => {
+    expect(agents.qoderwork).toBeDefined();
+  });
+
+  it('has correct name', () => {
+    expect(agents.qoderwork.name).toBe('qoderwork');
+  });
+
+  it('has correct displayName', () => {
+    expect(agents.qoderwork.displayName).toBe('QoderWork');
+  });
+
+  it('has correct skillsDir', () => {
+    expect(agents.qoderwork.skillsDir).toBe('.qoderwork/skills');
+  });
+
+  it('has correct globalSkillsDir', () => {
+    const expected = join(home, '.qoderwork', 'skills');
+    expect(agents.qoderwork.globalSkillsDir).toBe(expected);
+  });
+
+  it('uses home-based paths (not XDG)', () => {
+    expect(agents.qoderwork.globalSkillsDir).not.toContain('.config');
+    expect(agents.qoderwork.globalSkillsDir).not.toContain('Library');
+    expect(agents.qoderwork.globalSkillsDir).not.toContain('AppData');
+  });
+
+  it('is a valid AgentType', () => {
+    const agentType: AgentType = 'qoderwork';
+    expect(agentType).toBe('qoderwork');
+  });
+
+  it('has detectInstalled function', () => {
+    expect(typeof agents.qoderwork.detectInstalled).toBe('function');
+  });
+});
+
+describe('QoderWork skill installation', () => {
+  async function makeSkillSource(root: string, name: string): Promise<string> {
+    const dir = join(root, 'source-skill');
+    await mkdir(dir, { recursive: true });
+    const skillMd = `---\nname: ${name}\ndescription: test skill for qoderwork\n---\n`;
+    await writeFile(join(dir, 'SKILL.md'), skillMd, 'utf-8');
+    return dir;
+  }
+
+  it('installs skill to .qoderwork/skills via symlink', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'qoderwork-test-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'test-qoderwork-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'qoderwork',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      // Verify canonical location has the skill
+      const canonicalPath = join(projectDir, '.agents/skills', skillName);
+      const canonicalStats = await lstat(canonicalPath);
+      expect(canonicalStats.isDirectory()).toBe(true);
+
+      const contents = await readFile(join(canonicalPath, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+
+      // Verify agent-specific location has a symlink
+      const agentPath = join(projectDir, '.qoderwork/skills', skillName);
+      const agentStats = await lstat(agentPath);
+      expect(agentStats.isSymbolicLink()).toBe(true);
+
+      // Verify content is accessible through symlink
+      const agentContents = await readFile(join(agentPath, 'SKILL.md'), 'utf-8');
+      expect(agentContents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('installs skill to .qoderwork/skills via copy', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'qoderwork-test-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'test-copy-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'qoderwork',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('copy');
+
+      // Verify skill was copied directly to agent location
+      const agentPath = join(projectDir, '.qoderwork/skills', skillName);
+      const stats = await lstat(agentPath);
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
+
+      const contents = await readFile(join(agentPath, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for the QoderWork agent to the skills CLI, enabling skill installation and management for QoderWork users.

- New agent definition for QoderWork with:
  - Project-local skills directory: `.qoderwork/skills/`
  - Global skills directory: `~/.qoderwork/skills/`
  - Detection based on `~/.qoderwork` directory existence
- Updated skill discovery paths to include `.qoderwork/skills/`
- Updated README.md with QoderWork in supported agents list and compatibility matrix
- Added comprehensive test coverage for QoderWork agent support

## Changes

| File | Description |
|------|-------------|
| `src/agents.ts` | Added QoderWork agent definition |
| `src/skills.ts` | Added `.qoderwork/skills/` to skill discovery paths |
| `src/types.ts` | Added `qoderwork` to `AgentType` union |
| `README.md` | Updated agent count, added QoderWork to tables |
| `package.json` | Added `qoderwork` to agent keywords |
| `tests/qoderwork-agent.test.ts` | New test file with 138 lines covering agent definition and skill installation |

## Test Plan

- All existing tests pass
- New tests verify:
  - Agent definition correctness (name, displayName, paths)
  - Home-based path configuration (not XDG)
  - Skill installation via symlink mode
  - Skill installation via copy mode
  - Canonical and agent-specific path handling

## Agent Details

| Property | Value |
|----------|-------|
| Name | `qoderwork` |
| Display Name | `QoderWork` |
| Project Skills Dir | `.qoderwork/skills/` |
| Global Skills Dir | `~/.qoderwork/skills/` |
| Detection | `~/.qoderwork` directory exists |