### PR TITLE
feat(cli): add a status command for tracked skills

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
+import { runStatus } from './status.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
@@ -77,6 +78,9 @@ function showBanner(): void {
     `  ${DIM}$${RESET} ${TEXT}npx skills list${RESET}                 ${DIM}List installed skills${RESET}`
   );
   console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills status${RESET}               ${DIM}Check installed skill state${RESET}`
+  );
+  console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills find ${DIM}[query]${RESET}         ${DIM}Search for skills${RESET}`
   );
   console.log();
@@ -113,6 +117,7 @@ ${BOLD}Manage Skills:${RESET}
                             https://github.com/vercel-labs/agent-skills
   remove [skills]      Remove installed skills
   list, ls             List installed skills
+  status               Check installed skill state
   find [query]         Search for skills interactively
 
 ${BOLD}Updates:${RESET}
@@ -149,6 +154,11 @@ ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
   -a, --agent <agents>   Filter by specific agents
   --json                 Output as JSON (machine-readable, no ANSI codes)
+  --audit                Append security audit summary in text mode
+
+${BOLD}Status Options:${RESET}
+  -g, --global           Check global skills (default: project)
+  --json                 Output as JSON
 
 ${BOLD}Options:${RESET}
   --help, -h        Show this help message
@@ -166,6 +176,8 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills ls -g                         ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
   ${DIM}$${RESET} skills ls --json                      ${DIM}# JSON output${RESET}
+  ${DIM}$${RESET} skills status                        ${DIM}# check project skill state${RESET}
+  ${DIM}$${RESET} skills status -g                     ${DIM}# check global skill state${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}
   ${DIM}$${RESET} skills check
