### PR TITLE
fix: skip broken symlinks during skill installation

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -347,14 +347,29 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
         if (entry.isDirectory()) {
           await copyDirectory(srcPath, destPath);
         } else {
-          await cp(srcPath, destPath, {
-            // If the file is a symlink to elsewhere in a remote skill, it may not
-            // resolve correctly once it has been copied to the local location.
-            // `dereference: true` tells Node to copy the file instead of copying
-            // the symlink. `recursive: true` handles symlinks pointing to directories.
-            dereference: true,
-            recursive: true,
-          });
+          try {
+            await cp(srcPath, destPath, {
+              // If the file is a symlink to elsewhere in a remote skill, it may not
+              // resolve correctly once it has been copied to the local location.
+              // `dereference: true` tells Node to copy the file instead of copying
+              // the symlink. `recursive: true` handles symlinks pointing to directories.
+              dereference: true,
+              recursive: true,
+            });
+          } catch (err: unknown) {
+            // Skip broken symlinks (e.g., pointing to absolute paths on another machine)
+            // instead of aborting the entire install.
+            if (
+              err instanceof Error &&
+              'code' in err &&
+              (err as NodeJS.ErrnoException).code === 'ENOENT' &&
+              entry.isSymbolicLink()
+            ) {
+              console.warn(`Skipping broken symlink: ${srcPath}`);
+            } else {
+              throw err;
+            }
+          }
         }
       })
   );


### PR DESCRIPTION
## Summary

When a skill source repo contains symlinks pointing to absolute paths on the author's machine (e.g., `/home/author/project/...`), the install fails with `ENOENT` on other hosts. This change catches the `ENOENT` for broken symbolic links and skips them with a warning instead of aborting the entire install.

Fixes #530

## Changes

- **`src/installer.ts`**: Wrap the `cp()` call in `copyDirectory()` with try/catch. On `ENOENT` + `entry.isSymbolicLink()`, log a warning and skip. All other errors propagate as before.

## Repro

```bash
npx skills add jmagar/claude-homelab@unraid --agent openclaw -y
```

**Before:** `ENOENT: no such file or directory, stat '.../unraid/unraid'` → install aborted
**After:** `Skipping broken symlink: .../unraid/unraid` → install succeeds with remaining files