### PR TITLE
feat: support top-level internal frontmatter to exclude meta skills

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -45,7 +45,7 @@ export async function parseSkillMd(
     // Skip internal skills unless:
     // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
     // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const isInternal = data.metadata?.internal === true;
+    const isInternal = data.internal === true || data.metadata?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
     }


### PR DESCRIPTION
## Summary

Closes #572

Support top-level `internal: true` frontmatter in SKILL.md to exclude internal/meta skills from discovery and installation.

## Before

Only the nested form was recognized:

```yaml
---
name: sync-create-skills
metadata:
  internal: true
---
```

## After

Both top-level and nested forms work:

```yaml
---
name: sync-create-skills
internal: true
description: Internal tooling skill for repo maintainers
---
```

## Behavior

Skills marked as internal:
- ❌ Not shown in `skills find` / discovery UI
- ❌ Not installable via normal `skills add` flow
- ✅ Still functional locally within the repository
- ✅ Installable via `INSTALL_INTERNAL_SKILLS=1` env var
- ✅ Installable when explicitly named via `--skill`

## Changes

- `src/skills.ts`: Check `data.internal` in addition to `data.metadata?.internal`

## Testing

All 375 tests pass.