### PR TITLE
fix: remove only lockfile-managed global skills

### DIFF
--- a/src/remove.ts
+++ b/src/remove.ts
@@ -4,7 +4,7 @@ import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
-import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLock, getSkillFromLock, getAllLockedSkills } from './skill-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -61,7 +61,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   const installedSkills = Array.from(skillNamesSet).sort();
   spinner.stop(`Found ${installedSkills.length} unique installed skill(s)`);
 
-  if (installedSkills.length === 0) {
+  if (installedSkills.length === 0 && !(options.all && isGlobal)) {
     p.outro(pc.yellow('No skills found to remove.'));
     return;
   }
@@ -80,7 +80,10 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
   let selectedSkills: string[] = [];
 
-  if (options.all) {
+  if (options.all && isGlobal) {
+    const lockedSkills = Object.keys(await getAllLockedSkills()).sort();
+    selectedSkills = lockedSkills;
+  } else if (options.all) {
     selectedSkills = installedSkills;
   } else if (skillNames.length > 0) {
     selectedSkills = installedSkills.filter((s) =>
@@ -109,6 +112,15 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
 
     selectedSkills = selected as string[];
+  }
+
+  if (selectedSkills.length === 0) {
+    if (options.all && isGlobal) {
+      p.outro(pc.yellow('No globally managed skills found to remove.'));
+    } else {
+      p.outro(pc.yellow('No skills found to remove.'));
+    }
+    return;
   }
 
   let targetAgents: AgentType[];

--- a/tests/remove-global-lockfile.test.ts
+++ b/tests/remove-global-lockfile.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { removeCommand } from '../src/remove.ts';
+
+const {
+  mockOutro,
+  mockWarn,
+  mockGetAllLockedSkills,
+  mockGetSkillFromLock,
+  mockRemoveSkillFromLock,
+  mockDetectInstalledAgents,
+  mockGetCanonicalSkillsDir,
+  mockGetCanonicalPath,
+  mockGetInstallPath,
+  mockSanitizeName,
+  mockTrack,
+  mockReaddir,
+  mockLstat,
+  mockRm,
+} = vi.hoisted(() => ({
+  mockOutro: vi.fn(),
+  mockWarn: vi.fn(),
+  mockGetAllLockedSkills: vi.fn(),
+  mockGetSkillFromLock: vi.fn(),
+  mockRemoveSkillFromLock: vi.fn(),
+  mockDetectInstalledAgents: vi.fn(),
+  mockGetCanonicalSkillsDir: vi.fn(),
+  mockGetCanonicalPath: vi.fn(),
+  mockGetInstallPath: vi.fn(),
+  mockSanitizeName: vi.fn((name: string) => name),
+  mockTrack: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockLstat: vi.fn(),
+  mockRm: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', async () => {
+  const actual = await vi.importActual<typeof import('@clack/prompts')>('@clack/prompts');
+  return {
+    ...actual,
+    outro: mockOutro,
+    log: {
+      ...actual.log,
+      warn: mockWarn,
+    },
+  };
+});
+
+vi.mock('../src/skill-lock.ts', () => ({
+  getAllLockedSkills: mockGetAllLockedSkills,
+  getSkillFromLock: mockGetSkillFromLock,
+  removeSkillFromLock: mockRemoveSkillFromLock,
+}));
+
+vi.mock('../src/agents.ts', () => ({
+  agents: {
+    codex: {
+      displayName: 'Codex',
+      skillsDir: '.codex/skills',
+      globalSkillsDir: '/global/codex/skills',
+    },
+  },
+  detectInstalledAgents: mockDetectInstalledAgents,
+}));
+
+vi.mock('../src/installer.ts', () => ({
+  getCanonicalSkillsDir: mockGetCanonicalSkillsDir,
+  getCanonicalPath: mockGetCanonicalPath,
+  getInstallPath: mockGetInstallPath,
+  sanitizeName: mockSanitizeName,
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  track: mockTrack,
+}));
+
+vi.mock('fs/promises', () => ({
+  readdir: mockReaddir,
+  lstat: mockLstat,
+  rm: mockRm,
+}));
+
+describe('removeCommand global lockfile ownership', () => {
+  const originalCwd = process.cwd();
+  let testCwd: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testCwd = join(tmpdir(), `skills-remove-global-lock-${Date.now()}`);
+    mkdirSync(testCwd, { recursive: true });
+    process.chdir(testCwd);
+
+    mockGetCanonicalSkillsDir.mockReturnValue('/global/canonical/skills');
+    mockGetCanonicalPath.mockImplementation(
+      (skillName: string) => `/global/canonical/skills/${skillName}`
+    );
+    mockGetInstallPath.mockImplementation(
+      (skillName: string) => `/global/canonical/skills/${skillName}`
+    );
+    mockDetectInstalledAgents.mockResolvedValue([]);
+    mockGetSkillFromLock.mockResolvedValue({
+      source: 'https://example.com/managed-skill',
+      sourceType: 'url',
+    });
+    mockReaddir.mockImplementation(async (dir: string) => {
+      if (dir === '/global/canonical/skills') {
+        return [
+          { name: 'managed-skill', isDirectory: () => true },
+          { name: 'manual-skill', isDirectory: () => true },
+        ];
+      }
+      return [];
+    });
+    mockLstat.mockResolvedValue({});
+    mockRm.mockResolvedValue(undefined);
+    mockGetAllLockedSkills.mockResolvedValue({
+      'managed-skill': {
+        source: 'https://example.com/managed-skill',
+        agents: ['codex'],
+        scope: 'global',
+      },
+    });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(testCwd, { recursive: true, force: true });
+    mockOutro.mockClear();
+    mockWarn.mockClear();
+  });
+
+  it('should remove only lockfile-tracked skills for --all --global', async () => {
+    await removeCommand([], { all: true, global: true, yes: true });
+
+    expect(mockRm).toHaveBeenCalledWith('/global/canonical/skills/managed-skill', {
+      recursive: true,
+      force: true,
+    });
+    expect(mockRm).not.toHaveBeenCalledWith('/global/canonical/skills/manual-skill', {
+      recursive: true,
+      force: true,
+    });
+    expect(mockRemoveSkillFromLock).toHaveBeenCalledWith('managed-skill');
+    expect(mockRemoveSkillFromLock).not.toHaveBeenCalledWith('manual-skill');
+  });
+
+  it('should still consult the lockfile when global directories are empty', async () => {
+    mockReaddir.mockResolvedValue([]);
+
+    await removeCommand([], { all: true, global: true, yes: true });
+
+    expect(mockRm).toHaveBeenCalledWith('/global/canonical/skills/managed-skill', {
+      recursive: true,
+      force: true,
+    });
+    expect(mockRemoveSkillFromLock).toHaveBeenCalledWith('managed-skill');
+    expect(mockOutro).not.toHaveBeenCalledWith('No skills found to remove.');
+  });
+});


### PR DESCRIPTION
## Summary
- make global `remove --all` derive ownership from the global lockfile
- avoid early-returning before consulting lockfile state when global directories are empty
- add regressions for both mixed managed/unmanaged globals and stale-lockfile cases

## Why
`remove --all -g` was treating directory presence in the shared global skills path as if it meant ownership by this tool. In practice that can delete user-managed skills that happen to live in the same directory.

Related: #610 isolates CLI tests from real user homes. That test-harness leak made reproducing/debugging this behavior capable of mutating real global state again.

## Verification
- `pnpm exec vitest run tests/remove-global-lockfile.test.ts --reporter=dot`

Closes #604
