### PR TITLE
feat: add --ref flag for specifying git branch/tag/commit

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -389,6 +389,20 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse --ref flag', () => {
+    const result = parseAddOptions(['source', '--ref', 'feat/my-branch']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.ref).toBe('feat/my-branch');
+  });
+
+  it('should parse --ref with other flags', () => {
+    const result = parseAddOptions(['source', '--ref', 'v2.0.0', '--skill', 'my-skill', '-y']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.ref).toBe('v2.0.0');
+    expect(result.options.skill).toEqual(['my-skill']);
+    expect(result.options.yes).toBe(true);
+  });
 });
 
 describe('find-skills prompt with -y flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -418,6 +418,7 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  ref?: string;
 }
 
 /**
@@ -925,7 +926,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     spinner.start('Parsing source...');
     const parsed = parseSource(source);
     spinner.stop(
-      `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
+      `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${(options.ref ?? parsed.ref) ? ` @ ${pc.yellow((options.ref ?? parsed.ref)!)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
 
     // Handle well-known skills from arbitrary URLs
@@ -949,7 +950,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     } else {
       // Clone repository for remote sources
       spinner.start('Cloning repository...');
-      tempDir = await cloneRepo(parsed.url, parsed.ref);
+      tempDir = await cloneRepo(parsed.url, options.ref ?? parsed.ref);
       skillsDir = tempDir;
       spinner.stop('Repository cloned');
     }
@@ -1779,6 +1780,9 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       i--; // Back up one since the loop will increment
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
+    } else if (arg === '--ref') {
+      i++;
+      options.ref = args[i];
     } else if (arg === '--copy') {
       options.copy = true;
     } else if (arg && !arg.startsWith('-')) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,6 +131,7 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
+  --ref <ref>            Specify a git branch, tag, or commit to clone
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 


### PR DESCRIPTION
## Summary

- Adds `--ref <ref>` CLI option to `skills add` command
- Allows specifying a git branch, tag, or commit hash when cloning a repository
- CLI flag takes precedence over any ref extracted from the URL by the source-parser

## Motivation

Currently, the only way to specify a non-default branch is through URL path patterns (e.g., `/tree/<branch>`). This fails in several cases:

1. **Branch names with slashes** (e.g., `feat/my-branch`) — the source-parser splits on `/` and misinterprets the branch name as a subpath
2. **Non-GitHub/GitLab hosts** (e.g., CNB, Gitea, self-hosted) — the source-parser doesn't recognize the URL format and falls back to a plain git clone without extracting the ref
3. **Tags and commit hashes** — no clean way to specify these via URL

Related: #394

## Usage

```bash
# Branch with slashes
npx skills add https://example.com/org/repo.git --ref feat/my-branch

# Specific tag
npx skills add owner/repo --ref v2.0.0

# Combined with other flags
npx skills add https://example.com/repo.git --ref main --skill my-skill -y
```

## Changes

| File | Change |
|------|--------|
| `src/add.ts` | Add `ref` to `AddOptions`, parse `--ref` in `parseAddOptions()`, use `options.ref ?? parsed.ref` in `cloneRepo()` and source display |
| `src/cli.ts` | Add `--ref` to help text |
| `src/add.test.ts` | Add 2 unit tests for `--ref` parsing |

## Test plan

- [x] All 375 existing + new tests pass (`pnpm test -- --run`)
- [x] `--ref` flag correctly parsed standalone and combined with other flags
- [x] `--ref` takes precedence over URL-parsed ref