### PR TITLE
fix(build): generate bundled license notices correctly under pnpm

### DIFF
--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,23 +9,6 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
-Package: @clack/core@0.4.1
-License: MIT
-Repository: https://github.com/natemoo-re/clack
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) Nate Moore
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -40,6 +23,46 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
+Package: @clack/core@0.5.0
+License: MIT
+Repository: git+https://github.com/bombshell-dev/clack.git
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
+Package: picocolors@1.1.1
+License: ISC
+Repository: https://github.com/alexeyraspopov/picocolors
+--------------------------------------------------------------------------------
+
+ISC License
+
+Copyright (c) 2021-2024 Oleksii Raspopov, Kostiantyn Denysov, Anton Verinov
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ================================================================================
@@ -72,64 +95,12 @@ THE SOFTWARE.
 
 
 ================================================================================
-Package: picocolors@1.1.1
-License: ISC
-Repository: https://github.com/alexeyraspopov/picocolors
---------------------------------------------------------------------------------
-
-ISC License
-
-Copyright (c) 2021-2024 Oleksii Raspopov, Kostiantyn Denysov, Anton Verinov
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-
-================================================================================
 Package: simple-git@3.30.0
 License: MIT
 Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-================================================================================
-Package: sisteransi@1.0.5
-License: MIT
-Repository: https://github.com/terkelg/sisteransi
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -165,6 +136,35 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
+Package: sisteransi@1.0.5
+License: MIT
+Repository: https://github.com/terkelg/sisteransi
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2018 Terkel Gjervig Nielsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ================================================================================

--- a/scripts/generate-licenses.ts
+++ b/scripts/generate-licenses.ts
@@ -5,11 +5,12 @@
  */
 
 import { execSync } from 'child_process';
-import { writeFileSync, readFileSync, existsSync } from 'fs';
-import { join } from 'path';
+import { writeFileSync, readFileSync, existsSync, readdirSync } from 'fs';
+import { basename, join } from 'path';
+import { pathToFileURL } from 'url';
 
 // Dependencies that get bundled into the CLI
