### PR TITLE
fix: prevent global lockfile collisions and lossy rewrites

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -334,13 +334,11 @@ function readSkillLock(): SkillLockFile {
   try {
     const content = readFileSync(lockPath, 'utf-8');
     const parsed = JSON.parse(content) as SkillLockFile;
-    if (typeof parsed.version !== 'number' || !parsed.skills) {
+    if (!parsed || typeof parsed !== 'object' || !parsed.skills || typeof parsed.skills !== 'object') {
       return { version: CURRENT_LOCK_VERSION, skills: {} };
     }
-    // If old version, wipe and start fresh (backwards incompatible change)
-    // v3 adds skillFolderHash - we want fresh installs to populate it
     if (parsed.version < CURRENT_LOCK_VERSION) {
-      return { version: CURRENT_LOCK_VERSION, skills: {} };
+      return { version: CURRENT_LOCK_VERSION, skills: parsed.skills };
     }
     return parsed;
   } catch {

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -134,6 +134,8 @@ export async function writeSkillLock(lock: SkillLockFile): Promise<void> {
 
 const SKILL_LOCK_KEY_SEPARATOR = '::';
 
+// Keep lock entries keyed by source+skill so identically named skills from different
+// providers (for example, an official source and a fork) do not overwrite each other.
 function makeSkillLockKey(source: string, skillName: string): string {
   return `${source}${SKILL_LOCK_KEY_SEPARATOR}${skillName}`;
 }

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -54,6 +54,8 @@ export interface SkillLockFile {
   dismissed?: DismissedPrompts;
   /** Last selected agents for installation */
   lastSelectedAgents?: string[];
+  /** Preserve unknown top-level fields for forward compatibility */
+  [key: string]: unknown;
 }
 
 /**
@@ -72,7 +74,6 @@ export function getSkillLockPath(): string {
 /**
  * Read the skill lock file.
  * Returns an empty lock file structure if the file doesn't exist.
- * Wipes the lock file if it's an old format (version < CURRENT_VERSION).
  */
 export async function readSkillLock(): Promise<SkillLockFile> {
   const lockPath = getSkillLockPath();
@@ -81,18 +82,35 @@ export async function readSkillLock(): Promise<SkillLockFile> {
     const content = await readFile(lockPath, 'utf-8');
     const parsed = JSON.parse(content) as SkillLockFile;
 
-    // Validate version - wipe if old format
-    if (typeof parsed.version !== 'number' || !parsed.skills) {
+    // Validate minimum structure
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !parsed.skills ||
+      typeof parsed.skills !== 'object'
+    ) {
       return createEmptyLockFile();
     }
 
-    // If old version, wipe and start fresh (backwards incompatible change)
-    // v3 adds skillFolderHash - we want fresh installs to populate it
+    // Migrate older lockfiles forward without discarding tracked skills.
+    // Missing v3 fields like skillFolderHash can remain empty until the next reinstall/update.
     if (parsed.version < CURRENT_VERSION) {
-      return createEmptyLockFile();
+      return {
+        ...parsed,
+        version: CURRENT_VERSION,
+        skills: parsed.skills,
+        dismissed: parsed.dismissed ?? {},
+        lastSelectedAgents: parsed.lastSelectedAgents,
+      };
     }
 
-    return parsed;
+    return {
+      ...parsed,
+      version: parsed.version,
+      skills: parsed.skills,
+      dismissed: parsed.dismissed ?? {},
+      lastSelectedAgents: parsed.lastSelectedAgents,
+    };
   } catch (error) {
     // File doesn't exist or is invalid - return empty
     return createEmptyLockFile();
@@ -112,6 +130,44 @@ export async function writeSkillLock(lock: SkillLockFile): Promise<void> {
   // Write with pretty formatting for human readability
   const content = JSON.stringify(lock, null, 2);
   await writeFile(lockPath, content, 'utf-8');
+}
+
+const SKILL_LOCK_KEY_SEPARATOR = '::';
+
+function makeSkillLockKey(source: string, skillName: string): string {
+  return `${source}${SKILL_LOCK_KEY_SEPARATOR}${skillName}`;
+}
+
+function getSkillNameFromLockKey(lockKey: string): string {
+  const separatorIndex = lockKey.indexOf(SKILL_LOCK_KEY_SEPARATOR);
+  if (separatorIndex === -1) {
+    return lockKey;
+  }
+  return lockKey.slice(separatorIndex + SKILL_LOCK_KEY_SEPARATOR.length);
+}
+
+function getLockEntriesForSkill(
+  lock: SkillLockFile,
+  skillName: string
+): Array<[string, SkillLockEntry]> {
+  if (skillName in lock.skills) {
+    return [[skillName, lock.skills[skillName]!]];
+  }
+
+  return Object.entries(lock.skills).filter(
+    ([lockKey]) => getSkillNameFromLockKey(lockKey) === skillName
+  );
+}
+
+function pickRepresentativeEntry(
+  entries: Array<[string, SkillLockEntry]>
+): SkillLockEntry | null {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const sorted = [...entries].sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+  return sorted[0]![1];
 }
 
 /**
@@ -237,14 +293,23 @@ export async function addSkillToLock(
 ): Promise<void> {
   const lock = await readSkillLock();
   const now = new Date().toISOString();
+  const lockKey = makeSkillLockKey(entry.source, skillName);
+  const existingEntries = getLockEntriesForSkill(lock, skillName);
+  const existingEntry =
+    lock.skills[lockKey] ??
+    existingEntries.find(([, existing]) => existing.source === entry.source)?.[1];
 
-  const existingEntry = lock.skills[skillName];
-
-  lock.skills[skillName] = {
+  lock.skills[lockKey] = {
     ...entry,
     installedAt: existingEntry?.installedAt ?? now,
     updatedAt: now,
   };
+
+  for (const [existingKey, existing] of existingEntries) {
+    if (existingKey !== lockKey && existing.source === entry.source) {
+      delete lock.skills[existingKey];
+    }
+  }
 
   await writeSkillLock(lock);
 }
@@ -254,12 +319,14 @@ export async function addSkillToLock(
  */
 export async function removeSkillFromLock(skillName: string): Promise<boolean> {
   const lock = await readSkillLock();
-
-  if (!(skillName in lock.skills)) {
+  const entries = getLockEntriesForSkill(lock, skillName);
+  if (entries.length === 0) {
     return false;
   }
 
-  delete lock.skills[skillName];
+  for (const [lockKey] of entries) {
+    delete lock.skills[lockKey];
+  }
   await writeSkillLock(lock);
   return true;
 }
@@ -269,7 +336,7 @@ export async function removeSkillFromLock(skillName: string): Promise<boolean> {
  */
 export async function getSkillFromLock(skillName: string): Promise<SkillLockEntry | null> {
   const lock = await readSkillLock();
-  return lock.skills[skillName] ?? null;
+  return pickRepresentativeEntry(getLockEntriesForSkill(lock, skillName));
 }
 
 /**
@@ -277,7 +344,16 @@ export async function getSkillFromLock(skillName: string): Promise<SkillLockEntr
  */
 export async function getAllLockedSkills(): Promise<Record<string, SkillLockEntry>> {
   const lock = await readSkillLock();
-  return lock.skills;
+  const aggregated: Record<string, SkillLockEntry> = {};
+
+  for (const [lockKey, entry] of Object.entries(lock.skills)) {
+    const skillName = getSkillNameFromLockKey(lockKey);
+    if (!(skillName in aggregated)) {
+      aggregated[skillName] = entry;
+    }
+  }
+
+  return aggregated;
 }
 
 /**
@@ -289,7 +365,8 @@ export async function getSkillsBySource(): Promise<
   const lock = await readSkillLock();
   const bySource = new Map<string, { skills: string[]; entry: SkillLockEntry }>();
 
-  for (const [skillName, entry] of Object.entries(lock.skills)) {
+  for (const [lockKey, entry] of Object.entries(lock.skills)) {
+    const skillName = getSkillNameFromLockKey(lockKey);
     const existing = bySource.get(entry.source);
     if (existing) {
       existing.skills.push(skillName);

--- a/tests/skill-lock.test.ts
+++ b/tests/skill-lock.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+async function loadSkillLockModule(fakeHome: string) {
+  vi.resetModules();
+  vi.doMock('os', async () => {
+    const actual = await vi.importActual<typeof import('node:os')>('node:os');
+    return {
+      ...actual,
+      homedir: () => fakeHome,
+    };
+  });
+
+  return import('../src/skill-lock.ts');
+}
+
+describe('skill-lock global lockfile behavior', () => {
+  let testDir: string;
+  let fakeHome: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), 'skill-lock-test-'));
+    fakeHome = join(testDir, 'home');
+    lockPath = join(fakeHome, '.agents', '.skill-lock.json');
+    await mkdir(join(fakeHome, '.agents'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    vi.doUnmock('os');
+    vi.resetModules();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('dismissPrompt should not wipe tracked skills from a legacy lockfile', async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 2,
+          skills: {
+            'tracked-skill': {
+              source: 'org/repo',
+              sourceType: 'github',
+              sourceUrl: 'https://github.com/org/repo',
+              skillPath: 'skills/tracked-skill/SKILL.md',
+              skillFolderHash: 'abc123',
+              installedAt: '2026-03-12T00:00:00.000Z',
+              updatedAt: '2026-03-12T00:00:00.000Z',
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    const skillLock = await loadSkillLockModule(fakeHome);
+    await skillLock.dismissPrompt('findSkillsPrompt');
+
+    const written = JSON.parse(await readFile(lockPath, 'utf-8'));
+    expect(written.skills['tracked-skill']).toBeDefined();
+    expect(written.dismissed.findSkillsPrompt).toBe(true);
+  });
+
+  it('saveSelectedAgents should not wipe tracked skills from a legacy lockfile', async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 2,
+          skills: {
+            'tracked-skill': {
+              source: 'org/repo',
+              sourceType: 'github',
+              sourceUrl: 'https://github.com/org/repo',
+              skillPath: 'skills/tracked-skill/SKILL.md',
+              skillFolderHash: 'abc123',
+              installedAt: '2026-03-12T00:00:00.000Z',
+              updatedAt: '2026-03-12T00:00:00.000Z',
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    const skillLock = await loadSkillLockModule(fakeHome);
+    await skillLock.saveSelectedAgents(['codex', 'opencode']);
+
+    const written = JSON.parse(await readFile(lockPath, 'utf-8'));
+    expect(written.skills['tracked-skill']).toBeDefined();
+    expect(written.lastSelectedAgents).toEqual(['codex', 'opencode']);
+  });
+
+  it('dismissPrompt should preserve unknown top-level fields when rewriting the lockfile', async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 3,
+          skills: {
+            'tracked-skill': {
+              source: 'org/repo',
+              sourceType: 'github',
+              sourceUrl: 'https://github.com/org/repo',
+              skillPath: 'skills/tracked-skill/SKILL.md',
+              skillFolderHash: 'abc123',
+              installedAt: '2026-03-12T00:00:00.000Z',
+              updatedAt: '2026-03-12T00:00:00.000Z',
+            },
+          },
+          customMetadata: {
+            sourceGroupingMode: 'composite-keys',
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    const skillLock = await loadSkillLockModule(fakeHome);
+    await skillLock.dismissPrompt('findSkillsPrompt');
+
+    const written = JSON.parse(await readFile(lockPath, 'utf-8'));
+    expect(written.skills['tracked-skill']).toBeDefined();
+    expect(written.dismissed.findSkillsPrompt).toBe(true);
+    expect(written.customMetadata).toEqual({
+      sourceGroupingMode: 'composite-keys',
+    });
+  });
+
+  it('addSkillToLock should not overwrite a different source that shares the same skill name', async () => {
+    const skillLock = await loadSkillLockModule(fakeHome);
+
+    await skillLock.addSkillToLock('shared-skill', {
+      source: 'org/alpha',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/org/alpha',
+      skillPath: 'skills/shared-skill/SKILL.md',
+      skillFolderHash: 'hash-alpha',
+    });
+
+    await skillLock.addSkillToLock('shared-skill', {
+      source: 'org/beta',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/org/beta',
+      skillPath: 'skills/shared-skill/SKILL.md',
+      skillFolderHash: 'hash-beta',
+    });
+
+    const written = JSON.parse(await readFile(lockPath, 'utf-8'));
+    expect(Object.keys(written.skills)).toHaveLength(2);
+    expect(
+      Object.values(written.skills).some(
+        (entry: any) => entry.source === 'org/alpha' && entry.skillFolderHash === 'hash-alpha'
+      )
+    ).toBe(true);
+    expect(
+      Object.values(written.skills).some(
+        (entry: any) => entry.source === 'org/beta' && entry.skillFolderHash === 'hash-beta'
+      )
+    ).toBe(true);
+  });
+
+  it('getSkillsBySource should preserve same-name skills from different sources', async () => {
+    const skillLock = await loadSkillLockModule(fakeHome);
+
+    await skillLock.addSkillToLock('shared-skill', {
+      source: 'org/alpha',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/org/alpha',
+      skillPath: 'skills/shared-skill/SKILL.md',
+      skillFolderHash: 'hash-alpha',
+    });
+
+    await skillLock.addSkillToLock('shared-skill', {
+      source: 'org/beta',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/org/beta',
+      skillPath: 'skills/shared-skill/SKILL.md',
+      skillFolderHash: 'hash-beta',
+    });
+
+    const bySource = await skillLock.getSkillsBySource();
+    expect(Array.from(bySource.keys()).sort()).toEqual(['org/alpha', 'org/beta']);
+    expect(bySource.get('org/alpha')?.skills).toEqual(['shared-skill']);
+    expect(bySource.get('org/beta')?.skills).toEqual(['shared-skill']);
+  });
+
+  it('removeSkillFromLock should remove all tracked variants of a colliding skill name', async () => {
+    const skillLock = await loadSkillLockModule(fakeHome);
+
+    await skillLock.addSkillToLock('shared-skill', {
+      source: 'org/alpha',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/org/alpha',
+      skillPath: 'skills/shared-skill/SKILL.md',
+      skillFolderHash: 'hash-alpha',
+    });
+
+    await skillLock.addSkillToLock('shared-skill', {
+      source: 'org/beta',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/org/beta',
+      skillPath: 'skills/shared-skill/SKILL.md',
+      skillFolderHash: 'hash-beta',
+    });
+
+    const removed = await skillLock.removeSkillFromLock('shared-skill');
+    const written = JSON.parse(await readFile(lockPath, 'utf-8'));
+
+    expect(removed).toBe(true);
+    expect(Object.keys(written.skills)).toHaveLength(0);
+  });
+
+  it('removeSkillFromLock should remove all source-aware entries for a shared skill name', async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 3,
+          skills: {
+            'org/alpha::shared-skill': {
+              source: 'org/alpha',
+              sourceType: 'github',
+              sourceUrl: 'https://github.com/org/alpha',
+              skillPath: 'skills/shared-skill/SKILL.md',
+              skillFolderHash: 'hash-alpha',
+              installedAt: '2026-03-12T00:00:00.000Z',
+              updatedAt: '2026-03-12T00:00:00.000Z',
+            },
+            'org/beta::shared-skill': {
+              source: 'org/beta',
+              sourceType: 'github',
+              sourceUrl: 'https://github.com/org/beta',
+              skillPath: 'skills/shared-skill/SKILL.md',
+              skillFolderHash: 'hash-beta',
+              installedAt: '2026-03-12T00:00:00.000Z',
+              updatedAt: '2026-03-12T00:00:00.000Z',
+            },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    const skillLock = await loadSkillLockModule(fakeHome);
+    const removed = await skillLock.removeSkillFromLock('shared-skill');
+    const written = JSON.parse(await readFile(lockPath, 'utf-8'));
+
+    expect(removed).toBe(true);
+    expect(Object.keys(written.skills)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve unknown top-level lockfile fields instead of dropping them on rewrite
- preserve tracked state when migrating older global lockfiles forward
- use source-aware keys for global lock entries so same-name skills from different sources do not collide
- update lockfile helpers and regressions around collisions and lossy rewrites

## Why
Two separate correctness problems were compounding here:
- harmless-looking lockfile metadata writes could be lossy
- same-name skills from different sources collided because lock entries were keyed only by visible skill name

## Verification
- `pnpm exec vitest run tests/skill-lock.test.ts --reporter=dot`

Closes #606
