### PR TITLE
feat: add --dev flag for skill developers

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -158,6 +158,41 @@ description: Test
     expect(result.stdout).toContain('No project skills found in skills-lock.json');
   });
 
+  it('should install skill from local path with --link flag', () => {
+    const skillDir = join(testDir, 'skills', 'link-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: link-skill
+description: A skill installed via link mode
+---
+
+# Link Skill
+
+Instructions here.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(
+      ['add', testDir, '--link', '-y', '-g', '--agent', 'claude-code'],
+      targetDir
+    );
+    expect(result.stdout).toContain('link-skill');
+    expect(result.stdout).toContain('linked');
+    expect(result.stdout).toContain('Done!');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('should error when --link is used with remote source', () => {
+    const result = runCli(['add', 'vercel-labs/agent-skills', '--link', '-y'], testDir);
+    expect(result.stdout).toContain('--link flag requires a local path');
+    expect(result.exitCode).toBe(1);
+  });
+
   describe('internal skills', () => {
     it('should skip internal skills by default', () => {
       // Create an internal skill
@@ -388,6 +423,14 @@ describe('parseAddOptions', () => {
     expect(result.options.fullDepth).toBe(true);
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
+  });
+
+  it('should parse --link flag', () => {
+    const result = parseAddOptions(['./my-skills', '--link', '-g', '-y']);
+    expect(result.source).toEqual(['./my-skills']);
+    expect(result.options.link).toBe(true);
+    expect(result.options.global).toBe(true);
+    expect(result.options.yes).toBe(true);
   });
 });
 

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -158,7 +158,7 @@ description: Test
     expect(result.stdout).toContain('No project skills found in skills-lock.json');
   });
 
-  it('should install skill from local path with --link flag', () => {
+  it('should install skill from local path with --dev flag', () => {
     const skillDir = join(testDir, 'skills', 'link-skill');
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(
@@ -178,18 +178,18 @@ Instructions here.
     mkdirSync(targetDir, { recursive: true });
 
     const result = runCli(
-      ['add', testDir, '--link', '-y', '-g', '--agent', 'claude-code'],
+      ['add', testDir, '--dev', '-y', '-g', '--agent', 'claude-code'],
       targetDir
     );
     expect(result.stdout).toContain('link-skill');
-    expect(result.stdout).toContain('linked');
+    expect(result.stdout).toContain('dev');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
   });
 
-  it('should error when --link is used with remote source', () => {
-    const result = runCli(['add', 'vercel-labs/agent-skills', '--link', '-y'], testDir);
-    expect(result.stdout).toContain('--link flag requires a local path');
+  it('should error when --dev is used with remote source', () => {
+    const result = runCli(['add', 'vercel-labs/agent-skills', '--dev', '-y'], testDir);
+    expect(result.stdout).toContain('--dev flag requires a local path');
     expect(result.exitCode).toBe(1);
   });
 
@@ -425,10 +425,10 @@ describe('parseAddOptions', () => {
     expect(result.options.global).toBe(true);
   });
 
-  it('should parse --link flag', () => {
-    const result = parseAddOptions(['./my-skills', '--link', '-g', '-y']);
+  it('should parse --dev flag', () => {
+    const result = parseAddOptions(['./my-skills', '--dev', '-g', '-y']);
     expect(result.source).toEqual(['./my-skills']);
-    expect(result.options.link).toBe(true);
+    expect(result.options.dev).toBe(true);
     expect(result.options.global).toBe(true);
     expect(result.options.yes).toBe(true);
   });

--- a/src/add.ts
+++ b/src/add.ts
@@ -205,12 +205,12 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
   const lines: string[] = [];
   const { universal, symlinked } = splitAgentsByType(targetAgents);
 
-  if (installMode === 'link') {
+  if (installMode === 'dev') {
     if (universal.length > 0) {
       lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
     }
     if (symlinked.length > 0) {
-      lines.push(`  ${pc.dim('link →')} ${formatList(symlinked)}`);
+      lines.push(`  ${pc.dim('dev →')} ${formatList(symlinked)}`);
     }
   } else if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -425,7 +425,7 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
-  link?: boolean;
+  dev?: boolean;
 }
 
 /**
@@ -936,11 +936,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
 
-    // --link requires a local path
-    if (options.link && parsed.type !== 'local') {
+    // --dev requires a local path
+    if (options.dev && parsed.type !== 'local') {
       p.outro(
         pc.red(
-          'The --link flag requires a local path (e.g., ./my-skills or /path/to/repo).\n' +
+          'The --dev flag requires a local path (e.g., ./my-skills or /path/to/repo).\n' +
             'It symlinks agent directories directly to your local clone for development.'
         )
       );
@@ -1261,10 +1261,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       installGlobally = scope as boolean;
     }
 
-    // Determine install mode (symlink vs copy vs link)
-    let installMode: InstallMode = options.link ? 'link' : options.copy ? 'copy' : 'symlink';
+    // Determine install mode (symlink vs copy vs dev)
+    let installMode: InstallMode = options.dev ? 'dev' : options.copy ? 'copy' : 'symlink';
 
-    if (!options.link && !options.copy && !options.yes) {
+    if (!options.dev && !options.copy && !options.yes) {
       const modeOptions: Array<{ value: string; label: string; hint: string }> = [
         {
           value: 'symlink',
@@ -1274,12 +1274,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         { value: 'copy', label: 'Copy to all agents', hint: 'Independent copies for each agent' },
       ];
 
-      // Only show link option for local sources
+      // Only show dev option for local sources
       if (parsed.type === 'local') {
         modeOptions.push({
-          value: 'link',
-          label: 'Link to source (Developer)',
-          hint: 'Symlink directly to local clone, edits are live',
+          value: 'dev',
+          label: 'Dev mode',
+          hint: 'Symlink to local clone — edits are live',
         });
       }
 
@@ -1505,8 +1505,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Add to skill lock file for update tracking (only for global installs, skip link mode)
-    if (successful.length > 0 && installGlobally && normalizedSource && installMode !== 'link') {
+    // Add to skill lock file for update tracking (only for global installs, skip dev mode)
+    if (successful.length > 0 && installGlobally && normalizedSource && installMode !== 'dev') {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
@@ -1536,8 +1536,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Add to local lock file for project-scoped installs (skip link mode)
-    if (successful.length > 0 && !installGlobally && installMode !== 'link') {
+    // Add to local lock file for project-scoped installs (skip dev mode)
+    if (successful.length > 0 && !installGlobally && installMode !== 'dev') {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
@@ -1602,13 +1602,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               const shortPath = shortenPath(r.path, cwd);
               resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
             }
-          } else if (firstResult.mode === 'link') {
-            // Link mode: show the source path being linked to
+          } else if (firstResult.mode === 'dev') {
+            // Dev mode: show the source path being linked to
             if (firstResult.canonicalPath) {
               const shortPath = shortenPath(firstResult.canonicalPath, cwd);
-              resultLines.push(`${pc.green('✓')} ${shortPath} ${pc.dim('(linked)')}`);
+              resultLines.push(`${pc.green('✓')} ${shortPath} ${pc.dim('(dev)')}`);
             } else {
-              resultLines.push(`${pc.green('✓')} ${entry.skill} ${pc.dim('(linked)')}`);
+              resultLines.push(`${pc.green('✓')} ${entry.skill} ${pc.dim('(dev)')}`);
             }
             resultLines.push(...buildResultLines(skillResults, targetAgents));
           } else {
@@ -1820,8 +1820,8 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
-    } else if (arg === '--link') {
-      options.link = true;
+    } else if (arg === '--dev') {
+      options.dev = true;
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/add.ts
+++ b/src/add.ts
@@ -205,7 +205,14 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
   const lines: string[] = [];
   const { universal, symlinked } = splitAgentsByType(targetAgents);
 
-  if (installMode === 'symlink') {
+  if (installMode === 'link') {
+    if (universal.length > 0) {
+      lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
+    }
+    if (symlinked.length > 0) {
+      lines.push(`  ${pc.dim('link →')} ${formatList(symlinked)}`);
+    }
+  } else if (installMode === 'symlink') {
     if (universal.length > 0) {
       lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
     }
@@ -418,6 +425,7 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  link?: boolean;
 }
 
 /**
@@ -928,6 +936,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
 
+    // --link requires a local path
+    if (options.link && parsed.type !== 'local') {
+      p.outro(
+        pc.red(
+          'The --link flag requires a local path (e.g., ./my-skills or /path/to/repo).\n' +
+            'It symlinks agent directories directly to your local clone for development.'
+        )
+      );
+      process.exit(1);
+    }
+
     // Handle well-known skills from arbitrary URLs
     if (parsed.type === 'well-known') {
       await handleWellKnownSkills(source, parsed.url, options, spinner);
@@ -1242,20 +1261,31 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       installGlobally = scope as boolean;
     }
 
-    // Determine install mode (symlink vs copy)
-    let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
+    // Determine install mode (symlink vs copy vs link)
+    let installMode: InstallMode = options.link ? 'link' : options.copy ? 'copy' : 'symlink';
 
-    if (!options.copy && !options.yes) {
+    if (!options.link && !options.copy && !options.yes) {
+      const modeOptions: Array<{ value: string; label: string; hint: string }> = [
+        {
+          value: 'symlink',
+          label: 'Symlink (Recommended)',
+          hint: 'Single source of truth, easy updates',
+        },
+        { value: 'copy', label: 'Copy to all agents', hint: 'Independent copies for each agent' },
+      ];
+
+      // Only show link option for local sources
+      if (parsed.type === 'local') {
+        modeOptions.push({
+          value: 'link',
+          label: 'Link to source (Developer)',
+          hint: 'Symlink directly to local clone, edits are live',
+        });
+      }
+
       const modeChoice = await p.select({
         message: 'Installation method',
-        options: [
-          {
-            value: 'symlink',
-            label: 'Symlink (Recommended)',
-            hint: 'Single source of truth, easy updates',
-          },
-          { value: 'copy', label: 'Copy to all agents', hint: 'Independent copies for each agent' },
-        ],
+        options: modeOptions,
       });
 
       if (p.isCancel(modeChoice)) {
@@ -1475,8 +1505,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Add to skill lock file for update tracking (only for global installs)
-    if (successful.length > 0 && installGlobally && normalizedSource) {
+    // Add to skill lock file for update tracking (only for global installs, skip link mode)
+    if (successful.length > 0 && installGlobally && normalizedSource && installMode !== 'link') {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
@@ -1506,8 +1536,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Add to local lock file for project-scoped installs
-    if (successful.length > 0 && !installGlobally) {
+    // Add to local lock file for project-scoped installs (skip link mode)
+    if (successful.length > 0 && !installGlobally && installMode !== 'link') {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
@@ -1572,6 +1602,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               const shortPath = shortenPath(r.path, cwd);
               resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
             }
+          } else if (firstResult.mode === 'link') {
+            // Link mode: show the source path being linked to
+            if (firstResult.canonicalPath) {
+              const shortPath = shortenPath(firstResult.canonicalPath, cwd);
+              resultLines.push(`${pc.green('✓')} ${shortPath} ${pc.dim('(linked)')}`);
+            } else {
+              resultLines.push(`${pc.green('✓')} ${entry.skill} ${pc.dim('(linked)')}`);
+            }
+            resultLines.push(...buildResultLines(skillResults, targetAgents));
           } else {
             // Symlink mode: show canonical path and universal/symlinked agents
             if (firstResult.canonicalPath) {
@@ -1781,6 +1820,8 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--link') {
+      options.link = true;
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,6 +131,7 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
+  --link                 Symlink directly to local source (for skill developers)
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,7 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
-  --link                 Symlink directly to local source (for skill developers)
+  --dev                  Symlink directly to local source (for skill developers)
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -19,7 +19,7 @@ import { agents, detectInstalledAgents, isUniversalAgent } from './agents.ts';
 import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
 import { parseSkillMd } from './skills.ts';
 
-export type InstallMode = 'symlink' | 'copy' | 'link';
+export type InstallMode = 'symlink' | 'copy' | 'dev';
 
 interface InstallResult {
   success: boolean;
@@ -274,7 +274,7 @@ export async function installSkillForAgent(
     }
 
     // Link mode: symlink canonical location directly to source path (no copy)
-    if (installMode === 'link') {
+    if (installMode === 'dev') {
       // Remove existing canonical dir (could be a previous copy or broken symlink)
       try {
         await rm(canonicalDir, { recursive: true, force: true });
@@ -288,7 +288,7 @@ export async function installSkillForAgent(
         return {
           success: false,
           path: canonicalDir,
-          mode: 'link',
+          mode: 'dev',
           error: 'Failed to create symlink to source directory',
         };
       }
@@ -300,7 +300,7 @@ export async function installSkillForAgent(
           success: true,
           path: canonicalDir,
           canonicalPath: canonicalDir,
-          mode: 'link',
+          mode: 'dev',
         };
       }
 
@@ -310,7 +310,7 @@ export async function installSkillForAgent(
         success: true,
         path: agentDir,
         canonicalPath: canonicalDir,
-        mode: 'link',
+        mode: 'dev',
         symlinkFailed: !agentSymlinkCreated,
       };
     }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -19,7 +19,7 @@ import { agents, detectInstalledAgents, isUniversalAgent } from './agents.ts';
 import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
 import { parseSkillMd } from './skills.ts';
 
-export type InstallMode = 'symlink' | 'copy';
+export type InstallMode = 'symlink' | 'copy' | 'link';
 
 interface InstallResult {
   success: boolean;
@@ -270,6 +270,48 @@ export async function installSkillForAgent(
         success: true,
         path: agentDir,
         mode: 'copy',
+      };
+    }
+
+    // Link mode: symlink canonical location directly to source path (no copy)
+    if (installMode === 'link') {
+      // Remove existing canonical dir (could be a previous copy or broken symlink)
+      try {
+        await rm(canonicalDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+      await mkdir(canonicalBase, { recursive: true });
+
+      const symlinkCreated = await createSymlink(skill.path, canonicalDir);
+      if (!symlinkCreated) {
+        return {
+          success: false,
+          path: canonicalDir,
+          mode: 'link',
+          error: 'Failed to create symlink to source directory',
+        };
+      }
+
+      // For universal agents with global install, the skill is already in the canonical
+      // ~/.agents/skills directory. Skip creating an agent-specific symlink.
+      if (isGlobal && isUniversalAgent(agentType)) {
+        return {
+          success: true,
+          path: canonicalDir,
+          canonicalPath: canonicalDir,
+          mode: 'link',
+        };
+      }
+
+      // Symlink agent dir → canonical dir (which itself points to source)
+      const agentSymlinkCreated = await createSymlink(canonicalDir, agentDir);
+      return {
+        success: true,
+        path: agentDir,
+        canonicalPath: canonicalDir,
+        mode: 'link',
+        symlinkFailed: !agentSymlinkCreated,
       };
     }
 


### PR DESCRIPTION
## Summary

- Adds a `--dev` install mode (`npx skills add ./my-repo --dev -g -y`) that symlinks agent directories directly to the local source repository instead of copying files
- Lets skill maintainers/developers work on skills with live reloading — edits in the source repo are immediately reflected in agent runtimes
- Only works with local paths (errors with a clear message on remote sources)
- Skips lock file tracking for dev-installed skills (local dev doesn't need version tracking)
- Also appears as an interactive option ("Dev mode") when the source is a local path

## Motivation

Skill authors who actively develop and iterate on their skills currently need custom install scripts to symlink their local git clones into agent directories. The existing `symlink` mode copies files to `~/.agents/skills/` and symlinks agent dirs to that copy — which breaks the edit-and-reload workflow because the canonical directory is a copy, not a pointer to the source.

With `--dev`, the canonical directory itself becomes a symlink to the source path, so any edit in the repo is live immediately across all agents.

**Before:**
```bash
# Custom script needed per repo
find "$REPO" -name "SKILL.md" | while read f; do
  ln -sf "$(dirname "$f")" ~/.claude/skills/$(basename "$(dirname "$f")")
done
```

**After:**
```bash
npx skills add ./my-skills-repo --dev -g --skill '*' --agent '*' -y
```

## Test plan

- [x] `parseAddOptions` correctly parses `--dev` flag
- [x] `--dev` with remote source shows clear error message
- [x] `--dev` with local path installs skills as symlinks and shows "(dev)" in output
- [x] All 370 existing tests continue to pass
- [x] Pre-commit hooks pass (prettier via lint-staged)