### PR TITLE
fix: resolve skill folder hash for dot-prefixed paths and non-default branches

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1487,7 +1487,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
               const token = getGitHubToken();
-              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token);
+              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token, parsed.ref);
               if (hash) skillFolderHash = hash;
             }
 
@@ -1497,6 +1497,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               sourceUrl: parsed.url,
               skillPath: skillPathValue,
               skillFolderHash,
+              ref: parsed.ref,
               pluginName: skill.pluginName,
             });
           } catch {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -287,6 +287,8 @@ interface SkillLockEntry {
   skillPath?: string;
   /** GitHub tree SHA for the entire skill folder (v3) */
   skillFolderHash: string;
+  /** Git ref (branch/tag) used during installation */
+  ref?: string;
   installedAt: string;
   updatedAt: string;
 }
@@ -441,7 +443,7 @@ async function runCheck(args: string[] = []): Promise<void> {
   for (const [source, skills] of skillsBySource) {
     for (const { name, entry } of skills) {
       try {
-        const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token);
+        const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token, entry.ref);
 
         if (!latestHash) {
           errors.push({ name, source, error: 'Could not fetch from GitHub' });
@@ -526,7 +528,7 @@ async function runUpdate(): Promise<void> {
     }
 
     try {
-      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
+      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token, entry.ref);
 
       if (latestHash && latestHash !== entry.skillFolderHash) {
         updates.push({ name: skillName, source: entry.source, entry });

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -26,6 +26,8 @@ export interface SkillLockEntry {
    * Fetched via GitHub Trees API by the telemetry server.
    */
   skillFolderHash: string;
+  /** Git ref (branch/tag) used during installation */
+  ref?: string;
   /** ISO timestamp when the skill was first installed */
   installedAt: string;
   /** ISO timestamp when the skill was last updated */
@@ -163,7 +165,8 @@ export function getGitHubToken(): string | null {
 export async function fetchSkillFolderHash(
   ownerRepo: string,
   skillPath: string,
-  token?: string | null
+  token?: string | null,
+  ref?: string | null
 ): Promise<string | null> {
   // Normalize to forward slashes first (for GitHub API compatibility)
   let folderPath = skillPath.replace(/\\/g, '/');
@@ -180,25 +183,30 @@ export async function fetchSkillFolderHash(
     folderPath = folderPath.slice(0, -1);
   }
 
-  const branches = ['main', 'master'];
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json',
+    'User-Agent': 'skills-cli',
+  };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  // Build branch candidates: explicit ref first, then main/master, then default branch from API
+  const branches: string[] = [];
+  if (ref) branches.push(ref);
+  if (!branches.includes('main')) branches.push('main');
+  if (!branches.includes('master')) branches.push('master');
 
   for (const branch of branches) {
     try {
       const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
-      const headers: Record<string, string> = {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'skills-cli',
-      };
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-      }
-
       const response = await fetch(url, { headers });
 
       if (!response.ok) continue;
 
       const data = (await response.json()) as {
         sha: string;
+        truncated?: boolean;
         tree: Array<{ path: string; type: string; sha: string }>;
       };
 
@@ -215,12 +223,103 @@ export async function fetchSkillFolderHash(
       if (folderEntry) {
         return folderEntry.sha;
       }
+
+      // If the response was truncated, the entry might be missing.
+      // Fall back to walking the tree level by level.
+      if (data.truncated) {
+        const result = await walkTreeForPath(ownerRepo, branch, folderPath, headers);
+        if (result) return result;
+      }
     } catch {
       continue;
     }
   }
 
+  // Last resort: ask GitHub for the repo's default branch and try that
+  try {
+    const repoResponse = await fetch(`https://api.github.com/repos/${ownerRepo}`, { headers });
+    if (repoResponse.ok) {
+      const repoData = (await repoResponse.json()) as { default_branch: string };
+      const defaultBranch = repoData.default_branch;
+      if (!branches.includes(defaultBranch)) {
+        const result = await fetchTreeHash(ownerRepo, defaultBranch, folderPath, headers);
+        if (result) return result;
+      }
+    }
+  } catch {
+    // ignore
+  }
+
   return null;
+}
+
+/**
+ * Fetch tree SHA using recursive API, with truncation fallback.
+ */
+async function fetchTreeHash(
+  ownerRepo: string,
+  branch: string,
+  folderPath: string,
+  headers: Record<string, string>
+): Promise<string | null> {
+  try {
+    const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
+    const response = await fetch(url, { headers });
+    if (!response.ok) return null;
+
+    const data = (await response.json()) as {
+      sha: string;
+      truncated?: boolean;
+      tree: Array<{ path: string; type: string; sha: string }>;
+    };
+
+    if (!folderPath) return data.sha;
+
+    const entry = data.tree.find((e) => e.type === 'tree' && e.path === folderPath);
+    if (entry) return entry.sha;
+
+    if (data.truncated) {
+      return await walkTreeForPath(ownerRepo, branch, folderPath, headers);
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/**
+ * Walk the tree level by level to find a nested path.
+ * Used as fallback when the recursive tree response is truncated.
+ */
+async function walkTreeForPath(
+  ownerRepo: string,
+  branch: string,
+  folderPath: string,
+  headers: Record<string, string>
+): Promise<string | null> {
+  const segments = folderPath.split('/');
+  let currentSha = branch;
+
+  for (const segment of segments) {
+    try {
+      const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${currentSha}`;
+      const response = await fetch(url, { headers });
+      if (!response.ok) return null;
+
+      const data = (await response.json()) as {
+        tree: Array<{ path: string; type: string; sha: string }>;
+      };
+
+      const entry = data.tree.find((e) => e.type === 'tree' && e.path === segment);
+      if (!entry) return null;
+
+      currentSha = entry.sha;
+    } catch {
+      return null;
+    }
+  }
+
+  return currentSha;
 }
 
 /**


### PR DESCRIPTION
## Summary

`fetchSkillFolderHash` previously hardcoded `['main', 'master']` as branch candidates and did not handle truncated GitHub Trees API responses. This caused empty `skillFolderHash` for repos with dot-prefixed skill directories (e.g., `.claude/skills/`) and repos using non-default branches.

Fixes #490

## Root cause

1. **Hardcoded branches** — only tried `main` and `master`, ignoring the actual ref used during installation and the repo's configured default branch
2. **No truncation handling** — GitHub Trees API truncates responses for large repos (>100K entries), silently dropping entries including dot-prefixed paths

## Changes

### `src/skill-lock.ts`
- `fetchSkillFolderHash` now accepts optional `ref` parameter, tried first
- Falls back to GitHub `GET /repos/{owner}/{repo}` to discover actual `default_branch`
- When `truncated: true`, walks the tree level-by-level via non-recursive API
- New helper: `walkTreeForPath()` for level-by-level tree traversal
- New helper: `fetchTreeHash()` for recursive+fallback fetch
- `SkillLockEntry` gains optional `ref` field

### `src/add.ts`
- Passes `parsed.ref` to `fetchSkillFolderHash` during install
- Stores `ref` in lock file entry

### `src/cli.ts`
- Passes `entry.ref` to `fetchSkillFolderHash` in check/update commands
- `SkillLockEntry` interface updated with `ref?` field

## Backward compatibility

- `ref` is optional everywhere — existing lock files without it continue to work
- Branch resolution order: explicit ref → main → master → API default branch