### PR TITLE
feat: add Arcan agent

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -7,6 +7,7 @@ import type { AgentConfig, AgentType } from './types.ts';
 const home = homedir();
 // Use xdg-basedir (not env-paths) to match OpenCode/Amp/Goose behavior on all platforms.
 const configHome = xdgConfig ?? join(home, '.config');
+const arcanHome = process.env.ARCAN_DATA_DIR?.trim() || join(home, '.arcan');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 
@@ -43,6 +44,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.gemini/antigravity/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.gemini/antigravity'));
+    },
+  },
+  arcan: {
+    name: 'arcan',
+    displayName: 'Arcan',
+    skillsDir: '.arcan/skills',
+    globalSkillsDir: join(arcanHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(arcanHome) || existsSync('.arcan');
     },
   },
   augment: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type AgentType =
   | 'amp'
   | 'antigravity'
+  | 'arcan'
   | 'augment'
   | 'claude-code'
   | 'openclaw'


### PR DESCRIPTION
## Summary
Adds [Arcan](https://github.com/broomva/arcan) as a recognized agent in the skills CLI.

Arcan is a Rust-based agent runtime daemon with:
- SKILL.md discovery and activation via `/skill-name` prefix
- Skill-aware tool filtering (`allowed_tools` whitelist)
- MCP server lifecycle management for skill-declared servers
- Event-sourced skill analytics via Lago journal
- System prompt injection ("liquid prompt") with skill catalog

## Agent Configuration

| Field | Value |
|-------|-------|
| `name` | `arcan` |
| `displayName` | `Arcan` |
| `skillsDir` | `.arcan/skills` |
| `globalSkillsDir` | `~/.arcan/skills` (or `$ARCAN_DATA_DIR/skills`) |
| `detectInstalled` | `~/.arcan` or `.arcan` exists |

## Install
```bash
cargo install arcan
```

## Changes
- `src/types.ts`: Add `'arcan'` to `AgentType` union
- `src/agents.ts`: Add `arcanHome` constant + agent config entry (alphabetically sorted)