### PR TITLE
perf(github): reuse and isolate GitHub tree fetch work

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -49,13 +49,12 @@ import {
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
-  fetchSkillFolderHash,
-  getGitHubToken,
   isPromptDismissed,
   dismissPrompt,
   getLastSelectedAgents,
   saveSelectedAgents,
 } from './skill-lock.ts';
+import { fetchSkillFolderHash, getGitHubToken } from './github-tree.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import packageJson from '../package.json' with { type: 'json' };

--- a/src/add.ts
+++ b/src/add.ts
@@ -1498,6 +1498,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Add to skill lock file for update tracking (only for global installs)
     if (successful.length > 0 && installGlobally && normalizedSource) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
+      const githubToken = parsed.type === 'github' ? getGitHubToken() : null;
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
@@ -1506,8 +1507,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
-              const token = getGitHubToken();
-              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token);
+              const hash = await fetchSkillFolderHash(
+                normalizedSource,
+                skillPathValue,
+                githubToken
+              );
               if (hash) skillFolderHash = hash;
             }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
-import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { fetchSkillFolderHash, getGitHubToken } from './github-tree.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/src/github-tree.ts
+++ b/src/github-tree.ts
@@ -1,0 +1,142 @@
+import { execSync } from 'child_process';
+
+type GitHubTreeEntry = {
+  path: string;
+  type: string;
+  sha: string;
+};
+
+type GitHubTreeResponse = {
+  sha: string;
+  tree: GitHubTreeEntry[];
+};
+
+// Cache repo tree fetches for the lifetime of the current process. Failed lookups are evicted so
+// transient network or API errors do not poison later retries.
+const repoTreeCache = new Map<string, Promise<GitHubTreeResponse | null>>();
+
+/**
+ * Get a GitHub token for authenticated API requests.
+ * Tries environment variables first, then falls back to `gh auth token`.
+ *
+ * @returns The token string, or null if no token is available
+ */
+export function getGitHubToken(): string | null {
+  if (process.env.GITHUB_TOKEN) {
+    return process.env.GITHUB_TOKEN;
+  }
+  if (process.env.GH_TOKEN) {
+    return process.env.GH_TOKEN;
+  }
+
+  try {
+    const token = execSync('gh auth token', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    if (token) {
+      return token;
+    }
+  } catch {
+    // gh CLI not installed or not authenticated
+  }
+
+  return null;
+}
+
+/**
+ * Fetch the full recursive GitHub tree for a repository branch.
+ * Results are cached per `owner/repo@branch` for the lifetime of the current process.
+ *
+ * @param ownerRepo - GitHub owner/repo (e.g. "vercel-labs/agent-skills")
+ * @param branch - Branch to query (typically "main" or "master")
+ * @param token - Optional GitHub token for authenticated requests
+ * @returns The recursive tree payload, or null if the branch/tree could not be fetched
+ */
+async function fetchRepoTree(
+  ownerRepo: string,
+  branch: string,
+  token?: string | null
+): Promise<GitHubTreeResponse | null> {
+  const cacheKey = `${ownerRepo}@${branch}`;
+  let treePromise = repoTreeCache.get(cacheKey);
+  if (!treePromise) {
+    treePromise = (async () => {
+      const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
+      const headers: Record<string, string> = {
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'skills-cli',
+      };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      const response = await fetch(url, { headers });
+      if (!response.ok) {
+        return null;
+      }
+      return (await response.json()) as GitHubTreeResponse;
+    })();
+    repoTreeCache.set(cacheKey, treePromise);
+  }
+
+  try {
+    return await treePromise;
+  } catch {
+    repoTreeCache.delete(cacheKey);
+    return null;
+  }
+}
+
+/**
+ * Fetch the GitHub tree SHA for a skill folder.
+ * Tries `main` first, then falls back to `master`.
+ *
+ * @param ownerRepo - GitHub owner/repo (e.g. "vercel-labs/agent-skills")
+ * @param skillPath - Path to the skill folder or its SKILL.md file
+ * @param token - Optional GitHub token for authenticated requests
+ * @returns The tree SHA for the skill folder, or null if not found
+ */
+export async function fetchSkillFolderHash(
+  ownerRepo: string,
+  skillPath: string,
+  token?: string | null
+): Promise<string | null> {
+  let folderPath = skillPath.replace(/\\/g, '/');
+
+  if (folderPath.endsWith('/SKILL.md')) {
+    folderPath = folderPath.slice(0, -9);
+  } else if (folderPath.endsWith('SKILL.md')) {
+    folderPath = folderPath.slice(0, -8);
+  }
+
+  if (folderPath.endsWith('/')) {
+    folderPath = folderPath.slice(0, -1);
+  }
+
+  const branches = ['main', 'master'];
+  for (const branch of branches) {
+    try {
+      const data = await fetchRepoTree(ownerRepo, branch, token);
+      if (!data) {
+        repoTreeCache.delete(`${ownerRepo}@${branch}`);
+        continue;
+      }
+
+      if (!folderPath) {
+        return data.sha;
+      }
+
+      const folderEntry = data.tree.find(
+        (entry) => entry.type === 'tree' && entry.path === folderPath
+      );
+      if (folderEntry) {
+        return folderEntry.sha;
+      }
+    } catch {
+      repoTreeCache.delete(`${ownerRepo}@${branch}`);
+    }
+  }
+
+  return null;
+}

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -195,35 +195,38 @@ export async function fetchSkillFolderHash(
   const branches = ['main', 'master'];
 
   for (const branch of branches) {
+    const cacheKey = `${ownerRepo}@${branch}`;
+    let treePromise = repoTreeCache.get(cacheKey);
+
+    if (!treePromise) {
+      treePromise = (async () => {
+        const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
+        const headers: Record<string, string> = {
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'skills-cli',
+        };
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`;
+        }
+
+        const response = await fetch(url, { headers });
+
+        if (!response.ok) return null;
+
+        return (await response.json()) as {
+          sha: string;
+          tree: Array<{ path: string; type: string; sha: string }>;
+        };
+      })();
+      repoTreeCache.set(cacheKey, treePromise);
+    }
+
     try {
-      const cacheKey = `${ownerRepo}@${branch}`;
-      let treePromise = repoTreeCache.get(cacheKey);
-
-      if (!treePromise) {
-        treePromise = (async () => {
-          const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
-          const headers: Record<string, string> = {
-            Accept: 'application/vnd.github.v3+json',
-            'User-Agent': 'skills-cli',
-          };
-          if (token) {
-            headers['Authorization'] = `Bearer ${token}`;
-          }
-
-          const response = await fetch(url, { headers });
-
-          if (!response.ok) return null;
-
-          return (await response.json()) as {
-            sha: string;
-            tree: Array<{ path: string; type: string; sha: string }>;
-          };
-        })();
-        repoTreeCache.set(cacheKey, treePromise);
-      }
-
       const data = await treePromise;
-      if (!data) continue;
+      if (!data) {
+        repoTreeCache.delete(cacheKey);
+        continue;
+      }
 
       // If folderPath is empty, this is a root-level skill - use the root tree SHA
       if (!folderPath) {
@@ -239,6 +242,7 @@ export async function fetchSkillFolderHash(
         return folderEntry.sha;
       }
     } catch {
+      repoTreeCache.delete(cacheKey);
       continue;
     }
   }

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -2,18 +2,10 @@ import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
-import { execSync } from 'child_process';
 
 const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
 const CURRENT_VERSION = 3; // Bumped from 2 to 3 for folder hash support (GitHub tree SHA)
-const repoTreeCache = new Map<
-  string,
-  Promise<{
-    sha: string;
-    tree: Array<{ path: string; type: string; sha: string }>;
-  } | null>
->();
 
 /**
  * Represents a single installed skill entry in the lock file.
@@ -126,128 +118,6 @@ export async function writeSkillLock(lock: SkillLockFile): Promise<void> {
  */
 export function computeContentHash(content: string): string {
   return createHash('sha256').update(content, 'utf-8').digest('hex');
-}
-
-/**
- * Get GitHub token from user's environment.
- * Tries in order:
- * 1. GITHUB_TOKEN environment variable
- * 2. GH_TOKEN environment variable
- * 3. gh CLI auth token (if gh is installed)
- *
- * @returns The token string or null if not available
- */
-export function getGitHubToken(): string | null {
-  // Check environment variables first
-  if (process.env.GITHUB_TOKEN) {
-    return process.env.GITHUB_TOKEN;
-  }
-  if (process.env.GH_TOKEN) {
-    return process.env.GH_TOKEN;
-  }
-
-  // Try gh CLI
-  try {
-    const token = execSync('gh auth token', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    if (token) {
-      return token;
-    }
-  } catch {
-    // gh not installed or not authenticated
-  }
-
-  return null;
-}
-
-/**
- * Fetch the tree SHA (folder hash) for a skill folder using GitHub's Trees API.
- * This makes ONE API call to get the entire repo tree, then extracts the SHA
- * for the specific skill folder.
- *
- * @param ownerRepo - GitHub owner/repo (e.g., "vercel-labs/agent-skills")
- * @param skillPath - Path to skill folder or SKILL.md (e.g., "skills/react-best-practices/SKILL.md")
- * @param token - Optional GitHub token for authenticated requests (higher rate limits)
- * @returns The tree SHA for the skill folder, or null if not found
- */
-export async function fetchSkillFolderHash(
-  ownerRepo: string,
-  skillPath: string,
-  token?: string | null
-): Promise<string | null> {
-  // Normalize to forward slashes first (for GitHub API compatibility)
-  let folderPath = skillPath.replace(/\\/g, '/');
-
-  // Remove SKILL.md suffix to get folder path
-  if (folderPath.endsWith('/SKILL.md')) {
-    folderPath = folderPath.slice(0, -9);
-  } else if (folderPath.endsWith('SKILL.md')) {
-    folderPath = folderPath.slice(0, -8);
-  }
-
-  // Remove trailing slash
-  if (folderPath.endsWith('/')) {
-    folderPath = folderPath.slice(0, -1);
-  }
-
-  const branches = ['main', 'master'];
-
-  for (const branch of branches) {
-    const cacheKey = `${ownerRepo}@${branch}`;
-    let treePromise = repoTreeCache.get(cacheKey);
-
-    if (!treePromise) {
-      treePromise = (async () => {
-        const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
-        const headers: Record<string, string> = {
-          Accept: 'application/vnd.github.v3+json',
-          'User-Agent': 'skills-cli',
-        };
-        if (token) {
-          headers['Authorization'] = `Bearer ${token}`;
-        }
-
-        const response = await fetch(url, { headers });
-
-        if (!response.ok) return null;
-
-        return (await response.json()) as {
-          sha: string;
-          tree: Array<{ path: string; type: string; sha: string }>;
-        };
-      })();
-      repoTreeCache.set(cacheKey, treePromise);
-    }
-
-    try {
-      const data = await treePromise;
-      if (!data) {
-        repoTreeCache.delete(cacheKey);
-        continue;
-      }
-
-      // If folderPath is empty, this is a root-level skill - use the root tree SHA
-      if (!folderPath) {
-        return data.sha;
-      }
-
-      // Find the tree entry for the skill folder
-      const folderEntry = data.tree.find(
-        (entry) => entry.type === 'tree' && entry.path === folderPath
-      );
-
-      if (folderEntry) {
-        return folderEntry.sha;
-      }
-    } catch {
-      repoTreeCache.delete(cacheKey);
-      continue;
-    }
-  }
-
-  return null;
 }
 
 /**

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -7,6 +7,13 @@ import { execSync } from 'child_process';
 const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
 const CURRENT_VERSION = 3; // Bumped from 2 to 3 for folder hash support (GitHub tree SHA)
+const repoTreeCache = new Map<
+  string,
+  Promise<{
+    sha: string;
+    tree: Array<{ path: string; type: string; sha: string }>;
+  } | null>
+>();
 
 /**
  * Represents a single installed skill entry in the lock file.
@@ -189,23 +196,34 @@ export async function fetchSkillFolderHash(
 
   for (const branch of branches) {
     try {
-      const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
-      const headers: Record<string, string> = {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'skills-cli',
-      };
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
+      const cacheKey = `${ownerRepo}@${branch}`;
+      let treePromise = repoTreeCache.get(cacheKey);
+
+      if (!treePromise) {
+        treePromise = (async () => {
+          const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
+          const headers: Record<string, string> = {
+            Accept: 'application/vnd.github.v3+json',
+            'User-Agent': 'skills-cli',
+          };
+          if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+          }
+
+          const response = await fetch(url, { headers });
+
+          if (!response.ok) return null;
+
+          return (await response.json()) as {
+            sha: string;
+            tree: Array<{ path: string; type: string; sha: string }>;
+          };
+        })();
+        repoTreeCache.set(cacheKey, treePromise);
       }
 
-      const response = await fetch(url, { headers });
-
-      if (!response.ok) continue;
-
-      const data = (await response.json()) as {
-        sha: string;
-        tree: Array<{ path: string; type: string; sha: string }>;
-      };
+      const data = await treePromise;
+      if (!data) continue;
 
       // If folderPath is empty, this is a root-level skill - use the root tree SHA
       if (!folderPath) {

--- a/tests/add-global-hash-fetch.test.ts
+++ b/tests/add-global-hash-fetch.test.ts
@@ -97,11 +97,20 @@ vi.mock('../src/skill-lock.ts', async () => {
   return {
     ...actual,
     addSkillToLock: mockAddSkillToLock,
-    getGitHubToken: mockGetGitHubToken,
     isPromptDismissed: vi.fn(),
     dismissPrompt: vi.fn(),
     getLastSelectedAgents: vi.fn(),
     saveSelectedAgents: vi.fn(),
+  };
+});
+
+vi.mock('../src/github-tree.ts', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/github-tree.ts')>('../src/github-tree.ts');
+
+  return {
+    ...actual,
+    getGitHubToken: mockGetGitHubToken,
   };
 });
 
@@ -197,7 +206,6 @@ describe('runAdd global hash fetching', () => {
     });
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(mockGetGitHubToken).toHaveBeenCalledTimes(1);
     expect(mockAddSkillToLock).toHaveBeenCalledTimes(4);
     expect(mockAddSkillToLock).toHaveBeenNthCalledWith(
       1,

--- a/tests/add-global-hash-fetch.test.ts
+++ b/tests/add-global-hash-fetch.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockSpinnerStart,
+  mockSpinnerStop,
+  mockCloneRepo,
+  mockCleanupTempDir,
+  mockDiscoverSkills,
+  mockInstallSkillForAgent,
+  mockIsSkillInstalled,
+  mockGetCanonicalPath,
+  mockDetectInstalledAgents,
+  mockTrack,
+  mockFetchAuditData,
+  mockAddSkillToLock,
+  mockGetGitHubToken,
+} = vi.hoisted(() => ({
+  mockSpinnerStart: vi.fn(),
+  mockSpinnerStop: vi.fn(),
+  mockCloneRepo: vi.fn(),
+  mockCleanupTempDir: vi.fn(),
+  mockDiscoverSkills: vi.fn(),
+  mockInstallSkillForAgent: vi.fn(),
+  mockIsSkillInstalled: vi.fn(),
+  mockGetCanonicalPath: vi.fn(),
+  mockDetectInstalledAgents: vi.fn(),
+  mockTrack: vi.fn(),
+  mockFetchAuditData: vi.fn(),
+  mockAddSkillToLock: vi.fn(),
+  mockGetGitHubToken: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  note: vi.fn(),
+  cancel: vi.fn(),
+  isCancel: vi.fn(() => false),
+  log: {
+    info: vi.fn(),
+    message: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    step: vi.fn(),
+  },
+  spinner: vi.fn(() => ({
+    start: mockSpinnerStart,
+    stop: mockSpinnerStop,
+  })),
+}));
+
+vi.mock('../src/git.ts', () => ({
+  GitCloneError: class GitCloneError extends Error {},
+  cloneRepo: mockCloneRepo,
+  cleanupTempDir: mockCleanupTempDir,
+}));
+
+vi.mock('../src/skills.ts', () => ({
+  discoverSkills: mockDiscoverSkills,
+  getSkillDisplayName: (skill: { name: string }) => skill.name,
+  filterSkills: (skills: Array<{ name: string }>, names: string[]) =>
+    skills.filter((skill) => names.includes(skill.name)),
+}));
+
+vi.mock('../src/installer.ts', () => ({
+  installSkillForAgent: mockInstallSkillForAgent,
+  isSkillInstalled: mockIsSkillInstalled,
+  getInstallPath: vi.fn(),
+  getCanonicalPath: mockGetCanonicalPath,
+}));
+
+vi.mock('../src/agents.ts', () => ({
+  detectInstalledAgents: mockDetectInstalledAgents,
+  agents: {
+    codex: {
+      displayName: 'Codex',
+      skillsDir: '.codex/skills',
+      globalSkillsDir: '/fake/home/.codex/skills',
+    },
+  },
+  getUniversalAgents: vi.fn(() => []),
+  getNonUniversalAgents: vi.fn(() => ['codex']),
+  isUniversalAgent: vi.fn(() => false),
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  track: mockTrack,
+  setVersion: vi.fn(),
+  fetchAuditData: mockFetchAuditData,
+}));
+
+vi.mock('../src/skill-lock.ts', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/skill-lock.ts')>('../src/skill-lock.ts');
+
+  return {
+    ...actual,
+    addSkillToLock: mockAddSkillToLock,
+    getGitHubToken: mockGetGitHubToken,
+    isPromptDismissed: vi.fn(),
+    dismissPrompt: vi.fn(),
+    getLastSelectedAgents: vi.fn(),
+    saveSelectedAgents: vi.fn(),
+  };
+});
+
+vi.mock('../src/local-lock.ts', () => ({
+  addSkillToLocalLock: vi.fn(),
+  computeSkillFolderHash: vi.fn(),
+}));
+
+vi.mock('../src/source-parser.ts', () => ({
+  parseSource: vi.fn(() => ({
+    type: 'github',
+    url: 'https://github.com/org/repo.git',
+  })),
+  getOwnerRepo: vi.fn(() => 'org/repo'),
+  parseOwnerRepo: vi.fn(() => ({ owner: 'org', repo: 'repo' })),
+  isRepoPrivate: vi.fn(async () => false),
+}));
+
+vi.mock('../src/prompts/search-multiselect.ts', () => ({
+  searchMultiselect: vi.fn(),
+  cancelSymbol: Symbol('cancel'),
+}));
+
+import { runAdd } from '../src/add.ts';
+
+describe('runAdd global hash fetching', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCloneRepo.mockResolvedValue('/tmp/cloned-repo');
+    mockCleanupTempDir.mockResolvedValue(undefined);
+    mockDiscoverSkills.mockResolvedValue([
+      {
+        name: 'root-skill',
+        description: 'Root skill',
+        path: '/tmp/cloned-repo/root-skill',
+      },
+      {
+        name: 'alpha',
+        description: 'Alpha skill',
+        path: '/tmp/cloned-repo/skills/alpha',
+      },
+      {
+        name: 'beta',
+        description: 'Beta skill',
+        path: '/tmp/cloned-repo/skills/beta',
+      },
+      {
+        name: 'gamma',
+        description: 'Gamma skill',
+        path: '/tmp/cloned-repo/skills/gamma',
+      },
+    ]);
+    mockDetectInstalledAgents.mockResolvedValue(['codex']);
+    mockIsSkillInstalled.mockResolvedValue(false);
+    mockInstallSkillForAgent.mockResolvedValue({
+      success: true,
+      path: '/fake/path',
+      canonicalPath: '/fake/canonical',
+      mode: 'symlink',
+    });
+    mockGetCanonicalPath.mockImplementation((skillName: string) => `/fake/canonical/${skillName}`);
+    mockFetchAuditData.mockResolvedValue(null);
+    mockAddSkillToLock.mockResolvedValue(undefined);
+    mockGetGitHubToken.mockReturnValue(null);
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        sha: 'root-tree-sha',
+        tree: [
+          { path: 'root-skill', type: 'tree', sha: 'tree-root' },
+          { path: 'skills/alpha', type: 'tree', sha: 'tree-alpha' },
+          { path: 'skills/beta', type: 'tree', sha: 'tree-beta' },
+          { path: 'skills/gamma', type: 'tree', sha: 'tree-gamma' },
+        ],
+      }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('reuses external GitHub work for multiple global skills from the same source', async () => {
+    await runAdd(['org/repo'], {
+      global: true,
+      yes: true,
+      agent: ['codex'],
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockGetGitHubToken).toHaveBeenCalledTimes(1);
+    expect(mockAddSkillToLock).toHaveBeenCalledTimes(4);
+    expect(mockAddSkillToLock).toHaveBeenNthCalledWith(
+      1,
+      'root-skill',
+      expect.objectContaining({
+        skillPath: 'root-skill/SKILL.md',
+        skillFolderHash: 'tree-root',
+      })
+    );
+    expect(mockAddSkillToLock).toHaveBeenNthCalledWith(
+      2,
+      'alpha',
+      expect.objectContaining({
+        skillPath: 'skills/alpha/SKILL.md',
+        skillFolderHash: 'tree-alpha',
+      })
+    );
+    expect(mockAddSkillToLock).toHaveBeenNthCalledWith(
+      3,
+      'beta',
+      expect.objectContaining({
+        skillPath: 'skills/beta/SKILL.md',
+        skillFolderHash: 'tree-beta',
+      })
+    );
+    expect(mockAddSkillToLock).toHaveBeenNthCalledWith(
+      4,
+      'gamma',
+      expect.objectContaining({
+        skillPath: 'skills/gamma/SKILL.md',
+        skillFolderHash: 'tree-gamma',
+      })
+    );
+  });
+});

--- a/tests/skill-lock-fetch-retry.test.ts
+++ b/tests/skill-lock-fetch-retry.test.ts
@@ -25,7 +25,7 @@ describe('fetchSkillFolderHash retry behavior', () => {
         }),
       }) as typeof fetch;
 
-    const { fetchSkillFolderHash } = await import('../src/skill-lock.ts');
+    const { fetchSkillFolderHash } = await import('../src/github-tree.ts');
 
     expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBeNull();
     expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBe('tree-alpha');
@@ -45,7 +45,7 @@ describe('fetchSkillFolderHash retry behavior', () => {
         }),
       }) as typeof fetch;
 
-    const { fetchSkillFolderHash } = await import('../src/skill-lock.ts');
+    const { fetchSkillFolderHash } = await import('../src/github-tree.ts');
 
     expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBeNull();
     expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBe('tree-alpha');

--- a/tests/skill-lock-fetch-retry.test.ts
+++ b/tests/skill-lock-fetch-retry.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('fetchSkillFolderHash retry behavior', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('does not memoize non-ok tree fetch failures', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sha: 'root-tree-sha',
+          tree: [{ path: 'skills/alpha', type: 'tree', sha: 'tree-alpha' }],
+        }),
+      }) as typeof fetch;
+
+    const { fetchSkillFolderHash } = await import('../src/skill-lock.ts');
+
+    expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBeNull();
+    expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBe('tree-alpha');
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not memoize thrown tree fetch failures', async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sha: 'root-tree-sha',
+          tree: [{ path: 'skills/alpha', type: 'tree', sha: 'tree-alpha' }],
+        }),
+      }) as typeof fetch;
+
+    const { fetchSkillFolderHash } = await import('../src/skill-lock.ts');
+
+    expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBeNull();
+    expect(await fetchSkillFolderHash('org/repo', 'skills/alpha/SKILL.md')).toBe('tree-alpha');
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
This pull request resolves #622 by reusing GitHub tree work during add, retrying cleanly after transient failures, and isolating GitHub tree/hash logic in its own module.

The original repeated-work problem was that one add run could fetch the same GitHub repo tree multiple times for skills from the same source. A transient fetch failure could also poison later lookups in the same process. This branch keeps the fix centered on that GitHub-tree seam and moves the tree/hash logic out of `skill-lock.ts` so the boundary is easier to reason about.

This pull request supersedes #612 and continues the original repeated-fetch work from #607 in a more modular form.