-const BUNDLED_PACKAGES = [
+export const BUNDLED_PACKAGES = [
   '@clack/prompts',
   '@clack/core',
   'picocolors',
@@ -17,7 +18,6 @@ const BUNDLED_PACKAGES = [
   'simple-git',
   'xdg-basedir',
   'sisteransi',
-  'is-unicode-supported',
 ];
 
 interface LicenseInfo {
@@ -25,9 +25,10 @@ interface LicenseInfo {
   repository?: string;
   publisher?: string;
   licenseFile?: string;
+  path?: string;
 }
 
-function getLicenseText(pkgPath: string): string {
+export function getLicenseText(pkgPath: string): string {
   const possibleFiles = ['LICENSE', 'LICENSE.md', 'LICENSE.txt', 'license', 'license.md'];
   for (const file of possibleFiles) {
     const filePath = join(pkgPath, file);
@@ -38,13 +39,44 @@ function getLicenseText(pkgPath: string): string {
   return '';
 }
 
-function main() {
-  console.log('Generating ThirdPartyNoticeText.txt...');
+export function resolveInstalledPackagePath(pkgName: string): string | null {
+  const directPath = join(process.cwd(), 'node_modules', pkgName);
+  if (existsSync(directPath)) {
+    return directPath;
+  }
 
-  // Get license info from license-checker
-  const output = execSync('npx license-checker --json', { encoding: 'utf-8' });
-  const allLicenses: Record<string, LicenseInfo> = JSON.parse(output);
+  const pnpmRoot = join(process.cwd(), 'node_modules', '.pnpm');
+  if (!existsSync(pnpmRoot)) {
+    return null;
+  }
 
+  for (const entry of readdirSync(pnpmRoot)) {
+    const candidatePath = join(pnpmRoot, entry, 'node_modules', pkgName);
+    if (existsSync(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return null;
+}
+
+export function resolveLicenseText(info: LicenseInfo, pkgName: string): string {
+  const licenseFileName = info.licenseFile ? basename(info.licenseFile).toLowerCase() : '';
+  const looksLikeLicenseFile =
+    licenseFileName === 'license' ||
+    licenseFileName.startsWith('license.') ||
+    licenseFileName === 'copying' ||
+    licenseFileName.startsWith('copying.');
+
+  if (info.licenseFile && looksLikeLicenseFile && existsSync(info.licenseFile)) {
+    return readFileSync(info.licenseFile, 'utf-8').trim();
+  }
+
+  const pkgPath = info.path ?? resolveInstalledPackagePath(pkgName);
+  return pkgPath ? getLicenseText(pkgPath) : '';
+}
+
+export function buildThirdPartyNotice(allLicenses: Record<string, LicenseInfo>) {
   const lines: string[] = [
     '/*!----------------- Skills CLI ThirdPartyNotices -------------------------------------------------------',
     '',
@@ -58,26 +90,64 @@ function main() {
     '',
   ];
 
+  const bundledEntries = new Map<string, { pkgNameVersion: string; info: LicenseInfo }>();
+
   for (const [pkgNameVersion, info] of Object.entries(allLicenses)) {
-    // Extract package name (remove version)
     const pkgName = pkgNameVersion.replace(/@[\d.]+(-.*)?$/, '').replace(/^(.+)@.*$/, '$1');
+    if (
+      !BUNDLED_PACKAGES.some(
+        (bundled) => pkgName === bundled || pkgNameVersion.startsWith(bundled + '@')
+      )
+    )
+      continue;
 
-    // Check if this is a bundled package
-    const isBundled = BUNDLED_PACKAGES.some(
-      (bundled) => pkgName === bundled || pkgNameVersion.startsWith(bundled + '@')
-    );
+    if (!bundledEntries.has(pkgName)) {
+      bundledEntries.set(pkgName, { pkgNameVersion, info });
+    }
+  }
 
-    if (!isBundled) continue;
+  for (const pkgName of BUNDLED_PACKAGES) {
+    let entry = bundledEntries.get(pkgName);
+    if (!entry) {
+      const pkgDir = resolveInstalledPackagePath(pkgName);
+      const pkgJsonPath = pkgDir ? join(pkgDir, 'package.json') : '';
+      if (!existsSync(pkgJsonPath)) {
+        console.warn(`package metadata missing for ${pkgName}`);
+        continue;
+      }
+      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as Record<string, any>;
+      const licenseField =
+        typeof pkgJson.license === 'string'
+          ? pkgJson.license
+          : pkgJson.license?.type ||
+            pkgJson.license?.name ||
+            (Array.isArray(pkgJson.licenses)
+              ? pkgJson.licenses
+                  .map((item) => (typeof item === 'string' ? item : item?.type || item?.name))
+                  .filter(Boolean)
+                  .join(', ')
+              : undefined);
+      const info: LicenseInfo = {
+        licenses: licenseField || 'UNKNOWN',
+        repository:
+          typeof pkgJson.repository === 'string' ? pkgJson.repository : pkgJson.repository?.url,
+        publisher: typeof pkgJson.author === 'string' ? pkgJson.author : pkgJson.author?.name,
+        path: pkgDir,
+      };
+      entry = {
+        pkgNameVersion: `${pkgName}@${pkgJson.version ?? 'unknown'}`,
+        info,
+      };
+      bundledEntries.set(pkgName, entry);
+    }
 
-    // Get the actual license text from the package
-    const pkgPath = join(process.cwd(), 'node_modules', pkgName);
-    const licenseText = getLicenseText(pkgPath);
+    const licenseText = resolveLicenseText(entry.info, pkgName);
 
     lines.push('='.repeat(80));
-    lines.push(`Package: ${pkgNameVersion}`);
-    lines.push(`License: ${info.licenses}`);
-    if (info.repository) {
-      lines.push(`Repository: ${info.repository}`);
+    lines.push(`Package: ${entry.pkgNameVersion}`);
+    lines.push(`License: ${entry.info.licenses}`);
+    if (entry.info.repository) {
+      lines.push(`Repository: ${entry.info.repository}`);
     }
     lines.push('-'.repeat(80));
     lines.push('');
@@ -85,7 +155,7 @@ function main() {
       lines.push(licenseText);
     } else {
       // Fallback to generic MIT/ISC text
-      if (info.licenses === 'MIT') {
+      if (entry.info.licenses === 'MIT') {
         lines.push('MIT License');
         lines.push('');
         lines.push('Permission is hereby granted, free of charge, to any person obtaining a copy');
@@ -107,7 +177,7 @@ function main() {
         lines.push('LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,');
         lines.push('OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE');
         lines.push('SOFTWARE.');
-      } else if (info.licenses === 'ISC') {
+      } else if (entry.info.licenses === 'ISC') {
         lines.push('ISC License');
         lines.push('');
         lines.push('Permission to use, copy, modify, and/or distribute this software for any');
@@ -130,9 +200,20 @@ function main() {
   lines.push('='.repeat(80));
   lines.push('*/');
 
-  const content = lines.join('\n');
+  return lines.join('\n');
+}
+
+function main() {
+  console.log('Generating ThirdPartyNoticeText.txt...');
+
+  // Get license info from license-checker
+  const output = execSync('npx license-checker --json', { encoding: 'utf-8' });
+  const allLicenses: Record<string, LicenseInfo> = JSON.parse(output);
+  const content = buildThirdPartyNotice(allLicenses);
   writeFileSync('ThirdPartyNoticeText.txt', content);
   console.log('Generated ThirdPartyNoticeText.txt');
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/generate-licenses.test.ts
+++ b/tests/generate-licenses.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { buildThirdPartyNotice } from '../scripts/generate-licenses.ts';
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'skills-generate-licenses-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writePackage(dir: string, pkgName: string, files: Record<string, string>) {
+  const pkgDir = join(dir, ...pkgName.split('/'));
+  mkdirSync(pkgDir, { recursive: true });
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = join(pkgDir, relativePath);
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content);
+  }
+  return pkgDir;
+}
+
+function writePnpmPackage(
+  rootDir: string,
+  storeEntry: string,
+  pkgName: string,
+  files: Record<string, string>
+) {
+  return writePackage(
+    join(rootDir, 'node_modules', '.pnpm', storeEntry, 'node_modules'),
+    pkgName,
+    files
+  );
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('generate-licenses', () => {
+  it('includes bundled transitive deps and ignores bogus README license files', () => {
+    const fixtureRoot = createTempDir();
+
+    const promptsDir = writePackage(join(fixtureRoot, 'node_modules'), '@clack/prompts', {
+      LICENSE: 'PROMPTS LICENSE',
+    });
+    const coreDir = writePnpmPackage(fixtureRoot, '@clack+core@0.5.0', '@clack/core', {
+      'package.json': JSON.stringify(
+        {
+          version: '0.5.0',
+          license: 'MIT',
+          repository: { url: 'https://github.com/bombshell-dev/clack.git' },
+          author: { name: 'Nate Moore' },
+        },
+        null,
+        2
+      ),
+      LICENSE: 'CORE LICENSE',
+    });
+    const sisteransiDir = writePnpmPackage(fixtureRoot, 'sisteransi@1.0.5', 'sisteransi', {
+      'package.json': JSON.stringify(
+        {
+          version: '1.0.5',
+          license: 'MIT',
+          repository: { url: 'https://github.com/terkelg/sisteransi' },
+          author: { name: 'Terkel Gjervig Nielsen' },
+        },
+        null,
+        2
+      ),
+      LICENSE: 'SISTERANSI LICENSE',
+    });
+    const simpleGitDir = writePackage(join(fixtureRoot, 'node_modules'), 'simple-git', {
+      LICENSE: 'SIMPLE GIT LICENSE',
+      README: 'THIS SHOULD NOT BE USED AS LICENSE TEXT',
+    });
+    writePackage(join(fixtureRoot, 'node_modules'), 'picocolors', {
+      'package.json': JSON.stringify({ version: '1.1.1', license: 'ISC' }, null, 2),
+      LICENSE: 'PICOCOLORS LICENSE',
+    });
+    writePackage(join(fixtureRoot, 'node_modules'), 'gray-matter', {
+      'package.json': JSON.stringify({ version: '4.0.3', license: 'MIT' }, null, 2),
+      LICENSE: 'GRAY MATTER LICENSE',
+    });
+    writePackage(join(fixtureRoot, 'node_modules'), 'xdg-basedir', {
+      'package.json': JSON.stringify({ version: '5.1.0', license: 'MIT' }, null, 2),
+      LICENSE: 'XDG LICENSE',
+    });
+
+    const previousCwd = process.cwd();
+    process.chdir(fixtureRoot);
+    try {
+      const notice = buildThirdPartyNotice({
+        '@clack/prompts@0.11.0': {
+          licenses: 'MIT',
+          repository: 'https://github.com/bombshell-dev/clack',
+          licenseFile: join(promptsDir, 'LICENSE'),
+          path: promptsDir,
+        },
+        'simple-git@3.30.0': {
+          licenses: 'MIT',
+          repository: 'https://github.com/steveukx/git-js',
+          licenseFile: join(simpleGitDir, 'README'),
+          path: simpleGitDir,
+        },
+      });
+
+      expect(notice).toContain('Package: @clack/core@0.5.0');
+      expect(notice).toContain('CORE LICENSE');
+      expect(notice).toContain('Package: sisteransi@1.0.5');
+      expect(notice).toContain('SISTERANSI LICENSE');
+      expect(notice).toContain('Package: simple-git@3.30.0');
+      expect(notice).toContain('SIMPLE GIT LICENSE');
+      expect(notice).not.toContain('THIS SHOULD NOT BE USED AS LICENSE TEXT');
+
+      // Sanity-check fallback metadata path wiring was used.
+      expect(coreDir).toContain('@clack');
+      expect(sisteransiDir).toContain('sisteransi');
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+});


### PR DESCRIPTION
This pull request resolves #619 by making bundled third-party notice generation work correctly under pnpm installs.

The previous generator assumed bundled packages lived at `node_modules/<pkg>` and relied entirely on `license-checker --json` to enumerate bundled dependencies. Under pnpm, bundled transitive dependencies such as `@clack/core` and `sisteransi` can live under `.pnpm/.../node_modules/<pkg>` and may be omitted from the JSON output the script consumes.

This change prefers `license-checker` metadata such as `licenseFile` and `path`, resolves installed package paths from pnpm layouts when needed, explicitly walks the bundled package allowlist, and adds a focused regression test so bundled transitive dependencies continue to appear in `ThirdPartyNoticeText.txt`.
