### PR TITLE
feat(telemetry): support configurable telemetry endpoint

### DIFF
--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { track } from './telemetry.js';
+
+const mockFetch = vi.fn(() => Promise.resolve() as Promise<unknown>);
+vi.stubGlobal('fetch', mockFetch);
+
+const savedEnv = { ...process.env };
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  delete process.env.SKILLS_TELEMETRY_URL;
+  delete process.env.npm_config_skills_telemetry_url;
+  delete process.env.DISABLE_TELEMETRY;
+  delete process.env.DO_NOT_TRACK;
+});
+
+afterEach(() => {
+  process.env = { ...savedEnv };
+});
+
+const payload = { event: 'check' as const, skillCount: '1', updatesAvailable: '0' };
+
+describe('telemetry URL resolution', () => {
+  it('sends to default URL when no overrides are set', () => {
+    track(payload);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toMatch(/^https:\/\/add-skill\.vercel\.sh\/t\?/);
+  });
+
+  it('uses SKILLS_TELEMETRY_URL env var when set', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    track(payload);
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toMatch(/^https:\/\/custom\.example\.com\/t\?/);
+  });
+
+  it('uses npm_config_skills_telemetry_url when set', () => {
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    track(payload);
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toMatch(/^https:\/\/npmrc\.example\.com\/t\?/);
+  });
+
+  it('prefers SKILLS_TELEMETRY_URL over npm_config_skills_telemetry_url', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://envvar.example.com/t';
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    track(payload);
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toMatch(/^https:\/\/envvar\.example\.com\/t\?/);
+  });
+});
+
+describe('telemetry opt-out', () => {
+  it('does not send when DISABLE_TELEMETRY is set', () => {
+    process.env.DISABLE_TELEMETRY = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not send when DO_NOT_TRACK is set', () => {
+    process.env.DO_NOT_TRACK = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends when neither opt-out var is set', () => {
+    track(payload);
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+});

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,13 @@
-const TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
+const DEFAULT_TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
 const AUDIT_URL = 'https://add-skill.vercel.sh/audit';
+
+function getTelemetryUrl(): string {
+  return (
+    process.env.SKILLS_TELEMETRY_URL ||
+    process.env.npm_config_skills_telemetry_url ||
+    DEFAULT_TELEMETRY_URL
+  );
+}
 
 interface InstallTelemetryData {
   event: 'install';
@@ -152,7 +160,7 @@ export function track(data: TelemetryData): void {
     }
 
     // Fire and forget - don't await, silently ignore errors
-    fetch(`${TELEMETRY_URL}?${params.toString()}`).catch(() => {});
+    fetch(`${getTelemetryUrl()}?${params.toString()}`).catch(() => {});
   } catch {
     // Silently fail - telemetry should never break the CLI
   }


### PR DESCRIPTION
## Summary

Closes #349

- Support custom telemetry endpoint via `SKILLS_TELEMETRY_URL` env var or `skills_telemetry_url` in `.npmrc`
- Priority: `SKILLS_TELEMETRY_URL` env var > `.npmrc` value > default (`https://add-skill.vercel.sh/t`)
- If `DISABLE_TELEMETRY` or `DO_NOT_TRACK` is set, nothing is sent (unchanged behavior)

### How it works

When run via `npx`, npm reads `.npmrc` files and injects config keys as `npm_config_<key>` env vars into the child process. So a `~/.npmrc` entry like:

```
skills_telemetry_url=https://telemetry.myco.example/t
```

becomes `process.env.npm_config_skills_telemetry_url` — no subprocess or new dependencies needed.

Alternatively, set the env var directly:

```bash
export SKILLS_TELEMETRY_URL=https://telemetry.myco.example/t
```

### Changes

- **`src/telemetry.ts`** — Replace hardcoded `TELEMETRY_URL` constant with `getTelemetryUrl()` resolver (pure env var reads, zero overhead)
- **`src/telemetry.test.ts`** — 7 new tests covering URL resolution priority and opt-out behavior

## Test plan

- [x] Default URL unchanged when no overrides set
- [x] `SKILLS_TELEMETRY_URL` env var overrides default
- [x] `npm_config_skills_telemetry_url` env var overrides default
- [x] `SKILLS_TELEMETRY_URL` takes priority over `npm_config_skills_telemetry_url`
- [x] `DISABLE_TELEMETRY` and `DO_NOT_TRACK` still prevent telemetry
- [x] Manually tested all three methods against a local HTTP server
- [x] Full test suite passes (382 tests)