### PR TITLE
feat: Add Builder.io support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Skills can be installed to any of these agents:
 | Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
 | Antigravity | `antigravity` | `.agent/skills/` | `~/.gemini/antigravity/skills/` |
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
+| Builder.io | `builder` | `.builder/skills/` | `~/.builder/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
 | Cline | `cline` | `.agents/skills/` | `~/.agents/skills/` |
@@ -319,6 +320,7 @@ The CLI searches for skills in these locations within a repository:
 - `.agents/skills/`
 - `.agent/skills/`
 - `.augment/skills/`
+- `.builder/skills/`
 - `.claude/skills/`
 - `./skills/`
 - `.codebuddy/skills/`
@@ -424,6 +426,7 @@ Telemetry is automatically disabled in CI environments.
 - [Skills Directory](https://skills.sh)
 - [Amp Skills Documentation](https://ampcode.com/manual#agent-skills)
 - [Antigravity Skills Documentation](https://antigravity.google/docs/skills)
+- [Builder.io Skills Documentation](https://www.builder.io/c/docs/skills)
 - [Factory AI / Droid Skills Documentation](https://docs.factory.ai/cli/configuration/skills)
 - [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)
 - [OpenClaw Skills Documentation](https://docs.openclaw.ai/tools/skills)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "amp",
     "antigravity",
     "augment",
+    "builder",
     "claude-code",
     "openclaw",
     "cline",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -54,6 +54,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.augment'));
     },
   },
+  builder: {
+    name: 'builder',
+    displayName: 'Builder.io',
+    skillsDir: '.builder/skills',
+    globalSkillsDir: join(home, '.builder/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.builder')) || existsSync(join(home, '.builder'));
+    },
+  },
   'claude-code': {
     name: 'claude-code',
     displayName: 'Claude Code',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type AgentType =
   | 'amp'
   | 'antigravity'
   | 'augment'
+  | 'builder'
   | 'claude-code'
   | 'openclaw'
   | 'cline'


### PR DESCRIPTION
This pull request adds support for the Builder.io agent across the codebase and documentation. The most important changes include updating the agent configuration, skills directory search locations, and documentation references.

Builder.io agent support:

* Added `builder` to the list of supported agents in `src/types.ts`, `package.json`, and `src/agents.ts`, including its display name, skills directory paths, and installation detection logic. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR5) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R42) [[3]](diffhunk://#diff-0dd7b6150e3673f42fe6a289e0656e83bb3c0f4d0b60ee357ce3a6f7db7292c0R57-R65)

Documentation updates:

* Included Builder.io in the skills installation table and skills directory search locations in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R215) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R323)
* Added a link to Builder.io Skills Documentation in `README.md`.