### PR TITLE
feat: add CodeArts Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Skills can be installed to any of these agents:
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
 | Cline, Warp | `cline`, `warp` | `.agents/skills/` | `~/.agents/skills/` |
+| CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -85,6 +85,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.cline'));
     },
   },
+  'codearts-agent': {
+    name: 'codearts-agent',
+    displayName: 'CodeArts Agent',
+    skillsDir: '.codeartsdoer/skills',
+    globalSkillsDir: join(home, '.codeartsdoer/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.codeartsdoer'));
+    },
+  },
   codebuddy: {
     name: 'codebuddy',
     displayName: 'CodeBuddy',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -160,6 +160,7 @@ export async function discoverSkills(
     join(searchPath, '.agents/skills'),
     join(searchPath, '.claude/skills'),
     join(searchPath, '.cline/skills'),
+    join(searchPath, '.codeartsdoer/skills'),
     join(searchPath, '.codebuddy/skills'),
     join(searchPath, '.codex/skills'),
     join(searchPath, '.commandcode/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type AgentType =
   | 'claude-code'
   | 'openclaw'
   | 'cline'
+  | 'codearts-agent'
   | 'codebuddy'
   | 'codex'
   | 'command-code'


### PR DESCRIPTION
This pull request adds support for the "CodeArts Agent" throughout the codebase. The changes ensure that the agent can be detected, its skills discovered, and its documentation is updated accordingly.

**Support for CodeArts Agent:**

* Added "codearts-agent" as a new `AgentType` in `src/types.ts`.
* Registered "CodeArts Agent" in the `agents` configuration, including detection logic and skills directories in `src/agents.ts`.
* Updated the skills discovery logic to include the `.codeartsdoer/skills` directory in `src/skills.ts`.

**Documentation update:**

* Added "CodeArts Agent" to the skills installation table in `README.md`.

**Additional Context about CodeArts Agent:**

* Official website: https://codearts.huaweicloud.com/
* Skills documentation: https://support.huaweicloud.com/productdesc-codeartssnap/codeartsdoer_pd_0001.html