### PR TITLE
feat: add pre-commit hooks for skills check and update

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,33 @@
+# Pre-commit hooks for the skills CLI.
+# Usage: add the following to your .pre-commit-config.yaml:
+#
+#   repos:
+#     - repo: https://github.com/vercel-labs/skills
+#       rev: main
+#       hooks:
+#         - id: skills-check
+#
+# See https://pre-commit.com for more information.
+
+- id: skills-check
+  name: Check for skill updates
+  entry: npx -y skills check
+  language: system
+  pass_filenames: false
+  always_run: true
+  stages: [pre-commit]
+  description: >-
+    Check whether installed skills are up to date.
+    Fails with a non-zero exit code when updates are available.
+
+- id: skills-update
+  name: Update skills
+  entry: npx -y skills update -y
+  language: system
+  pass_filenames: false
+  always_run: true
+  stages: [manual]
+  description: >-
+    Update all installed skills to the latest version.
+    Recommended as a manual stage — run with
+    `pre-commit run --hook-stage manual skills-update`.


### PR DESCRIPTION
## Summary

Closes #525

Adds `.pre-commit-hooks.yaml` so external projects can integrate skills checks into their [pre-commit](https://pre-commit.com) workflow.

## Hooks

| Hook ID | Stage | Description |
|---------|-------|-------------|
| `skills-check` | `pre-commit` | Runs `npx skills check` — fails if updates are available |
| `skills-update` | `manual` | Runs `npx skills update -y` — opt-in, no auto-mutation |

## Usage

```yaml
# .pre-commit-config.yaml
repos:
  - repo: https://github.com/vercel-labs/skills
    rev: main
    hooks:
      - id: skills-check
```

```bash
# Manual update when needed
pre-commit run --hook-stage manual skills-update
```

## Design decisions

- **`skills-check` on commit, `skills-update` as manual** — per issue discussion, checking is safe as a gate but updating shouldn't mutate files during every commit
- **`language: system`** — uses the user's existing Node.js/npx installation
- **`pass_filenames: false` + `always_run: true`** — skills are project-wide, not per-file