### PR TITLE
test: isolate CLI tests from the real user home

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -90,6 +90,36 @@ Instructions here.
     expect(result.exitCode).toBe(0);
   });
 
+  it('should isolate global installs under a test home', () => {
+    const skillName = 'isolated-global-add-test-skill';
+    const skillDir = join(testDir, 'skills', skillName);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: ${skillName}
+description: Isolated global install test skill
+---
+
+# Isolated Global Install Test Skill
+
+Instructions here.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(['add', testDir, '-y', '-g', '--agent', 'claude-code'], targetDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(
+      existsSync(
+        join(targetDir, '.skills-cli-test-home', '.agents', 'skills', skillName, 'SKILL.md')
+      )
+    ).toBe(true);
+  });
+
   it('should filter skills by name with --skill flag', () => {
     // Create multiple test skills
     const skill1Dir = join(testDir, 'skills', 'skill-one');

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -226,9 +226,29 @@ description: A project skill
 `
       );
 
+      // Create an isolated global skill under the test HOME used by runCli()
+      const globalSkillDir = join(
+        testDir,
+        '.skills-cli-test-home',
+        '.agents',
+        'skills',
+        'global-skill'
+      );
+      mkdirSync(globalSkillDir, { recursive: true });
+      writeFileSync(
+        join(globalSkillDir, 'SKILL.md'),
+        `---
+name: global-skill
+description: A global skill
+---
+# Global Skill
+`
+      );
+
       const result = runCli(['list', '-g'], testDir);
       // Should not show project skill when -g is specified
       expect(result.stdout).not.toContain('project-skill');
+      expect(result.stdout).toContain('global-skill');
       expect(result.stdout).toContain('Global Skills');
     });
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,5 +1,7 @@
 import { execSync } from 'child_process';
+import { mkdirSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 
 // const PROJECT_ROOT = join(import.meta.dirname, '..');
 const CLI_PATH = join(import.meta.dirname, 'cli.ts');
@@ -20,6 +22,27 @@ export function hasLogo(str: string): boolean {
   return str.includes('███') || str.includes('╔') || str.includes('╚');
 }
 
+function getIsolatedHome(cwd?: string): string {
+  const baseDir = cwd ?? join(tmpdir(), `skills-cli-test-home-${process.pid}`);
+  const isolatedHome = join(baseDir, '.skills-cli-test-home');
+  mkdirSync(join(isolatedHome, '.config'), { recursive: true });
+  return isolatedHome;
+}
+
+function getCliEnv(cwd?: string, env?: Record<string, string>) {
+  const isolatedHome = getIsolatedHome(cwd);
+
+  return {
+    ...process.env,
+    HOME: isolatedHome,
+    USERPROFILE: isolatedHome,
+    XDG_CONFIG_HOME: join(isolatedHome, '.config'),
+    CODEX_HOME: join(isolatedHome, '.codex'),
+    CLAUDE_CONFIG_DIR: join(isolatedHome, '.claude'),
+    ...env,
+  };
+}
+
 export function runCli(
   args: string[],
   cwd?: string,
@@ -31,7 +54,7 @@ export function runCli(
       encoding: 'utf-8',
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: env ? { ...process.env, ...env } : undefined,
+      env: getCliEnv(cwd, env),
       timeout: timeout ?? 30000,
     });
     return { stdout: stripAnsi(output), stderr: '', exitCode: 0 };
@@ -60,6 +83,7 @@ export function runCliWithInput(
       cwd,
       input: input + '\n',
       stdio: ['pipe', 'pipe', 'pipe'],
+      env: getCliEnv(cwd),
     });
     return { stdout: stripAnsi(output), stderr: '', exitCode: 0 };
   } catch (error: any) {

--- a/tests/list-installed.test.ts
+++ b/tests/list-installed.test.ts
@@ -116,13 +116,45 @@ ${skillData.description}
   });
 
   it('should handle global scope option', async () => {
-    // Test with global: true - verifies the function doesn't crash
-    // Note: This checks ~/.agents/skills, results depend on system state
-    const skills = await listInstalledSkills({
+    const fakeHome = join(testDir, '.fake-home');
+    const fakeGlobalSkillDir = join(fakeHome, '.agents', 'skills', 'global-skill');
+
+    await mkdir(fakeGlobalSkillDir, { recursive: true });
+    await writeFile(
+      join(fakeGlobalSkillDir, 'SKILL.md'),
+      `---
+name: global-skill
+description: A global test skill
+---
+
+# global-skill
+
+A global test skill
+`
+    );
+
+    vi.resetModules();
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof import('os')>('os');
+      return { ...actual, homedir: () => fakeHome };
+    });
+
+    const isolatedInstallerModule = await import('../src/installer.ts');
+    const isolatedAgentsModule = await import('../src/agents.ts');
+
+    vi.spyOn(isolatedAgentsModule, 'detectInstalledAgents').mockResolvedValue([]);
+
+    const skills = await isolatedInstallerModule.listInstalledSkills({
       global: true,
       cwd: testDir,
     });
-    expect(Array.isArray(skills)).toBe(true);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.name).toBe('global-skill');
+    expect(skills[0]!.scope).toBe('global');
+
+    vi.doUnmock('os');
+    vi.resetModules();
   });
 
   it('should apply agent filter', async () => {


### PR DESCRIPTION
## Summary
- isolate CLI test runs under a fake home by default
- override `HOME`, `USERPROFILE`, `XDG_CONFIG_HOME`, `CODEX_HOME`, and `CLAUDE_CONFIG_DIR`
- update/add regressions so `-g` tests exercise isolated global paths instead of the real user environment

## Why
CLI tests were inheriting the real user home, so tests using `-g` could mutate real global skill directories during debugging and reproduction.

This was uncovered while reproducing and fixing #609.

## Verification
- `pnpm exec vitest run src/add.test.ts src/list.test.ts tests/list-installed.test.ts --reporter=dot`

Closes #605
