### PR TITLE
fix(git): use a typed prompt suppression path for clone

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -25,8 +25,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     timeout: { block: CLONE_TIMEOUT_MS },
   });
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
-  const previousPromptSetting = process.env.GIT_TERMINAL_PROMPT;
-  process.env.GIT_TERMINAL_PROMPT = '0';
+  git.env('GIT_TERMINAL_PROMPT', '0');
 
   try {
     await git.clone(url, tempDir, cloneOptions);
@@ -68,12 +67,6 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     }
 
     throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);
-  } finally {
-    if (previousPromptSetting === undefined) {
-      delete process.env.GIT_TERMINAL_PROMPT;
-    } else {
-      process.env.GIT_TERMINAL_PROMPT = previousPromptSetting;
-    }
   }
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -23,9 +23,10 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const git = simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
   });
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const previousPromptSetting = process.env.GIT_TERMINAL_PROMPT;
+  process.env.GIT_TERMINAL_PROMPT = '0';
 
   try {
     await git.clone(url, tempDir, cloneOptions);
@@ -67,6 +68,12 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     }
 
     throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);
+  } finally {
+    if (previousPromptSetting === undefined) {
+      delete process.env.GIT_TERMINAL_PROMPT;
+    } else {
+      process.env.GIT_TERMINAL_PROMPT = previousPromptSetting;
+    }
   }
 }
 


### PR DESCRIPTION
This pull request resolves #618 by moving clone prompt suppression onto a typed, supported path in `src/git.ts`.

The current clone helper sets `GIT_TERMINAL_PROMPT=0` by passing `env` into the `simpleGit(...)` constructor config, but that option shape is not part of the typed `simple-git` config surface. This keeps the runtime behavior but leaves the clone path leaning on an unsupported API shape.

This change sets `process.env.GIT_TERMINAL_PROMPT='0'` only around the clone operation and restores the previous value in `finally`, preserving non-interactive clone behavior without relying on the untyped constructor option.
