### PR TITLE
feat: support top-level `internal: true` in SKILL.md frontmatter

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -293,6 +293,62 @@ metadata:
       const result = runCli(['add', testDir, '--list'], testDir);
       expect(result.stdout).toContain('not-internal-skill');
     });
+
+    it('should skip skills with top-level internal: true', () => {
+      const skillDir = join(testDir, 'top-level-internal');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: top-level-internal
+description: A top-level internal skill
+internal: true
+---
+# Top-Level Internal
+`
+      );
+
+      const result = runCli(['add', testDir, '--list'], testDir);
+      expect(result.stdout).not.toContain('top-level-internal');
+    });
+
+    it('should show top-level internal skills when INSTALL_INTERNAL_SKILLS=1', () => {
+      const skillDir = join(testDir, 'top-level-internal');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: top-level-internal
+description: A top-level internal skill
+internal: true
+---
+# Top-Level Internal
+`
+      );
+
+      const result = runCli(['add', testDir, '--list'], testDir, {
+        INSTALL_INTERNAL_SKILLS: '1',
+      });
+      expect(result.stdout).toContain('top-level-internal');
+    });
+
+    it('should not treat top-level internal: false as internal', () => {
+      const skillDir = join(testDir, 'not-internal-top');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: not-internal-top
+description: Explicitly not internal at top level
+internal: false
+---
+# Not Internal
+`
+      );
+
+      const result = runCli(['add', testDir, '--list'], testDir);
+      expect(result.stdout).toContain('not-internal-top');
+    });
   });
 });
 

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -258,6 +258,11 @@ export class WellKnownProvider implements HostProvider {
         return null;
       }
 
+      // Skip internal skills during discovery
+      if (data.internal === true || data.metadata?.internal === true) {
+        return null;
+      }
+
       // Fetch all other files
       const files = new Map<string, string>();
       files.set('SKILL.md', content);

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -45,7 +45,8 @@ export async function parseSkillMd(
     // Skip internal skills unless:
     // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
     // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const isInternal = data.metadata?.internal === true;
+    // Supports both top-level `internal: true` and legacy `metadata.internal: true`
+    const isInternal = data.internal === true || data.metadata?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
     }
@@ -55,6 +56,7 @@ export async function parseSkillMd(
       description: data.description,
       path: dirname(skillMdPath),
       rawContent: content,
+      internal: isInternal || undefined,
       metadata: data.metadata,
     };
   } catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export interface Skill {
   rawContent?: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  /** Whether this skill is internal (excluded from discovery by default) */
+  internal?: boolean;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

Adds support for marking skills as internal using a top-level `internal: true` field in SKILL.md frontmatter:

```yaml
---
name: sync-create-skills
internal: true
description: Review and synchronize workflow sections across paired create skills.
---
```

This is in addition to the existing `metadata.internal: true` format, which continues to work for backward compatibility.

## Changes

- **`src/skills.ts`**: `parseSkillMd()` now checks both `data.internal === true` (top-level) and `data.metadata?.internal === true` (legacy). Internal skills are set on the `Skill` object for downstream consumers.
- **`src/types.ts`**: Added `internal?: boolean` field to the `Skill` interface.
- **`src/providers/wellknown.ts`**: Well-known provider skips internal skills during remote fetch/discovery.
- **`src/add.test.ts`**: Added 3 tests for top-level `internal` frontmatter (skip by default, show with env var, `false` not treated as internal).

## Behavior

| Scenario | Result |
|----------|--------|
| `internal: true` (top-level) | Excluded from discovery |
| `metadata: { internal: true }` (legacy) | Excluded from discovery |
| `INSTALL_INTERNAL_SKILLS=1` set | Internal skills included |
| Explicit `--skill` / `@skill` request | Internal skills included |
| `internal: false` or omitted | Normal behavior |

All 30 existing + new tests pass.

Fixes #572