@@ -684,6 +696,9 @@ async function main(): Promise<void> {
     case 'list':
     case 'ls':
       await runList(restArgs);
+      break;
+    case 'status':
+      await runStatus(restArgs);
       break;
     case 'check':
       runCheck(restArgs);

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,7 +1,16 @@
 import type { InstalledSkill } from './installer.ts';
+import { listInstalledSkills } from './installer.ts';
 import type { LocalSkillLockFile } from './local-lock.ts';
-import type { SkillLockFile, SkillLockEntry } from './skill-lock.ts';
 import { computeSkillFolderHash } from './local-lock.ts';
+import { readLocalLock } from './local-lock.ts';
+import type { SkillLockFile, SkillLockEntry } from './skill-lock.ts';
+import { getAllLockedSkills } from './skill-lock.ts';
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[38;5;102m';
+const CYAN = '\x1b[36m';
+const YELLOW = '\x1b[33m';
 
 export type SkillScope = 'project' | 'global';
 export type SkillStatusKind = 'tracked' | 'missing-lock-entry' | 'hash-mismatch';
@@ -21,17 +30,22 @@ export interface SkillStatusOptions {
   hashFn?: (skillDir: string) => Promise<string>;
 }
 
+interface StatusCommandOptions {
+  global?: boolean;
+  json?: boolean;
+}
+
 function getLockEntry(
   skill: InstalledSkill,
-  globalLock: SkillLockFile,
+  globalLock: Record<string, SkillLockEntry>,
   localLock: LocalSkillLockFile
 ): SkillLockEntry | LocalSkillLockFile['skills'][string] | undefined {
-  return skill.scope === 'global' ? globalLock.skills[skill.name] : localLock.skills[skill.name];
+  return skill.scope === 'global' ? globalLock[skill.name] : localLock.skills[skill.name];
 }
 
 export async function evaluateSkillStatus(
   installedSkills: InstalledSkill[],
-  globalLock: SkillLockFile,
+  globalLock: Record<string, SkillLockEntry>,
   localLock: LocalSkillLockFile,
   options: SkillStatusOptions = {}
 ): Promise<SkillStatus[]> {
@@ -74,4 +88,77 @@ export async function evaluateSkillStatus(
   }
 
   return statuses;
+}
+
+export function parseStatusOptions(args: string[]): StatusCommandOptions {
+  const options: StatusCommandOptions = {};
+
+  for (const arg of args) {
+    if (arg === '-g' || arg === '--global') {
+      options.global = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    }
+  }
+
+  return options;
+}
+
+export async function runStatus(args: string[]): Promise<void> {
+  const options = parseStatusOptions(args);
+  const scope = options.global === true ? true : false;
+  const scopeLabel = scope ? 'Global' : 'Project';
+
+  const installedSkills = await listInstalledSkills({ global: scope });
+  const globalLock = await getAllLockedSkills();
+  const localLock = await readLocalLock();
+  const statuses = await evaluateSkillStatus(installedSkills, globalLock, localLock);
+
+  if (options.json) {
+    console.log(JSON.stringify(statuses, null, 2));
+    return;
+  }
+
+  if (statuses.length === 0) {
+    console.log(`${DIM}No ${scopeLabel.toLowerCase()} skills found.${RESET}`);
+    if (scope) {
+      console.log(`${DIM}Try checking project skills without -g${RESET}`);
+    } else {
+      console.log(`${DIM}Try checking global skills with -g${RESET}`);
+    }
+    return;
+  }
+
+  console.log(`${BOLD}${scopeLabel} Status${RESET}`);
+  console.log();
+
+  const tracked = statuses.filter((status) => status.status === 'tracked');
+  const missing = statuses.filter((status) => status.status === 'missing-lock-entry');
+  const mismatched = statuses.filter((status) => status.status === 'hash-mismatch');
+
+  if (tracked.length > 0) {
+    console.log(`${BOLD}Tracked${RESET}`);
+    for (const status of tracked) {
+      console.log(`${CYAN}${status.name}${RESET} ${DIM}${status.lockType}${RESET}`);
+    }
+    console.log();
+  }
+
+  if (missing.length > 0) {
+    console.log(`${BOLD}Missing lock entry${RESET}`);
+    for (const status of missing) {
+      console.log(`${YELLOW}${status.name}${RESET}`);
+    }
+    console.log();
+  }
+
+  if (mismatched.length > 0) {
+    console.log(`${BOLD}Hash mismatch${RESET}`);
+    for (const status of mismatched) {
+      console.log(`${YELLOW}${status.name}${RESET}`);
+      console.log(`  ${DIM}Expected:${RESET} ${status.expectedHash}`);
+      console.log(`  ${DIM}Actual:${RESET}   ${status.actualHash}`);
+    }
+    console.log();
+  }
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,77 @@
+import type { InstalledSkill } from './installer.ts';
+import type { LocalSkillLockFile } from './local-lock.ts';
+import type { SkillLockFile, SkillLockEntry } from './skill-lock.ts';
+import { computeSkillFolderHash } from './local-lock.ts';
+
+export type SkillScope = 'project' | 'global';
+export type SkillStatusKind = 'tracked' | 'missing-lock-entry' | 'hash-mismatch';
+
+export interface SkillStatus {
+  name: string;
+  scope: SkillScope;
+  status: SkillStatusKind;
+  installedPath: string;
+  canonicalPath: string;
+  lockType?: 'local' | 'global';
+  expectedHash?: string;
+  actualHash?: string;
+}
+
+export interface SkillStatusOptions {
+  hashFn?: (skillDir: string) => Promise<string>;
+}
+
+function getLockEntry(
+  skill: InstalledSkill,
+  globalLock: SkillLockFile,
+  localLock: LocalSkillLockFile
+): SkillLockEntry | LocalSkillLockFile['skills'][string] | undefined {
+  return skill.scope === 'global' ? globalLock.skills[skill.name] : localLock.skills[skill.name];
+}
+
+export async function evaluateSkillStatus(
+  installedSkills: InstalledSkill[],
+  globalLock: SkillLockFile,
+  localLock: LocalSkillLockFile,
+  options: SkillStatusOptions = {}
+): Promise<SkillStatus[]> {
+  const hashFn = options.hashFn ?? computeSkillFolderHash;
+  const statuses: SkillStatus[] = [];
+
+  for (const skill of installedSkills) {
+    const lockEntry = getLockEntry(skill, globalLock, localLock);
+
+    if (!lockEntry) {
+      statuses.push({
+        name: skill.name,
+        scope: skill.scope,
+        status: 'missing-lock-entry',
+        installedPath: skill.path,
+        canonicalPath: skill.canonicalPath,
+      });
+      continue;
+    }
+
+    const lockType = skill.scope === 'global' ? 'global' : 'local';
+    const expectedHash =
+      lockType === 'global'
+        ? (lockEntry as SkillLockEntry).skillFolderHash
+        : (lockEntry as LocalSkillLockFile['skills'][string]).computedHash;
+
+    const actualHash = await hashFn(skill.canonicalPath);
+    const status: SkillStatusKind = actualHash === expectedHash ? 'tracked' : 'hash-mismatch';
+
+    statuses.push({
+      name: skill.name,
+      scope: skill.scope,
+      status,
+      installedPath: skill.path,
+      canonicalPath: skill.canonicalPath,
+      lockType,
+      expectedHash,
+      actualHash,
+    });
+  }
+
+  return statuses;
+}

--- a/tests/status-run.test.ts
+++ b/tests/status-run.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InstalledSkill } from '../src/installer.ts';
+import type { LocalSkillLockFile } from '../src/local-lock.ts';
+import type { SkillLockFile } from '../src/skill-lock.ts';
+import { stripAnsi } from '../src/test-utils.ts';
+
+const mocks = vi.hoisted(() => ({
+  listInstalledSkills: vi.fn(),
+  getAllLockedSkills: vi.fn(),
+  readLocalLock: vi.fn(),
+  computeSkillFolderHash: vi.fn(),
+}));
+
+vi.mock('../src/installer.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/installer.ts')>('../src/installer.ts');
+  return {
+    ...actual,
+    listInstalledSkills: mocks.listInstalledSkills,
+  };
+});
+
+vi.mock('../src/skill-lock.ts', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/skill-lock.ts')>('../src/skill-lock.ts');
+  return {
+    ...actual,
+    getAllLockedSkills: mocks.getAllLockedSkills,
+  };
+});
+
+vi.mock('../src/local-lock.ts', async () => {
+  const actual =
+    await vi.importActual<typeof import('../src/local-lock.ts')>('../src/local-lock.ts');
+  return {
+    ...actual,
+    readLocalLock: mocks.readLocalLock,
+    computeSkillFolderHash: mocks.computeSkillFolderHash,
+  };
+});
+
+const statusModulePromise = import('../src/status.ts');
+
+describe('runStatus', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('prints tracked, missing, and mismatched skills in text mode', async () => {
+    const installedSkills: InstalledSkill[] = [
+      {
+        name: 'tracked-skill',
+        description: 'Tracked',
+        path: '/tmp/tracked',
+        canonicalPath: '/tmp/tracked',
+        scope: 'project',
+        agents: [],
+      },
+      {
+        name: 'missing-skill',
+        description: 'Missing',
+        path: '/tmp/missing',
+        canonicalPath: '/tmp/missing',
+        scope: 'project',
+        agents: [],
+      },
+      {
+        name: 'mismatched-skill',
+        description: 'Mismatch',
+        path: '/tmp/mismatch',
+        canonicalPath: '/tmp/mismatch',
+        scope: 'global',
+        agents: [],
+      },
+    ];
+
+    const globalLock: SkillLockFile = {
+      version: 3,
+      skills: {
+        'mismatched-skill': {
+          source: 'owner/repo',
+          sourceType: 'github',
+          sourceUrl: 'https://github.com/owner/repo',
+          skillFolderHash: 'remote-hash',
+          installedAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+        },
+      },
+      dismissed: {},
+    };
+
+    const localLock: LocalSkillLockFile = {
+      version: 1,
+      skills: {
+        'tracked-skill': {
+          source: 'local',
+          sourceType: 'local',
+          computedHash: 'tracked-hash',
+        },
+      },
+    };
+
+    mocks.listInstalledSkills.mockResolvedValue(installedSkills);
+    mocks.getAllLockedSkills.mockResolvedValue(globalLock.skills);
+    mocks.readLocalLock.mockResolvedValue(localLock);
+    mocks.computeSkillFolderHash.mockImplementation(async (skillDir: string) => {
+      if (skillDir === '/tmp/tracked') return 'tracked-hash';
+      if (skillDir === '/tmp/mismatch') return 'local-hash';
+      return 'unknown-hash';
+    });
+
+    const { runStatus } = await statusModulePromise;
+    await runStatus([]);
+
+    const output = stripAnsi(
+      consoleLogSpy.mock.calls
+        .flat()
+        .map((value) => String(value))
+        .join('\n')
+    );
+
+    expect(output).toContain('Project Status');
+    expect(output).toContain('Tracked');
+    expect(output).toContain('tracked-skill');
+    expect(output).toContain('Missing lock entry');
+    expect(output).toContain('missing-skill');
+    expect(output).toContain('Hash mismatch');
+    expect(output).toContain('mismatched-skill');
+    expect(output).toContain('Expected: remote-hash');
+    expect(mocks.listInstalledSkills).toHaveBeenCalledWith({ global: false });
+  });
+
+  it('keeps JSON output machine-readable', async () => {
+    const installedSkills: InstalledSkill[] = [
+      {
+        name: 'json-skill',
+        description: 'JSON',
+        path: '/tmp/json',
+        canonicalPath: '/tmp/json',
+        scope: 'project',
+        agents: [],
+      },
+    ];
+
+    const localLock: LocalSkillLockFile = {
+      version: 1,
+      skills: {
+        'json-skill': {
+          source: 'local',
+          sourceType: 'local',
+          computedHash: 'json-hash',
+        },
+      },
+    };
+
+    mocks.listInstalledSkills.mockResolvedValue(installedSkills);
+    mocks.getAllLockedSkills.mockResolvedValue({});
+    mocks.readLocalLock.mockResolvedValue(localLock);
+    mocks.computeSkillFolderHash.mockResolvedValue('json-hash');
+
+    const { runStatus } = await statusModulePromise;
+    await runStatus(['--json']);
+
+    const output = consoleLogSpy.mock.calls
+      .flat()
+      .map((value) => String(value))
+      .join('\n');
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toEqual([
+      {
+        name: 'json-skill',
+        scope: 'project',
+        status: 'tracked',
+        installedPath: '/tmp/json',
+        canonicalPath: '/tmp/json',
+        lockType: 'local',
+        expectedHash: 'json-hash',
+        actualHash: 'json-hash',
+      },
+    ]);
+    expect(output).not.toContain('Project Status');
+  });
+
+  it('uses global scope when -g is provided', async () => {
+    mocks.listInstalledSkills.mockResolvedValue([]);
+    mocks.getAllLockedSkills.mockResolvedValue({});
+    mocks.readLocalLock.mockResolvedValue({ version: 1, skills: {} });
+
+    const { runStatus } = await statusModulePromise;
+    await runStatus(['-g']);
+
+    expect(mocks.listInstalledSkills).toHaveBeenCalledWith({ global: true });
+  });
+});

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -43,9 +43,14 @@ describe('evaluateSkillStatus', () => {
   it('flags a tracked skill when the lock hash matches', async () => {
     const hashFn = vi.fn(async () => 'expected-hash');
 
-    const statuses = await evaluateSkillStatus([baseLocalSkill], emptyGlobalLock, localLock, {
-      hashFn,
-    });
+    const statuses = await evaluateSkillStatus(
+      [baseLocalSkill],
+      emptyGlobalLock.skills,
+      localLock,
+      {
+        hashFn,
+      }
+    );
 
     expect(statuses).toHaveLength(1);
     expect(statuses[0]).toEqual({
@@ -62,7 +67,7 @@ describe('evaluateSkillStatus', () => {
   });
 
   it('reports missing lock entry when the skill is not tracked', async () => {
-    const statuses = await evaluateSkillStatus([baseLocalSkill], emptyGlobalLock, {
+    const statuses = await evaluateSkillStatus([baseLocalSkill], emptyGlobalLock.skills, {
       version: 1,
       skills: {},
     });
@@ -96,7 +101,7 @@ describe('evaluateSkillStatus', () => {
           },
         },
         dismissed: {},
-      },
+      }.skills,
       { version: 1, skills: {} },
       { hashFn }
     );

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateSkillStatus } from '../src/status.ts';
+import type { InstalledSkill } from '../src/installer.ts';
+import type { LocalSkillLockFile } from '../src/local-lock.ts';
+import type { SkillLockFile } from '../src/skill-lock.ts';
+
+const baseLocalSkill: InstalledSkill = {
+  name: 'local-skill',
+  description: 'Local skill for testing',
+  path: '/tmp/local',
+  canonicalPath: '/tmp/local',
+  scope: 'project',
+  agents: [],
+};
+
+const baseGlobalSkill: InstalledSkill = {
+  name: 'global-skill',
+  description: 'Global skill for testing',
+  path: '/tmp/global',
+  canonicalPath: '/tmp/global',
+  scope: 'global',
+  agents: [],
+};
+
+const emptyGlobalLock: SkillLockFile = {
+  version: 3,
+  skills: {},
+  dismissed: {},
+};
+
+const localLock: LocalSkillLockFile = {
+  version: 1,
+  skills: {
+    'local-skill': {
+      source: 'local',
+      sourceType: 'local',
+      computedHash: 'expected-hash',
+    },
+  },
+};
+
+describe('evaluateSkillStatus', () => {
+  it('flags a tracked skill when the lock hash matches', async () => {
+    const hashFn = vi.fn(async () => 'expected-hash');
+
+    const statuses = await evaluateSkillStatus([baseLocalSkill], emptyGlobalLock, localLock, {
+      hashFn,
+    });
+
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0]).toEqual({
+      name: 'local-skill',
+      scope: 'project',
+      status: 'tracked',
+      installedPath: '/tmp/local',
+      canonicalPath: '/tmp/local',
+      lockType: 'local',
+      expectedHash: 'expected-hash',
+      actualHash: 'expected-hash',
+    });
+    expect(hashFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports missing lock entry when the skill is not tracked', async () => {
+    const statuses = await evaluateSkillStatus([baseLocalSkill], emptyGlobalLock, {
+      version: 1,
+      skills: {},
+    });
+
+    expect(statuses).toEqual([
+      {
+        name: 'local-skill',
+        scope: 'project',
+        status: 'missing-lock-entry',
+        installedPath: '/tmp/local',
+        canonicalPath: '/tmp/local',
+      },
+    ]);
+  });
+
+  it('flags hash mismatch for global skills when hashes diverge', async () => {
+    const hashFn = vi.fn(async () => 'local-hash');
+    const statuses = await evaluateSkillStatus(
+      [baseGlobalSkill],
+      {
+        version: 3,
+        skills: {
+          'global-skill': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            sourceUrl: 'https://github.com/owner/repo',
+            skillPath: 'skills/global-skill',
+            skillFolderHash: 'remote-hash',
+            installedAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+        },
+        dismissed: {},
+      },
+      { version: 1, skills: {} },
+      { hashFn }
+    );
+
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0]?.status).toBe('hash-mismatch');
+    expect(statuses[0]?.expectedHash).toBe('remote-hash');
+    expect(statuses[0]?.actualHash).toBe('local-hash');
+  });
+});


### PR DESCRIPTION
This pull request resolves #629 by adding a dedicated `skills status` command for checking installed skills against lockfile state.

The CLI could install and lock skills, but it did not provide a focused way to inspect tracked, missing, or mismatched entries. This branch adds a pure status evaluation core, wires it into the CLI, and supports both text and JSON output without depending on the brittle child-process CLI test path.
