### PR TITLE
fix: preserve SSH source URLs in lock files

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1444,6 +1444,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Normalize source to owner/repo format for telemetry
     const normalizedSource = getOwnerRepo(parsed);
 
+    // Preserve SSH URLs in lock files instead of normalizing to owner/repo shorthand.
+    // When normalizedSource is used, parseSource() later resolves it to HTTPS,
+    // breaking restore for private repos that require SSH authentication.
+    const isSSH = parsed.url.startsWith('git@');
+    const lockSource = isSSH ? parsed.url : normalizedSource;
+
     // Only track if we have a valid remote source and it's not a private repo
     if (normalizedSource) {
       const ownerRepo = parseOwnerRepo(normalizedSource);
@@ -1492,7 +1498,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             }
 
             await addSkillToLock(skill.name, {
-              source: normalizedSource,
+              source: lockSource || normalizedSource,
               sourceType: parsed.type,
               sourceUrl: parsed.url,
               skillPath: skillPathValue,
@@ -1517,7 +1523,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             await addSkillToLocalLock(
               skill.name,
               {
-                source: normalizedSource || parsed.url,
+                source: lockSource || parsed.url,
                 sourceType: parsed.type,
                 computedHash,
               },


### PR DESCRIPTION
## Problem

When a skill is installed from an SSH URL (`git@github.com:org/repo.git`), the lock file `source` field is overwritten with the `owner/repo` shorthand (via `getOwnerRepo()`). On the next `experimental_install`, `parseSource()` resolves this shorthand to an HTTPS URL, breaking restore for private repos that require SSH authentication.

## Root Cause

`add.ts` unconditionally uses `normalizedSource` (the `owner/repo` extraction) when writing to both global and local lock files:
```ts
source: normalizedSource,        // global lock
source: normalizedSource || parsed.url,  // local lock
```

## Fix

Detect SSH URLs (`git@...`) and preserve them as-is in lock files instead of normalizing:
```ts
const isSSH = parsed.url.startsWith('git@');
const lockSource = isSSH ? parsed.url : normalizedSource;
```

Telemetry still uses `normalizedSource` (the `owner/repo` form) — only the lock file storage is affected.

## Changes

- **`src/add.ts`**: Added `lockSource` variable that preserves SSH URLs; used in both global lock (`addSkillToLock`) and local lock (`addSkillToLocalLock`) writes.

Fixes #567