### PR TITLE
feat(list): add list-specific help and concise mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,20 @@ npx skills ls -g
 
 # Filter by specific agents
 npx skills ls -a claude-code -a cursor
+
+# Concise output (skill names only)
+npx skills ls --short
+
+# JSON output (takes precedence over --short)
+npx skills ls --json --short
 ```
+
+| Option         | Description                                                       |
+| -------------- | ----------------------------------------------------------------- |
+| `-g, --global` | List global skills instead of project skills                      |
+| `-a, --agent`  | Filter by specific agents                                         |
+| `--short`      | Print concise output (one skill name per line)                   |
+| `--json`       | Output JSON; when combined with `--short`, JSON output is used   |
 
 ### `skills find`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,6 +148,7 @@ ${BOLD}Experimental Sync Options:${RESET}
 ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
   -a, --agent <agents>   Filter by specific agents
+  --short                Output concise skill names only (one per line)
   --json                 Output as JSON (machine-readable, no ANSI codes)
 
 ${BOLD}Options:${RESET}
@@ -165,6 +166,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills list                          ${DIM}# list project skills${RESET}
   ${DIM}$${RESET} skills ls -g                         ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
+  ${DIM}$${RESET} skills ls --short                    ${DIM}# concise output${RESET}
   ${DIM}$${RESET} skills ls --json                      ${DIM}# JSON output${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}
@@ -224,6 +226,7 @@ ${BOLD}Aliases:${RESET}
 ${BOLD}Options:${RESET}
   -g, --global       List global skills instead of project skills
   -a, --agent        Filter by specific agents (use '*' for all agents)
+  --short            Output concise skill names only (one per line)
   --json             Output as JSON (machine-readable, no ANSI codes)
   -h, --help         Show this help message
 
@@ -231,6 +234,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills list                         ${DIM}# list project skills${RESET}
   ${DIM}$${RESET} skills ls -g                        ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills list -a claude-code cursor   ${DIM}# filter by agents${RESET}
+  ${DIM}$${RESET} skills list --short                 ${DIM}# concise output${RESET}
   ${DIM}$${RESET} skills list --json                  ${DIM}# JSON output${RESET}
 
 Discover more skills at ${TEXT}https://skills.sh/${RESET}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,6 +210,33 @@ Discover more skills at ${TEXT}https://skills.sh/${RESET}
 `);
 }
 
