### PR TITLE
fix: list skills installed for undetected agents

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -11,6 +11,7 @@ import {
   stat,
   realpath,
 } from 'fs/promises';
+import { existsSync } from 'fs';
 import { join, basename, normalize, resolve, sep, relative, dirname } from 'path';
 import { homedir, platform } from 'os';
 import type { Skill, AgentType, RemoteSkill } from './types.ts';
@@ -771,6 +772,22 @@ export async function listInstalledSkills(
       const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
       // Avoid duplicate paths
       if (!scopes.some((s) => s.path === agentDir && s.global === isGlobal)) {
+        scopes.push({ global: isGlobal, path: agentDir, agentType });
+      }
+    }
+
+    // Also scan skill directories for agents NOT in agentsToCheck, in case
+    // skills were installed with `--agent <name>` but the agent is no longer
+    // detected (e.g. ~/.openclaw was removed).  Only add dirs that actually
+    // exist on disk to avoid unnecessary readdir errors.
+    const allAgentTypes = Object.keys(agents) as AgentType[];
+    for (const agentType of allAgentTypes) {
+      if (agentsToCheck.includes(agentType)) continue;
+      const agent = agents[agentType];
+      if (isGlobal && agent.globalSkillsDir === undefined) continue;
+      const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+      if (scopes.some((s) => s.path === agentDir && s.global === isGlobal)) continue;
+      if (existsSync(agentDir)) {
         scopes.push({ global: isGlobal, path: agentDir, agentType });
       }
     }


### PR DESCRIPTION
## Summary

Closes #653

Skills installed with `--agent <name>` become invisible to `skills list` when the agent is not detected by `detectInstalledAgents()`.

## Root Cause

`listInstalledSkills()` only scans skill directories for agents returned by `detectInstalledAgents()`. If an agent's detection check fails (e.g. `~/.openclaw` doesn't exist), its skill directory is never scanned — even though skills were previously installed there via `-a openclaw`.

## Reproduction

```bash
npx skills add vercel-labs/skills -a openclaw   # installs to ./skills/
npx skills list                                  # 'No project skills found'
```

## Fix

After scanning detected agents, also scan all other agent skill directories that **physically exist on disk**. This catches skills installed for agents that are no longer detected, without adding overhead for non-existent directories.

## Changes

- `src/installer.ts`: Add fallback scan of existing-but-undetected agent skill directories in `listInstalledSkills()`

## Testing

All 375 tests pass.