### PR TITLE
feat: support fallback to skills/<subpath> when subpath is not found at repo root

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -25,6 +25,15 @@ async function hasSkillMd(dir: string): Promise<boolean> {
   }
 }
 
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function parseSkillMd(
   skillMdPath: string,
   options?: { includeInternal?: boolean }
@@ -120,7 +129,24 @@ export async function discoverSkills(
     );
   }
 
-  const searchPath = subpath ? join(basePath, subpath) : basePath;
+  // Resolve the effective search path with fallback:
+  // 1. basePath/subpath           (exact path as specified)
+  // 2. basePath/skills/subpath    (community convention: repo named "skills" with skills/<name>/ layout)
+  // 3. directPath                 (keep original so downstream error reporting is accurate)
+  let searchPath = basePath;
+
+  if (subpath) {
+    const directPath = join(basePath, subpath);
+    const skillsPrefixedPath = join(basePath, 'skills', subpath);
+
+    if (await pathExists(directPath)) {
+      searchPath = directPath;
+    } else if (await pathExists(skillsPrefixedPath)) {
+      searchPath = skillsPrefixedPath;
+    } else {
+      searchPath = directPath;
+    }
+  }
 
   // Get plugin groupings to map skills to their parent plugin
   // We search for plugin definitions from the base search path

--- a/tests/subpath-skills-fallback.test.ts
+++ b/tests/subpath-skills-fallback.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the skills/<subpath> fallback in discoverSkills.
+ *
+ * Community convention: repos named "skills" often store individual skills
+ * under a skills/<name>/ subdirectory. When a user runs:
+ *   npx skills add repo/skills/ui-design
+ * the subpath "ui-design" may not exist at the repo root, but exists under
+ * skills/ui-design. This fallback resolves that transparently.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { discoverSkills } from '../src/skills.ts';
+
+const SKILL_MD = (name: string) => `---
+name: ${name}
+description: Test skill ${name}
+---
+
+# ${name}
+`;
+
+describe('discoverSkills subpath fallback (community convention)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-subpath-fallback-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('uses exact subpath when it exists', async () => {
+    mkdirSync(join(testDir, 'ui-design'), { recursive: true });
+    writeFileSync(join(testDir, 'ui-design', 'SKILL.md'), SKILL_MD('ui-design'));
+
+    const skills = await discoverSkills(testDir, 'ui-design');
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('ui-design');
+  });
+
+  it('falls back to skills/<subpath> when exact subpath does not exist', async () => {
+    mkdirSync(join(testDir, 'skills', 'ui-design'), { recursive: true });
+    writeFileSync(join(testDir, 'skills', 'ui-design', 'SKILL.md'), SKILL_MD('ui-design'));
+
+    const skills = await discoverSkills(testDir, 'ui-design');
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('ui-design');
+  });
+
+  it('prefers exact subpath over skills/<subpath> when both exist', async () => {
+    mkdirSync(join(testDir, 'ui-design'), { recursive: true });
+    writeFileSync(join(testDir, 'ui-design', 'SKILL.md'), SKILL_MD('ui-design-direct'));
+
+    mkdirSync(join(testDir, 'skills', 'ui-design'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'ui-design', 'SKILL.md'),
+      SKILL_MD('ui-design-in-skills')
+    );
+
+    const skills = await discoverSkills(testDir, 'ui-design');
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('ui-design-direct');
+  });
+
+  it('returns empty when neither exact nor skills/<subpath> exists', async () => {
+    const skills = await discoverSkills(testDir, 'nonexistent');
+
+    expect(skills).toHaveLength(0);
+  });
+
+  it('does not double-prefix when subpath already starts with skills/', async () => {
+    mkdirSync(join(testDir, 'skills', 'ui-design'), { recursive: true });
+    writeFileSync(join(testDir, 'skills', 'ui-design', 'SKILL.md'), SKILL_MD('ui-design'));
+
+    const skills = await discoverSkills(testDir, 'skills/ui-design');
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('ui-design');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #716

When using the shorthand `npx skills add owner/repo/<subpath>`, the CLI now
falls back to `<repo>/skills/<subpath>` if the exact path doesn't exist at
the repo root.

## Problem

`discoverSkills()` resolved the search path as `join(basePath, subpath)` with
no fallback. This caused "No skills found" when users followed the community
convention of storing skills under a `skills/` subdirectory — as both
[`anthropics/skills`](https://github.com/anthropics/skills) and
[`vercel-labs/skills`](https://github.com/vercel-labs/skills) do.

A user with a repo named `skills` structured as `skills/<name>/SKILL.md` had
to write:

```bash
npx skills add mrlyk/skills/skills/ui-design  # unintuitive double-nesting
```

instead of the natural:

```bash
npx skills add mrlyk/skills/ui-design
```

## Solution

### In `discoverSkills()` (`src/skills.ts`)
- Added `pathExists()` helper to check whether a path exists on disk
- When `subpath` is provided, resolve `searchPath` in order:
  1. `<repo>/<subpath>` exact match, existing behavior (unchanged)
  2. `<repo>/skills/<subpath>` — community convention fallback (new)
  3. Fall back to `directPath` so error reporting remains accurate

## Testing

- `pnpm build` ✅
- `pnpm test` ✅ (all existing tests pass)
- New test file `tests/subpath-skills-fallback.test.ts` adds 5 cases:
  - Exact subpath is used when it exists
  - Falls back to `skills/<subpath>` when exact path is missing
  - Exact path takes priority when both exist
  - Returns empty when neither path exists
  - No double-prefix when subpath already starts with `skills/`
```