### PR TITLE
feat: Add Baidu.Comate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [37 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [38 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -217,6 +217,7 @@ Skills can be installed to any of these agents:
 | Cline | `cline` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
+| Comate | `comate` | `.comate/skills/` | `~/.comate/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
 | Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
@@ -322,6 +323,7 @@ The CLI searches for skills in these locations within a repository:
 - `.claude/skills/`
 - `./skills/`
 - `.codebuddy/skills/`
+- `.comate/skills/`
 - `.commandcode/skills/`
 - `.continue/skills/`
 - `.cortex/skills/`

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cline",
     "codebuddy",
     "codex",
+    "comate",
     "command-code",
     "continue",
     "cortex",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -103,6 +103,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(codexHome) || existsSync('/etc/codex');
     },
   },
+  comate: {
+    name: 'comate',
+    displayName: 'Comate',
+    skillsDir: '.comate/skills',
+    globalSkillsDir: join(home, '.comate/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.comate'));
+    },
+  },
   'command-code': {
     name: 'command-code',
     displayName: 'Command Code',

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export type AgentType =
   | 'cline'
   | 'codebuddy'
   | 'codex'
+  | 'comate'
   | 'command-code'
   | 'continue'
   | 'cortex'


### PR DESCRIPTION
This PR adds support for Comate skills to align with the directory conventions documented.

### Motivation
Support the Baidu.Comate product by adding a new agent type that uses the same project skill path but a separate global skills directory at ~/.comate/skills.

### Description
1. Add `comate` to the AgentType union in src/types.ts.
2. Add a new agent configuration for `comate` in src/agents.ts with skillsDir set to .comate/skills and globalSkillsDir set to join(home, '.comate/skills'), and a detectInstalled check against ~/.comate.
3. Document the new `comate` entry in the supported agents table in README.md.

### Reference
1. Official website: https://comate.baidu.com/
2. Skills documentation: https://cloud.baidu.com/doc/COMATE/s/Nmma28iqe