### PR TITLE
feat: support update/check for git and gitlab source types

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -21,7 +21,7 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   }
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
-import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
+import { cloneRepo, cleanupTempDir, GitCloneError, getLocalHeadCommit } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
   installSkillForAgent,
@@ -1482,13 +1482,18 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
-            // Fetch the folder hash from GitHub Trees API
+            // Fetch the folder hash for update tracking
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
+              // Use GitHub Trees API for GitHub sources
               const token = getGitHubToken();
               const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token);
               if (hash) skillFolderHash = hash;
+            } else if ((parsed.type === 'git' || parsed.type === 'gitlab') && tempDir) {
+              // Use git HEAD commit SHA for generic git/gitlab sources
+              const commitHash = await getLocalHeadCommit(tempDir);
+              if (commitHash) skillFolderHash = commitHash;
             }
 
             await addSkillToLock(skill.name, {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1519,12 +1519,32 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
             const computedHash = await computeSkillFolderHash(skill.path);
+            const skillPathValue = skillFiles[skill.name];
+
+            // Build extended local lock entry with update tracking info
+            let skillFolderHash: string | undefined;
+            if (parsed.type === 'github' && skillPathValue) {
+              const token = getGitHubToken();
+              const hash = await fetchSkillFolderHash(
+                normalizedSource || parsed.url,
+                skillPathValue,
+                token
+              );
+              if (hash) skillFolderHash = hash;
+            } else if ((parsed.type === 'git' || parsed.type === 'gitlab') && tempDir) {
+              const commitHash = await getLocalHeadCommit(tempDir);
+              if (commitHash) skillFolderHash = commitHash;
+            }
+
             await addSkillToLocalLock(
               skill.name,
               {
                 source: normalizedSource || parsed.url,
                 sourceType: parsed.type,
                 computedHash,
+                sourceUrl: parsed.url,
+                skillFolderHash,
+                skillPath: skillPathValue,
               },
               cwd
             );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
 import { getRemoteHeadCommit } from './git.ts';
+import { readLocalLock } from './local-lock.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -292,6 +293,8 @@ interface SkillLockEntry {
   skillFolderHash: string;
   installedAt: string;
   updatedAt: string;
+  /** Whether this entry comes from the local (project-scoped) lock file */
+  isLocal?: boolean;
 }
 
 interface SkillLockFile {
@@ -354,6 +357,38 @@ function writeSkillLock(lock: SkillLockFile): void {
   writeFileSync(lockPath, JSON.stringify(lock, null, 2), 'utf-8');
 }
 
+/**
+ * Read both global and local (project-scoped) lock files and merge them.
+ * Local lock entries are converted to SkillLockEntry format.
+ * If a skill exists in both, the global lock takes precedence.
+ */
+async function readMergedSkillLock(): Promise<SkillLockFile> {
+  const globalLock = readSkillLock();
+  const localLock = await readLocalLock();
+
+  // Merge local lock entries into the result, but don't overwrite global entries
+  for (const [skillName, localEntry] of Object.entries(localLock.skills)) {
+    if (globalLock.skills[skillName]) {
+      // Global lock already has this skill, skip
+      continue;
+    }
+
+    // Convert local lock entry to SkillLockEntry format
+    globalLock.skills[skillName] = {
+      source: localEntry.source,
+      sourceType: localEntry.sourceType,
+      sourceUrl: localEntry.sourceUrl || '',
+      skillPath: localEntry.skillPath,
+      skillFolderHash: localEntry.skillFolderHash || '',
+      installedAt: '',
+      updatedAt: '',
+      isLocal: true,
+    };
+  }
+
+  return globalLock;
+}
+
 interface SkippedSkill {
   name: string;
   reason: string;
@@ -397,7 +432,7 @@ async function runCheck(args: string[] = []): Promise<void> {
   console.log(`${TEXT}Checking for skill updates...${RESET}`);
   console.log();
 
-  const lock = readSkillLock();
+  const lock = await readMergedSkillLock();
   const skillNames = Object.keys(lock.skills);
 
   if (skillNames.length === 0) {
@@ -535,7 +570,7 @@ async function runUpdate(): Promise<void> {
   console.log(`${TEXT}Checking for skill updates...${RESET}`);
   console.log();
 
-  const lock = readSkillLock();
+  const lock = await readMergedSkillLock();
   const skillNames = Object.keys(lock.skills);
 
   if (skillNames.length === 0) {
@@ -614,7 +649,11 @@ async function runUpdate(): Promise<void> {
       // For git/gitlab sources, use the original sourceUrl directly
       // e.g., git@git.example.com:owner/repo.git
       // The --skill flag targets the specific skill within the repo
-      const addArgs = ['-y', 'skills', 'add', installUrl, '-g', '-y'];
+      const addArgs = ['-y', 'skills', 'add', installUrl, '-y'];
+      // Only add -g flag for globally installed skills
+      if (!update.entry.isLocal) {
+        addArgs.push('-g');
+      }
       // If we know the skill name, add --skill flag to target it
       addArgs.push('--skill', update.name);
 
@@ -650,8 +689,13 @@ async function runUpdate(): Promise<void> {
         installUrl = `${installUrl}/tree/main/${skillFolder}`;
       }
 
-      // Use skills CLI to reinstall with -g -y flags
-      const result = spawnSync('npx', ['-y', 'skills', 'add', installUrl, '-g', '-y'], {
+      // Use skills CLI to reinstall with -y flags (add -g only for global installs)
+      const addArgs = ['-y', 'skills', 'add', installUrl, '-y'];
+      if (!update.entry.isLocal) {
+        addArgs.push('-g');
+      }
+
+      const result = spawnSync('npx', addArgs, {
         stdio: ['inherit', 'pipe', 'pipe'],
         shell: process.platform === 'win32',
       });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { getRemoteHeadCommit } from './git.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -366,13 +367,13 @@ function getSkipReason(entry: SkillLockEntry): string {
   if (entry.sourceType === 'local') {
     return 'Local path';
   }
-  if (entry.sourceType === 'git') {
-    return 'Git URL (hash tracking not supported)';
-  }
   if (!entry.skillFolderHash) {
+    if (entry.sourceType === 'git' || entry.sourceType === 'gitlab') {
+      return 'Git URL (no commit hash recorded - reinstall to enable update tracking)';
+    }
     return 'No version hash available';
   }
-  if (!entry.skillPath) {
+  if (entry.sourceType === 'github' && !entry.skillPath) {
     return 'No skill path recorded';
   }
   return 'No version tracking';
@@ -408,28 +409,41 @@ async function runCheck(args: string[] = []): Promise<void> {
   // Get GitHub token from user's environment for higher rate limits
   const token = getGitHubToken();
 
-  // Group skills by source (owner/repo) to batch GitHub API calls
-  const skillsBySource = new Map<string, Array<{ name: string; entry: SkillLockEntry }>>();
+  // Separate skills into checkable and skipped
+  const githubSkills: Array<{ name: string; entry: SkillLockEntry }> = [];
+  const gitSkills: Array<{ name: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
 
   for (const skillName of skillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check skills with folder hash and skill path
-    if (!entry.skillFolderHash || !entry.skillPath) {
+    if (entry.sourceType === 'local') {
       skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
       continue;
     }
 
-    const existing = skillsBySource.get(entry.source) || [];
-    existing.push({ name: skillName, entry });
-    skillsBySource.set(entry.source, existing);
+    if (!entry.skillFolderHash) {
+      skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
+      continue;
+    }
+
+    if (entry.sourceType === 'git' || entry.sourceType === 'gitlab') {
+      // Git/GitLab skills: use git ls-remote to check for updates
+      gitSkills.push({ name: skillName, entry });
+    } else {
+      // GitHub skills: need skillPath for Trees API
+      if (!entry.skillPath) {
+        skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
+        continue;
+      }
+      githubSkills.push({ name: skillName, entry });
+    }
   }
 
-  const totalSkills = skillNames.length - skipped.length;
+  const totalSkills = githubSkills.length + gitSkills.length;
   if (totalSkills === 0) {
-    console.log(`${DIM}No GitHub skills to check.${RESET}`);
+    console.log(`${DIM}No skills to check.${RESET}`);
     printSkippedSkills(skipped);
     return;
   }
@@ -439,27 +453,47 @@ async function runCheck(args: string[] = []): Promise<void> {
   const updates: Array<{ name: string; source: string }> = [];
   const errors: Array<{ name: string; source: string; error: string }> = [];
 
-  // Check each source (one API call per repo)
-  for (const [source, skills] of skillsBySource) {
-    for (const { name, entry } of skills) {
-      try {
-        const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token);
+  // Check GitHub skills via Trees API
+  for (const { name, entry } of githubSkills) {
+    try {
+      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath!, token);
 
-        if (!latestHash) {
-          errors.push({ name, source, error: 'Could not fetch from GitHub' });
-          continue;
-        }
-
-        if (latestHash !== entry.skillFolderHash) {
-          updates.push({ name, source });
-        }
-      } catch (err) {
-        errors.push({
-          name,
-          source,
-          error: err instanceof Error ? err.message : 'Unknown error',
-        });
+      if (!latestHash) {
+        errors.push({ name, source: entry.source, error: 'Could not fetch from GitHub' });
+        continue;
       }
+
+      if (latestHash !== entry.skillFolderHash) {
+        updates.push({ name, source: entry.source });
+      }
+    } catch (err) {
+      errors.push({
+        name,
+        source: entry.source,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  }
+
+  // Check git/gitlab skills via git ls-remote
+  for (const { name, entry } of gitSkills) {
+    try {
+      const latestCommit = await getRemoteHeadCommit(entry.sourceUrl);
+
+      if (!latestCommit) {
+        errors.push({ name, source: entry.source, error: 'Could not fetch from git remote' });
+        continue;
+      }
+
+      if (latestCommit !== entry.skillFolderHash) {
+        updates.push({ name, source: entry.source });
+      }
+    } catch (err) {
+      errors.push({
+        name,
+        source: entry.source,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
     }
   }
 
@@ -513,7 +547,7 @@ async function runUpdate(): Promise<void> {
   // Get GitHub token from user's environment for higher rate limits
   const token = getGitHubToken();
 
-  // Find skills that need updates by checking GitHub directly
+  // Find skills that need updates
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
 
@@ -521,14 +555,26 @@ async function runUpdate(): Promise<void> {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check skills with folder hash and skill path
-    if (!entry.skillFolderHash || !entry.skillPath) {
+    if (entry.sourceType === 'local') {
+      skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
+      continue;
+    }
+
+    if (!entry.skillFolderHash) {
       skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
       continue;
     }
 
     try {
-      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
+      let latestHash: string | null = null;
+
+      if (entry.sourceType === 'git' || entry.sourceType === 'gitlab') {
+        // Use git ls-remote to check for updates
+        latestHash = await getRemoteHeadCommit(entry.sourceUrl);
+      } else if (entry.sourceType === 'github' && entry.skillPath) {
+        // Use GitHub Trees API
+        latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
+      }
 
       if (latestHash && latestHash !== entry.skillFolderHash) {
         updates.push({ name: skillName, source: entry.source, entry });
@@ -562,39 +608,61 @@ async function runUpdate(): Promise<void> {
   for (const update of updates) {
     console.log(`${TEXT}Updating ${update.name}...${RESET}`);
 
-    // Build the URL with subpath to target the specific skill directory
-    // e.g., https://github.com/owner/repo/tree/main/skills/my-skill
     let installUrl = update.entry.sourceUrl;
-    if (update.entry.skillPath) {
-      // Extract the skill folder path (remove /SKILL.md suffix)
-      let skillFolder = update.entry.skillPath;
-      if (skillFolder.endsWith('/SKILL.md')) {
-        skillFolder = skillFolder.slice(0, -9);
-      } else if (skillFolder.endsWith('SKILL.md')) {
-        skillFolder = skillFolder.slice(0, -8);
+
+    if (update.entry.sourceType === 'git' || update.entry.sourceType === 'gitlab') {
+      // For git/gitlab sources, use the original sourceUrl directly
+      // e.g., git@git.example.com:owner/repo.git
+      // The --skill flag targets the specific skill within the repo
+      const addArgs = ['-y', 'skills', 'add', installUrl, '-g', '-y'];
+      // If we know the skill name, add --skill flag to target it
+      addArgs.push('--skill', update.name);
+
+      const result = spawnSync('npx', addArgs, {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        shell: process.platform === 'win32',
+      });
+
+      if (result.status === 0) {
+        successCount++;
+        console.log(`  ${TEXT}✓${RESET} Updated ${update.name}`);
+      } else {
+        failCount++;
+        console.log(`  ${DIM}✗ Failed to update ${update.name}${RESET}`);
       }
-      if (skillFolder.endsWith('/')) {
-        skillFolder = skillFolder.slice(0, -1);
-      }
-
-      // Convert git URL to tree URL with path
-      // https://github.com/owner/repo.git -> https://github.com/owner/repo/tree/main/path
-      installUrl = update.entry.sourceUrl.replace(/\.git$/, '').replace(/\/$/, '');
-      installUrl = `${installUrl}/tree/main/${skillFolder}`;
-    }
-
-    // Use skills CLI to reinstall with -g -y flags
-    const result = spawnSync('npx', ['-y', 'skills', 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      shell: process.platform === 'win32',
-    });
-
-    if (result.status === 0) {
-      successCount++;
-      console.log(`  ${TEXT}✓${RESET} Updated ${update.name}`);
     } else {
-      failCount++;
-      console.log(`  ${DIM}✗ Failed to update ${update.name}${RESET}`);
+      // GitHub sources: build tree URL with subpath
+      if (update.entry.skillPath) {
+        // Extract the skill folder path (remove /SKILL.md suffix)
+        let skillFolder = update.entry.skillPath;
+        if (skillFolder.endsWith('/SKILL.md')) {
+          skillFolder = skillFolder.slice(0, -9);
+        } else if (skillFolder.endsWith('SKILL.md')) {
+          skillFolder = skillFolder.slice(0, -8);
+        }
+        if (skillFolder.endsWith('/')) {
+          skillFolder = skillFolder.slice(0, -1);
+        }
+
+        // Convert git URL to tree URL with path
+        // https://github.com/owner/repo.git -> https://github.com/owner/repo/tree/main/path
+        installUrl = update.entry.sourceUrl.replace(/\.git$/, '').replace(/\/$/, '');
+        installUrl = `${installUrl}/tree/main/${skillFolder}`;
+      }
+
+      // Use skills CLI to reinstall with -g -y flags
+      const result = spawnSync('npx', ['-y', 'skills', 'add', installUrl, '-g', '-y'], {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        shell: process.platform === 'win32',
+      });
+
+      if (result.status === 0) {
+        successCount++;
+        console.log(`  ${TEXT}✓${RESET} Updated ${update.name}`);
+      } else {
+        failCount++;
+        console.log(`  ${DIM}✗ Failed to update ${update.name}${RESET}`);
+      }
     }
   }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 
 const CLONE_TIMEOUT_MS = 60000; // 60 seconds
+const LS_REMOTE_TIMEOUT_MS = 15000; // 15 seconds for ls-remote
 
 export class GitCloneError extends Error {
   readonly url: string;
@@ -80,4 +81,50 @@ export async function cleanupTempDir(dir: string): Promise<void> {
   }
 
   await rm(dir, { recursive: true, force: true });
+}
+
+/**
+ * Get the HEAD commit SHA of a remote git repository using `git ls-remote`.
+ * This works with any git URL (GitHub, GitLab, self-hosted, SSH, HTTPS).
+ *
+ * @param url - The git remote URL (e.g., "git@git.example.com:owner/repo.git")
+ * @param ref - Optional ref to check (defaults to "HEAD")
+ * @returns The commit SHA string, or null if unable to fetch
+ */
+export async function getRemoteHeadCommit(url: string, ref?: string): Promise<string | null> {
+  const git = simpleGit({
+    timeout: { block: LS_REMOTE_TIMEOUT_MS },
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+
+  try {
+    const result = await git.listRemote([url, ref || 'HEAD']);
+    const sha = result.trim().split(/\s+/)[0];
+    if (sha && /^[0-9a-f]{40}$/i.test(sha)) {
+      return sha;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the HEAD commit SHA of a local git repository clone.
+ *
+ * @param repoDir - Path to the cloned repository directory
+ * @returns The commit SHA string, or null if not a git repo or unable to read
+ */
+export async function getLocalHeadCommit(repoDir: string): Promise<string | null> {
+  const git = simpleGit(repoDir);
+  try {
+    const result = await git.revparse(['HEAD']);
+    const sha = result.trim();
+    if (sha && /^[0-9a-f]{40}$/i.test(sha)) {
+      return sha;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -23,6 +23,15 @@ export interface LocalSkillLockEntry {
    * computes the hash from actual file contents on disk.
    */
   computedHash: string;
+  /** The original URL used to install the skill (for re-fetching updates) */
+  sourceUrl?: string;
+  /**
+   * For git/gitlab sources: the HEAD commit SHA at install time.
+   * Used by check/update to detect remote changes via git ls-remote.
+   */
+  skillFolderHash?: string;
+  /** Subpath within the source repo, if applicable */
+  skillPath?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds support for `npx skills check` and `npx skills update` to work with skills installed from **generic git URLs** (e.g., `git@git.example.com:owner/repo.git`) and **GitLab** repositories.

Previously, only skills with `sourceType: "github"` were tracked for updates. Skills installed from other git sources were silently skipped during `check` and `update` because:
1. The update tracking relied exclusively on GitHub's Trees API
2. No commit hash was recorded for non-GitHub sources
3. The `check`/`update` commands explicitly skipped `sourceType: "git"`

## Changes

### `src/git.ts`
- Added `getRemoteHeadCommit(url, ref?)` — uses `git ls-remote` to fetch the latest HEAD commit SHA from any git remote (works with SSH, HTTPS, self-hosted servers)
- Added `getLocalHeadCommit(repoDir)` — gets the HEAD commit SHA from a cloned repository using `git rev-parse HEAD`

### `src/add.ts`
- When installing a skill with `sourceType` `"git"` or `"gitlab"`, the HEAD commit SHA of the cloned repository is now recorded in the `skillFolderHash` field of the lock file (previously left as empty string for non-GitHub sources)

### `src/cli.ts`
- Updated `getSkipReason()` to no longer unconditionally skip `"git"` type — only skips if no hash is recorded (with a helpful message to reinstall)
- Updated `runCheck()` to check git/gitlab skills using `git ls-remote` (comparing stored commit SHA vs remote HEAD)
- Updated `runUpdate()` to reinstall git/gitlab skills using the original source URL with `--skill` flag

## How It Works

| Source Type | Hash Mechanism | Check Method | Update Method |
|------------|---------------|-------------|---------------|
| `github` | GitHub Trees API SHA | GitHub Trees API | Reconstruct tree URL |
| `git` | **Git commit SHA** (new) | **`git ls-remote`** (new) | **Re-add with `--skill` flag** (new) |
| `gitlab` | **Git commit SHA** (new) | **`git ls-remote`** (new) | **Re-add with `--skill` flag** (new) |
| `local` | N/A (skipped) | N/A | N/A |

## Testing

- Verified that all existing tests pass with no regressions (same test results before and after changes)
- TypeScript compilation passes (existing `env` type issue in `simpleGit()` is pre-existing)

## Backward Compatibility

- Skills installed before this change with `sourceType: "git"` will have an empty `skillFolderHash`. They will show a helpful message: _"Git URL (no commit hash recorded - reinstall to enable update tracking)"_ instead of the previous _"Git URL (hash tracking not supported)"_
- After reinstalling such skills, the commit hash will be recorded and future `check`/`update` calls will work normally
