### PR TITLE
feat(list): add an audit view for installed skills

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -46,6 +46,7 @@ import {
   type SkillAuditData,
   type PartnerAudit,
 } from './telemetry.ts';
+import { buildSecurityLines } from './security-audit.ts';
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
@@ -61,91 +62,6 @@ import type { Skill, AgentType } from './types.ts';
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
   setVersion(version);
-}
-
-// ─── Security Advisory ───
-
-function riskLabel(risk: string): string {
-  switch (risk) {
-    case 'critical':
-      return pc.red(pc.bold('Critical Risk'));
-    case 'high':
-      return pc.red('High Risk');
-    case 'medium':
-      return pc.yellow('Med Risk');
-    case 'low':
-      return pc.green('Low Risk');
-    case 'safe':
-      return pc.green('Safe');
-    default:
-      return pc.dim('--');
-  }
-}
-
-function socketLabel(audit: PartnerAudit | undefined): string {
-  if (!audit) return pc.dim('--');
-  const count = audit.alerts ?? 0;
-  return count > 0 ? pc.red(`${count} alert${count !== 1 ? 's' : ''}`) : pc.green('0 alerts');
-}
-
-/** Pad a string to a given visible width (ignoring ANSI escape codes). */
-function padEnd(str: string, width: number): string {
-  // Strip ANSI codes to measure visible length
-  const visible = str.replace(/\x1b\[[0-9;]*m/g, '');
-  const pad = Math.max(0, width - visible.length);
-  return str + ' '.repeat(pad);
-}
-
-/**
- * Render a compact security table showing partner audit results.
- * Returns the lines to display, or empty array if no data.
- */
-function buildSecurityLines(
-  auditData: AuditResponse | null,
-  skills: Array<{ slug: string; displayName: string }>,
-  source: string
-): string[] {
-  if (!auditData) return [];
-
-  // Check if we have any audit data at all
-  const hasAny = skills.some((s) => {
-    const data = auditData[s.slug];
-    return data && Object.keys(data).length > 0;
-  });
-  if (!hasAny) return [];
-
-  // Compute column width for skill names
-  const nameWidth = Math.min(Math.max(...skills.map((s) => s.displayName.length)), 36);
-
-  // Header
-  const lines: string[] = [];
-  const header =
-    padEnd('', nameWidth + 2) +
-    padEnd(pc.dim('Gen'), 18) +
-    padEnd(pc.dim('Socket'), 18) +
-    pc.dim('Snyk');
-  lines.push(header);
-
-  // Rows
-  for (const skill of skills) {
-    const data = auditData[skill.slug];
-    const name =
-      skill.displayName.length > nameWidth
-        ? skill.displayName.slice(0, nameWidth - 1) + '\u2026'
-        : skill.displayName;
-
-    const ath = data?.ath ? riskLabel(data.ath.risk) : pc.dim('--');
-    const socket = data?.socket ? socketLabel(data.socket) : pc.dim('--');
-    const snyk = data?.snyk ? riskLabel(data.snyk.risk) : pc.dim('--');
-
-    lines.push(padEnd(pc.cyan(name), nameWidth + 2) + padEnd(ath, 18) + padEnd(socket, 18) + snyk);
-  }
-
-  // Footer link
-  lines.push('');
-  lines.push(`${pc.dim('Details:')} ${pc.dim(`https://skills.sh/${source}`)}`);
-
-  return lines;
 }
 
 /**

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -61,10 +61,21 @@ describe('list command', () => {
       expect(options.json).toBe(true);
     });
 
+    it('should parse --audit flag', () => {
+      const options = parseListOptions(['--audit']);
+      expect(options.audit).toBe(true);
+    });
+
     it('should parse combined --json and -g flags', () => {
       const options = parseListOptions(['-g', '--json']);
       expect(options.global).toBe(true);
       expect(options.json).toBe(true);
+    });
+
+    it('should parse combined --json and --audit flags', () => {
+      const options = parseListOptions(['--json', '--audit']);
+      expect(options.json).toBe(true);
+      expect(options.audit).toBe(true);
     });
 
     it('should stop collecting agents at next flag', () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -3,6 +3,10 @@ import type { AgentType } from './types.ts';
 import { agents } from './agents.ts';
 import { listInstalledSkills, type InstalledSkill } from './installer.ts';
 import { getAllLockedSkills } from './skill-lock.ts';
+import { readLocalLock } from './local-lock.ts';
+import { buildSecurityLines } from './security-audit.ts';
+import { fetchAuditData } from './telemetry.ts';
+import { groupInstalledSkillAudits, type SecurityAuditGroup } from './security-audit-list.ts';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -15,6 +19,7 @@ interface ListOptions {
   global?: boolean;
   agent?: string[];
   json?: boolean;
+  audit?: boolean;
 }
 
 /**
@@ -52,6 +57,8 @@ export function parseListOptions(args: string[]): ListOptions {
       options.global = true;
     } else if (arg === '--json') {
       options.json = true;
+    } else if (arg === '--audit') {
+      options.audit = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       // Collect all following arguments until next flag
@@ -62,6 +69,45 @@ export function parseListOptions(args: string[]): ListOptions {
   }
 
   return options;
+}
+
+async function renderSecurityAudit(groups: SecurityAuditGroup[]): Promise<void> {
+  if (groups.length === 0) {
+    return;
+  }
+
+  const auditResults = await Promise.all(
+    groups.map(async (group) => {
+      try {
+        const auditData = await fetchAuditData(
+          group.source,
+          group.skills.map((skill) => skill.slug)
+        );
+        if (!auditData) {
+          return null;
+        }
+        const lines = buildSecurityLines(auditData, group.skills, group.source);
+        return lines.length > 0 ? lines : null;
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  const blocks = auditResults.filter(
+    (lines): lines is string[] => Array.isArray(lines) && lines.length > 0
+  );
+
+  if (blocks.length === 0) {
+    return;
+  }
+
+  console.log(`${BOLD}Security audit${RESET}`);
+
+  for (const lines of blocks) {
+    console.log();
+    console.log(lines.join('\n'));
+  }
 }
 
 export async function runList(args: string[]): Promise<void> {
@@ -188,5 +234,11 @@ export async function runList(args: string[]): Promise<void> {
       printSkill(skill);
     }
     console.log();
+  }
+
+  if (options.audit) {
+    const localLock = await readLocalLock();
+    const auditGroups = groupInstalledSkillAudits(installedSkills, lockedSkills, localLock.skills);
+    await renderSecurityAudit(auditGroups);
   }
 }

--- a/src/security-audit-list.ts
+++ b/src/security-audit-list.ts
@@ -1,0 +1,60 @@
+import type { InstalledSkill } from './installer.ts';
+import type { SkillLockEntry } from './skill-lock.ts';
+import type { LocalSkillLockEntry } from './local-lock.ts';
+
+export interface SecurityAuditSkill {
+  slug: string;
+  displayName: string;
+}
+
+export interface SecurityAuditGroup {
+  source: string;
+  skills: SecurityAuditSkill[];
+}
+
+function isRemoteSource(
+  entry?: SkillLockEntry | LocalSkillLockEntry
+): entry is SkillLockEntry | LocalSkillLockEntry {
+  if (!entry?.source) return false;
+  if (entry.sourceType === 'local') return false;
+  if (!entry.source.includes('/')) return false;
+  return true;
+}
+
+export function groupInstalledSkillAudits(
+  installedSkills: InstalledSkill[],
+  lockedSkills: Record<string, SkillLockEntry>,
+  localSkills: Record<string, LocalSkillLockEntry>
+): SecurityAuditGroup[] {
+  const grouped = new Map<string, Map<string, SecurityAuditSkill>>();
+
+  for (const skill of installedSkills) {
+    const entry = lockedSkills[skill.name] ?? localSkills[skill.name];
+    if (!isRemoteSource(entry)) continue;
+
+    const source = entry.source.trim();
+    if (!source) continue;
+
+    let skillsForSource = grouped.get(source);
+    if (!skillsForSource) {
+      skillsForSource = new Map();
+      grouped.set(source, skillsForSource);
+    }
+
+    if (!skillsForSource.has(skill.name)) {
+      skillsForSource.set(skill.name, {
+        slug: skill.name,
+        displayName: skill.name,
+      });
+    }
+  }
+
+  return Array.from(grouped.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([source, skills]) => ({
+      source,
+      skills: Array.from(skills.values()).sort((a, b) =>
+        a.displayName.localeCompare(b.displayName)
+      ),
+    }));
+}

--- a/src/security-audit.ts
+++ b/src/security-audit.ts
@@ -1,0 +1,75 @@
+import pc from 'picocolors';
+import { type AuditResponse, type PartnerAudit } from './telemetry.ts';
+
+export function riskLabel(risk: string): string {
+  switch (risk) {
+    case 'critical':
+      return pc.red(pc.bold('Critical Risk'));
+    case 'high':
+      return pc.red('High Risk');
+    case 'medium':
+      return pc.yellow('Med Risk');
+    case 'low':
+      return pc.green('Low Risk');
+    case 'safe':
+      return pc.green('Safe');
+    default:
+      return pc.dim('--');
+  }
+}
+
+export function socketLabel(audit: PartnerAudit | undefined): string {
+  if (!audit) return pc.dim('--');
+  const count = audit.alerts ?? 0;
+  return count > 0 ? pc.red(`${count} alert${count !== 1 ? 's' : ''}`) : pc.green('0 alerts');
+}
+
+/** Pad a string to a given visible width (ignoring ANSI escape codes). */
+export function padEnd(str: string, width: number): string {
+  const visible = str.replace(/\x1b\[[0-9;]*m/g, '');
+  const pad = Math.max(0, width - visible.length);
+  return str + ' '.repeat(pad);
+}
+
+export function buildSecurityLines(
+  auditData: AuditResponse | null,
+  skills: Array<{ slug: string; displayName: string }>,
+  source: string
+): string[] {
+  if (!auditData) return [];
+
+  const hasAny = skills.some((s) => {
+    const data = auditData[s.slug];
+    return data && Object.keys(data).length > 0;
+  });
+  if (!hasAny) return [];
+
+  const nameWidth = Math.min(Math.max(...skills.map((s) => s.displayName.length)), 36);
+
+  const lines: string[] = [];
+  const header =
+    padEnd('', nameWidth + 2) +
+    padEnd(pc.dim('Gen'), 18) +
+    padEnd(pc.dim('Socket'), 18) +
+    pc.dim('Snyk');
+  lines.push(header);
+
+  for (const skill of skills) {
+    const data = auditData[skill.slug];
+    const name =
+      skill.displayName.length > nameWidth
+        ? skill.displayName.slice(0, nameWidth - 1) + '\u2026'
+        : skill.displayName;
+
+    const ath = data?.ath ? riskLabel(data.ath.risk) : pc.dim('--');
+    const socket = data?.socket ? socketLabel(data.socket) : pc.dim('--');
+    const snyk = data?.snyk ? riskLabel(data.snyk.risk) : pc.dim('--');
+
+    lines.push(padEnd(pc.cyan(name), nameWidth + 2) + padEnd(ath, 18) + padEnd(socket, 18) + snyk);
+  }
+
+  lines.push('');
+  lines.push(`${pc.dim('Details:')} ${pc.dim(`https://skills.sh/${source}`)}`);
+
+  return lines;
+}

--- a/tests/list-audit.test.ts
+++ b/tests/list-audit.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InstalledSkill } from '../src/installer.ts';
+import type { SkillLockEntry } from '../src/skill-lock.ts';
+import type { LocalSkillLock } from '../src/local-lock.ts';
+import { stripAnsi } from '../src/test-utils.ts';
+
+const mocks = vi.hoisted(() => ({
+  listInstalledSkills: vi.fn(),
+  getAllLockedSkills: vi.fn(),
+  readLocalLock: vi.fn(),
+  fetchAuditData: vi.fn(),
+}));
+
+vi.mock('../src/installer.ts', () => ({
+  listInstalledSkills: mocks.listInstalledSkills,
+}));
+
+vi.mock('../src/skill-lock.ts', () => ({
+  getAllLockedSkills: mocks.getAllLockedSkills,
+}));
+
+vi.mock('../src/local-lock.ts', () => ({
+  readLocalLock: mocks.readLocalLock,
+}));
+
+vi.mock('../src/telemetry.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/telemetry.ts')>('../src/telemetry.ts');
+  return {
+    ...actual,
+    fetchAuditData: mocks.fetchAuditData,
+  };
+});
+
+const listModulePromise = import('../src/list.ts');
+
+describe('runList --audit', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('appends security audit output in text mode', async () => {
+    const installedSkills: InstalledSkill[] = [
+      {
+        name: 'alpha',
+        description: 'Alpha skill',
+        path: '/tmp/alpha',
+        canonicalPath: '/tmp/alpha',
+        scope: 'project',
+        agents: [],
+      },
+    ];
+
+    const lockedSkills: Record<string, SkillLockEntry> = {
+      alpha: {
+        source: 'vercel-labs/agent-skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/vercel-labs/agent-skills',
+        skillFolderHash: 'tree-alpha',
+        installedAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    };
+
+    const localLock: LocalSkillLock = {
+      version: 1,
+      skills: {},
+    };
+
+    mocks.listInstalledSkills.mockResolvedValue(installedSkills);
+    mocks.getAllLockedSkills.mockResolvedValue(lockedSkills);
+    mocks.readLocalLock.mockResolvedValue(localLock);
+    mocks.fetchAuditData.mockResolvedValue({
+      alpha: {
+        ath: { risk: 'high', analyzedAt: '2025-01-01T00:00:00.000Z' },
+        socket: { risk: 'safe', alerts: 0, analyzedAt: '2025-01-01T00:00:00.000Z' },
+        snyk: { risk: 'medium', analyzedAt: '2025-01-01T00:00:00.000Z' },
+      },
+    });
+
+    const { runList } = await listModulePromise;
+    await runList(['--audit']);
+
+    const output = stripAnsi(
+      consoleLogSpy.mock.calls
+        .flat()
+        .map((value) => String(value))
+        .join('\n')
+    );
+
+    expect(output).toContain('Project Skills');
+    expect(output).toContain('Security audit');
+    expect(output).toContain('alpha');
+    expect(output).toContain('Details: https://skills.sh/vercel-labs/agent-skills');
+    expect(mocks.fetchAuditData).toHaveBeenCalledWith('vercel-labs/agent-skills', ['alpha']);
+  });
+
+  it('keeps --json output unchanged when --audit is also set', async () => {
+    const installedSkills: InstalledSkill[] = [
+      {
+        name: 'json-audit-skill',
+        description: 'A skill for JSON audit testing',
+        path: '/tmp/json-audit-skill',
+        canonicalPath: '/tmp/json-audit-skill',
+        scope: 'project',
+        agents: [],
+      },
+    ];
+
+    mocks.listInstalledSkills.mockResolvedValue(installedSkills);
+
+    const { runList } = await listModulePromise;
+    await runList(['--json', '--audit']);
+
+    const output = consoleLogSpy.mock.calls
+      .flat()
+      .map((value) => String(value))
+      .join('\n');
+    const parsed = JSON.parse(output);
+
+    expect(parsed).toEqual([
+      {
+        name: 'json-audit-skill',
+        path: '/tmp/json-audit-skill',
+        scope: 'project',
+        agents: [],
+      },
+    ]);
+    expect(output).not.toContain('Security audit');
+    expect(mocks.getAllLockedSkills).not.toHaveBeenCalled();
+    expect(mocks.readLocalLock).not.toHaveBeenCalled();
+    expect(mocks.fetchAuditData).not.toHaveBeenCalled();
+  });
+});

--- a/tests/security-audit-list.test.ts
+++ b/tests/security-audit-list.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { groupInstalledSkillAudits } from '../src/security-audit-list.ts';
+import type { InstalledSkill } from '../src/installer.ts';
+import type { SkillLockEntry } from '../src/skill-lock.ts';
+import type { LocalSkillLockEntry } from '../src/local-lock.ts';
+
+describe('groupInstalledSkillAudits', () => {
+  const baseSkill: Partial<InstalledSkill> = {
+    description: 'desc',
+    path: '/tmp/skill',
+    canonicalPath: '/tmp/skill',
+    scope: 'project',
+    agents: [],
+  };
+
+  it('groups skills by source and ignores non-remote entries', () => {
+    const installedSkills: InstalledSkill[] = [
+      { ...baseSkill, name: 'foo' },
+      { ...baseSkill, name: 'bar' },
+      { ...baseSkill, name: 'baz' },
+    ] as InstalledSkill[];
+
+    const lockedSkills: Record<string, SkillLockEntry> = {
+      foo: {
+        source: 'vercel-labs/agent-skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/vercel-labs/agent-skills',
+        skillFolderHash: '123',
+        installedAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      },
+    };
+
+    const localSkills: Record<string, LocalSkillLockEntry> = {
+      bar: {
+        source: 'vercel-labs/agent-skills',
+        sourceType: 'github',
+        computedHash: 'abc',
+      },
+      baz: {
+        source: '/Users/test/skills/local-baz',
+        sourceType: 'local',
+        computedHash: 'def',
+      },
+    };
+
+    const groups = groupInstalledSkillAudits(installedSkills, lockedSkills, localSkills);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.source).toBe('vercel-labs/agent-skills');
+    expect(groups[0]!.skills.map((skill) => skill.slug)).toEqual(['bar', 'foo']);
+  });
+});


### PR DESCRIPTION
This pull request resolves #628 by adding an audit view to `skills list` and extracting the security audit rendering seam that supports it.

The CLI already had audit-related logic, but it did not expose a lightweight way to view audit information alongside installed skills. This branch adds `skills list --audit`, keeps JSON output unchanged, and groups the audit rendering so it can be reused cleanly instead of being duplicated inside the list path.
