### PR TITLE
fix: declare actual Node runtime floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        node: ['22.18.0', 'lts/*']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -26,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node }}
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -105,7 +105,12 @@
     "xdg-basedir": "^5.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22.18.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   },
   "packageManager": "pnpm@10.17.1"
 }

--- a/tests/package-metadata.test.ts
+++ b/tests/package-metadata.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const packageJsonPath = join(import.meta.dirname, '..', 'package.json');
+
+describe('package metadata', () => {
+  it('declares the supported Node.js floor explicitly', () => {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    expect(pkg.engines?.node).toBe('>=22.18.0');
+  });
+});

--- a/tests/package-metadata.test.ts
+++ b/tests/package-metadata.test.ts
@@ -7,6 +7,7 @@ const packageJsonPath = join(import.meta.dirname, '..', 'package.json');
 describe('package metadata', () => {
   it('declares the supported Node.js floor explicitly', () => {
     const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    // Intentionally mirror package.json so this test fails if the declared floor drifts.
     expect(pkg.engines?.node).toBe('>=22.18.0');
   });
 });


### PR DESCRIPTION
## Summary
- raise the declared Node floor to `>=22.18.0`
- align CI with the actual runtime behavior this repo depends on
- add a small metadata test so the floor does not drift again
- persist `esbuild` as an allowed build dependency in package metadata

## Why
This repo executes `.ts` files directly with plain `node` in places like `src/cli.ts` and `scripts/generate-licenses.ts`.

Per the official Node TypeScript docs, built-in type stripping is enabled by default starting in `v22.18.0`, so the previous `engines.node: >=18` claim was broader than what the repo actually supports in practice.

I reproduced the failure on Node 20, and I reproduced a clean `pnpm test` run on Node `22.22.1`.

This repo also pins `pnpm@10.17.1`, and `esbuild` approval was creating avoidable install friction. I chose the repo-local `package.json` `pnpm.onlyBuiltDependencies` setting instead of introducing a separate `pnpm-workspace.yaml`, since this is a single-package repo rather than a real workspace.

## Verification
- `pnpm exec vitest run tests/package-metadata.test.ts --reporter=dot`

Closes #603
