### PR TITLE
feat: add ForgeCode agent support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -157,6 +157,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.factory'));
     },
   },
+  forgecode: {
+    name: 'forgecode',
+    displayName: 'ForgeCode',
+    skillsDir: '.forge/skills',
+    globalSkillsDir: join(home, 'forge/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, 'forge'));
+    },
+  },
   'gemini-cli': {
     name: 'gemini-cli',
     displayName: 'Gemini CLI',

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type AgentType =
   | 'crush'
   | 'cursor'
   | 'droid'
+  | 'forgecode'
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'


### PR DESCRIPTION
## Summary

Closes #635

Adds [ForgeCode](https://forgecode.dev/docs/skills/) to the agent registry.

## Agent configuration

| Field | Value |
|-------|-------|
| Name | `forgecode` |
| Display name | ForgeCode |
| Project skills dir | `.forge/skills` |
| Global skills dir | `~/forge/skills` |
| Detection | `~/forge` exists |

## Changes

- `src/types.ts`: Add `'forgecode'` to `AgentType` union
- `src/agents.ts`: Add ForgeCode agent config (alphabetical order)

## Testing

All 375 tests pass.