### PR TITLE
feat: support ref and subpath parsing for SSH git URLs

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -114,7 +114,7 @@ function isLocalPath(input: string): boolean {
     input.startsWith('../') ||
     input === '.' ||
     input === '..' ||
-    // Windows absolute paths like C:\ or D:\
+    // Windows absolute paths like C:\\ or D:\\
     /^[a-zA-Z]:[/\\]/.test(input)
   );
 }
@@ -268,6 +268,26 @@ export function parseSource(input: string): ParsedSource {
     return {
       type: 'well-known',
       url: input,
+    };
+  }
+
+  // SSH git URL with optional #ref or #ref:subpath fragment
+  // Supports:
+  //   git@host:owner/repo.git#ref:subpath
+  //   git@host:owner/repo.git#ref
+  //   ssh://git@host/owner/repo.git#ref:subpath
+  //   git+ssh://git@host/owner/repo.git#ref:subpath
+  // The #ref:subpath convention extends npm's #ref fragment syntax.
+  const sshWithFragmentMatch = input.match(
+    /^((?:(?:git\+)?ssh:\/\/git@[^#]+?\.git)|(?:git@[^#:]+:[^#]+?\.git))#([^:]+)(?::(.+))?$/
+  );
+  if (sshWithFragmentMatch) {
+    const [, url, ref, subpath] = sshWithFragmentMatch;
+    return {
+      type: 'git',
+      url: url!,
+      ref,
+      ...(subpath && { subpath: sanitizeSubpath(subpath) }),
     };
   }
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -204,6 +204,96 @@ describe('parseSource', () => {
       expect(result.url).toBe('https://git.example.com/owner/repo.git');
     });
   });
+
+  describe('SSH URL with fragment tests', () => {
+    it('SSH git@ URL - with ref only', () => {
+      const result = parseSource('git@github.com:owner/repo.git#main');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@github.com:owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('SSH git@ URL - with ref and subpath', () => {
+      const result = parseSource('git@github.com:owner/repo.git#main:skills/my-skill');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@github.com:owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('skills/my-skill');
+    });
+
+    it('SSH git@ URL - self-hosted GitLab with deep path', () => {
+      const result = parseSource(
+        'git@gitlab.example.com:group/subgroup/repo.git#develop:plugins/common'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@gitlab.example.com:group/subgroup/repo.git');
+      expect(result.ref).toBe('develop');
+      expect(result.subpath).toBe('plugins/common');
+    });
+
+    it('SSH ssh:// URL - with ref and subpath', () => {
+      const result = parseSource(
+        'ssh://git@gitlab.example.com/owner/repo.git#main:src/skills'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('ssh://git@gitlab.example.com/owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('src/skills');
+    });
+
+    it('SSH git+ssh:// URL - with ref and subpath', () => {
+      const result = parseSource(
+        'git+ssh://git@gitlab.example.com/team/repo.git#main:plugins/common'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git+ssh://git@gitlab.example.com/team/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('plugins/common');
+    });
+
+    it('SSH git+ssh:// URL - with ref only', () => {
+      const result = parseSource(
+        'git+ssh://git@github.com/owner/repo.git#develop'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git+ssh://git@github.com/owner/repo.git');
+      expect(result.ref).toBe('develop');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('SSH URL - without fragment falls through to plain git fallback', () => {
+      const result = parseSource('git@github.com:owner/repo.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@github.com:owner/repo.git');
+      expect(result.ref).toBeUndefined();
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('SSH URL - subpath traversal is rejected', () => {
+      expect(() =>
+        parseSource('git@github.com:owner/repo.git#main:../escape')
+      ).toThrow('path traversal');
+    });
+
+    it('SSH URL - nested subpath', () => {
+      const result = parseSource(
+        'git@github.com:owner/repo.git#main:path/to/deeply/nested/skill'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@github.com:owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('path/to/deeply/nested/skill');
+    });
+
+    it('SSH URL - tag as ref', () => {
+      const result = parseSource('git@github.com:owner/repo.git#v1.0.0:skills');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@github.com:owner/repo.git');
+      expect(result.ref).toBe('v1.0.0');
+      expect(result.subpath).toBe('skills');
+    });
+  });
 });
 
 describe('getOwnerRepo', () => {


### PR DESCRIPTION
## Summary

Currently, SSH URLs (`git@host:path.git`) are passed directly to `git clone` as a fallback, with no support for specifying a branch (`ref`) or subdirectory (`subpath`). This means users of private GitLab/Gitea/self-hosted repos that rely on SSH keys cannot install skills from a specific subdirectory.

This PR adds `#ref:subpath` fragment parsing for SSH URLs in `parseSource()`, using a convention borrowed from npm's git dependency syntax and extended with `:subpath`.

### Supported formats

```bash
# git@ with ref and subpath
npx skills add "git@gitlab.example.com:team/skills-repo.git#main:plugins/common" --all

# git@ with ref only
npx skills add "git@github.com:owner/repo.git#develop"

# ssh:// protocol
npx skills add "ssh://git@gitlab.example.com/team/repo.git#main:src/skills" --all

# git+ssh:// protocol
npx skills add "git+ssh://git@gitlab.example.com/team/repo.git#main:plugins/common" --all

# Without fragment (unchanged behavior)
npx skills add git@github.com:owner/repo.git --all
```

### Motivation

Many organizations host private skill repositories on self-hosted GitLab/Gitea instances where SSH key authentication is the standard. These repos often organize skills into subdirectories by team (e.g., `plugins/common/`, `plugins/team-a/`).

Without this feature, the only way to install skills from a subdirectory is:
1. Use HTTPS URLs with `/-/tree/` syntax + configure HTTPS credentials separately, or
2. Set up global `git config url.insteadOf` to rewrite HTTPS→SSH, which affects all git operations

Both workarounds add unnecessary friction. The `#ref:subpath` syntax provides a native, intuitive solution.

### Changes

- **`src/source-parser.ts`**: Added SSH URL fragment parsing before the git fallback. The regex matches `git@host:path.git`, `ssh://git@host/path.git`, and `git+ssh://git@host/path.git`, extracting the optional `#ref` and `:subpath` from the fragment. Subpath is validated through the existing `sanitizeSubpath()` to prevent path traversal.
- **`tests/source-parser.test.ts`**: Added 10 test cases covering all SSH URL variants, ref-only, ref+subpath, nested subpaths, tag refs, path traversal rejection, and fallback behavior for URLs without fragments.

## Test plan

- [x] All existing `parseSource` tests pass (no behavior change for URLs without `#fragment`)
- [x] New SSH fragment tests cover: `git@`, `ssh://`, `git+ssh://` protocols
- [x] Path traversal (`../escape`) is properly rejected
- [x] URLs without `#fragment` continue to fall through to the plain git fallback