### PR TITLE
fix: initialize git submodules when cloning repositories

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -29,6 +29,19 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
   try {
     await git.clone(url, tempDir, cloneOptions);
+
+    // Initialize submodules if any exist
+    try {
+      const repoGit = simpleGit({
+        timeout: { block: CLONE_TIMEOUT_MS },
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      });
+      await repoGit.cwd(tempDir);
+      await repoGit.submoduleUpdate(['--init', '--recursive', '--depth', '1']);
+    } catch {
+      // Submodule init is best-effort — skip silently if no submodules or if it fails
+    }
+
     return tempDir;
   } catch (error) {
     // Clean up temp dir on failure


### PR DESCRIPTION
## Summary

Closes #492

When a skill repository uses git submodules, `skills add` now initializes them so skills in submodule directories are discoverable.

## Changes

After cloning, runs `git submodule update --init --recursive --depth 1`:

- **Shallow depth** (`--depth 1`) to minimize clone overhead
- **Best-effort** — if no submodules exist or init fails, cloning proceeds normally (no user-visible change)
- Works with both `--branch` (ref) and default branch clones

## Testing

All 375 existing tests pass. The change is backward-compatible — repos without submodules are unaffected.