### PR TITLE
fix: clean up skills-lock.json (project) entries when removing skills

### DIFF
--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,23 +9,6 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
-Package: @clack/core@0.4.1
-License: MIT
-Repository: https://github.com/natemoo-re/clack
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) Nate Moore
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -101,35 +84,6 @@ Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-================================================================================
-Package: sisteransi@1.0.5
-License: MIT
-Repository: https://github.com/terkelg/sisteransi
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, runCliWithInput } from './test-utils.js';
@@ -265,6 +265,48 @@ This is a test skill.
 
       // Invalid directory should still be removed
       expect(existsSync(join(skillsDir, 'invalid-skill'))).toBe(true);
+    });
+  });
+
+  describe('skills-lock.json cleanup', () => {
+    beforeEach(() => {
+      createTestSkill('skill-one', 'First test skill');
+      createTestSkill('skill-two', 'Second test skill');
+
+      // Write a skills-lock.json with entries for both skills
+      const lockContent = {
+        version: 1,
+        skills: {
+          'skill-one': {
+            source: 'test/repo',
+            sourceType: 'github',
+            computedHash: 'abc123',
+          },
+          'skill-two': {
+            source: 'test/repo',
+            sourceType: 'github',
+            computedHash: 'def456',
+          },
+        },
+      };
+      writeFileSync(join(testDir, 'skills-lock.json'), JSON.stringify(lockContent, null, 2) + '\n');
+    });
+
+    it('should remove skill entry from skills-lock.json', () => {
+      const result = runCli(['remove', 'skill-one', '-y'], testDir);
+      expect(result.stdout).toContain('Successfully removed');
+
+      const lockContent = JSON.parse(readFileSync(join(testDir, 'skills-lock.json'), 'utf-8'));
+      expect(lockContent.skills['skill-one']).toBeUndefined();
+      expect(lockContent.skills['skill-two']).toBeDefined();
+    });
+
+    it('should remove all skill entries from skills-lock.json with --all', () => {
+      const result = runCli(['remove', '--all', '-y'], testDir);
+      expect(result.stdout).toContain('Successfully removed');
+
+      const lockContent = JSON.parse(readFileSync(join(testDir, 'skills-lock.json'), 'utf-8'));
+      expect(Object.keys(lockContent.skills)).toHaveLength(0);
     });
   });
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLocalLock, readLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -208,12 +209,23 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         await rm(canonicalPath, { recursive: true, force: true });
       }
 
-      const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
-      const effectiveSource = lockEntry?.source || 'local';
-      const effectiveSourceType = lockEntry?.sourceType || 'local';
+      let effectiveSource = 'local';
+      let effectiveSourceType = 'local';
+      if (isGlobal) {
+        const lockEntry = await getSkillFromLock(skillName);
+        effectiveSource = lockEntry?.source || 'local';
+        effectiveSourceType = lockEntry?.sourceType || 'local';
+      } else {
+        const localLock = await readLocalLock(cwd);
+        const localEntry = localLock.skills[skillName];
+        effectiveSource = localEntry?.source || 'local';
+        effectiveSourceType = localEntry?.sourceType || 'local';
+      }
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);
+      } else {
+        await removeSkillFromLocalLock(skillName, cwd);
       }
 
       results.push({


### PR DESCRIPTION
This PR fixes an issue where the `skills remove` command was not cleaning up entries in the `skills-lock.json` file after successfully removing skill directories.

## Problem
When removing skills using `npx skills remove <skill-name>`, the command would:
- ✅ Remove skill directories from `.claude/skills/` and `.agents/skills/`
- ❌ Leave stale entries in `skills-lock.json`

This caused the lock file to become out of sync with the actual installed skills.

## Changes Made
1. **Enhanced remove.ts**: Updated the removal logic to clean up both global and local lock files:
   - For global skills: existing `removeSkillFromLock()` call
   - For local skills: added `removeSkillFromLocalLock()` call
   - Improved source/sourceType detection for both global and local scenarios

2. **Added comprehensive tests**: New test suite covering:
   - Single skill removal from lock file
   - Bulk removal with `--all` flag
   - Verification that remaining skills stay intact

3. **Updated dependencies**: Removed unused third-party license entries for `@clack/core@0.4.1` and `sisteransi@1.0.5`

The fix ensures that `skills-lock.json` stays in sync with the filesystem state after skill removal operations.

Fixes #577