### PR TITLE
fix: recognize dot-directories as local paths

### DIFF
--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -72,6 +72,43 @@ describe('source-parser', () => {
     });
   });
 
+  describe('Local Paths', () => {
+    it('parses dot-directories as local paths', () => {
+      const result = parseSource('.agents');
+      expect(result.type).toBe('local');
+    });
+
+    it('parses .claude as local path', () => {
+      const result = parseSource('.claude');
+      expect(result.type).toBe('local');
+    });
+
+    it('parses .cursor/rules as local path', () => {
+      const result = parseSource('.cursor/rules');
+      expect(result.type).toBe('local');
+    });
+
+    it('parses relative paths as local', () => {
+      const result = parseSource('./my-skills');
+      expect(result.type).toBe('local');
+    });
+
+    it('parses parent-relative paths as local', () => {
+      const result = parseSource('../skills');
+      expect(result.type).toBe('local');
+    });
+
+    it('parses current directory as local', () => {
+      const result = parseSource('.');
+      expect(result.type).toBe('local');
+    });
+
+    it('does not treat .. prefix with path segments as dotfile', () => {
+      const result = parseSource('../skills');
+      expect(result.type).toBe('local');
+    });
+  });
+
   describe('Existing GitHub Support', () => {
     it('parses github shorthand', () => {
       const result = parseSource('vercel-labs/agent-skills');

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -114,6 +114,8 @@ function isLocalPath(input: string): boolean {
     input.startsWith('../') ||
     input === '.' ||
     input === '..' ||
+    // Dotfiles/dot-directories like .agents, .claude, .cursor
+    /^\.[^./]/.test(input) ||
     // Windows absolute paths like C:\ or D:\
     /^[a-zA-Z]:[/\\]/.test(input)
   );


### PR DESCRIPTION
## Summary

- Paths like `.agents`, `.claude`, `.cursor` were not recognized as local paths by `isLocalPath()`, causing `npx skills add .agents` to fall through to the git clone fallback instead of using the local directory
- Added a regex check (`/^\.[^./]/`) for paths starting with a dot followed by a non-dot, non-slash character
- Added test cases covering dot-directories, nested dot-paths (`.cursor/rules`), and existing local path formats

## Reproduce

```bash
npx skills add .agents
# Expected: uses local .agents/ directory
# Actual: tries to git clone ".agents" and fails
```

## Fix

The `isLocalPath()` function now recognizes dot-prefixed directory names (e.g., `.agents`, `.claude`, `.cursor/rules`) as local filesystem paths, matching the common convention of agent skill directories.

## Test plan

- [x] All existing tests pass
- [x] New tests for `.agents`, `.claude`, `.cursor/rules` as local paths
- [x] Verified `.` and `..` still work as before
- [x] GitHub shorthand like `owner/repo` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)