### PR TITLE
perf: cache repo tree fetches during global add

### DIFF
--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -160,6 +160,17 @@ export function getGitHubToken(): string | null {
  * @param token - Optional GitHub token for authenticated requests (higher rate limits)
  * @returns The tree SHA for the skill folder, or null if not found
  */
+const repoTreeCache = new Map<
+  string,
+  Promise<
+    | {
+        sha: string;
+        tree: Array<{ path: string; type: string; sha: string }>;
+      }
+    | null
+  >
+>();
+
 export async function fetchSkillFolderHash(
   ownerRepo: string,
   skillPath: string,
@@ -184,23 +195,35 @@ export async function fetchSkillFolderHash(
 
   for (const branch of branches) {
     try {
-      const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
-      const headers: Record<string, string> = {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'skills-cli',
-      };
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
+      const cacheKey = `${ownerRepo}@${branch}`;
+      let treePromise = repoTreeCache.get(cacheKey);
+
+      if (!treePromise) {
+        treePromise = (async () => {
+          const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
+          const headers: Record<string, string> = {
+            Accept: 'application/vnd.github.v3+json',
+            'User-Agent': 'skills-cli',
+          };
+          if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+          }
+
+          const response = await fetch(url, { headers });
+          if (!response.ok) {
+            return null;
+          }
+
+          return (await response.json()) as {
+            sha: string;
+            tree: Array<{ path: string; type: string; sha: string }>;
+          };
+        })();
+        repoTreeCache.set(cacheKey, treePromise);
       }
 
-      const response = await fetch(url, { headers });
-
-      if (!response.ok) continue;
-
-      const data = (await response.json()) as {
-        sha: string;
-        tree: Array<{ path: string; type: string; sha: string }>;
-      };
+      const data = await treePromise;
+      if (!data) continue;
 
       // If folderPath is empty, this is a root-level skill - use the root tree SHA
       if (!folderPath) {

--- a/tests/add-global-hash-fetch.test.ts
+++ b/tests/add-global-hash-fetch.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockSpinnerStart,
+  mockSpinnerStop,
+  mockCloneRepo,
+  mockCleanupTempDir,
+  mockDiscoverSkills,
+  mockInstallSkillForAgent,
+  mockIsSkillInstalled,
+  mockGetCanonicalPath,
+  mockDetectInstalledAgents,
+  mockTrack,
+  mockFetchAuditData,
+  mockAddSkillToLock,
+  mockGetGitHubToken,
+} = vi.hoisted(() => ({
+  mockSpinnerStart: vi.fn(),
+  mockSpinnerStop: vi.fn(),
+  mockCloneRepo: vi.fn(),
+  mockCleanupTempDir: vi.fn(),
+  mockDiscoverSkills: vi.fn(),
+  mockInstallSkillForAgent: vi.fn(),
+  mockIsSkillInstalled: vi.fn(),
+  mockGetCanonicalPath: vi.fn(),
+  mockDetectInstalledAgents: vi.fn(),
+  mockTrack: vi.fn(),
+  mockFetchAuditData: vi.fn(),
+  mockAddSkillToLock: vi.fn(),
+  mockGetGitHubToken: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  note: vi.fn(),
+  cancel: vi.fn(),
+  isCancel: vi.fn(() => false),
+  log: {
+    info: vi.fn(),
+    message: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    start: mockSpinnerStart,
+    stop: mockSpinnerStop,
+  })),
+}));
+
+vi.mock('../src/git.ts', () => ({
+  GitCloneError: class GitCloneError extends Error {},
+  cloneRepo: mockCloneRepo,
+  cleanupTempDir: mockCleanupTempDir,
+}));
+
+vi.mock('../src/skills.ts', () => ({
+  discoverSkills: mockDiscoverSkills,
+  getSkillDisplayName: (skill: { name: string }) => skill.name,
+  filterSkills: (skills: Array<{ name: string }>, names: string[]) =>
+    skills.filter((skill) => names.includes(skill.name)),
+}));
+
+vi.mock('../src/installer.ts', () => ({
+  installSkillForAgent: mockInstallSkillForAgent,
+  isSkillInstalled: mockIsSkillInstalled,
+  getInstallPath: vi.fn(),
+  getCanonicalPath: mockGetCanonicalPath,
+}));
+
+vi.mock('../src/agents.ts', () => ({
+  detectInstalledAgents: mockDetectInstalledAgents,
+  agents: {
+    codex: {
+      displayName: 'Codex',
+      skillsDir: '.codex/skills',
+      globalSkillsDir: '/fake/home/.codex/skills',
+    },
+  },
+  getUniversalAgents: vi.fn(() => []),
+  getNonUniversalAgents: vi.fn(() => ['codex']),
+  isUniversalAgent: vi.fn(() => false),
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  track: mockTrack,
+  setVersion: vi.fn(),
+  fetchAuditData: mockFetchAuditData,
+}));
+
+vi.mock('../src/skill-lock.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/skill-lock.ts')>(
+    '../src/skill-lock.ts'
+  );
+
+  return {
+    ...actual,
+    addSkillToLock: mockAddSkillToLock,
+    getGitHubToken: mockGetGitHubToken,
+    isPromptDismissed: vi.fn(),
+    dismissPrompt: vi.fn(),
+    getLastSelectedAgents: vi.fn(),
+    saveSelectedAgents: vi.fn(),
+  };
+});
+
+vi.mock('../src/local-lock.ts', () => ({
+  addSkillToLocalLock: vi.fn(),
+  computeSkillFolderHash: vi.fn(),
+}));
+
+vi.mock('../src/source-parser.ts', () => ({
+  parseSource: vi.fn(() => ({
+    type: 'github',
+    url: 'https://github.com/org/repo.git',
+  })),
+  getOwnerRepo: vi.fn(() => 'org/repo'),
+  parseOwnerRepo: vi.fn(() => ({ owner: 'org', repo: 'repo' })),
+  isRepoPrivate: vi.fn(async () => false),
+}));
+
+vi.mock('../src/prompts/search-multiselect.ts', () => ({
+  searchMultiselect: vi.fn(),
+  cancelSymbol: Symbol('cancel'),
+}));
+
+import { runAdd } from '../src/add.ts';
+
+describe('runAdd global hash fetching', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCloneRepo.mockResolvedValue('/tmp/cloned-repo');
+    mockCleanupTempDir.mockResolvedValue(undefined);
+    mockDiscoverSkills.mockResolvedValue([
+      {
+        name: 'alpha',
+        description: 'Alpha skill',
+        path: '/tmp/cloned-repo/skills/alpha',
+      },
+      {
+        name: 'beta',
+        description: 'Beta skill',
+        path: '/tmp/cloned-repo/skills/beta',
+      },
+    ]);
+    mockDetectInstalledAgents.mockResolvedValue(['codex']);
+    mockIsSkillInstalled.mockResolvedValue(false);
+    mockInstallSkillForAgent.mockResolvedValue({
+      success: true,
+      path: '/fake/path',
+      canonicalPath: '/fake/canonical',
+      mode: 'symlink',
+    });
+    mockGetCanonicalPath.mockImplementation((skillName: string) => `/fake/canonical/${skillName}`);
+    mockFetchAuditData.mockResolvedValue(null);
+    mockAddSkillToLock.mockResolvedValue(undefined);
+    mockGetGitHubToken.mockReturnValue(null);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sha: 'root-tree-sha',
+        tree: [
+          { path: 'skills/alpha', type: 'tree', sha: 'tree-alpha' },
+          { path: 'skills/beta', type: 'tree', sha: 'tree-beta' },
+        ],
+      }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch repo tree data only once for multiple global skills from the same source', async () => {
+    await runAdd(['org/repo'], {
+      global: true,
+      yes: true,
+      agent: ['codex'],
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- cache GitHub recursive tree fetches per `ownerRepo@branch`
- reuse the cached tree when multiple skills are installed from the same source in one global add run
- add a regression around repeated tree fetches during multi-skill global add

## Why
Global add was repeatedly fetching the same full GitHub repo tree for each selected skill from the same source. That makes multi-skill installs much slower than they need to be.

## Verification
- `pnpm exec vitest run tests/add-global-hash-fetch.test.ts --reporter=dot`

Closes #607
