### PR TITLE
Support check and update for non-GitHub sources

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -55,6 +55,7 @@ import {
   saveSelectedAgents,
 } from './skill-lock.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
+import { computeTextFileHash, computeTrackedSkillDirectoryHash } from './skill-hash.ts';
 import type { Skill, AgentType } from './types.ts';
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
@@ -780,7 +781,7 @@ async function handleWellKnownSkills(
             source: sourceIdentifier,
             sourceType: 'well-known',
             sourceUrl: skill.sourceUrl,
-            skillFolderHash: '', // Well-known skills don't have a folder hash
+            skillFolderHash: computeTextFileHash(skill.files),
           });
         } catch {
           // Don't fail installation if lock file update fails
@@ -1501,7 +1502,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
-            // Fetch the folder hash from GitHub Trees API
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
@@ -1513,6 +1513,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 parsed.ref
               );
               if (hash) skillFolderHash = hash;
+            } else {
+              const matchingResult = successful.find((result) => result.skill === skillDisplayName);
+              const installDir = matchingResult?.canonicalPath || matchingResult?.path;
+              if (installDir) {
+                skillFolderHash = await computeTrackedSkillDirectoryHash(installDir);
+              }
             }
 
             await addSkillToLock(skill.name, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,12 @@ import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
-import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { getGitHubToken } from './skill-lock.ts';
+import {
+  buildUpdateCommandArgs,
+  getInstalledTrackingHash,
+  getLatestTrackingHash,
+} from './update-tracking.ts';
 import { buildUpdateInstallSource, formatSourceInput } from './update-source.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -287,7 +292,7 @@ interface SkillLockEntry {
   sourceUrl: string;
   ref?: string;
   skillPath?: string;
-  /** GitHub tree SHA for the entire skill folder (v3) */
+  /** Version tracking hash for the skill folder (v3) */
   skillFolderHash: string;
   installedAt: string;
   updatedAt: string;
@@ -325,6 +330,17 @@ function readSkillLock(): SkillLockFile {
   }
 }
 
