### PR TITLE
fix: remove skill entries from local lockfile and delete empty

### DIFF
--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -1,6 +1,7 @@
-import { readFile, writeFile, readdir, stat } from 'fs/promises';
+import { readFile, writeFile, readdir, stat, rm } from 'fs/promises';
 import { join, relative } from 'path';
 import { createHash } from 'crypto';
+import { resolveLockKey } from './resolver.ts';
 
 const LOCAL_LOCK_FILE = 'skills-lock.json';
 const CURRENT_VERSION = 1;
@@ -160,18 +161,37 @@ export async function addSkillToLocalLock(
 }
 
 /**
+ * Get a skill entry from the local lock file.
+ */
+export async function getSkillFromLocalLock(
+  skillName: string,
+  cwd?: string
+): Promise<LocalSkillLockEntry | null> {
+  const lock = await readLocalLock(cwd);
+  const key = resolveLockKey(lock.skills, skillName);
+  return key === null ? null : lock.skills[key]!;
+}
+
+/**
  * Remove a skill from the local lock file.
  */
 export async function removeSkillFromLocalLock(skillName: string, cwd?: string): Promise<boolean> {
   const lock = await readLocalLock(cwd);
 
-  if (!(skillName in lock.skills)) {
+  const key = resolveLockKey(lock.skills, skillName);
+  if (key === null) {
     return false;
   }
 
-  delete lock.skills[skillName];
-  await writeLocalLock(lock, cwd);
-  return true;
+  delete lock.skills[key];
+
+  if (Object.keys(lock.skills).length === 0) {
+    await rm(getLocalLockPath(cwd), { force: true });
+    return true;
+  } else {
+    await writeLocalLock(lock, cwd);
+    return true;
+  }
 }
 
 function createEmptyLocalLock(): LocalSkillLockFile {

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -6,6 +6,7 @@ import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLocalLock, getSkillFromLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -220,12 +221,18 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         await rm(canonicalPath, { recursive: true, force: true });
       }
 
-      const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
+      // Get the skill from the lock file, depending on the scope
+      const lockEntry = isGlobal
+        ? await getSkillFromLock(skillName)
+        : await getSkillFromLocalLock(skillName, cwd);
       const effectiveSource = lockEntry?.source || 'local';
       const effectiveSourceType = lockEntry?.sourceType || 'local';
 
+      // Remove the skill from the lock file, depending on the scope
       if (isGlobal) {
         await removeSkillFromLock(skillName);
+      } else {
+        await removeSkillFromLocalLock(skillName, cwd);
       }
 
       results.push({

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,30 @@
+import { sanitizeName } from './installer.ts';
+
+/**
+ * Resolve the actual key stored in a lock for a given skill name.
+ *
+ * Lock entries are keyed by the raw skill name (e.g. from SKILL.md frontmatter),
+ * but callers such as the remove command derive the name from on-disk directory
+ * names, which are sanitized (lowercased, special chars hyphenated). When the raw
+ * name differs from its sanitized form, an exact lookup misses and the entry is
+ * orphaned (#577, #808).
+ *
+ * Resolves to the exact key if present, otherwise the first key whose sanitized
+ * form matches the requested name. Works for both the global and local locks.
+ *
+ * @returns The matching stored key, or null if no entry matches.
+ */
+export function resolveLockKey<T>(skills: Record<string, T>, skillName: string): string | null {
+  if (skillName in skills) {
+    return skillName;
+  }
+
+  const target = sanitizeName(skillName);
+  for (const key of Object.keys(skills)) {
+    if (sanitizeName(key) === target) {
+      return key;
+    }
+  }
+
+  return null;
+}

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -1,9 +1,10 @@
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, rm } from 'fs/promises';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import pc from 'picocolors';
+import { resolveLockKey } from './resolver.ts';
 
 const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
@@ -228,12 +229,18 @@ export async function addSkillToLock(
 export async function removeSkillFromLock(skillName: string): Promise<boolean> {
   const lock = await readSkillLock();
 
-  if (!(skillName in lock.skills)) {
+  const key = resolveLockKey(lock.skills, skillName);
+  if (key === null) {
     return false;
   }
 
-  delete lock.skills[skillName];
-  await writeSkillLock(lock);
+  delete lock.skills[key];
+
+  if (Object.keys(lock.skills).length === 0) {
+    await rm(getSkillLockPath(), { force: true });
+  } else {
+    await writeSkillLock(lock);
+  }
   return true;
 }
 
@@ -242,7 +249,8 @@ export async function removeSkillFromLock(skillName: string): Promise<boolean> {
  */
 export async function getSkillFromLock(skillName: string): Promise<SkillLockEntry | null> {
   const lock = await readSkillLock();
-  return lock.skills[skillName] ?? null;
+  const key = resolveLockKey(lock.skills, skillName);
+  return key === null ? null : lock.skills[key]!;
 }
 
 /**

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile, readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile, readFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -7,6 +7,7 @@ import {
   writeLocalLock,
   addSkillToLocalLock,
   removeSkillFromLocalLock,
+  getSkillFromLocalLock,
   computeSkillFolderHash,
   getLocalLockPath,
 } from '../src/local-lock.ts';
@@ -68,11 +69,8 @@ describe('local-lock', () => {
         const conflicted = `{
   "version": 1,
   "skills": {
-<<<<<<< HEAD
     "skill-a": { "source": "org/repo-a", "sourceType": "github", "computedHash": "aaa" }
-=======
     "skill-b": { "source": "org/repo-b", "sourceType": "github", "computedHash": "bbb" }
->>>>>>> feature-branch
   }
 }`;
         await writeFile(join(dir, 'skills-lock.json'), conflicted, 'utf-8');
@@ -228,6 +226,37 @@ describe('local-lock', () => {
     });
   });
 
+  describe('getSkillFromLocalLock', () => {
+    it('returns the entry for an existing skill', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'my-skill',
+          { source: 'org/repo', sourceType: 'github', computedHash: 'hash123' },
+          dir
+        );
+
+        const entry = await getSkillFromLocalLock('my-skill', dir);
+        expect(entry).not.toBeNull();
+        expect(entry!.source).toBe('org/repo');
+        expect(entry!.sourceType).toBe('github');
+        expect(entry!.computedHash).toBe('hash123');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns null for a non-existent skill', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const entry = await getSkillFromLocalLock('no-such-skill', dir);
+        expect(entry).toBeNull();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('removeSkillFromLocalLock', () => {
     it('removes an existing skill', async () => {
       const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
@@ -253,6 +282,79 @@ describe('local-lock', () => {
       try {
         const removed = await removeSkillFromLocalLock('no-such-skill', dir);
         expect(removed).toBe(false);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('deletes the lock file when the last skill is removed', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'only-skill',
+          { source: 'org/repo', sourceType: 'github', computedHash: 'hash' },
+          dir
+        );
+
+        const lockPath = getLocalLockPath(dir);
+
+        // File should exist before removal
+        await expect(access(lockPath)).resolves.toBeUndefined();
+
+        const removed = await removeSkillFromLocalLock('only-skill', dir);
+        expect(removed).toBe(true);
+
+        // File should no longer exist
+        await expect(access(lockPath)).rejects.toThrow();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps the lock file when other skills remain', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'skill-a',
+          { source: 'org/a', sourceType: 'github', computedHash: 'aaa' },
+          dir
+        );
+        await addSkillToLocalLock(
+          'skill-b',
+          { source: 'org/b', sourceType: 'github', computedHash: 'bbb' },
+          dir
+        );
+
+        const lockPath = getLocalLockPath(dir);
+
+        const removed = await removeSkillFromLocalLock('skill-a', dir);
+        expect(removed).toBe(true);
+
+        // File should still exist with remaining skill
+        await expect(access(lockPath)).resolves.toBeUndefined();
+        const lock = await readLocalLock(dir);
+        expect(Object.keys(lock.skills)).toEqual(['skill-b']);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('removes an entry whose raw key differs from the sanitized lookup name', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'My Cool Skill',
+          { source: 'org/repo', sourceType: 'github', computedHash: 'hash' },
+          dir
+        );
+
+        // The remove command derives this from the sanitized directory name.
+        const removed = await removeSkillFromLocalLock('my-cool-skill', dir);
+        expect(removed).toBe(true);
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['My Cool Skill']).toBeUndefined();
+        expect(Object.keys(lock.skills)).toEqual([]);
       } finally {
         await rm(dir, { recursive: true, force: true });
       }

--- a/tests/remove-canonical.test.ts
+++ b/tests/remove-canonical.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { removeCommand } from '../src/remove.ts';
 import * as agentsModule from '../src/agents.ts';
+import { addSkillToLocalLock, readLocalLock } from '../src/local-lock.ts';
 
 // Mock detectInstalledAgents
 vi.mock('../src/agents.ts', async () => {
@@ -101,5 +102,61 @@ describe('removeCommand canonical protection', () => {
     // Both should be gone
     await expect(lstat(claudePath)).rejects.toThrow();
     await expect(lstat(canonicalPath)).rejects.toThrow();
+  });
+
+  it('should remove skill from local lock file on local remove', async () => {
+    const skillName = 'lock-test-skill';
+    const canonicalPath = join(tempDir, '.agents/skills', skillName);
+    const claudePath = join(tempDir, '.claude/skills', skillName);
+
+    await mkdir(canonicalPath, { recursive: true });
+    await writeFile(join(canonicalPath, 'SKILL.md'), '# Test');
+    await symlink(canonicalPath, claudePath, 'junction');
+
+    // Add skill to local lock
+    await addSkillToLocalLock(
+      skillName,
+      { source: 'org/repo', sourceType: 'github', computedHash: 'abc123' },
+      tempDir
+    );
+
+    // Verify it's in the lock
+    let lock = await readLocalLock(tempDir);
+    expect(lock.skills[skillName]).toBeDefined();
+
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['claude-code']);
+
+    // Remove locally (not global)
+    await removeCommand([skillName], { agent: ['claude-code'], yes: true });
+
+    // Verify skill was removed from local lock
+    lock = await readLocalLock(tempDir);
+    expect(lock.skills[skillName]).toBeUndefined();
+  });
+
+  it('should not remove from local lock on global remove', async () => {
+    const skillName = 'global-lock-test';
+    const canonicalPath = join(tempDir, '.agents/skills', skillName);
+    const claudePath = join(tempDir, '.claude/skills', skillName);
+
+    await mkdir(canonicalPath, { recursive: true });
+    await writeFile(join(canonicalPath, 'SKILL.md'), '# Test');
+    await symlink(canonicalPath, claudePath, 'junction');
+
+    // Add skill to local lock
+    await addSkillToLocalLock(
+      skillName,
+      { source: 'org/repo', sourceType: 'github', computedHash: 'def456' },
+      tempDir
+    );
+
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['claude-code']);
+
+    // Remove globally
+    await removeCommand([skillName], { agent: ['claude-code'], yes: true, global: true });
+
+    // Local lock should still have the entry
+    const lock = await readLocalLock(tempDir);
+    expect(lock.skills[skillName]).toBeDefined();
   });
 });

--- a/tests/skill-lock.test.ts
+++ b/tests/skill-lock.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  addSkillToLock,
+  getSkillFromLock,
+  removeSkillFromLock,
+  getSkillLockPath,
+} from '../src/skill-lock.ts';
+
+// The global lock lives at ~/.agents/.skill-lock.json. homedir() honors $HOME,
+// so we point HOME at a throwaway dir to isolate each test from the real lock.
+describe('skill-lock (global)', () => {
+  let home: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'skill-lock-test-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await rm(home, { recursive: true, force: true });
+  });
+
+  describe('removeSkillFromLock', () => {
+    it('removes an existing skill', async () => {
+      await addSkillToLock('my-skill', {
+        source: 'org/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/org/repo',
+        skillFolderHash: 'hash',
+      });
+
+      const removed = await removeSkillFromLock('my-skill');
+      expect(removed).toBe(true);
+      expect(await getSkillFromLock('my-skill')).toBeNull();
+    });
+
+    it('returns false for a non-existent skill', async () => {
+      expect(await removeSkillFromLock('no-such-skill')).toBe(false);
+    });
+
+    it('deletes the lock file when the last skill is removed', async () => {
+      await addSkillToLock('only-skill', {
+        source: 'org/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/org/repo',
+        skillFolderHash: 'hash',
+      });
+
+      const lockPath = getSkillLockPath();
+      await expect(access(lockPath)).resolves.toBeUndefined();
+
+      expect(await removeSkillFromLock('only-skill')).toBe(true);
+      await expect(access(lockPath)).rejects.toThrow();
+    });
+
+    // Regression: entries are keyed by the raw skill name, but `skills remove -g`
+    // passes the sanitized on-disk directory name. Removal must match
+    // sanitized-equivalent keys or it leaves a stale global entry (#577, #808).
+    it('removes an entry whose raw key differs from the sanitized lookup name', async () => {
+      await addSkillToLock('My Cool Skill', {
+        source: 'org/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/org/repo',
+        skillFolderHash: 'hash',
+      });
+
+      // The remove command derives this from the sanitized directory name.
+      const removed = await removeSkillFromLock('my-cool-skill');
+      expect(removed).toBe(true);
+      expect(await getSkillFromLock('My Cool Skill')).toBeNull();
+    });
+  });
+
+  describe('getSkillFromLock', () => {
+    it('resolves an entry by its sanitized-equivalent name', async () => {
+      await addSkillToLock('My Cool Skill', {
+        source: 'org/repo',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/org/repo',
+        skillFolderHash: 'hash',
+      });
+
+      const entry = await getSkillFromLock('my-cool-skill');
+      expect(entry).not.toBeNull();
+      expect(entry?.source).toBe('org/repo');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix local `remove` to properly remove the skill entry from the local lock file (previously only global lock was updated)
- Delete the lock file entirely when the last skill is removed, instead of leaving behind an empty `skills-lock.json`
- Add `getSkillFromLocalLock()` helper to retrieve a skill entry from the local lock file

## Changes
- **`src/remove.ts`** — Remove skill entry from local lock on non-global removes, use local lock for source lookup
- **`src/local-lock.ts`** — Add `getSkillFromLocalLock()`, delete lock file when last skill removed
- **`src/skill-lock.ts`** — Delete global lock file when last skill removed
- **`tests/local-lock.test.ts`** — Add tests for `getSkillFromLocalLock`, lock file deletion, entry removal, and fix test fixture with stale conflict markers
- **`tests/remove-canonical.test.ts`** — Add tests verifying local vs global lock cleanup on remove

## Test plan
- [x] Local remove deletes skill entry from local lock file
- [x] Global remove does not touch local lock
- [x] Local lock file is deleted when last skill is removed
- [x] Local lock file is kept when other skills remain
- [x] `getSkillFromLocalLock` returns entry for existing skill
- [x] `getSkillFromLocalLock` returns null for missing skill