### PR TITLE
fix: support check/update for local skills

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1509,6 +1509,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               const token = getGitHubToken();
               const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token);
               if (hash) skillFolderHash = hash;
+            } else if (parsed.type === 'local' && parsed.localPath) {
+              // For local skills, compute a hash from the source directory
+              // so `skills check/update` can detect changes later
+              try {
+                skillFolderHash = await computeSkillFolderHash(parsed.localPath);
+              } catch {
+                // Non-fatal: skill works without hash, just can't detect updates
+              }
             }
 
             await addSkillToLock(skill.name, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { computeSkillFolderHash } from './local-lock.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -367,8 +368,12 @@ interface SkippedSkill {
  * Determine why a skill cannot be checked for updates automatically.
  */
 function getSkipReason(entry: SkillLockEntry): string {
+  if (entry.sourceType === 'local' && entry.skillFolderHash) {
+    // Local skills with a stored hash can be checked via local hash comparison
+    return '';
+  }
   if (entry.sourceType === 'local') {
-    return 'Local path';
+    return 'Local path (no hash recorded — reinstall to enable tracking)';
   }
   if (entry.sourceType === 'git') {
     return 'Git URL (hash tracking not supported)';
@@ -414,15 +419,25 @@ async function runCheck(args: string[] = []): Promise<void> {
 
   // Group skills by source (owner/repo) to batch GitHub API calls
   const skillsBySource = new Map<string, Array<{ name: string; entry: SkillLockEntry }>>();
+  const localSkills: Array<{ name: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
 
   for (const skillName of skillNames) {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check skills with folder hash and skill path
+    // Local skills with a stored hash can be checked via local hash comparison
+    if (entry.sourceType === 'local' && entry.skillFolderHash) {
+      localSkills.push({ name: skillName, entry });
+      continue;
+    }
+
+    // Only check GitHub skills with folder hash and skill path
     if (!entry.skillFolderHash || !entry.skillPath) {
-      skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
+      const reason = getSkipReason(entry);
+      if (reason) {
+        skipped.push({ name: skillName, reason, sourceUrl: entry.sourceUrl });
+      }
       continue;
     }
 
@@ -464,6 +479,28 @@ async function runCheck(args: string[] = []): Promise<void> {
           error: err instanceof Error ? err.message : 'Unknown error',
         });
       }
+    }
+  }
+
+  // Check local skills by computing fresh hash from source path
+  for (const { name, entry } of localSkills) {
+    try {
+      const sourcePath = entry.sourceUrl;
+      if (!existsSync(sourcePath)) {
+        errors.push({ name, source: sourcePath, error: 'Source path no longer exists' });
+        continue;
+      }
+
+      const currentHash = await computeSkillFolderHash(sourcePath);
+      if (currentHash !== entry.skillFolderHash) {
+        updates.push({ name, source: sourcePath });
+      }
+    } catch (err) {
+      errors.push({
+        name,
+        source: entry.sourceUrl,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
     }
   }
 
@@ -525,9 +562,28 @@ async function runUpdate(): Promise<void> {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check skills with folder hash and skill path
+    // Local skills with a stored hash: compare via local hash
+    if (entry.sourceType === 'local' && entry.skillFolderHash) {
+      try {
+        const sourcePath = entry.sourceUrl;
+        if (existsSync(sourcePath)) {
+          const currentHash = await computeSkillFolderHash(sourcePath);
+          if (currentHash !== entry.skillFolderHash) {
+            updates.push({ name: skillName, source: sourcePath, entry });
+          }
+        }
+      } catch {
+        // Skip local skills that fail to check
+      }
+      continue;
+    }
+
+    // Only check GitHub skills with folder hash and skill path
     if (!entry.skillFolderHash || !entry.skillPath) {
-      skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
+      const reason = getSkipReason(entry);
+      if (reason) {
+        skipped.push({ name: skillName, reason, sourceUrl: entry.sourceUrl });
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fixes #522

`skills check` and `skills update` now work with locally installed skills.

## Problem

Local skills (installed via `npx skills add ./path`) were always skipped by `check` and `update` because:
1. `getSkipReason()` returned `'Local path'` for all local sources
2. The check loop required `skillFolderHash` and `skillPath` — but local skills had neither stored at install time
3. GitHub API (`fetchSkillFolderHash`) was the only hash comparison method

## Solution

### At install time (`add.ts`)
- Compute a folder hash for local skills using `computeSkillFolderHash()` and store it in `skillFolderHash`

### At check/update time (`cli.ts`)
- Local skills with a stored hash are no longer skipped
- Fresh hash is computed from the source path and compared against the stored hash
- If the source path no longer exists, an error is reported instead of silently skipping

### Skip message improvement
- Local skills without a stored hash (installed before this fix) show: `'Local path (no hash recorded — reinstall to enable tracking)'`

## Testing

- `pnpm build` ✅
- `pnpm test` ✅ (375/375 tests pass)