### PR TITLE
fix: check/update reads both global and project-level lock files

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1514,12 +1514,26 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
             const computedHash = await computeSkillFolderHash(skill.path);
+            const skillPathValue = skillFiles[skill.name];
+
+            // Fetch GitHub tree SHA for remote change detection
+            let skillFolderHash: string | undefined;
+            if (parsed.type === 'github' && normalizedSource && skillPathValue) {
+              const token = getGitHubToken();
+              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token);
+              if (hash) skillFolderHash = hash;
+            }
+
             await addSkillToLocalLock(
               skill.name,
               {
                 source: normalizedSource || parsed.url,
                 sourceType: parsed.type,
                 computedHash,
+                skillFolderHash,
+                skillPath: skillPathValue,
+                ref: parsed.ref,
+                sourceUrl: parsed.url,
               },
               cwd
             );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { readLocalLock } from './local-lock.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -395,9 +396,17 @@ async function runCheck(args: string[] = []): Promise<void> {
   console.log();
 
   const lock = readSkillLock();
-  const skillNames = Object.keys(lock.skills);
+  const globalSkillNames = Object.keys(lock.skills);
 
-  if (skillNames.length === 0) {
+  // Also check local (project-scoped) lock file
+  const localLock = await readLocalLock();
+  const localSkillNames = Object.keys(localLock.skills).filter(
+    (name) => !lock.skills[name] // avoid duplicates with global lock
+  );
+
+  const allSkillCount = globalSkillNames.length + localSkillNames.length;
+
+  if (allSkillCount === 0) {
     console.log(`${DIM}No skills tracked in lock file.${RESET}`);
     console.log(`${DIM}Install skills with${RESET} ${TEXT}npx skills add <package>${RESET}`);
     return;
@@ -410,7 +419,8 @@ async function runCheck(args: string[] = []): Promise<void> {
   const skillsBySource = new Map<string, Array<{ name: string; entry: SkillLockEntry }>>();
   const skipped: SkippedSkill[] = [];
 
-  for (const skillName of skillNames) {
+  // Add global skills
+  for (const skillName of globalSkillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
@@ -425,7 +435,39 @@ async function runCheck(args: string[] = []): Promise<void> {
     skillsBySource.set(entry.source, existing);
   }
 
-  const totalSkills = skillNames.length - skipped.length;
+  // Add local skills with GitHub tracking
+  for (const skillName of localSkillNames) {
+    const localEntry = localLock.skills[skillName];
+    if (!localEntry) continue;
+
+    if (!localEntry.skillFolderHash || !localEntry.skillPath) {
+      if (localEntry.sourceUrl) {
+        skipped.push({
+          name: skillName,
+          reason: 'No remote hash tracking (reinstall to enable)',
+          sourceUrl: localEntry.sourceUrl,
+        });
+      }
+      continue;
+    }
+
+    // Convert to SkillLockEntry-compatible for uniform processing
+    const entry: SkillLockEntry = {
+      source: localEntry.source,
+      sourceType: localEntry.sourceType,
+      sourceUrl: localEntry.sourceUrl || '',
+      skillPath: localEntry.skillPath,
+      skillFolderHash: localEntry.skillFolderHash,
+      installedAt: '',
+      updatedAt: '',
+    };
+
+    const existing = skillsBySource.get(localEntry.source) || [];
+    existing.push({ name: skillName, entry });
+    skillsBySource.set(localEntry.source, existing);
+  }
+
+  const totalSkills = allSkillCount - skipped.length;
   if (totalSkills === 0) {
     console.log(`${DIM}No GitHub skills to check.${RESET}`);
     printSkippedSkills(skipped);
@@ -500,9 +542,17 @@ async function runUpdate(): Promise<void> {
   console.log();
 
   const lock = readSkillLock();
-  const skillNames = Object.keys(lock.skills);
+  const globalSkillNames = Object.keys(lock.skills);
 
-  if (skillNames.length === 0) {
+  // Also check local (project-scoped) lock file
+  const localLock = await readLocalLock();
+  const localSkillNames = Object.keys(localLock.skills).filter(
+    (name) => !lock.skills[name] // avoid duplicates with global lock
+  );
+
+  const allSkillCount = globalSkillNames.length + localSkillNames.length;
+
+  if (allSkillCount === 0) {
     console.log(`${DIM}No skills tracked in lock file.${RESET}`);
     console.log(`${DIM}Install skills with${RESET} ${TEXT}npx skills add <package>${RESET}`);
     return;
@@ -515,7 +565,8 @@ async function runUpdate(): Promise<void> {
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
 
-  for (const skillName of skillNames) {
+  // Check global skills
+  for (const skillName of globalSkillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
@@ -536,7 +587,47 @@ async function runUpdate(): Promise<void> {
     }
   }
 
-  const checkedCount = skillNames.length - skipped.length;
+  // Check local (project-scoped) skills with GitHub tracking
+  for (const skillName of localSkillNames) {
+    const localEntry = localLock.skills[skillName];
+    if (!localEntry) continue;
+
+    // Only check skills with GitHub tree SHA tracking
+    if (!localEntry.skillFolderHash || !localEntry.skillPath) {
+      if (localEntry.sourceUrl) {
+        skipped.push({
+          name: skillName,
+          reason: 'No remote hash tracking (reinstall to enable)',
+          sourceUrl: localEntry.sourceUrl,
+        });
+      }
+      continue;
+    }
+
+    try {
+      const latestHash = await fetchSkillFolderHash(localEntry.source, localEntry.skillPath, token);
+
+      if (latestHash && latestHash !== localEntry.skillFolderHash) {
+        updates.push({
+          name: skillName,
+          source: localEntry.source,
+          entry: {
+            source: localEntry.source,
+            sourceType: localEntry.sourceType,
+            sourceUrl: localEntry.sourceUrl || '',
+            skillPath: localEntry.skillPath,
+            skillFolderHash: localEntry.skillFolderHash,
+            installedAt: '',
+            updatedAt: '',
+          },
+        });
+      }
+    } catch {
+      // Skip skills that fail to check
+    }
+  }
+
+  const checkedCount = allSkillCount - skipped.length;
 
   if (checkedCount === 0) {
     console.log(`${DIM}No skills to check.${RESET}`);

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -23,6 +23,14 @@ export interface LocalSkillLockEntry {
    * computes the hash from actual file contents on disk.
    */
   computedHash: string;
+  /** GitHub tree SHA for the skill folder (for remote change detection) */
+  skillFolderHash?: string;
+  /** Path to SKILL.md relative to repo root */
+  skillPath?: string;
+  /** Git ref (branch/tag) used during installation */
+  ref?: string;
+  /** The original URL used to install the skill */
+  sourceUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #484 — `skills check` and `skills update` now detect remote changes for project-scoped (non-global) skills.

## Problem

Previously, `skills check` and `skills update` only read the global lock file (`~/.agents/.skill-lock.json`). Skills installed without `-g` are tracked in the local lock file (`./skills-lock.json`) which uses a content-based hash (`computedHash`) but had no GitHub tree SHA for remote change detection. This meant locally-installed skills were invisible to the update system.

## Changes

### `src/local-lock.ts`
- Extended `LocalSkillLockEntry` with optional `skillFolderHash`, `skillPath`, `ref`, and `sourceUrl` fields

### `src/add.ts`
- During project-scoped installation from GitHub sources, fetch and store the GitHub tree SHA (`skillFolderHash`) alongside the existing `computedHash`
- Also store `skillPath`, `ref`, and `sourceUrl` for complete tracking metadata

### `src/cli.ts`
- `runCheck()`: Read both global and local lock files; convert local entries with GitHub tracking into `SkillLockEntry`-compatible objects for uniform processing
- `runUpdate()`: Same dual-lock approach; local skills with `skillFolderHash` are now checked against GitHub for remote changes
- Skills in local lock without GitHub tracking are reported as skipped with a helpful message

## Backward Compatibility

- Existing local lock files without the new fields continue to work — skills are simply skipped with a "reinstall to enable" message
- No changes to the global lock format
- The new fields are all optional in the interface