### PR TITLE
feat: add --skills-dir for universal agent-type-agnostic installation

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -28,6 +28,7 @@ import {
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
+  installSkillToDir,
   type InstallMode,
 } from './installer.ts';
 import {
@@ -416,6 +417,8 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  /** Install directly to a specific directory, bypassing agent detection and prompts */
+  targetDir?: string;
 }
 
 /**
@@ -1132,6 +1135,51 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       selectedSkills = selected as Skill[];
     }
 
+    // --skills-dir fast path: copy skills directly to the target directory,
+    // bypassing agent detection, scope selection, and lock files.
+    if (options.targetDir) {
+      const targetDir = options.targetDir;
+      spinner.start('Installing skills...');
+
+      const results: { skill: string; success: boolean; path: string; error?: string }[] = [];
+      for (const skill of selectedSkills) {
+        const result = await installSkillToDir(skill, targetDir);
+        results.push({ skill: getSkillDisplayName(skill), ...result });
+      }
+
+      spinner.stop('Installation complete');
+
+      console.log();
+      const successful = results.filter((r) => r.success);
+      const failed = results.filter((r) => !r.success);
+
+      if (successful.length > 0) {
+        const resultLines = successful.map(
+          (r) => `${pc.green('✓')} ${r.skill} ${pc.dim('→')} ${r.path}`
+        );
+        const title = pc.green(
+          `Installed ${successful.length} skill${successful.length !== 1 ? 's' : ''}`
+        );
+        p.note(resultLines.join('\n'), title);
+      }
+
+      if (failed.length > 0) {
+        p.log.error(pc.red(`Failed to install ${failed.length}`));
+        for (const r of failed) {
+          p.log.message(`  ${pc.red('✗')} ${r.skill}: ${pc.dim(r.error)}`);
+        }
+      }
+
+      console.log();
+      p.outro(
+        pc.green('Done!') +
+          pc.dim('  Review skills before use; they run with full agent permissions.')
+      );
+
+      await cleanup(tempDir);
+      return;
+    }
+
     // Kick off security audit fetch early (non-blocking) so it runs
     // in parallel with agent selection, scope, and mode prompts.
     const ownerRepoForAudit = getOwnerRepo(parsed);
@@ -1799,6 +1847,9 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--skills-dir') {
+      i++;
+      options.targetDir = args[i];
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,6 +132,7 @@ ${BOLD}Add Options:${RESET}
   --copy                 Copy files instead of symlinking to agent directories
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
+  --skills-dir <path>    Install directly to a directory, skipping agent detection
 
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope
@@ -173,6 +174,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills init my-skill
   ${DIM}$${RESET} skills experimental_sync              ${DIM}# sync from node_modules${RESET}
   ${DIM}$${RESET} skills experimental_sync -y           ${DIM}# sync without prompts${RESET}
+  ${DIM}$${RESET} skills add owner/repo@skill --skills-dir <your-skills-dir> -y  ${DIM}# install directly to a directory${RESET}
 
 Discover more skills at ${TEXT}https://skills.sh/${RESET}
 `);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -940,3 +940,39 @@ export async function listInstalledSkills(
 
   return Array.from(skillsMap.values());
 }
+
+/**
+ * Install a skill directly to a caller-specified directory.
+ *
+ * This bypasses all agent detection, scope selection, symlink logic, and lock
+ * files. It is designed for non-interactive, agent-driven installation where
+ * the caller already knows the target directory.
+ */
+export async function installSkillToDir(
+  skill: Skill,
+  targetDir: string
+): Promise<{ success: boolean; path: string; error?: string }> {
+  const rawSkillName = skill.name || basename(skill.path);
+  const skillName = sanitizeName(rawSkillName);
+  const destDir = join(targetDir, skillName);
+
+  if (!isPathSafe(targetDir, destDir)) {
+    return {
+      success: false,
+      path: destDir,
+      error: 'Invalid skill name: potential path traversal detected',
+    };
+  }
+
+  try {
+    await cleanAndCreateDirectory(destDir);
+    await copyDirectory(skill.path, destDir);
+    return { success: true, path: destDir };
+  } catch (error) {
+    return {
+      success: false,
+      path: destDir,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}

--- a/tests/skills-dir.test.ts
+++ b/tests/skills-dir.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for the --skills-dir option.
+ *
+ * This option installs skills directly to a caller-specified directory,
+ * bypassing agent detection, scope selection, symlink logic, and lock files.
+ * It enables non-interactive, agent-driven installation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCli } from '../src/test-utils.ts';
+import { installSkillToDir, sanitizeName } from '../src/installer.ts';
+import { parseAddOptions } from '../src/add.ts';
+
+// ─── CLI integration tests ───
+
+describe('--skills-dir CLI', () => {
+  let testDir: string;
+  let targetDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-dir-test-${Date.now()}`);
+    targetDir = join(testDir, 'target-skills');
+    mkdirSync(testDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('installs a single skill to the specified directory', () => {
+    const skillDir = join(testDir, 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: A test skill
+---
+
+# My Skill
+
+Instructions here.
+`
+    );
+
+    const result = runCli(['add', testDir, '--skills-dir', targetDir, '-y'], testDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Installed 1 skill');
+    expect(result.stdout).toContain('Done!');
+
+    // Verify the skill was copied
+    const installedSkillDir = join(targetDir, 'my-skill');
+    expect(existsSync(installedSkillDir)).toBe(true);
+    expect(existsSync(join(installedSkillDir, 'SKILL.md'))).toBe(true);
+
+    const content = readFileSync(join(installedSkillDir, 'SKILL.md'), 'utf-8');
+    expect(content).toContain('name: my-skill');
+  });
+
+  it('installs multiple skills to the specified directory', () => {
+    // Create two skills
+    for (const name of ['skill-alpha', 'skill-beta']) {
+      const dir = join(testDir, 'skills', name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: ${name} description\n---\n# ${name}\n`
+      );
+    }
+
+    const result = runCli(['add', testDir, '--skills-dir', targetDir, '-y'], testDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Installed 2 skills');
+    expect(existsSync(join(targetDir, 'skill-alpha', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(targetDir, 'skill-beta', 'SKILL.md'))).toBe(true);
+  });
+
+  it('works with --skill filter', () => {
+    for (const name of ['wanted-skill', 'unwanted-skill']) {
+      const dir = join(testDir, 'skills', name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: ${name}\n---\n# ${name}\n`
+      );
+    }
+
+    const result = runCli(
+      ['add', testDir, '--skills-dir', targetDir, '--skill', 'wanted-skill', '-y'],
+      testDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(targetDir, 'wanted-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(targetDir, 'unwanted-skill'))).toBe(false);
+  });
+
+  it('creates target directory if it does not exist', () => {
+    const newTargetDir = join(testDir, 'nested', 'target');
+    // newTargetDir does not exist yet
+
+    const skillDir = join(testDir, 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: my-skill\ndescription: test\n---\n# My Skill\n`
+    );
+
+    const result = runCli(['add', testDir, '--skills-dir', newTargetDir, '-y'], testDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(newTargetDir, 'my-skill', 'SKILL.md'))).toBe(true);
+  });
+
+  it('does not create lock files', () => {
+    const skillDir = join(testDir, 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: my-skill\ndescription: test\n---\n# My Skill\n`
+    );
+
+    runCli(['add', testDir, '--skills-dir', targetDir, '-y'], testDir);
+
+    // No skills-lock.json should be created in the test working directory
+    expect(existsSync(join(testDir, 'skills-lock.json'))).toBe(false);
+  });
+
+  it('does not create agent directories', () => {
+    const skillDir = join(testDir, 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: my-skill\ndescription: test\n---\n# My Skill\n`
+    );
+
+    runCli(['add', testDir, '--skills-dir', targetDir, '-y'], testDir);
+
+    // No .agents or .claude directories should be created
+    expect(existsSync(join(testDir, '.agents'))).toBe(false);
+    expect(existsSync(join(testDir, '.claude'))).toBe(false);
+  });
+
+  it('shows error for empty skill source', () => {
+    // Empty directory — no skills
+    const result = runCli(['add', testDir, '--skills-dir', targetDir, '-y'], testDir);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('No skills found');
+  });
+});
+
+// ─── parseAddOptions tests ───
+
+describe('parseAddOptions --skills-dir', () => {
+  it('parses --skills-dir with a path', () => {
+    const { options } = parseAddOptions(['owner/repo', '--skills-dir', '/my/skills', '-y']);
+    expect(options.targetDir).toBe('/my/skills');
+    expect(options.yes).toBe(true);
+  });
+
+  it('parses --skills-dir with relative path', () => {
+    const { options } = parseAddOptions(['source', '--skills-dir', './skills']);
+    expect(options.targetDir).toBe('./skills');
+  });
+
+  it('does not set targetDir when --skills-dir is not used', () => {
+    const { options } = parseAddOptions(['owner/repo', '-y', '-g']);
+    expect(options.targetDir).toBeUndefined();
+  });
+});
+
+// ─── installSkillToDir unit tests ───
+
+describe('installSkillToDir', () => {
+  let testDir: string;
+  let targetDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `install-to-dir-test-${Date.now()}`);
+    targetDir = join(testDir, 'target');
+    mkdirSync(testDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('copies skill files to the target directory', async () => {
+    const skillSrc = join(testDir, 'source-skill');
+    mkdirSync(skillSrc, { recursive: true });
+    writeFileSync(join(skillSrc, 'SKILL.md'), '---\nname: demo\ndescription: demo\n---\n');
+    writeFileSync(join(skillSrc, 'extra.txt'), 'extra content');
+
+    const result = await installSkillToDir(
+      { name: 'demo', description: 'demo', path: skillSrc },
+      targetDir
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.path).toBe(join(targetDir, 'demo'));
+    expect(readFileSync(join(targetDir, 'demo', 'SKILL.md'), 'utf-8')).toContain('name: demo');
+    expect(readFileSync(join(targetDir, 'demo', 'extra.txt'), 'utf-8')).toBe('extra content');
+  });
+
+  it('sanitizes the skill name', async () => {
+    const skillSrc = join(testDir, 'source');
+    mkdirSync(skillSrc, { recursive: true });
+    writeFileSync(join(skillSrc, 'SKILL.md'), '---\nname: My Skill!\ndescription: test\n---\n');
+
+    const result = await installSkillToDir(
+      { name: 'My Skill!', description: 'test', path: skillSrc },
+      targetDir
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.path).toBe(join(targetDir, sanitizeName('My Skill!')));
+    expect(existsSync(join(targetDir, 'my-skill', 'SKILL.md'))).toBe(true);
+  });
+
+  it('rejects path traversal in skill name', async () => {
+    const skillSrc = join(testDir, 'source');
+    mkdirSync(skillSrc, { recursive: true });
+    writeFileSync(join(skillSrc, 'SKILL.md'), 'content');
+
+    // sanitizeName turns '../escape' into 'escape' which is safe,
+    // but let's verify the function doesn't break on adversarial names
+    const result = await installSkillToDir(
+      { name: '../../../escape', description: 'test', path: skillSrc },
+      targetDir
+    );
+
+    // sanitizeName normalizes this to 'escape', which is safe
+    expect(result.success).toBe(true);
+    expect(result.path).toBe(join(targetDir, 'escape'));
+  });
+
+  it('overwrites existing skill directory', async () => {
+    const skillSrc = join(testDir, 'source');
+    mkdirSync(skillSrc, { recursive: true });
+    writeFileSync(join(skillSrc, 'SKILL.md'), 'version 2');
+
+    // Pre-create old version
+    const existingDir = join(targetDir, 'overwrite-me');
+    mkdirSync(existingDir, { recursive: true });
+    writeFileSync(join(existingDir, 'SKILL.md'), 'version 1');
+    writeFileSync(join(existingDir, 'old-file.txt'), 'should be removed');
+
+    const result = await installSkillToDir(
+      { name: 'overwrite-me', description: 'test', path: skillSrc },
+      targetDir
+    );
+
+    expect(result.success).toBe(true);
+    expect(readFileSync(join(targetDir, 'overwrite-me', 'SKILL.md'), 'utf-8')).toBe('version 2');
+    // Old files should be cleaned up
+    expect(existsSync(join(targetDir, 'overwrite-me', 'old-file.txt'))).toBe(false);
+  });
+
+  it('uses basename of path when skill name is empty', async () => {
+    const skillSrc = join(testDir, 'fallback-name');
+    mkdirSync(skillSrc, { recursive: true });
+    writeFileSync(join(skillSrc, 'SKILL.md'), 'content');
+
+    const result = await installSkillToDir(
+      { name: '', description: 'test', path: skillSrc },
+      targetDir
+    );
+
+    expect(result.success).toBe(true);
+    // sanitizeName('') returns 'unnamed-skill', but since name is empty
+    // it falls back to basename(skill.path) = 'fallback-name'
+    expect(result.path).toBe(join(targetDir, 'fallback-name'));
+  });
+});


### PR DESCRIPTION
## Summary

Add a `--skills-dir <path>` option to `skills add` that installs skills directly to a caller-specified directory, bypassing agent detection, scope selection, symlink logic, and lock files.

## Problem

With the rise of AI agents like OpenClaw and custom personal assistants, the current `skills add` installation flow has three key limitations:

1. **Requires known agent type names** — The current directory convention is tied to specific agent types (e.g., `claude-code` → `.claude/skills`, `cursor` → `.cursor/skills`). This doesn't work for custom agents with directories like `/my-skills` or `.my-agent/skills`.
2. **No universal cross-agent install command** — There's no single command that works across all agents. Each agent needs its own `--agent <type>` value, and new/custom agents aren't supported at all.
3. **Non-TTY environments block on interactive prompts** — While agents *can* interact with terminals, in non-TTY execution contexts (e.g., CI, scripted environments), the interactive prompts for agent selection, scope, and install mode cause the process to block.

The existing `--yes (-y)` + `--global (-g)` + `--agent <name>` combination partially addresses this, but still requires knowing the exact agent type string and doesn't support custom agent directory layouts.

## Proposed Solution

A single `--skills-dir <path>` flag that accepts an explicit target directory. The core idea: a user can share one copyable command to any AI agent:

> Run this command to install the skill:
> `npx skills add vercel-labs/agent-skills@react-best-practices --skills-dir <your_skills_dir> -y`
> Replace `<your_skills_dir>` with your skills directory.

The agent knows its own skills directory, substitutes the path, and executes — fully non-interactive.

### Design Decisions

- **No lock files**: `--skills-dir` targets single-user agent scenarios (personal assistants, custom agents) where lock file tracking adds complexity without benefit. `skills-lock.json` is designed for team collaboration (clone → `skills experimental_install` → restore). Writing lock files from `--skills-dir` would pollute project-level configuration and interfere with team workflows.
- **No agent detection**: The caller specifies the exact path — no need to detect or match against known agent types.
- **Copy only**: Direct copy is the simplest and most universal approach. No symlinks to manage across agent directories.
- **Reuses existing code**: `installSkillToDir` is a thin wrapper around existing `copyDirectory` + `sanitizeName` + `isPathSafe` security validation.

## Usage

```bash
# Agent-driven install, zero interaction
npx skills add vercel-labs/agent-skills@react-best-practices --skills-dir ~/.my-agent/skills -y

# Custom directory that isn't tied to any known agent
npx skills add owner/repo@skill-name --skills-dir /project/skills -y

# Combined with --skill filter
npx skills add owner/repo --skills-dir ./skills --skill specific-skill -y
```

## Implementation

### `src/installer.ts`
- Added `installSkillToDir(skill, targetDir)` — copies skill files directly to a target directory
- Reuses existing `sanitizeName()`, `isPathSafe()`, `cleanAndCreateDirectory()`, and `copyDirectory()` helpers
- Returns `{ success, path, error? }`

### `src/add.ts`
- Added `targetDir?: string` to `AddOptions`
- Added `--skills-dir` parsing in `parseAddOptions()`
- Added fast-path in `runAdd()`: after skill selection, if `targetDir` is set → copy skills directly → print result → return. Skips agent detection, scope selection, symlink/copy prompts, and lock file updates entirely.

### `src/cli.ts`
- Added `--skills-dir <path>` to Add Options help section
- Added example in Examples section

### `tests/skills-dir.test.ts` (15 tests)
Three test groups:
1. **CLI integration** (7 tests): single/multiple skill install, `--skill` filter, directory creation, no lock files created, no agent directories created, error handling
2. **`parseAddOptions`** (3 tests): `--skills-dir` parsing with absolute/relative paths
3. **`installSkillToDir` unit** (5 tests): file copying, name sanitization, path traversal prevention, overwrite behavior, empty name fallback