### PR TITLE
fix: handle dot-prefixed paths in fetchSkillFolderHash

### DIFF
--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -180,11 +180,15 @@ export async function fetchSkillFolderHash(
     folderPath = folderPath.slice(0, -1);
   }
 
+  // Remove leading ./ if present (normalize for API matching)
+  if (folderPath.startsWith('./')) {
+    folderPath = folderPath.slice(2);
+  }
+
   const branches = ['main', 'master'];
 
   for (const branch of branches) {
     try {
-      const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
       const headers: Record<string, string> = {
         Accept: 'application/vnd.github.v3+json',
         'User-Agent': 'skills-cli',
@@ -193,12 +197,14 @@ export async function fetchSkillFolderHash(
         headers['Authorization'] = `Bearer ${token}`;
       }
 
+      const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}?recursive=1`;
       const response = await fetch(url, { headers });
 
       if (!response.ok) continue;
 
       const data = (await response.json()) as {
         sha: string;
+        truncated?: boolean;
         tree: Array<{ path: string; type: string; sha: string }>;
       };
 
@@ -214,6 +220,57 @@ export async function fetchSkillFolderHash(
 
       if (folderEntry) {
         return folderEntry.sha;
+      }
+
+      // If the recursive tree was truncated, the entry may be missing.
+      // Walk the path segments individually via non-recursive tree lookups.
+      if (data.truncated) {
+        const segments = folderPath.split('/');
+        let currentSha: string | null = null;
+
+        // Get the root tree SHA for this branch
+        const branchUrl = `https://api.github.com/repos/${ownerRepo}/git/trees/${branch}`;
+        const branchResp = await fetch(branchUrl, { headers });
+        if (!branchResp.ok) continue;
+
+        const branchData = (await branchResp.json()) as {
+          sha: string;
+          tree: Array<{ path: string; type: string; sha: string }>;
+        };
+
+        // Walk each path segment
+        let treeEntries = branchData.tree;
+        for (let i = 0; i < segments.length; i++) {
+          const segment = segments[i]!;
+          const child = treeEntries.find(
+            (entry) => entry.type === 'tree' && entry.path === segment
+          );
+
+          if (!child) {
+            currentSha = null;
+            break;
+          }
+
+          currentSha = child.sha;
+
+          // Fetch the next level tree (unless this is the last segment)
+          if (i < segments.length - 1) {
+            const childUrl = `https://api.github.com/repos/${ownerRepo}/git/trees/${child.sha}`;
+            const childResp = await fetch(childUrl, { headers });
+            if (!childResp.ok) {
+              currentSha = null;
+              break;
+            }
+            const childData = (await childResp.json()) as {
+              tree: Array<{ path: string; type: string; sha: string }>;
+            };
+            treeEntries = childData.tree;
+          }
+        }
+
+        if (currentSha) {
+          return currentSha;
+        }
       }
     } catch {
       continue;


### PR DESCRIPTION
## Summary

Fixes #490 — skills under dot-prefixed directories (e.g. `.claude/skills/my-skill/`) get an empty `skillFolderHash`, causing `skills check` and `skills update` to always report "up to date."

## Changes

Two fixes in `fetchSkillFolderHash()`:

1. **Strip leading `./`** from the folder path before matching against the GitHub Trees API response, preventing path mismatch on some systems.

2. **Truncated tree fallback** — when the recursive tree API response is truncated (large repos), the entry for deeply nested dot-prefixed paths may be missing. The fix walks path segments individually via non-recursive tree lookups.

## Testing

- Skills under `.claude/skills/` now get correct `skillFolderHash` values
- `skills check` / `skills update` correctly detect remote changes
- Root-level skills and non-dot-prefixed paths continue to work as before