### PR TITLE
fix: default isRepoPrivate to true when privacy cannot be determined

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -13,7 +13,7 @@ const isCancelled = (value: unknown): value is symbol => typeof value === 'symbo
  * Check if a source identifier (owner/repo format) represents a private GitHub repo.
  * Returns true if private, false if public, null if unable to determine or not a GitHub repo.
  */
-async function isSourcePrivate(source: string): Promise<boolean | null> {
+async function isSourcePrivate(source: string): Promise<boolean> {
   const ownerRepo = parseOwnerRepo(source);
   if (!ownerRepo) {
     // Not in owner/repo format, assume not private (could be other providers)
@@ -1468,9 +1468,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       if (ownerRepo) {
         // Check if repo is private - skip telemetry for private repos
         const isPrivate = await isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
-        // Only send telemetry if repo is public (isPrivate === false)
-        // If we can't determine (null), err on the side of caution and skip telemetry
-        if (isPrivate === false) {
+        // Only send telemetry if repo is confirmed public
+        if (!isPrivate) {
           track({
             event: 'install',
             source: normalizedSource,

--- a/src/find.ts
+++ b/src/find.ts
@@ -261,9 +261,7 @@ function getOwnerRepoFromString(pkg: string): { owner: string; repo: string } | 
 
 async function isRepoPublic(owner: string, repo: string): Promise<boolean> {
   const isPrivate = await isRepoPrivate(owner, repo);
-  // Return true only if we know it's public (isPrivate === false)
-  // Return false if private or unable to determine
-  return isPrivate === false;
+  return !isPrivate;
 }
 
 export async function runFind(args: string[]): Promise<void> {

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseSource } from './source-parser.js';
+import { describe, it, expect, vi } from 'vitest';
+import { parseSource, isRepoPrivate } from './source-parser.js';
 
 describe('source-parser', () => {
   describe('GitLab Custom Domains & Subgroups', () => {
@@ -69,6 +69,50 @@ describe('source-parser', () => {
         type: 'gitlab',
         url: 'https://gitlab.com/owner/repo.git',
       });
+    });
+  });
+
+  describe('isRepoPrivate', () => {
+    it('returns false for a confirmed public repo', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ private: false }),
+        })
+      );
+      expect(await isRepoPrivate('vercel', 'next.js')).toBe(false);
+      vi.unstubAllGlobals();
+    });
+
+    it('returns true for a confirmed private repo', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ private: true }),
+        })
+      );
+      expect(await isRepoPrivate('owner', 'private-repo')).toBe(true);
+      vi.unstubAllGlobals();
+    });
+
+    it('defaults to true when API returns non-OK status', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+        })
+      );
+      expect(await isRepoPrivate('owner', 'nonexistent')).toBe(true);
+      vi.unstubAllGlobals();
+    });
+
+    it('defaults to true when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+      expect(await isRepoPrivate('owner', 'repo')).toBe(true);
+      vi.unstubAllGlobals();
     });
   });
 

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -61,23 +61,24 @@ export function parseOwnerRepo(ownerRepo: string): { owner: string; repo: string
 
 /**
  * Check if a GitHub repository is private.
- * Returns true if private, false if public, null if unable to determine.
+ * Returns true if private or unable to determine (assumes private to be safe),
+ * false only if confirmed public.
  * Only works for GitHub repositories (GitLab not supported).
  */
-export async function isRepoPrivate(owner: string, repo: string): Promise<boolean | null> {
+export async function isRepoPrivate(owner: string, repo: string): Promise<boolean> {
   try {
     const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
 
     // If repo doesn't exist or we don't have access, assume private to be safe
     if (!res.ok) {
-      return null; // Unable to determine
+      return true;
     }
 
     const data = (await res.json()) as { private?: boolean };
     return data.private === true;
   } catch {
-    // On error, return null to indicate we couldn't determine
-    return null;
+    // On error, assume private to be safe
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary
- `isRepoPrivate()` now returns `true` (not `null`) when repo privacy cannot be determined, matching the existing comment "assume private to be safe"
- Return type narrowed from `boolean | null` to `boolean`, eliminating inconsistent null-handling across callers
- Callers in `src/add.ts` and `src/find.ts` simplified to use standard boolean checks

## Details
The function had a comment saying "assume private to be safe" but returned `null` when it couldn't determine privacy (API errors, inaccessible repos). This created a gap where callers had to independently handle the null case, and any caller that didn't would incorrectly treat unknown-privacy repos as non-private, leaking private repo metadata through telemetry/audit endpoints.

Fixes #699

This contribution was developed with AI assistance (Claude Code).