### PR TITLE
fix: use typed .env() method for git prompt suppression

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -23,8 +23,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const git = simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-  });
+  }).env('GIT_TERMINAL_PROMPT', '0');
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 
   try {


### PR DESCRIPTION
## Summary

Closes #618

The `simpleGit()` constructor receives an `env` property that is not part of the typed `SimpleGitOptions` interface, causing a TypeScript overload mismatch error.

## Before

```typescript
const git = simpleGit({
  timeout: { block: CLONE_TIMEOUT_MS },
  env: { ...process.env, GIT_TERMINAL_PROMPT: '0' }, // ← not typed
});
```

## After

```typescript
const git = simpleGit({
  timeout: { block: CLONE_TIMEOUT_MS },
}).env('GIT_TERMINAL_PROMPT', '0'); // ← typed method
```

## Notes

- `GIT_TERMINAL_PROMPT=0` still suppresses interactive prompts during clone
- The `.env()` method is part of simple-git's public API and properly typed
- This also fixes the pre-existing TypeScript compile error in `src/git.ts`

## Testing

All 375 tests pass (1 pre-existing timeout in sync.test.ts unrelated to this change).