### PR TITLE
feat: support sparse-checkout for large monorepos

### DIFF
--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,9 +9,9 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
-Package: @clack/core@0.4.1
+Package: @clack/core@0.5.0
 License: MIT
-Repository: https://github.com/natemoo-re/clack
+Repository: https://github.com/bombshell-dev/clack
 --------------------------------------------------------------------------------
 
 MIT License
@@ -95,7 +95,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ================================================================================
-Package: simple-git@3.30.0
+Package: simple-git@3.33.0
 License: MIT
 Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------

--- a/src/add.ts
+++ b/src/add.ts
@@ -949,7 +949,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     } else {
       // Clone repository for remote sources
       spinner.start('Cloning repository...');
-      tempDir = await cloneRepo(parsed.url, parsed.ref);
+      tempDir = await cloneRepo(parsed.url, parsed.ref, parsed.subpath);
       skillsDir = tempDir;
       spinner.stop('Repository cloned');
     }

--- a/src/git.ts
+++ b/src/git.ts
@@ -19,16 +19,33 @@ export class GitCloneError extends Error {
   }
 }
 
-export async function cloneRepo(url: string, ref?: string): Promise<string> {
+export async function cloneRepo(url: string, ref?: string, subpath?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
+  const gitEnv = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
   const git = simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    env: gitEnv,
   });
-  const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 
   try {
-    await git.clone(url, tempDir, cloneOptions);
+    if (subpath) {
+      // Use sparse-checkout to only fetch the target subdirectory.
+      // This dramatically reduces clone time for large monorepos.
+      const cloneOptions = ['--depth', '1', '--filter=blob:none', '--sparse'];
+      if (ref) cloneOptions.push('--branch', ref);
+      await git.clone(url, tempDir, cloneOptions);
+
+      const repoGit = simpleGit({
+        baseDir: tempDir,
+        timeout: { block: CLONE_TIMEOUT_MS },
+        env: gitEnv,
+      });
+      await repoGit.raw(['sparse-checkout', 'set', subpath]);
+    } else {
+      const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+      await git.clone(url, tempDir, cloneOptions);
+    }
+
     return tempDir;
   } catch (error) {
     // Clean up temp dir on failure


### PR DESCRIPTION
## Problem

When installing a skill from a subdirectory of a large monorepo (e.g. `npx skills add owner/repo/skills/my-skill`), the current implementation does a full shallow clone (`--depth 1`) of the entire repository. For massive monorepos this can timeout or take an unacceptably long time, even though only a small subdirectory is needed.

## Solution

When a `subpath` is specified, use git sparse-checkout with `--filter=blob:none` to only fetch the target subdirectory:

```
git clone --depth 1 --filter=blob:none --sparse <url>
git sparse-checkout set <subpath>
```

This fetches only the tree metadata on clone, then checks out only the files under the target path. For sources without a subpath, behavior is unchanged (plain `--depth 1` shallow clone).

## Changes

| File | Change |
|------|--------|
| `src/git.ts` | Added `subpath` parameter to `cloneRepo()`; when provided, uses `--filter=blob:none --sparse` + `sparse-checkout set` |
| `src/add.ts` | Passes `parsed.subpath` to `cloneRepo()` |

## Testing

- All 373 existing tests pass
- The `tsc` type errors in `git.ts` are pre-existing (SimpleGitOptions overload mismatch), not introduced by this change

Fixes #595