### PR TITLE
fix: preserve URL scheme in well-known source identifier

### DIFF
--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -362,8 +362,11 @@ export class WellKnownProvider implements HostProvider {
   getSourceIdentifier(url: string): string {
     try {
       const parsed = new URL(url);
-      // Use full hostname, only strip www. prefix
-      return parsed.hostname.replace(/^www\./, '');
+      // Preserve the scheme so experimental_install can re-use the source as a valid URL.
+      // Only strip www. prefix and trailing slash for cleanliness.
+      const host = parsed.hostname.replace(/^www\./, '');
+      const pathname = parsed.pathname.replace(/\/+$/, '');
+      return `${parsed.protocol}//${host}${pathname}`;
     } catch {
       return 'unknown';
     }

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -36,30 +36,30 @@ describe('WellKnownProvider', () => {
   });
 
   describe('getSourceIdentifier', () => {
-    it('should return full hostname', () => {
-      expect(provider.getSourceIdentifier('https://example.com')).toBe('example.com');
-      expect(provider.getSourceIdentifier('https://mintlify.com')).toBe('mintlify.com');
-      expect(provider.getSourceIdentifier('https://lovable.dev')).toBe('lovable.dev');
+    it('should return full URL with scheme', () => {
+      expect(provider.getSourceIdentifier('https://example.com')).toBe('https://example.com');
+      expect(provider.getSourceIdentifier('https://mintlify.com')).toBe('https://mintlify.com');
+      expect(provider.getSourceIdentifier('https://lovable.dev')).toBe('https://lovable.dev');
     });
 
-    it('should return same identifier regardless of path', () => {
-      expect(provider.getSourceIdentifier('https://example.com/docs')).toBe('example.com');
-      expect(provider.getSourceIdentifier('https://example.com/api/v1')).toBe('example.com');
+    it('should preserve path in identifier', () => {
+      expect(provider.getSourceIdentifier('https://example.com/docs')).toBe('https://example.com/docs');
+      expect(provider.getSourceIdentifier('https://example.com/api/v1')).toBe('https://example.com/api/v1');
     });
 
     it('should preserve subdomains', () => {
-      expect(provider.getSourceIdentifier('https://docs.example.com')).toBe('docs.example.com');
+      expect(provider.getSourceIdentifier('https://docs.example.com')).toBe('https://docs.example.com');
       expect(provider.getSourceIdentifier('https://api.mintlify.com/docs')).toBe(
-        'api.mintlify.com'
+        'https://api.mintlify.com/docs'
       );
       expect(provider.getSourceIdentifier('https://mppx-discovery-skills.vercel.app')).toBe(
-        'mppx-discovery-skills.vercel.app'
+        'https://mppx-discovery-skills.vercel.app'
       );
     });
 
     it('should strip www. prefix', () => {
-      expect(provider.getSourceIdentifier('https://www.example.com')).toBe('example.com');
-      expect(provider.getSourceIdentifier('https://www.mintlify.com/docs')).toBe('mintlify.com');
+      expect(provider.getSourceIdentifier('https://www.example.com')).toBe('https://example.com');
+      expect(provider.getSourceIdentifier('https://www.mintlify.com/docs')).toBe('https://mintlify.com/docs');
     });
 
     it('should return unknown for invalid URLs', () => {


### PR DESCRIPTION
## Summary

Fixes #666 — `experimental_install` fails for well-known skills because the `source` in `skills-lock.json` is missing the URL scheme.

## Root Cause

`WellKnownProvider.getSourceIdentifier()` only returned the hostname (e.g. `react-spectrum.adobe.com`), stripping the `https://` scheme. When `experimental_install` later passed this source to `runAdd()`, it tried to clone `react-spectrum.adobe.com` as a git repo, which fails.

## Fix

Preserve the full URL with scheme in `getSourceIdentifier()`:

**Before:** `react-spectrum.adobe.com`
**After:** `https://react-spectrum.adobe.com`

## Testing

- `npx skills add https://react-spectrum.adobe.com` stores `https://react-spectrum.adobe.com` as source
- `npx skills experimental_install` successfully reinstalls the skill
- `www.` prefix is still stripped for cleanliness