+function showListHelp(): void {
+  console.log(`
+${BOLD}Usage:${RESET} skills list [options]
+
+${BOLD}Description:${RESET}
+  List installed skills from project scope by default.
+  Use --global to list globally installed skills.
+
+${BOLD}Aliases:${RESET}
+  ls
+
+${BOLD}Options:${RESET}
+  -g, --global       List global skills instead of project skills
+  -a, --agent        Filter by specific agents (use '*' for all agents)
+  --json             Output as JSON (machine-readable, no ANSI codes)
+  -h, --help         Show this help message
+
+${BOLD}Examples:${RESET}
+  ${DIM}$${RESET} skills list                         ${DIM}# list project skills${RESET}
+  ${DIM}$${RESET} skills ls -g                        ${DIM}# list global skills${RESET}
+  ${DIM}$${RESET} skills list -a claude-code cursor   ${DIM}# filter by agents${RESET}
+  ${DIM}$${RESET} skills list --json                  ${DIM}# JSON output${RESET}
+
+Discover more skills at ${TEXT}https://skills.sh/${RESET}
+`);
+}
+
 function runInit(args: string[]): void {
   const cwd = process.cwd();
   const skillName = args[0] || basename(cwd);
@@ -679,6 +706,14 @@ async function main(): Promise<void> {
     }
     case 'list':
     case 'ls':
+      if (
+        restArgs.includes('--help') ||
+        restArgs.includes('-h') ||
+        (restArgs.length > 0 && restArgs[0] === 'help')
+      ) {
+        showListHelp();
+        break;
+      }
       await runList(restArgs);
       break;
     case 'check':

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -61,6 +61,11 @@ describe('list command', () => {
       expect(options.json).toBe(true);
     });
 
+    it('should parse --short flag', () => {
+      const options = parseListOptions(['--short']);
+      expect(options.short).toBe(true);
+    });
+
     it('should parse combined --json and -g flags', () => {
       const options = parseListOptions(['-g', '--json']);
       expect(options.global).toBe(true);
@@ -146,6 +151,47 @@ description: A skill for JSON testing
       expect(Array.isArray(parsed[0].agents)).toBe(true);
       // No ANSI codes in JSON output
       expect(result.stdout).not.toMatch(/\x1b\[/);
+    });
+
+    it('should output concise names with --short flag', () => {
+      const skill1Dir = join(testDir, '.agents', 'skills', 'short-alpha');
+      const skill2Dir = join(testDir, '.agents', 'skills', 'short-beta');
+      mkdirSync(skill1Dir, { recursive: true });
+      mkdirSync(skill2Dir, { recursive: true });
+
+      writeFileSync(
+        join(skill1Dir, 'SKILL.md'),
+        `---\nname: short-alpha\ndescription: Alpha\n---\n# A\n`
+      );
+      writeFileSync(
+        join(skill2Dir, 'SKILL.md'),
+        `---\nname: short-beta\ndescription: Beta\n---\n# B\n`
+      );
+
+      const result = runCli(['list', '--short'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('short-alpha');
+      expect(result.stdout).toContain('short-beta');
+      expect(result.stdout).not.toContain('Project Skills');
+      expect(result.stdout).not.toContain('.agents/skills');
+      expect(result.stdout).not.toContain('Agents:');
+    });
+
+    it('should prefer --json when --json and --short are both set', () => {
+      const skillDir = join(testDir, '.agents', 'skills', 'json-wins');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: json-wins\ndescription: Json wins\n---\n# Json\n`
+      );
+
+      const result = runCli(['list', '--json', '--short'], testDir);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].name).toBe('json-wins');
+      expect(result.stdout).not.toContain('Project Skills');
+      expect(result.stdout).not.toContain('Agents:');
     });
 
     it('should output multiple skills as JSON array', () => {
@@ -365,6 +411,8 @@ description: A test skill
       expect(result.stdout).toContain('List Options:');
       expect(result.stdout).toContain('-g, --global');
       expect(result.stdout).toContain('-a, --agent');
+      expect(result.stdout).toContain('--short');
+      expect(result.stdout).toContain('--json');
     });
 
     it('should include list examples in help', () => {

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -75,6 +75,32 @@ describe('list command', () => {
   });
 
   describe('CLI integration', () => {
+    it('should show list-specific help with --help', () => {
+      const result = runCli(['list', '--help'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Usage:');
+      expect(result.stdout).toContain('skills list [options]');
+      expect(result.stdout).toContain('List installed skills from project scope by default.');
+      expect(result.stdout).toContain('--json');
+    });
+
+    it('should show list-specific help with -h', () => {
+      const longHelp = runCli(['list', '--help'], testDir);
+      const shortHelp = runCli(['list', '-h'], testDir);
+
+      expect(shortHelp.exitCode).toBe(0);
+      expect(shortHelp.stdout).toContain('skills list [options]');
+      expect(shortHelp.stdout).toBe(longHelp.stdout);
+    });
+
+    it('should show list-specific help with help subcommand', () => {
+      const result = runCli(['list', 'help'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('skills list [options]');
+      expect(result.stdout).toContain('Aliases:');
+      expect(result.stdout).toContain('ls');
+    });
+
     it('should run list command', () => {
       const result = runCli(['list'], testDir);
       // Empty project dir shows "No project skills found"

--- a/src/list.ts
+++ b/src/list.ts
@@ -15,6 +15,7 @@ interface ListOptions {
   global?: boolean;
   agent?: string[];
   json?: boolean;
+  short?: boolean;
 }
 
 /**
@@ -52,6 +53,8 @@ export function parseListOptions(args: string[]): ListOptions {
       options.global = true;
     } else if (arg === '--json') {
       options.json = true;
+    } else if (arg === '--short') {
+      options.short = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       // Collect all following arguments until next flag
@@ -99,6 +102,13 @@ export async function runList(args: string[]): Promise<void> {
       agents: skill.agents.map((a) => agents[a].displayName),
     }));
     console.log(JSON.stringify(jsonOutput, null, 2));
+    return;
+  }
+
+  // Concise output mode: one skill name per line, no verbose metadata
+  if (options.short) {
+    const names = installedSkills.map((skill) => skill.name);
+    console.log(names.join('\n'));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add command-specific help handling for `skills list`/`skills ls`, including `--help`, `-h`, and `list help`, so help output is shown instead of executing list.
- Add `--short` to `skills list` for compact output (one skill name per line) while keeping default output unchanged.
- Document and test precedence so `--json` output is used when both `--json` and `--short` are passed.

## Test plan
- [x] Run `pnpm test src/list.test.ts`
- [x] Verify `skills list --help` and `skills list -h` show list-specific help and exit 0
- [x] Verify normal `skills list` behavior still works
- [x] Verify `skills list --short` prints concise output
- [x] Verify `skills list --json --short` returns JSON output

Made with [Cursor](https://cursor.com)