### PR TITLE
fix: default to copy mode for Antigravity installations

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -629,11 +629,18 @@ async function handleWellKnownSkills(
   // Determine install mode (symlink vs copy)
   let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
+  // Antigravity IDE does not follow symlinks during skill discovery,
+  // so default to copy mode when it is a target agent. (#633)
+  const hasAntigravity = targetAgents.includes('antigravity');
+  if (hasAntigravity && !options.copy) {
+    installMode = 'copy';
+  }
+
   // Only prompt for install mode when there are multiple unique target directories.
   // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
   const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
 
-  if (!options.copy && !options.yes && uniqueDirs.size > 1) {
+  if (!options.copy && !hasAntigravity && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
       message: 'Installation method',
       options: [
@@ -1252,11 +1259,18 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Determine install mode (symlink vs copy)
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
+    // Antigravity IDE does not follow symlinks during skill discovery,
+    // so default to copy mode when it is a target agent. (#633)
+    const hasAntigravity = targetAgents.includes('antigravity');
+    if (hasAntigravity && !options.copy) {
+      installMode = 'copy';
+    }
+
     // Only prompt for install mode when there are multiple unique target directories.
     // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
     const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
 
-    if (!options.copy && !options.yes && uniqueDirs.size > 1) {
+    if (!options.copy && !hasAntigravity && !options.yes && uniqueDirs.size > 1) {
       const modeChoice = await p.select({
         message: 'Installation method',
         options: [


### PR DESCRIPTION
## Summary

Fixes #633

Antigravity IDE does not follow symlinks during skill discovery — only real directories in `~/.gemini/antigravity/skills/` are loaded. This PR defaults to copy mode when Antigravity is among the target agents.

## Problem

When installing skills globally with symlink mode (the default):
- Skills are stored in `~/.agents/skills/` and symlinked into `~/.gemini/antigravity/skills/`
- The symlinks are valid and resolve correctly (`readlink`, `realpath`, `cat` all work)
- But **Antigravity IDE silently ignores symlinked directories** — only real directories are discovered
- Result: 75 symlinked skills → 0 loaded; 10 real directories → all loaded

## Solution

When Antigravity is a target agent, automatically default to copy mode instead of symlink. This ensures skills are always discoverable without requiring users to manually configure Custom Paths or use `--copy`.

The change applies to both the well-known and GitHub/local installation paths in `add.ts`.

Users can still explicitly use `--copy` or choose symlink mode via the interactive prompt for other agents.

## Testing

- `pnpm build` ✅
- `pnpm test` ✅ (375/375 tests pass)