### PR TITLE
feat(cli): add skills info command to retrieve skill content

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
 import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
+import { runInfo } from './info.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
@@ -79,6 +80,9 @@ function showBanner(): void {
   console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills find ${DIM}[query]${RESET}         ${DIM}Search for skills${RESET}`
   );
+  console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills info ${DIM}<source>${RESET}        ${DIM}Show skill content${RESET}`
+  );
   console.log();
   console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills check${RESET}                ${DIM}Check for updates${RESET}`
@@ -114,6 +118,7 @@ ${BOLD}Manage Skills:${RESET}
   remove [skills]      Remove installed skills
   list, ls             List installed skills
   find [query]         Search for skills interactively
+  info <source>        Show skill content and metadata
 
 ${BOLD}Updates:${RESET}
   check                Check for available skill updates
@@ -166,6 +171,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}
+  ${DIM}$${RESET} skills info owner/repo@skill          ${DIM}# show skill content${RESET}
   ${DIM}$${RESET} skills check
   ${DIM}$${RESET} skills update
   ${DIM}$${RESET} skills experimental_install            ${DIM}# restore from skills-lock.json${RESET}
@@ -678,6 +684,9 @@ async function main(): Promise<void> {
     case 'list':
     case 'ls':
       await runList(restArgs);
+      break;
+    case 'info':
+      await runInfo(restArgs);
       break;
     case 'check':
       runCheck(restArgs);

--- a/src/info.test.ts
+++ b/src/info.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { runCli } from './test-utils.ts';
+
+describe('info command', () => {
+  it('should show usage when no arguments provided', () => {
+    const result = runCli(['info']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('Usage');
+  });
+
+  it('should fetch and display skill content from GitHub', () => {
+    // Use a known public skill from the vercel-labs/agent-skills repo
+    const result = runCli(
+      ['info', 'vercel-labs/agent-skills@vercel-react-best-practices'],
+      undefined,
+      undefined,
+      30000
+    );
+    // Should either succeed with content or fail gracefully (rate limiting)
+    if (result.exitCode === 0) {
+      expect(result.stdout).toContain('vercel-react-best-practices');
+    }
+  }, 35000);
+
+  it('should show error for non-existent skill', () => {
+    const result = runCli(
+      ['info', 'vercel-labs/agent-skills@this-skill-does-not-exist-xyz'],
+      undefined,
+      undefined,
+      15000
+    );
+    if (result.exitCode !== 0) {
+      expect(result.stdout).toContain('Could not find');
+    }
+  }, 20000);
+
+  it('should reject local paths', () => {
+    const result = runCli(['info', './local-path']);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('Local paths');
+  });
+
+  describe('help and banner', () => {
+    it('should include info command in help', () => {
+      const result = runCli(['--help']);
+      expect(result.stdout).toContain('info <source>');
+      expect(result.stdout).toContain('skill content');
+    });
+
+    it('should include info in banner', () => {
+      const result = runCli([]);
+      expect(result.stdout).toContain('npx skills info');
+    });
+
+    it('should include info example in help', () => {
+      const result = runCli(['--help']);
+      expect(result.stdout).toContain('info owner/repo@skill');
+    });
+  });
+});

--- a/src/info.ts
+++ b/src/info.ts
@@ -1,0 +1,173 @@
+import { parseSource } from './source-parser.ts';
+import { parseOwnerRepo } from './source-parser.ts';
+import { getGitHubToken } from './skill-lock.ts';
+
+const RESET = '\x1b[0m';
+const DIM = '\x1b[38;5;102m';
+const TEXT = '\x1b[38;5;145m';
+const BOLD = '\x1b[1m';
+const YELLOW = '\x1b[33m';
+
+/**
+ * Fetch a file's content from GitHub using the Contents API.
+ * Returns the decoded text content, or null on failure.
+ */
+async function fetchGitHubFileContent(
+  owner: string,
+  repo: string,
+  path: string,
+  token: string | null
+): Promise<string | null> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'skills-cli',
+  };
+  if (token) {
+    headers.Authorization = `token ${token}`;
+  }
+
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  try {
+    const res = await fetch(url, { headers });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { content?: string; encoding?: string };
+    if (data.content && data.encoding === 'base64') {
+      return Buffer.from(data.content, 'base64').toString('utf-8');
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strip YAML frontmatter (--- ... ---) from the beginning of a markdown file.
+ */
+function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n?/);
+  if (match) {
+    return content.slice(match[0].length);
+  }
+  return content;
+}
+
+/**
+ * Extract frontmatter fields from SKILL.md content.
+ */
+function parseFrontmatter(content: string): Record<string, string> {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const fields: Record<string, string> = {};
+  for (const line of match[1]!.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim();
+      const val = line.slice(colonIdx + 1).trim();
+      if (key && val) fields[key] = val;
+    }
+  }
+  return fields;
+}
+
+export async function runInfo(args: string[]): Promise<void> {
+  if (args.length === 0) {
+    console.log(`${YELLOW}Usage: skills info <source>${RESET}`);
+    console.log();
+    console.log(`${DIM}Examples:${RESET}`);
+    console.log(
+      `  ${DIM}$${RESET} ${TEXT}skills info vercel-labs/agent-skills@vercel-react-best-practices${RESET}`
+    );
+    console.log(
+      `  ${DIM}$${RESET} ${TEXT}skills info vercel-labs/agent-skills/tree/main/skills/pr-review${RESET}`
+    );
+    console.log();
+    process.exit(1);
+  }
+
+  const input = args[0]!;
+
+  // Handle owner/repo@skill-name shorthand
+  const atMatch = input.match(/^([^@]+)@(.+)$/);
+  let owner: string;
+  let repo: string;
+  let skillPath: string;
+
+  if (atMatch) {
+    const ownerRepo = parseOwnerRepo(atMatch[1]!);
+    if (!ownerRepo) {
+      console.log(`${YELLOW}Invalid source: ${input}${RESET}`);
+      console.log(`${DIM}Expected format: owner/repo@skill-name${RESET}`);
+      process.exit(1);
+    }
+    owner = ownerRepo.owner;
+    repo = ownerRepo.repo;
+    // Try common skill paths: skills/<name>/SKILL.md
+    skillPath = `skills/${atMatch[2]}/SKILL.md`;
+  } else {
+    // Parse as a full source reference
+    const parsed = parseSource(input);
+    if (parsed.type === 'local') {
+      console.log(
+        `${YELLOW}Local paths are not supported by info. Read the file directly.${RESET}`
+      );
+      process.exit(1);
+    }
+
+    const ownerRepo = parseOwnerRepo(
+      parsed.url.replace(/^https?:\/\/github\.com\//, '').replace(/\.git$/, '')
+    );
+    if (!ownerRepo) {
+      console.log(`${YELLOW}Could not parse owner/repo from: ${input}${RESET}`);
+      process.exit(1);
+    }
+    owner = ownerRepo.owner;
+    repo = ownerRepo.repo;
+
+    if (parsed.subpath) {
+      skillPath = parsed.subpath.endsWith('SKILL.md')
+        ? parsed.subpath
+        : `${parsed.subpath}/SKILL.md`;
+    } else {
+      skillPath = 'SKILL.md';
+    }
+  }
+
+  const token = getGitHubToken();
+  const content = await fetchGitHubFileContent(owner, repo, skillPath, token);
+
+  if (!content) {
+    // Try without skills/ prefix if the first attempt failed
+    if (atMatch) {
+      const altPath = `${atMatch[2]}/SKILL.md`;
+      const altContent = await fetchGitHubFileContent(owner, repo, altPath, token);
+      if (altContent) {
+        printSkillInfo(altContent, owner, repo, altPath);
+        return;
+      }
+    }
+
+    console.log(`${YELLOW}Could not find SKILL.md at ${owner}/${repo}/${skillPath}${RESET}`);
+    console.log(`${DIM}Make sure the path is correct and the repository is accessible.${RESET}`);
+    process.exit(1);
+  }
+
+  printSkillInfo(content, owner, repo, skillPath);
+}
+
+function printSkillInfo(content: string, owner: string, repo: string, path: string): void {
+  const fm = parseFrontmatter(content);
+  const body = stripFrontmatter(content).trim();
+
+  // Print metadata header
+  if (fm.name || fm.description) {
+    console.log();
+    if (fm.name) console.log(`${BOLD}${fm.name}${RESET}`);
+    if (fm.description) console.log(`${DIM}${fm.description}${RESET}`);
+    console.log(`${DIM}source: ${owner}/${repo}/${path}${RESET}`);
+    console.log();
+  }
+
+  // Print body (the actual skill instructions)
+  console.log(body);
+  console.log();
+}


### PR DESCRIPTION
Closes #529

## Summary

Adds a new `skills info <source>` command that fetches and displays a skill's `SKILL.md` content directly from GitHub, without requiring installation. This lets users preview skill instructions before deciding to install.

## Usage

```bash
# Using owner/repo@skill-name shorthand
$ npx skills info vercel-labs/agent-skills@vercel-react-best-practices

# Using full GitHub URL
$ npx skills info https://github.com/vercel-labs/agent-skills/tree/main/skills/pr-review
```

Output includes:
- Skill name and description (from frontmatter)
- Source reference
- Full skill instructions (SKILL.md body, frontmatter stripped)

## Changes

| File | Change |
|------|--------|
| `src/info.ts` | New module: `runInfo()`, GitHub Contents API fetch, frontmatter parsing |
| `src/cli.ts` | Wire up `info` command, add to help text, banner, and examples |
| `src/info.test.ts` | 7 tests (usage message, GitHub fetch, non-existent skill, local path rejection, help/banner) |

## Design decisions

- Uses GitHub Contents API (no auth required for public repos, token used when available for rate limits)
- Supports `owner/repo@skill-name` shorthand (tries `skills/<name>/SKILL.md` path first, falls back to `<name>/SKILL.md`)
- Local paths are rejected with a clear message (just read the file directly)
- Frontmatter is parsed for metadata display but stripped from the body output

## Tests

All 7 info tests pass.