### PR TITLE
fix: use SEARCH_API_BASE for all links in find output

### DIFF
--- a/src/find.ts
+++ b/src/find.ts
@@ -298,7 +298,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
       console.log(
         `${TEXT}${pkg}@${skill.name}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`
       );
-      console.log(`${DIM}└ https://skills.sh/${skill.slug}${RESET}`);
+      console.log(`${DIM}└ ${SEARCH_API_BASE}/${skill.slug}${RESET}`);
       console.log();
     }
     return;
@@ -342,10 +342,10 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
   const info = getOwnerRepoFromString(pkg);
   if (info && (await isRepoPublic(info.owner, info.repo))) {
     console.log(
-      `${DIM}View the skill at${RESET} ${TEXT}https://skills.sh/${selected.slug}${RESET}`
+      `${DIM}View the skill at${RESET} ${TEXT}${SEARCH_API_BASE}/${selected.slug}${RESET}`
     );
   } else {
-    console.log(`${DIM}Discover more skills at${RESET} ${TEXT}https://skills.sh${RESET}`);
+    console.log(`${DIM}Discover more skills at${RESET} ${TEXT}${SEARCH_API_BASE}${RESET}`);
   }
 
   console.log();


### PR DESCRIPTION
## Summary

Closes #686 — replaces hardcoded `https://skills.sh/` URLs in `skills find` output with the configurable `SEARCH_API_BASE` constant.

## Problem

`src/find.ts` already respects `SKILLS_API_URL` env var for the search API request, but result rendering still hardcodes `https://skills.sh/` for skill links and the discovery footer. This means self-hosted deployments show links to the wrong host.

## Changes

Three hardcoded `https://skills.sh/` occurrences replaced with `${SEARCH_API_BASE}`:

- **Line 301**: Skill detail link (`└ https://skills.sh/{slug}`)
- **Line 345**: Selected skill link (`View the skill at ...`)
- **Line 348**: Discovery footer (`Discover more skills at ...`)

The default value (`https://skills.sh`) is unchanged, so behavior is identical for non-customized environments.