### PR TITLE
feat(list): add --json flag for machine-readable output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,6 +148,7 @@ ${BOLD}Experimental Sync Options:${RESET}
 ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
   -a, --agent <agents>   Filter by specific agents
+  --json                 Output as JSON (machine-readable, no ANSI codes)
 
 ${BOLD}Options:${RESET}
   --help, -h        Show this help message
@@ -164,6 +165,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills list                          ${DIM}# list project skills${RESET}
   ${DIM}$${RESET} skills ls -g                         ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
+  ${DIM}$${RESET} skills ls --json                      ${DIM}# JSON output${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}
   ${DIM}$${RESET} skills check

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -56,6 +56,17 @@ describe('list command', () => {
       expect(options.agent).toEqual(['claude-code', 'cursor']);
     });
 
+    it('should parse --json flag', () => {
+      const options = parseListOptions(['--json']);
+      expect(options.json).toBe(true);
+    });
+
+    it('should parse combined --json and -g flags', () => {
+      const options = parseListOptions(['-g', '--json']);
+      expect(options.global).toBe(true);
+      expect(options.json).toBe(true);
+    });
+
     it('should stop collecting agents at next flag', () => {
       const options = parseListOptions(['-a', 'claude-code', '-g']);
       expect(options.agent).toEqual(['claude-code']);
@@ -75,6 +86,64 @@ describe('list command', () => {
       const result = runCli(['ls'], testDir);
       expect(result.stdout).toContain('No project skills found');
       expect(result.exitCode).toBe(0);
+    });
+
+    it('should output empty JSON array when no skills', () => {
+      const result = runCli(['list', '--json'], testDir);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed).toEqual([]);
+    });
+
+    it('should output valid JSON with --json flag', () => {
+      const skillDir = join(testDir, '.agents', 'skills', 'json-skill');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: json-skill
+description: A skill for JSON testing
+---
+
+# JSON Skill
+`
+      );
+
+      const result = runCli(['list', '--json'], testDir);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].name).toBe('json-skill');
+      expect(parsed[0].path).toContain('json-skill');
+      expect(parsed[0].scope).toBe('project');
+      expect(Array.isArray(parsed[0].agents)).toBe(true);
+      // No ANSI codes in JSON output
+      expect(result.stdout).not.toMatch(/\x1b\[/);
+    });
+
+    it('should output multiple skills as JSON array', () => {
+      const skill1Dir = join(testDir, '.agents', 'skills', 'skill-alpha');
+      const skill2Dir = join(testDir, '.agents', 'skills', 'skill-beta');
+      mkdirSync(skill1Dir, { recursive: true });
+      mkdirSync(skill2Dir, { recursive: true });
+
+      writeFileSync(
+        join(skill1Dir, 'SKILL.md'),
+        `---\nname: skill-alpha\ndescription: Alpha\n---\n# Alpha\n`
+      );
+      writeFileSync(
+        join(skill2Dir, 'SKILL.md'),
+        `---\nname: skill-beta\ndescription: Beta\n---\n# Beta\n`
+      );
+
+      const result = runCli(['list', '--json'], testDir);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.length).toBe(2);
+      const names = parsed.map((s: any) => s.name);
+      expect(names).toContain('skill-alpha');
+      expect(names).toContain('skill-beta');
     });
 
     it('should show message when no project skills found', () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -14,6 +14,7 @@ const YELLOW = '\x1b[33m';
 interface ListOptions {
   global?: boolean;
   agent?: string[];
+  json?: boolean;
 }
 
 /**
@@ -49,6 +50,8 @@ export function parseListOptions(args: string[]): ListOptions {
     const arg = args[i];
     if (arg === '-g' || arg === '--global') {
       options.global = true;
+    } else if (arg === '--json') {
+      options.json = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       // Collect all following arguments until next flag
@@ -87,6 +90,18 @@ export async function runList(args: string[]): Promise<void> {
     agentFilter,
   });
 
+  // JSON output mode: structured, no ANSI, untruncated agent lists
+  if (options.json) {
+    const jsonOutput = installedSkills.map((skill) => ({
+      name: skill.name,
+      path: skill.canonicalPath,
+      scope: skill.scope,
+      agents: skill.agents.map((a) => agents[a].displayName),
+    }));
+    console.log(JSON.stringify(jsonOutput, null, 2));
+    return;
+  }
+
   // Fetch lock entries to get plugin grouping info
   const lockedSkills = await getAllLockedSkills();
 
@@ -94,6 +109,10 @@ export async function runList(args: string[]): Promise<void> {
   const scopeLabel = scope ? 'Global' : 'Project';
 
   if (installedSkills.length === 0) {
+    if (options.json) {
+      console.log('[]');
+      return;
+    }
     console.log(`${DIM}No ${scopeLabel.toLowerCase()} skills found.${RESET}`);
     if (scope) {
       console.log(`${DIM}Try listing project skills without -g${RESET}`);


### PR DESCRIPTION
Closes #527

## Summary

Adds a `--json` flag to `skills list` (and `skills ls`) that outputs structured JSON to stdout. This enables editor extensions, CI scripts, and other tooling to reliably consume skill data without parsing ANSI-colored text.

## Output format

```bash
$ npx skills list --json
```

```json
[
  {
    "name": "my-skill",
    "path": "/Users/alice/.agents/skills/my-skill",
    "scope": "global",
    "agents": ["Claude Code", "Cursor", "Cline", "...all agents, untruncated"]
  }
]
```

Key properties (per #527):
- No ANSI escape codes in output
- Full, untruncated agent list (no `+N more` truncation)
- Empty array `[]` when no skills found (exit code 0)
- Works with `-g` and `-a` flags

## Changes

| File | Change |
|------|--------|
| `src/list.ts` | Parse `--json` option, output JSON array before human-readable path |
| `src/cli.ts` | Add `--json` to help text and examples |
| `src/list.test.ts` | 5 new tests (option parsing + CLI integration) |

## Tests

All 28 list tests pass (5 new).