+function writeSkillLock(lock: SkillLockFile): void {
+  const lockPath = getSkillLockPath();
+  const lockDir = dirname(lockPath);
+
+  if (!existsSync(lockDir)) {
+    mkdirSync(lockDir, { recursive: true });
+  }
+
+  writeFileSync(lockPath, JSON.stringify(lock, null, 2), 'utf-8');
+}
+
 interface SkippedSkill {
   name: string;
   reason: string;
@@ -339,13 +355,13 @@ function getSkipReason(entry: SkillLockEntry): string {
   if (entry.sourceType === 'local') {
     return 'Local path';
   }
-  if (entry.sourceType === 'git') {
-    return 'Git URL (hash tracking not supported)';
+  if (!entry.sourceUrl) {
+    return 'No source URL recorded';
   }
-  if (!entry.skillFolderHash) {
+  if (entry.sourceType === 'github' && !entry.skillFolderHash) {
     return 'No version hash available';
   }
-  if (!entry.skillPath) {
+  if (entry.sourceType === 'github' && !entry.skillPath) {
     return 'No skill path recorded';
   }
   return 'No version tracking';
@@ -383,16 +399,16 @@ async function runCheck(args: string[] = []): Promise<void> {
   // Get GitHub token from user's environment for higher rate limits
   const token = getGitHubToken();
 
-  // Group skills by source (owner/repo) to batch GitHub API calls
-  const skillsBySource = new Map<string, Array<{ name: string; entry: SkillLockEntry }>>();
+  const trackedSkills: Array<{ name: string; entry: SkillLockEntry; currentHash: string }> = [];
   const skipped: SkippedSkill[] = [];
+  let lockChanged = false;
 
   for (const skillName of skillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check skills with folder hash and skill path
-    if (!entry.skillFolderHash || !entry.skillPath) {
+    const currentHash = await getInstalledTrackingHash(skillName, entry);
+    if (!currentHash) {
       skipped.push({
         name: skillName,
         reason: getSkipReason(entry),
@@ -402,14 +418,21 @@ async function runCheck(args: string[] = []): Promise<void> {
       continue;
     }
 
-    const existing = skillsBySource.get(entry.source) || [];
-    existing.push({ name: skillName, entry });
-    skillsBySource.set(entry.source, existing);
+    if (!entry.skillFolderHash) {
+      entry.skillFolderHash = currentHash;
+      lockChanged = true;
+    }
+
+    trackedSkills.push({ name: skillName, entry, currentHash });
   }
 
-  const totalSkills = skillNames.length - skipped.length;
+  if (lockChanged) {
+    writeSkillLock(lock);
+  }
+
+  const totalSkills = trackedSkills.length;
   if (totalSkills === 0) {
-    console.log(`${DIM}No GitHub skills to check.${RESET}`);
+    console.log(`${DIM}No skills to check.${RESET}`);
     printSkippedSkills(skipped);
     return;
   }
@@ -419,27 +442,24 @@ async function runCheck(args: string[] = []): Promise<void> {
   const updates: Array<{ name: string; source: string }> = [];
   const errors: Array<{ name: string; source: string; error: string }> = [];
 
-  // Check each source (one API call per repo)
-  for (const [source, skills] of skillsBySource) {
-    for (const { name, entry } of skills) {
-      try {
-        const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token, entry.ref);
+  for (const { name, entry, currentHash } of trackedSkills) {
+    try {
+      const latestHash = await getLatestTrackingHash(name, entry, token);
 
-        if (!latestHash) {
-          errors.push({ name, source, error: 'Could not fetch from GitHub' });
-          continue;
-        }
-
-        if (latestHash !== entry.skillFolderHash) {
-          updates.push({ name, source });
-        }
-      } catch (err) {
-        errors.push({
-          name,
-          source,
-          error: err instanceof Error ? err.message : 'Unknown error',
-        });
+      if (!latestHash) {
+        errors.push({ name, source: entry.source, error: 'Could not fetch latest version' });
+        continue;
       }
+
+      if (latestHash !== currentHash) {
+        updates.push({ name, source: entry.source });
+      }
+    } catch (err) {
+      errors.push({
+        name,
+        source: entry.source,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
     }
   }
 
@@ -498,16 +518,16 @@ async function runUpdate(): Promise<void> {
   // Get GitHub token from user's environment for higher rate limits
   const token = getGitHubToken();
 
-  // Find skills that need updates by checking GitHub directly
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
+  let lockChanged = false;
 
   for (const skillName of skillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check skills with folder hash and skill path
-    if (!entry.skillFolderHash || !entry.skillPath) {
+    const currentHash = await getInstalledTrackingHash(skillName, entry);
+    if (!currentHash) {
       skipped.push({
         name: skillName,
         reason: getSkipReason(entry),
@@ -517,20 +537,24 @@ async function runUpdate(): Promise<void> {
       continue;
     }
 
-    try {
-      const latestHash = await fetchSkillFolderHash(
-        entry.source,
-        entry.skillPath,
-        token,
-        entry.ref
-      );
+    if (!entry.skillFolderHash) {
+      entry.skillFolderHash = currentHash;
+      lockChanged = true;
+    }
 
-      if (latestHash && latestHash !== entry.skillFolderHash) {
+    try {
+      const latestHash = await getLatestTrackingHash(skillName, entry, token);
+
+      if (latestHash && latestHash !== currentHash) {
         updates.push({ name: skillName, source: entry.source, entry });
       }
     } catch {
       // Skip skills that fail to check
     }
+  }
+
+  if (lockChanged) {
+    writeSkillLock(lock);
   }
 
   const checkedCount = skillNames.length - skipped.length;
@@ -559,7 +583,7 @@ async function runUpdate(): Promise<void> {
 
     // Build the source input to target the specific skill directory/ref.
     // e.g., owner/repo/skills/my-skill#feature-branch
-    const installUrl = buildUpdateInstallSource(update.entry);
+    const installSource = buildUpdateInstallSource(update.entry);
 
     // Reinstall using the current CLI entrypoint directly (avoid nested npm exec/npx)
     const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
@@ -570,11 +594,15 @@ async function runUpdate(): Promise<void> {
       );
       continue;
     }
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-      shell: process.platform === 'win32',
-    });
+    const result = spawnSync(
+      process.execPath,
+      [cliEntry, ...buildUpdateCommandArgs(update.name, installSource)],
+      {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+        shell: process.platform === 'win32',
+      }
+    );
 
     if (result.status === 0) {
       successCount++;

--- a/src/git.ts
+++ b/src/git.ts
@@ -21,9 +21,9 @@ export class GitCloneError extends Error {
 
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const git = simpleGit({
-    timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  const git = simpleGit({ timeout: { block: CLONE_TIMEOUT_MS } }).env({
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
   });
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 

--- a/src/skill-hash.ts
+++ b/src/skill-hash.ts
@@ -1,0 +1,69 @@
+import { createHash } from 'crypto';
+import { readFile, readdir } from 'fs/promises';
+import { join, relative } from 'path';
+
+const EXCLUDED_FILES = new Set(['metadata.json']);
+const EXCLUDED_DIRS = new Set(['.git']);
+
+function isTrackedEntry(name: string, isDirectory: boolean): boolean {
+  if (EXCLUDED_FILES.has(name)) return false;
+  if (name.startsWith('_')) return false;
+  if (isDirectory && EXCLUDED_DIRS.has(name)) return false;
+  return true;
+}
+
+export async function computeTrackedSkillDirectoryHash(skillDir: string): Promise<string> {
+  const files: Array<{ relativePath: string; content: Buffer }> = [];
+  await collectTrackedFiles(skillDir, skillDir, files);
+
+  files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+  const hash = createHash('sha256');
+  for (const file of files) {
+    hash.update(file.relativePath);
+    hash.update(file.content);
+  }
+
+  return hash.digest('hex');
+}
+
+export function computeTextFileHash(files: Iterable<[string, string]>): string {
+  const sortedFiles = Array.from(files).sort(([left], [right]) => left.localeCompare(right));
+  const hash = createHash('sha256');
+
+  for (const [filePath, content] of sortedFiles) {
+    hash.update(filePath);
+    hash.update(content, 'utf-8');
+  }
+
+  return hash.digest('hex');
+}
+
+async function collectTrackedFiles(
+  baseDir: string,
+  currentDir: string,
+  results: Array<{ relativePath: string; content: Buffer }>
+): Promise<void> {
+  const entries = await readdir(currentDir, { withFileTypes: true });
+
+  await Promise.all(
+    entries
+      .filter((entry) => isTrackedEntry(entry.name, entry.isDirectory()))
+      .map(async (entry) => {
+        const fullPath = join(currentDir, entry.name);
+
+        if (entry.isDirectory()) {
+          await collectTrackedFiles(baseDir, fullPath, results);
+          return;
+        }
+
+        if (!entry.isFile()) {
+          return;
+        }
+
+        const content = await readFile(fullPath);
+        const relativePath = relative(baseDir, fullPath).split('\\').join('/');
+        results.push({ relativePath, content });
+      })
+  );
+}

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -23,9 +23,9 @@ export interface SkillLockEntry {
   /** Subpath within the source repo, if applicable */
   skillPath?: string;
   /**
-   * GitHub tree SHA for the entire skill folder.
-   * This hash changes when ANY file in the skill folder changes.
-   * Fetched via GitHub Trees API by the telemetry server.
+   * Version tracking hash for the installed skill.
+   * GitHub sources store the tree SHA from the GitHub Trees API.
+   * Other remote sources store a SHA-256 over the installed skill files.
    */
   skillFolderHash: string;
   /** ISO timestamp when the skill was first installed */

--- a/src/update-tracking.ts
+++ b/src/update-tracking.ts
@@ -1,0 +1,147 @@
+import { existsSync } from 'fs';
+import { cleanupTempDir, cloneRepo } from './git.ts';
+import { getCanonicalPath } from './installer.ts';
+import { wellKnownProvider } from './providers/index.ts';
+import { computeTextFileHash, computeTrackedSkillDirectoryHash } from './skill-hash.ts';
+import type { SkillLockEntry } from './skill-lock.ts';
+import { fetchSkillFolderHash } from './skill-lock.ts';
+import { discoverSkills, filterSkills, getSkillDisplayName } from './skills.ts';
+import type { Skill } from './types.ts';
+
+export async function getInstalledTrackingHash(
+  skillName: string,
+  entry: Pick<SkillLockEntry, 'skillFolderHash' | 'sourceType'>
+): Promise<string | null> {
+  if (entry.skillFolderHash) {
+    return entry.skillFolderHash;
+  }
+
+  if (entry.sourceType === 'github' || entry.sourceType === 'local') {
+    return null;
+  }
+
+  const installPath = getCanonicalPath(skillName, { global: true });
+  if (!existsSync(installPath)) {
+    return null;
+  }
+
+  try {
+    return await computeTrackedSkillDirectoryHash(installPath);
+  } catch {
+    return null;
+  }
+}
+
+export async function getLatestTrackingHash(
+  skillName: string,
+  entry: Pick<SkillLockEntry, 'source' | 'sourceType' | 'sourceUrl' | 'skillPath' | 'ref'>,
+  token?: string | null
+): Promise<string | null> {
+  switch (entry.sourceType) {
+    case 'github':
+      if (!entry.skillPath) {
+        return null;
+      }
+      return fetchSkillFolderHash(entry.source, entry.skillPath, token, entry.ref);
+    case 'well-known':
+      return fetchWellKnownSkillHash(skillName, entry.sourceUrl);
+    case 'git':
+    case 'gitlab':
+      return fetchRepositorySkillHash(skillName, entry.sourceUrl, entry.ref);
+    default:
+      return null;
+  }
+}
+
+export function buildUpdateCommandArgs(skillName: string, source: string): string[] {
+  return ['add', source, '-g', '-y', '--skill', skillName];
+}
+
+async function fetchRepositorySkillHash(
+  skillName: string,
+  sourceUrl: string,
+  ref?: string
+): Promise<string | null> {
+  let tempDir: string | null = null;
+
+  try {
+    tempDir = await cloneRepo(sourceUrl, ref);
+    const skills = await discoverSkills(tempDir, undefined, { includeInternal: true });
+    const selectedSkill = selectSkillByName(skills, skillName);
+    if (!selectedSkill) {
+      return null;
+    }
+
+    return await computeTrackedSkillDirectoryHash(selectedSkill.path);
+  } catch {
+    return null;
+  } finally {
+    if (tempDir) {
+      await cleanupTempDir(tempDir);
+    }
+  }
+}
+
+async function fetchWellKnownSkillHash(
+  skillName: string,
+  sourceUrl: string
+): Promise<string | null> {
+  const parsedSource = parseWellKnownSkillSource(sourceUrl);
+
+  if (parsedSource) {
+    const indexResult = await wellKnownProvider.fetchIndex(parsedSource.baseUrl);
+    const matchedEntry = indexResult?.index.skills.find(
+      (entry) => entry.name === parsedSource.skillSlug
+    );
+
+    if (indexResult && matchedEntry) {
+      const skill = await wellKnownProvider.fetchSkillByEntry(
+        indexResult.resolvedBaseUrl,
+        matchedEntry
+      );
+      if (skill) {
+        return computeTextFileHash(skill.files);
+      }
+    }
+  }
+
+  const skills = await wellKnownProvider.fetchAllSkills(sourceUrl);
+  const selectedSkill = skills.find(
+    (skill) => skill.installName === skillName || skill.name === skillName
+  );
+
+  return selectedSkill ? computeTextFileHash(selectedSkill.files) : null;
+}
+
+function selectSkillByName(skills: Skill[], skillName: string): Skill | null {
+  const exactMatch = skills.find(
+    (skill) => getSkillDisplayName(skill) === skillName || skill.name === skillName
+  );
+
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const filteredSkills = filterSkills(skills, [skillName]);
+  return filteredSkills.length === 1 ? filteredSkills[0]! : null;
+}
+
+function parseWellKnownSkillSource(
+  sourceUrl: string
+): { baseUrl: string; skillSlug: string } | null {
+  try {
+    const parsedUrl = new URL(sourceUrl);
+    const match = parsedUrl.pathname.match(/^(.*)\/\.well-known\/skills\/([^/]+)\/SKILL\.md$/i);
+    if (!match) {
+      return null;
+    }
+
+    const [, basePath, skillSlug] = match;
+    return {
+      baseUrl: `${parsedUrl.protocol}//${parsedUrl.host}${basePath || ''}`,
+      skillSlug: skillSlug!,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/tests/update-tracking.test.ts
+++ b/tests/update-tracking.test.ts
@@ -1,0 +1,159 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computeTextFileHash, computeTrackedSkillDirectoryHash } from '../src/skill-hash.ts';
+
+const {
+  cloneRepoMock,
+  cleanupTempDirMock,
+  fetchIndexMock,
+  fetchSkillByEntryMock,
+  fetchAllSkillsMock,
+} = vi.hoisted(() => ({
+  cloneRepoMock: vi.fn(),
+  cleanupTempDirMock: vi.fn(),
+  fetchIndexMock: vi.fn(),
+  fetchSkillByEntryMock: vi.fn(),
+  fetchAllSkillsMock: vi.fn(),
+}));
+
+vi.mock('../src/git.ts', () => ({
+  cloneRepo: cloneRepoMock,
+  cleanupTempDir: cleanupTempDirMock,
+}));
+
+vi.mock('../src/providers/index.ts', () => ({
+  wellKnownProvider: {
+    fetchIndex: fetchIndexMock,
+    fetchSkillByEntry: fetchSkillByEntryMock,
+    fetchAllSkills: fetchAllSkillsMock,
+  },
+}));
+
+import {
+  buildUpdateCommandArgs,
+  getInstalledTrackingHash,
+  getLatestTrackingHash,
+} from '../src/update-tracking.ts';
+
+describe('update tracking', () => {
+  let tempHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-update-tracking-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+    cloneRepoMock.mockReset();
+    cleanupTempDirMock.mockReset();
+    fetchIndexMock.mockReset();
+    fetchSkillByEntryMock.mockReset();
+    fetchAllSkillsMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('backfills installed hashes for non-GitHub skills from the canonical install directory', async () => {
+    const installDir = join(tempHome, '.agents', 'skills', 'gitlab-skill');
+    await mkdir(installDir, { recursive: true });
+    await writeFile(
+      join(installDir, 'SKILL.md'),
+      '---\nname: gitlab-skill\ndescription: Test skill\n---\n'
+    );
+    await writeFile(join(installDir, 'guide.md'), 'hello world');
+
+    const currentHash = await getInstalledTrackingHash('gitlab-skill', {
+      sourceType: 'gitlab',
+      skillFolderHash: '',
+    });
+
+    expect(currentHash).toBe(await computeTrackedSkillDirectoryHash(installDir));
+  });
+
+  it('does not synthesize GitHub hashes when the lock entry is missing one', async () => {
+    const currentHash = await getInstalledTrackingHash('github-skill', {
+      sourceType: 'github',
+      skillFolderHash: '',
+    });
+
+    expect(currentHash).toBeNull();
+  });
+
+  it('computes the latest hash for well-known skills from fetched skill files', async () => {
+    const files = new Map<string, string>([
+      ['SKILL.md', '---\nname: test-skill\ndescription: Test skill\n---\n'],
+      ['guide.md', 'latest content'],
+    ]);
+
+    fetchIndexMock.mockResolvedValue({
+      index: {
+        skills: [
+          { name: 'test-skill', description: 'Test skill', files: ['SKILL.md', 'guide.md'] },
+        ],
+      },
+      resolvedBaseUrl: 'https://docs.example.com',
+    });
+    fetchSkillByEntryMock.mockResolvedValue({ files });
+
+    const latestHash = await getLatestTrackingHash(
+      'test-skill',
+      {
+        source: 'docs.example.com',
+        sourceType: 'well-known',
+        sourceUrl: 'https://docs.example.com/.well-known/skills/test-skill/SKILL.md',
+      },
+      null
+    );
+
+    expect(latestHash).toBe(computeTextFileHash(files));
+    expect(fetchAllSkillsMock).not.toHaveBeenCalled();
+  });
+
+  it('computes the latest hash for GitLab skills from cloned repository contents', async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), 'skills-update-repo-'));
+    const skillDir = join(repoDir, 'skills', 'gitlab-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: gitlab-skill\ndescription: Test skill\n---\n'
+    );
+    await writeFile(join(skillDir, 'guide.md'), 'latest content');
+
+    cloneRepoMock.mockResolvedValue(repoDir);
+
+    const latestHash = await getLatestTrackingHash(
+      'gitlab-skill',
+      {
+        source: 'group/repo',
+        sourceType: 'gitlab',
+        sourceUrl: 'https://gitlab.com/group/repo.git',
+      },
+      null
+    );
+
+    expect(latestHash).toBe(await computeTrackedSkillDirectoryHash(skillDir));
+    expect(cloneRepoMock).toHaveBeenCalledWith('https://gitlab.com/group/repo.git');
+    expect(cleanupTempDirMock).toHaveBeenCalledWith(repoDir);
+
+    await rm(repoDir, { recursive: true, force: true });
+  });
+
+  it('builds update commands that reinstall only the selected skill', () => {
+    expect(buildUpdateCommandArgs('test-skill', 'https://example.com/source')).toEqual([
+      'add',
+      'https://example.com/source',
+      '-g',
+      '-y',
+      '--skill',
+      'test-skill',
+    ]);
+  });
+});

--- a/tests/update-tracking.test.ts
+++ b/tests/update-tracking.test.ts
@@ -140,7 +140,7 @@ describe('update tracking', () => {
     );
 
     expect(latestHash).toBe(await computeTrackedSkillDirectoryHash(skillDir));
-    expect(cloneRepoMock).toHaveBeenCalledWith('https://gitlab.com/group/repo.git');
+    expect(cloneRepoMock).toHaveBeenCalledWith('https://gitlab.com/group/repo.git', undefined);
     expect(cleanupTempDirMock).toHaveBeenCalledWith(repoDir);
 
     await rm(repoDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add version tracking and update checks for non-GitHub skill sources
- reuse source-aware hashing/update helpers for check and update flows
- fold the post-rebase CLI lock-writer integration fix into the feature commit so the rebased branch stays green
- keep the simple-git typing fix as a separate follow-up commit so type-check passes

Closes #386