### PR TITLE
fix: skip symlink/copy prompt when all agents share one directory

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -629,7 +629,11 @@ async function handleWellKnownSkills(
   // Determine install mode (symlink vs copy)
   let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
-  if (!options.copy && !options.yes) {
+  // Only prompt for install mode when there are multiple unique target directories.
+  // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
+  const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+
+  if (!options.copy && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
       message: 'Installation method',
       options: [
@@ -648,6 +652,9 @@ async function handleWellKnownSkills(
     }
 
     installMode = modeChoice as InstallMode;
+  } else if (uniqueDirs.size <= 1) {
+    // Single target directory — default to copy (no symlink needed)
+    installMode = 'copy';
   }
 
   const cwd = process.cwd();
@@ -1245,7 +1252,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Determine install mode (symlink vs copy)
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
-    if (!options.copy && !options.yes) {
+    // Only prompt for install mode when there are multiple unique target directories.
+    // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
+    const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+
+    if (!options.copy && !options.yes && uniqueDirs.size > 1) {
       const modeChoice = await p.select({
         message: 'Installation method',
         options: [
@@ -1265,6 +1276,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       installMode = modeChoice as InstallMode;
+    } else if (uniqueDirs.size <= 1) {
+      // Single target directory — default to copy (no symlink needed)
+      installMode = 'copy';
     }
 
     const cwd = process.cwd();


### PR DESCRIPTION
## Summary

Skip the installation method (symlink vs copy) prompt when all selected agents resolve to the same `skillsDir`. In this case, the choice is meaningless since there's only one target folder.

Fixes #519

## Changes

- **`src/add.ts`**: In both interactive install flows, compute unique target directories from selected agents. Only show the symlink/copy prompt when `uniqueDirs.size > 1`. Default to `copy` when there's a single directory.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Select only universal agents (all `.agents/skills`) | Prompt shown | Prompt skipped, defaults to copy |
| Select mixed agents (`.agents/skills` + `.claude/skills`) | Prompt shown | Prompt shown (as before) |
| `--copy` flag | No prompt | No prompt (unchanged) |
| `--yes` flag | No prompt | No prompt (unchanged) |