### PR TITLE
fix: store relative paths for local sources in lock files

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { sep } from 'path';
+import { relative, sep } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import { searchMultiselect, cancelSymbol } from './prompts/search-multiselect.ts';
 
@@ -1511,10 +1511,19 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               if (hash) skillFolderHash = hash;
             }
 
+            // For local sources, store relative path instead of absolute
+            // to make the lockfile portable across machines
+            const effectiveSource =
+              parsed.type === 'local'
+                ? relative(cwd, parsed.url) || '.'
+                : lockSource || normalizedSource;
+            const effectiveSourceUrl =
+              parsed.type === 'local' ? relative(cwd, parsed.url) || '.' : parsed.url;
+
             await addSkillToLock(skill.name, {
-              source: lockSource || normalizedSource,
+              source: effectiveSource,
               sourceType: parsed.type,
-              sourceUrl: parsed.url,
+              sourceUrl: effectiveSourceUrl,
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
@@ -1534,10 +1543,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
             const computedHash = await computeSkillFolderHash(skill.path);
+            // For local sources, store relative path instead of absolute
+            const localLockSource =
+              parsed.type === 'local' ? relative(cwd, parsed.url) || '.' : lockSource || parsed.url;
             await addSkillToLocalLock(
               skill.name,
               {
-                source: lockSource || parsed.url,
+                source: localLockSource,
                 sourceType: parsed.type,
                 computedHash,
               },


### PR DESCRIPTION
## Summary

Fixes #561

When installing a skill from a local path (e.g., `npx skills add ./docs`), the lock files now store the relative path instead of the resolved absolute path.

## Problem

`source-parser.ts` uses `resolve(input)` to convert relative paths to absolute. This absolute path then gets stored in both `skills-lock.json` and `.skill-lock.json`:
```json
{
  "source": "C:\\Users\\myUser\\code\\skills\\docs",
  "sourceUrl": "C:\\Users\\myUser\\code\\skills\\docs"
}
```

This makes the lock file non-portable across machines and leaks user directory structure.

## Solution

When `parsed.type === 'local'`, convert the absolute path back to relative (relative to `cwd`) before writing to either lock file:
```json
{
  "source": "docs",
  "sourceUrl": "docs"
}
```

Uses `path.relative(cwd, absolutePath)` with a fallback to `'.'}` for the project root case.

## Testing

- `pnpm build` ✅
- `pnpm test` ✅ (375/375)