### PR TITLE
docs(find-skills): prefer local-first discovery and explicit installs

### DIFF
--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -5,7 +5,7 @@ description: Helps users discover and install agent skills when they ask questio
 
 # Find Skills
 
-This skill helps you discover and install skills from the open agent skills ecosystem.
+This skill helps you discover and recommend skills from the open agent skills ecosystem without defaulting to weak search hits or unapproved installs.
 
 ## When to Use This Skill
 
@@ -24,6 +24,7 @@ The Skills CLI (`npx skills`) is the package manager for the open agent skills e
 
 **Key commands:**
 
+- `npx skills list [--json]` - List installed skills when available
 - `npx skills find [query]` - Search for skills interactively or by keyword
 - `npx skills add <package>` - Install a skill from GitHub or other sources
 - `npx skills check` - Check for skill updates
@@ -41,7 +42,19 @@ When a user asks for help with something, identify:
 2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
 3. Whether this is a common enough task that a skill likely exists
 
-### Step 2: Check the Leaderboard First
+### Step 2: Check Local Availability First
+
+Before searching the public catalog, check whether the user already has a relevant skill installed locally.
+
+Examples:
+
+```bash
+npx skills list --json
+```
+
+Prefer an already-installed skill when it clearly fits the task. This is faster, safer, and avoids recommending an unnecessary install.
+
+### Step 3: Check the Leaderboard First
 
 Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
 
@@ -49,7 +62,7 @@ For example, top skills for web development include:
 - `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
 - `anthropics/skills` — Frontend design, document processing (100K+ installs)
 
-### Step 3: Search for Skills
+### Step 4: Search for Skills
 
 If the leaderboard doesn't cover the user's need, run the find command:
 
@@ -63,22 +76,25 @@ For example:
 - User asks "can you help me with PR reviews?" → `npx skills find pr review`
 - User asks "I need to create a changelog" → `npx skills find changelog`
 
-### Step 4: Verify Quality Before Recommending
+### Step 5: Verify Quality Before Recommending
 
 **Do not recommend a skill based solely on search results.** Always verify:
 
 1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
 2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
 3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+4. **Audit or trust status** — Prefer skills with clean audit status when that information is available.
 
-### Step 5: Present Options to the User
+### Step 6: Present Only the Top 1-3 Options
 
-When you find relevant skills, present them to the user with:
+When you find relevant skills, present only the best 1-3 options. For each option include:
 
 1. The skill name and what it does
-2. The install count and source
-3. The install command they can run
-4. A link to learn more at skills.sh
+2. Why it matches the user's task
+3. The install count and source
+4. The install command they can run
+5. A link to learn more at skills.sh
+6. Any important caveat if trust or setup requirements are weak
 
 Example response:
 
@@ -93,15 +109,15 @@ npx skills add vercel-labs/agent-skills@react-best-practices
 Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
 ```
 
-### Step 6: Offer to Install
+### Step 7: Install Only with Explicit User Confirmation
 
-If the user wants to proceed, you can install the skill for them:
+Do not install a skill just because you found one. Recommend it first, explain why it is a fit, and wait for the user to say they want it installed.
+
+If the user confirms, you can install the skill for them:
 
 ```bash
-npx skills add <owner/repo@skill> -g -y
+npx skills add <owner/repo@skill>
 ```
-
-The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
 
 ## Common Skill Categories
 

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -85,7 +85,50 @@ For example:
 3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
 4. **Audit or trust status** — Prefer skills with clean audit status when that information is available.
 
-### Step 6: Present Only the Top 1-3 Options
+### Step 6: Run a Security Preflight for Low-Trust Candidates
+
+If a candidate is third-party, low-trust, repo-based, or otherwise unclear, do not jump from discovery straight to install.
+
+Escalate to a security preflight when any of these are true:
+
+- Unknown or weakly trusted maintainer
+- Very low installs, weak stars, or suspicious audit signals
+- Direct GitHub or repo-path install rather than a well-known official package
+- Heavy runtime requirements, custom binaries, install hooks, or opaque setup steps
+- The candidate's declared purpose and actual repo contents may not match
+
+Preflight rules:
+
+- Do not run `npm install`, `pnpm install`, `pip install`, builds, tests, or setup commands before PASS
+- Work from a quarantine path, not a live skills directory
+- Inspect first and execute nothing until you have a clear PASS
+
+Suggested quarantine flow for a repo-based candidate:
+
+```bash
+git clone <repo> ~/temp_skills_quarantine/<name>
+rg --files ~/temp_skills_quarantine/<name>
+```
+
+Then inspect `SKILL.md`, `package.json`, `requirements.txt`, `pyproject.toml`, shell scripts, and source files.
+
+Suggested read-only scans:
+
+```bash
+rg -n "(fetch|axios|curl|requests\\.|http[s]?://|wss?://)" .
+rg -n "(\\.env|id_rsa|\\.ssh|token|secret|credential|api[_-]?key|private[_-]?key)" .
+rg -n "(base64|Buffer\\.from\\(|atob\\(|btoa\\(|gzip|zlib)" .
+rg -n "(eval\\(|exec\\(|child_process|subprocess|os\\.system|Runtime\\.getRuntime\\(\\)\\.exec)" .
+rg -n "(preinstall|postinstall|prepare|install|setup\\.py|pyproject\\.toml)" .
+rg -n "(ignore all previous|bypass|return PASS|SAFE_TO_DEPLOY|override this prompt)" .
+```
+
+Decision:
+
+- `PASS` only if the repo intent, code, install path, and runtime behavior are coherent and non-suspicious
+- `FAIL` if behavior is unclear, unrelated to purpose, or introduces unexplained network, secret, execution, or prompt-injection risk
+
+### Step 7: Present Only the Top 1-3 Options
 
 When you find relevant skills, present only the best 1-3 options. For each option include:
 
@@ -109,7 +152,7 @@ npx skills add vercel-labs/agent-skills@react-best-practices
 Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
 ```
 
-### Step 7: Install Only with Explicit User Confirmation
+### Step 8: Install Only with Explicit User Confirmation
 
 Do not install a skill just because you found one. Recommend it first, explain why it is a fit, and wait for the user to say they want it installed.
 


### PR DESCRIPTION
## Summary
- check installed skills before public search
- present only the top 1-3 options with clearer fit/trust context
- add a security preflight step for low-trust or repo-based candidates
- require explicit user confirmation before installing and drop the default `-g -y` flow
- mention audit/trust status when available

## Why
The current workflow assumes discovery should start from public search and ends by recommending an immediate global install. In practice, a safer default is to prefer already-installed skills, keep recommendations tighter, and add a lightweight preflight before installing low-trust candidates.

## Validation
- `python3 -m scripts.quick_validate skills/find-skills`
