### PR TITLE
feat: add AiderDesk as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [38 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [39 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -247,6 +247,7 @@ Skills can be installed to any of these agents:
 | Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
+| AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 <!-- supported-agents:end -->
 
 > [!NOTE]

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "zencoder",
     "neovate",
     "pochi",
+    "aider-desk",
     "adal",
     "universal"
   ],

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -401,6 +401,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.adal'));
     },
   },
+  'aider-desk': {
+    name: 'aider-desk',
+    displayName: 'AiderDesk',
+    skillsDir: '.aider-desk/skills',
+    globalSkillsDir: join(home, '.aider-desk/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.aider-desk'));
+    },
+  },
   universal: {
     name: 'universal',
     displayName: 'Universal',

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export type AgentType =
   | 'zencoder'
   | 'pochi'
   | 'adal'
+  | 'aider-desk'
   | 'universal';
 
 export interface Skill {


### PR DESCRIPTION
## Summary

Adds [AiderDesk](https://github.com/hotovo/aider-desk) to the list of compatible AI coding agents.

## About AiderDesk

AiderDesk is a desktop application that brings the power of Aider to a user-friendly interface. It's a coding agent that supports the agent skills format natively, reading skills from `.aider-desk/skills/` in the project and `~/.aider-desk/skills/` globally.

Skills documentation: https://aiderdesk.hotovo.com/docs/features/skills

## Changes

- Added `aider-desk` to the `AgentType` union in `src/types.ts`
- Added the `aider-desk` agent config in `src/agents.ts` with:
  - `skillsDir: '.aider-desk/skills'`
  - `globalSkillsDir: ~/.aider-desk/skills`
  - Detection via `~/.aider-desk`
- Added `aider-desk` to keywords in `package.json`
- Updated README agent count (38 → 39) and added AiderDesk to the supported agents table