### PR TITLE
feat: add WorkBuddy agent support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -94,6 +94,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(process.cwd(), '.codebuddy')) || existsSync(join(home, '.codebuddy'));
     },
   },
+  workbuddy: {
+    name: 'workbuddy',
+    displayName: 'WorkBuddy',
+    skillsDir: '.workbuddy/skills',
+    globalSkillsDir: join(home, '.workbuddy/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.workbuddy')) || existsSync(join(home, '.workbuddy'));
+    },
+  },
   codex: {
     name: 'codex',
     displayName: 'Codex',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -161,6 +161,7 @@ export async function discoverSkills(
     join(searchPath, '.claude/skills'),
     join(searchPath, '.cline/skills'),
     join(searchPath, '.codebuddy/skills'),
+    join(searchPath, '.workbuddy/skills'),
     join(searchPath, '.codex/skills'),
     join(searchPath, '.commandcode/skills'),
     join(searchPath, '.continue/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type AgentType =
   | 'openclaw'
   | 'cline'
   | 'codebuddy'
+  | 'workbuddy'
   | 'codex'
   | 'command-code'
   | 'continue'


### PR DESCRIPTION
## Summary

- Add WorkBuddy as a supported agent in the skills CLI
- WorkBuddy is a coding assistant client that stores skills in `.workbuddy/skills/`, following the same directory convention as CodeBuddy (`.codebuddy/skills/`)
- This allows users to install skills directly to WorkBuddy via `npx skills add <package> -a workbuddy`

## Changes

1. **`src/types.ts`**: Add `'workbuddy'` to `AgentType` union type
2. **`src/agents.ts`**: Add `workbuddy` agent config entry with:
   - `skillsDir: '.workbuddy/skills'` (project-level)
   - `globalSkillsDir: ~/.workbuddy/skills` (user-level)
   - Detection via `.workbuddy` directory in cwd or home
3. **`src/skills.ts`**: Add `.workbuddy/skills` to `prioritySearchDirs` for skill discovery

## Test plan

- [ ] Verify `npx skills add <package> -g -a workbuddy` installs skills to `~/.workbuddy/skills/`
- [ ] Verify `npx skills list -g` shows WorkBuddy agent when `~/.workbuddy` exists
- [ ] Verify skill discovery finds skills in `.workbuddy/skills/` directories