### PR TITLE
fix: store relative path for local sources in skills-lock

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { sep } from 'path';
+import { relative, sep } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
@@ -1532,10 +1532,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
             const computedHash = await computeSkillFolderHash(skill.path);
+            // For local sources, store relative path instead of absolute
+            const lockSource =
+              parsed.type === 'local' && parsed.url
+                ? relative(cwd || process.cwd(), parsed.url).replace(/\\/g, '/') || '.'
+                : normalizedSource || parsed.url;
             await addSkillToLocalLock(
               skill.name,
               {
-                source: lockSource || parsed.url,
+                source: lockSource,
                 sourceType: parsed.type,
                 computedHash,
               },


### PR DESCRIPTION
## Summary

Fixes #561 — when installing a skill from a local path (`npx skills add ./docs`), the lock file now stores a relative path instead of an absolute one.

### Before
```json
{
  "source": "C:\\Users\\myUser\\code\\skills\\docs",
  "sourceType": "local"
}
```

### After
```json
{
  "source": "docs",
  "sourceType": "local"
}
```

### Root Cause

`parseSource()` resolves local paths to absolute via `path.resolve()`. This absolute path was stored directly as `source` in the local lock file.

### Fix

When `sourceType` is `local`, convert the absolute path to a relative path (relative to `cwd`) using `path.relative()` before writing to the lock file. Backslashes are normalized to forward slashes for cross-platform compatibility.

### Changes
- `src/add.ts`: use `relative()` for local source paths in lock file entries