### PR TITLE
Add Hermes Agent as a supported skill installation target

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gemini-cli",
     "github-copilot",
     "goose",
+    "hermes",
     "junie",
     "iflow-cli",
     "kilo",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -184,6 +184,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(configHome, 'goose'));
     },
   },
+  hermes: {
+    name: 'hermes',
+    displayName: 'Hermes Agent',
+    skillsDir: 'skills',
+    globalSkillsDir: join(home, '.hermes/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.hermes'));
+    },
+  },
   junie: {
     name: 'junie',
     displayName: 'Junie',

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type AgentType =
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'
+  | 'hermes'
   | 'iflow-cli'
   | 'junie'
   | 'kilo'


### PR DESCRIPTION
## Summary

- Adds [Hermes Agent](https://hermes-agent.nousresearch.com) by Nous Research as a supported agent for skill installation
- Project-level skills dir: `skills/` (same convention as OpenClaw)
- Global skills dir: `~/.hermes/skills/` (created during [Hermes installation](https://hermes-agent.nousresearch.com/docs/getting-started/installation))
- Detection: checks for `~/.hermes` config directory

## Changes

- `src/types.ts`: Added `'hermes'` to `AgentType` union
- `src/agents.ts`: Added `hermes` agent config entry
- `package.json`: Added `"hermes"` to keywords

## References

- [Hermes Agent - Creating Skills](https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills)
- [Hermes Agent - Installation](https://hermes-agent.nousresearch.com/docs/getting-started/installation) (see Step 6 for `~/.hermes/skills/` directory)
