### PR TITLE
feat: add global restore/relink from .skill-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ When installing interactively, you can choose:
 | `npx skills remove [skills]` | Remove installed skills from agents            |
 | `npx skills check`           | Check for available skill updates              |
 | `npx skills update`          | Update all installed skills to latest versions |
+| `npx skills experimental_install` | Restore skills from a lock file           |
 | `npx skills init [name]`     | Create a new SKILL.md template                 |
 
 ### `skills list`
@@ -137,6 +138,26 @@ npx skills check
 # Update all skills to latest versions
 npx skills update
 ```
+
+### `skills experimental_install`
+
+Restore skills from a lock file.
+
+```bash
+# Restore project skills from skills-lock.json
+npx skills experimental_install
+
+# Restore global skills from the global skill lock and relink detected/saved agents
+npx skills experimental_install -g
+
+# Restore global skills for specific agents
+npx skills experimental_install -g --agent codex claude-code
+```
+
+| Option                    | Description                                                                |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `-g, --global`            | Restore from the global skill lock and relink global agent skill dirs      |
+| `-a, --agent <agents...>` | Override the global relink targets (defaults to saved or detected agents)  |
 
 ### `skills init`
 

--- a/src/add-prompt.test.ts
+++ b/src/add-prompt.test.ts
@@ -51,6 +51,7 @@ describe('promptForAgents', () => {
         initialSelected: ['cursor'],
       })
     );
+    expect(skillLock.getLastSelectedAgents).toHaveBeenCalledWith('project');
   });
 
   it('should filter out invalid agents from history', async () => {
@@ -81,13 +82,22 @@ describe('promptForAgents', () => {
     );
   });
 
-  it('should save selected agents if not cancelled', async () => {
+  it('should read global history when prompting for global installs', async () => {
+    vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(['cursor']);
+    vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue(['cursor']);
+
+    await promptForAgents('Select agents', choices, { global: true });
+
+    expect(skillLock.getLastSelectedAgents).toHaveBeenCalledWith('global');
+  });
+
+  it('should not save selected agents directly', async () => {
     vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(undefined);
     vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue(['opencode']);
 
     await promptForAgents('Select agents', choices);
 
-    expect(skillLock.saveSelectedAgents).toHaveBeenCalledWith(['opencode']);
+    expect(skillLock.saveSelectedAgents).not.toHaveBeenCalled();
   });
 
   it('should not save agents if cancelled', async () => {

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, lstatSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
@@ -19,6 +19,50 @@ describe('add command', () => {
       rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  function writeSkillSource(sourceDir: string, skillName: string, description: string) {
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, 'SKILL.md'),
+      `---
+name: ${skillName}
+description: ${description}
+---
+
+# ${skillName}
+`
+    );
+  }
+
+  function writeGlobalLock(
+    lockPath: string,
+    skills: Record<string, { source: string; sourceType: string; sourceUrl?: string }>,
+    lastSelectedAgents?: string[]
+  ) {
+    mkdirSync(join(lockPath, '..'), { recursive: true });
+    writeFileSync(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 3,
+          skills: Object.fromEntries(
+            Object.entries(skills).map(([skillName, entry]) => [
+              skillName,
+              {
+                skillFolderHash: '',
+                installedAt: '2026-03-23T00:00:00.000Z',
+                updatedAt: '2026-03-23T00:00:00.000Z',
+                ...entry,
+              },
+            ])
+          ),
+          ...(lastSelectedAgents ? { lastSelectedAgents } : {}),
+        },
+        null,
+        2
+      )
+    );
+  }
 
   it('should show error when no source provided', () => {
     const result = runCli(['add'], testDir);
@@ -156,6 +200,218 @@ description: Test
   it('should restore from lock file with experimental_install', () => {
     const result = runCli(['experimental_install'], testDir);
     expect(result.stdout).toContain('No project skills found in skills-lock.json');
+  });
+
+  it('should relink codex from inside a project cwd during global restore', () => {
+    const homeDir = join(testDir, 'home');
+    const stateDir = join(testDir, 'state');
+    const codexHome = join(homeDir, '.codex');
+    const sourceDir = join(testDir, 'source-skill');
+    const projectDir = join(testDir, 'project');
+    const skillName = 'global-restore-skill';
+
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    writeSkillSource(sourceDir, skillName, 'A global restore skill');
+    writeGlobalLock(
+      join(stateDir, 'skills', '.skill-lock.json'),
+      {
+        [skillName]: {
+          source: sourceDir,
+          sourceType: 'local',
+          sourceUrl: sourceDir,
+        },
+      },
+      ['codex']
+    );
+
+    const result = runCli(['experimental_install', '-g'], projectDir, {
+      HOME: homeDir,
+      XDG_STATE_HOME: stateDir,
+      CODEX_HOME: codexHome,
+    });
+
+    const canonicalSkillDir = join(homeDir, '.agents', 'skills', skillName);
+    const codexSkillDir = join(codexHome, 'skills', skillName);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Restoring 1 skill from the global skill lock');
+    expect(result.stdout).toContain('Codex');
+    expect(existsSync(join(canonicalSkillDir, 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(codexSkillDir, 'SKILL.md'))).toBe(true);
+    expect(lstatSync(codexSkillDir).isSymbolicLink()).toBe(true);
+  });
+
+  it('should restore cline into the canonical global path', () => {
+    const homeDir = join(testDir, 'home');
+    const stateDir = join(testDir, 'state');
+    const clineHome = join(homeDir, '.cline');
+    const sourceDir = join(testDir, 'source-skill');
+    const projectDir = join(testDir, 'project');
+    const skillName = 'cline-global-skill';
+
+    mkdirSync(clineHome, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    writeSkillSource(sourceDir, skillName, 'A cline global restore skill');
+    writeGlobalLock(
+      join(stateDir, 'skills', '.skill-lock.json'),
+      {
+        [skillName]: {
+          source: sourceDir,
+          sourceType: 'local',
+          sourceUrl: sourceDir,
+        },
+      },
+      ['cline']
+    );
+
+    const result = runCli(['experimental_install', '-g'], projectDir, {
+      HOME: homeDir,
+      XDG_STATE_HOME: stateDir,
+    });
+    const canonicalSkillDir = join(homeDir, '.agents', 'skills', skillName);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Cline');
+    expect(existsSync(join(canonicalSkillDir, 'SKILL.md'))).toBe(true);
+    expect(lstatSync(canonicalSkillDir).isSymbolicLink()).toBe(false);
+  });
+
+  it('should relink codex and claude-code without touching overlapping project skills', () => {
+    const homeDir = join(testDir, 'home');
+    const stateDir = join(testDir, 'state');
+    const codexHome = join(homeDir, '.codex');
+    const claudeHome = join(homeDir, '.claude');
+    const sourceDir = join(testDir, 'source-skill');
+    const projectDir = join(testDir, 'project');
+    const skillName = 'overlap-skill';
+
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(claudeHome, { recursive: true });
+    mkdirSync(join(projectDir, '.agents', 'skills', skillName), { recursive: true });
+    writeFileSync(
+      join(projectDir, '.agents', 'skills', skillName, 'SKILL.md'),
+      `---
+name: ${skillName}
+description: Project overlap skill
+---
+
+# Project overlap skill
+`
+    );
+    writeSkillSource(sourceDir, skillName, 'Global overlap skill');
+    writeGlobalLock(join(stateDir, 'skills', '.skill-lock.json'), {
+      [skillName]: {
+        source: sourceDir,
+        sourceType: 'local',
+        sourceUrl: sourceDir,
+      },
+    });
+
+    const projectSkillDir = join(projectDir, '.agents', 'skills', skillName);
+    const result = runCli(
+      ['experimental_install', '-g', '--agent', 'codex', 'claude-code'],
+      projectDir,
+      {
+        HOME: homeDir,
+        XDG_STATE_HOME: stateDir,
+        CODEX_HOME: codexHome,
+        CLAUDE_CONFIG_DIR: claudeHome,
+      }
+    );
+    const globalCanonicalSkillDir = join(homeDir, '.agents', 'skills', skillName);
+
+    expect(result.exitCode).toBe(0);
+    expect(lstatSync(join(codexHome, 'skills', skillName)).isSymbolicLink()).toBe(true);
+    expect(lstatSync(join(claudeHome, 'skills', skillName)).isSymbolicLink()).toBe(true);
+    expect(readFileSync(join(projectSkillDir, 'SKILL.md'), 'utf-8')).toContain(
+      'Project overlap skill'
+    );
+    expect(readFileSync(join(globalCanonicalSkillDir, 'SKILL.md'), 'utf-8')).toContain(
+      'Global overlap skill'
+    );
+  });
+
+  it('should read the fallback global lock path when XDG_STATE_HOME is unset', () => {
+    const homeDir = join(testDir, 'home');
+    const codexHome = join(homeDir, '.codex');
+    const sourceDir = join(testDir, 'source-skill');
+    const projectDir = join(testDir, 'project');
+    const skillName = 'fallback-lock-skill';
+
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    writeSkillSource(sourceDir, skillName, 'A fallback lock skill');
+    writeGlobalLock(
+      join(homeDir, '.agents', '.skill-lock.json'),
+      {
+        [skillName]: {
+          source: sourceDir,
+          sourceType: 'local',
+          sourceUrl: sourceDir,
+        },
+      },
+      ['codex']
+    );
+
+    const result = runCli(['experimental_install', '-g'], projectDir, {
+      HOME: homeDir,
+      CODEX_HOME: codexHome,
+      XDG_STATE_HOME: '',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Codex');
+    expect(existsSync(join(codexHome, 'skills', skillName))).toBe(true);
+  });
+
+  it('should recreate a missing codex link from canonical global storage', () => {
+    const homeDir = join(testDir, 'home');
+    const stateDir = join(testDir, 'state');
+    const codexHome = join(homeDir, '.codex');
+    const sourceDir = join(testDir, 'source-skill');
+    const projectDir = join(testDir, 'project');
+    const skillName = 'relinked-codex-skill';
+    const canonicalSkillDir = join(homeDir, '.agents', 'skills', skillName);
+    const codexSkillDir = join(codexHome, 'skills', skillName);
+
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(canonicalSkillDir, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+    writeSkillSource(sourceDir, skillName, 'A relinked codex skill');
+    writeFileSync(
+      join(canonicalSkillDir, 'SKILL.md'),
+      `---
+name: ${skillName}
+description: Existing canonical global skill
+---
+
+# Existing canonical global skill
+`
+    );
+    writeGlobalLock(
+      join(stateDir, 'skills', '.skill-lock.json'),
+      {
+        [skillName]: {
+          source: sourceDir,
+          sourceType: 'local',
+          sourceUrl: sourceDir,
+        },
+      },
+      ['codex']
+    );
+
+    expect(existsSync(codexSkillDir)).toBe(false);
+
+    const result = runCli(['experimental_install', '-g'], projectDir, {
+      HOME: homeDir,
+      XDG_STATE_HOME: stateDir,
+      CODEX_HOME: codexHome,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(lstatSync(codexSkillDir).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(canonicalSkillDir, 'SKILL.md'))).toBe(true);
   });
 
   describe('internal skills', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -27,6 +27,8 @@ import {
   installSkillForAgent,
   isSkillInstalled,
   getCanonicalPath,
+  getAgentBaseDir,
+  sharesCanonicalSkillsDir,
   installWellKnownSkillForAgent,
   type InstallMode,
 } from './installer.ts';
@@ -35,7 +37,6 @@ import {
   agents,
   getUniversalAgents,
   getNonUniversalAgents,
-  isUniversalAgent,
 } from './agents.ts';
 import {
   track,
@@ -53,6 +54,7 @@ import {
   dismissPrompt,
   getLastSelectedAgents,
   saveSelectedAgents,
+  type AgentSelectionScope,
 } from './skill-lock.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
@@ -178,7 +180,10 @@ function formatList(items: string[], maxShow: number = 5): string {
  * Splits agents into universal and non-universal (symlinked) groups.
  * Returns display names for each group.
  */
-function splitAgentsByType(agentTypes: AgentType[]): {
+function splitAgentsByType(
+  agentTypes: AgentType[],
+  options: { global?: boolean } = {}
+): {
   universal: string[];
   symlinked: string[];
 } {
@@ -186,7 +191,7 @@ function splitAgentsByType(agentTypes: AgentType[]): {
   const symlinked: string[] = [];
 
   for (const a of agentTypes) {
-    if (isUniversalAgent(a)) {
+    if (sharesCanonicalSkillsDir(a, options.global ?? false)) {
       universal.push(agents[a].displayName);
     } else {
       symlinked.push(agents[a].displayName);
@@ -199,9 +204,13 @@ function splitAgentsByType(agentTypes: AgentType[]): {
 /**
  * Builds summary lines showing universal vs symlinked agents
  */
-function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallMode): string[] {
+function buildAgentSummaryLines(
+  targetAgents: AgentType[],
+  installMode: InstallMode,
+  options: { global?: boolean } = {}
+): string[] {
   const lines: string[] = [];
-  const { universal, symlinked } = splitAgentsByType(targetAgents);
+  const { universal, symlinked } = splitAgentsByType(targetAgents, options);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -244,12 +253,13 @@ function buildResultLines(
     agent: string;
     symlinkFailed?: boolean;
   }>,
-  targetAgents: AgentType[]
+  targetAgents: AgentType[],
+  options: { global?: boolean } = {}
 ): string[] {
   const lines: string[] = [];
 
   // Split target agents by type
-  const { universal, symlinked: symlinkAgents } = splitAgentsByType(targetAgents);
+  const { universal } = splitAgentsByType(targetAgents, options);
 
   // For symlink results, also track which ones actually succeeded vs failed
   const successfulSymlinks = results
@@ -268,6 +278,22 @@ function buildResultLines(
   }
 
   return lines;
+}
+
+function getUniqueTargetDirs(
+  targetAgents: AgentType[],
+  options: { global?: boolean; cwd?: string } = {}
+): Set<string> {
+  return new Set(targetAgents.map((a) => getAgentBaseDir(a, options.global ?? false, options.cwd)));
+}
+
+function isSymlinkModeMeaningful(
+  targetAgents: AgentType[],
+  options: { global?: boolean; cwd?: string } = {}
+): boolean {
+  return targetAgents.some(
+    (a) => !sharesCanonicalSkillsDir(a, options.global ?? false, options.cwd)
+  );
 }
 
 /**
@@ -291,16 +317,16 @@ function multiselect<Value>(opts: {
 /**
  * Prompts the user to select agents using interactive search.
  * Pre-selects the last used agents if available.
- * Saves the selection for future use.
  */
 export async function promptForAgents(
   message: string,
-  choices: Array<{ value: AgentType; label: string; hint?: string }>
+  choices: Array<{ value: AgentType; label: string; hint?: string }>,
+  options: { global?: boolean } = {}
 ): Promise<AgentType[] | symbol> {
   // Get last selected agents to pre-select
   let lastSelected: string[] | undefined;
   try {
-    lastSelected = await getLastSelectedAgents();
+    lastSelected = await getLastSelectedAgents(options.global ? 'global' : 'project');
   } catch {
     // Silently ignore errors reading lock file
   }
@@ -329,15 +355,6 @@ export async function promptForAgents(
     initialSelected: initialValues,
     required: true,
   });
-
-  if (!isCancelled(selected)) {
-    // Save selection for next time
-    try {
-      await saveSelectedAgents(selected as string[]);
-    } catch {
-      // Silently ignore errors writing lock file
-    }
-  }
 
   return selected as AgentType[] | symbol;
 }
@@ -374,7 +391,7 @@ async function selectAgentsInteractive(options: {
   // Get last selected agents (filter to only non-universal ones for initial selection)
   let lastSelected: string[] | undefined;
   try {
-    lastSelected = await getLastSelectedAgents();
+    lastSelected = await getLastSelectedAgents(options.global ? 'global' : 'project');
   } catch {
     // Silently ignore errors
   }
@@ -392,16 +409,18 @@ async function selectAgentsInteractive(options: {
     lockedSection: universalSection,
   });
 
-  if (!isCancelled(selected)) {
-    // Save selection (all agents including universal)
-    try {
-      await saveSelectedAgents(selected as string[]);
-    } catch {
-      // Silently ignore errors
-    }
-  }
-
   return selected as AgentType[] | symbol;
+}
+
+async function persistSelectedAgents(
+  targetAgents: AgentType[],
+  scope: AgentSelectionScope
+): Promise<void> {
+  try {
+    await saveSelectedAgents(targetAgents, scope);
+  } catch {
+    // Silently ignore errors writing lock file
+  }
 }
 
 const version = packageJson.version;
@@ -562,7 +581,8 @@ async function handleWellKnownSkills(
         // Use helper to prompt with search
         const selected = await promptForAgents(
           'Which agents do you want to install to?',
-          allAgentChoices
+          allAgentChoices,
+          { global: options.global }
         );
 
         if (p.isCancel(selected)) {
@@ -625,14 +645,21 @@ async function handleWellKnownSkills(
     installGlobally = scope as boolean;
   }
 
+  await persistSelectedAgents(targetAgents, installGlobally ? 'global' : 'project');
+
   // Determine install mode (symlink vs copy)
   let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
-  // Only prompt for install mode when there are multiple unique target directories.
-  // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-  const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+  const uniqueDirs = getUniqueTargetDirs(targetAgents, {
+    global: installGlobally,
+    cwd: process.cwd(),
+  });
+  const symlinkModeIsMeaningful = isSymlinkModeMeaningful(targetAgents, {
+    global: installGlobally,
+    cwd: process.cwd(),
+  });
 
-  if (!options.copy && !options.yes && uniqueDirs.size > 1) {
+  if (!options.copy && !options.yes && symlinkModeIsMeaningful && uniqueDirs.size > 0) {
     const modeChoice = await p.select({
       message: 'Installation method',
       options: [
@@ -651,8 +678,8 @@ async function handleWellKnownSkills(
     }
 
     installMode = modeChoice as InstallMode;
-  } else if (uniqueDirs.size <= 1) {
-    // Single target directory — default to copy (no symlink needed)
+  } else if (!symlinkModeIsMeaningful) {
+    // All target agents already use the canonical directory in this scope.
     installMode = 'copy';
   }
 
@@ -686,7 +713,9 @@ async function handleWellKnownSkills(
     const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
     const shortCanonical = shortenPath(canonicalPath, cwd);
     summaryLines.push(`${pc.cyan(shortCanonical)}`);
-    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+    summaryLines.push(
+      ...buildAgentSummaryLines(targetAgents, installMode, { global: installGlobally })
+    );
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
     }
@@ -847,7 +876,9 @@ async function handleWellKnownSkills(
         } else {
           resultLines.push(`${pc.green('✓')} ${skillName}`);
         }
-        resultLines.push(...buildResultLines(skillResults, targetAgents));
+        resultLines.push(
+          ...buildResultLines(skillResults, targetAgents, { global: installGlobally })
+        );
       }
     }
 
@@ -1182,7 +1213,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           // Use helper to prompt with search
           const selected = await promptForAgents(
             'Which agents do you want to install to?',
-            allAgentChoices
+            allAgentChoices,
+            { global: options.global }
           );
 
           if (p.isCancel(selected)) {
@@ -1248,14 +1280,21 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       installGlobally = scope as boolean;
     }
 
+    await persistSelectedAgents(targetAgents, installGlobally ? 'global' : 'project');
+
     // Determine install mode (symlink vs copy)
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
-    // Only prompt for install mode when there are multiple unique target directories.
-    // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-    const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+    const uniqueDirs = getUniqueTargetDirs(targetAgents, {
+      global: installGlobally,
+      cwd: process.cwd(),
+    });
+    const symlinkModeIsMeaningful = isSymlinkModeMeaningful(targetAgents, {
+      global: installGlobally,
+      cwd: process.cwd(),
+    });
 
-    if (!options.copy && !options.yes && uniqueDirs.size > 1) {
+    if (!options.copy && !options.yes && symlinkModeIsMeaningful && uniqueDirs.size > 0) {
       const modeChoice = await p.select({
         message: 'Installation method',
         options: [
@@ -1275,8 +1314,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       installMode = modeChoice as InstallMode;
-    } else if (uniqueDirs.size <= 1) {
-      // Single target directory — default to copy (no symlink needed)
+    } else if (!symlinkModeIsMeaningful) {
+      // All target agents already use the canonical directory in this scope.
       installMode = 'copy';
     }
 
@@ -1326,7 +1365,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally });
         const shortCanonical = shortenPath(canonicalPath, cwd);
         summaryLines.push(`${pc.cyan(shortCanonical)}`);
-        summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+        summaryLines.push(
+          ...buildAgentSummaryLines(targetAgents, installMode, { global: installGlobally })
+        );
 
         const skillOverwrites = overwriteStatus.get(skill.name);
         const overwriteAgents = targetAgents
@@ -1599,7 +1640,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             } else {
               resultLines.push(`${pc.green('✓')} ${entry.skill}`);
             }
-            resultLines.push(...buildResultLines(skillResults, targetAgents));
+            resultLines.push(
+              ...buildResultLines(skillResults, targetAgents, { global: installGlobally })
+            );
           }
         }
       };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,7 +87,7 @@ function showBanner(): void {
   );
   console.log();
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills experimental_install${RESET} ${DIM}Restore from skills-lock.json${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}npx skills experimental_install${RESET} ${DIM}Restore from a skills lock file${RESET}`
   );
   console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills init ${DIM}[name]${RESET}          ${DIM}Create a new skill${RESET}`
@@ -119,7 +119,7 @@ ${BOLD}Updates:${RESET}
   update               Update all skills to latest versions
 
 ${BOLD}Project:${RESET}
-  experimental_install Restore skills from skills-lock.json
+  experimental_install Restore skills from a skills lock file
   init [name]          Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
   experimental_sync    Sync skills from node_modules into agent directories
 
@@ -143,6 +143,10 @@ ${BOLD}Remove Options:${RESET}
 ${BOLD}Experimental Sync Options:${RESET}
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
   -y, --yes              Skip confirmation prompts
+
+${BOLD}Experimental Install Options:${RESET}
+  -g, --global           Restore from the global skill lock and relink global agent dirs
+  -a, --agent <agents>   Specify restore targets (defaults to saved or detected global agents)
 
 ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
@@ -170,6 +174,9 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills check
   ${DIM}$${RESET} skills update
   ${DIM}$${RESET} skills experimental_install            ${DIM}# restore from skills-lock.json${RESET}
+  ${DIM}$${RESET} skills experimental_install -g         ${DIM}# restore from the global skill lock${RESET}
+  ${DIM}$${RESET} skills experimental_install -g --agent codex claude-code
+                                             ${DIM}# relink specific global agents${RESET}
   ${DIM}$${RESET} skills init my-skill
   ${DIM}$${RESET} skills experimental_sync              ${DIM}# sync from node_modules${RESET}
   ${DIM}$${RESET} skills experimental_sync -y           ${DIM}# sync without prompts${RESET}

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -380,7 +380,7 @@ describe('experimental_install', () => {
           gamma: makeGlobalEntry('shared-local-source'),
           delta: makeGlobalEntry('shared-local-source'),
         },
-        ['codex']
+        { lastSelectedGlobalAgents: ['codex'] }
       )
     );
     vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['codex']);

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentType } from './types.ts';
+
+const { promptLog } = vi.hoisted(() => ({
+  promptLog: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+vi.mock('@clack/prompts', () => ({
+  log: promptLog,
+  intro: vi.fn(),
+  outro: vi.fn(),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('./add.ts', async () => {
+  const actual = await vi.importActual<typeof import('./add.ts')>('./add.ts');
+  return {
+    ...actual,
+    runAdd: vi.fn(),
+  };
+});
+
+vi.mock('./local-lock.ts', async () => {
+  const actual = await vi.importActual<typeof import('./local-lock.ts')>('./local-lock.ts');
+  return {
+    ...actual,
+    readLocalLock: vi.fn(),
+  };
+});
+
+vi.mock('./skill-lock.ts', async () => {
+  const actual = await vi.importActual<typeof import('./skill-lock.ts')>('./skill-lock.ts');
+  return {
+    ...actual,
+    readSkillLock: vi.fn(),
+  };
+});
+
+vi.mock('./sync.ts', async () => {
+  const actual = await vi.importActual<typeof import('./sync.ts')>('./sync.ts');
+  return {
+    ...actual,
+    parseSyncOptions: vi.fn(() => ({ options: {} })),
+    runSync: vi.fn(),
+  };
+});
+
+vi.mock('./agents.ts', async () => {
+  const actual = await vi.importActual<typeof import('./agents.ts')>('./agents.ts');
+  return {
+    ...actual,
+    detectInstalledAgents: vi.fn(),
+  };
+});
+
+import { parseInstallFromLockOptions, runInstallFromLock } from './install.ts';
+import { runAdd } from './add.ts';
+import { readLocalLock } from './local-lock.ts';
+import { readSkillLock } from './skill-lock.ts';
+import { parseSyncOptions, runSync } from './sync.ts';
+import * as agentsModule from './agents.ts';
+
+describe('experimental_install', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+      throw Object.assign(new Error('process.exit'), { code });
+    });
+
+    vi.mocked(readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {},
+    });
+    vi.mocked(readSkillLock).mockResolvedValue({
+      version: 3,
+      skills: {},
+      dismissed: {},
+      lastSelectedAgents: [],
+      lastSelectedGlobalAgents: [],
+    });
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue([]);
+    vi.mocked(parseSyncOptions).mockReturnValue({ options: {} });
+    vi.mocked(runSync).mockResolvedValue();
+    vi.mocked(runAdd).mockResolvedValue();
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  describe('parseInstallFromLockOptions', () => {
+    it('parses global and agent flags', () => {
+      const options = parseInstallFromLockOptions(['-g', '--agent', 'codex', 'claude-code']);
+      expect(options).toEqual({
+        global: true,
+        agent: ['codex', 'claude-code'],
+      });
+    });
+  });
+
+  it('warns when the project lock is empty', async () => {
+    await runInstallFromLock([]);
+
+    expect(promptLog.warn).toHaveBeenCalledWith('No project skills found in skills-lock.json');
+    expect(promptLog.info).toHaveBeenCalledWith(
+      expect.stringContaining('Add project-level skills with')
+    );
+    expect(runAdd).not.toHaveBeenCalled();
+    expect(runSync).not.toHaveBeenCalled();
+  });
+
+  it('replays non-node_modules project skills through runAdd with universal agents', async () => {
+    vi.mocked(readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {
+        alpha: {
+          source: 'vercel-labs/skills',
+          sourceType: 'github',
+          computedHash: 'alpha-hash',
+        },
+        beta: {
+          source: 'vercel-labs/skills',
+          sourceType: 'github',
+          computedHash: 'beta-hash',
+        },
+      },
+    });
+
+    await runInstallFromLock([]);
+
+    expect(runAdd).toHaveBeenCalledTimes(1);
+    expect(runAdd).toHaveBeenCalledWith(['vercel-labs/skills'], {
+      skill: ['alpha', 'beta'],
+      agent: agentsModule.getUniversalAgents(),
+      yes: true,
+    });
+    expect(runSync).not.toHaveBeenCalled();
+  });
+
+  it('replays node_modules project skills through runSync with universal agents', async () => {
+    vi.mocked(readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {
+        localSkill: {
+          source: 'vercel-labs/skills',
+          sourceType: 'github',
+          computedHash: 'local-hash',
+        },
+        packageSkill: {
+          source: '@acme/skills',
+          sourceType: 'node_modules',
+          computedHash: 'package-hash',
+        },
+      },
+    });
+    vi.mocked(parseSyncOptions).mockReturnValue({ options: { force: true } as any });
+
+    await runInstallFromLock(['--force']);
+
+    expect(runAdd).toHaveBeenCalledWith(['vercel-labs/skills'], {
+      skill: ['localSkill'],
+      agent: agentsModule.getUniversalAgents(),
+      yes: true,
+    });
+    expect(runSync).toHaveBeenCalledWith(['--force'], {
+      force: true,
+      yes: true,
+      agent: agentsModule.getUniversalAgents(),
+    });
+  });
+
+  it('uses an explicit single global restore agent', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock({
+        syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+      })
+    );
+
+    await runInstallFromLock(['-g', '--agent', 'codex']);
+
+    expect(runAdd).toHaveBeenCalledWith(['https://example.com/repo-one.git'], {
+      global: true,
+      skill: ['syncedSkill'],
+      agent: ['codex'],
+      yes: true,
+    });
+  });
+
+  it('uses explicit multiple global restore agents', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock({
+        syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+      })
+    );
+
+    await runInstallFromLock(['-g', '--agent', 'codex', 'claude-code']);
+
+    expect(runAdd).toHaveBeenCalledWith(['https://example.com/repo-one.git'], {
+      global: true,
+      skill: ['syncedSkill'],
+      agent: ['codex', 'claude-code'],
+      yes: true,
+    });
+  });
+
+  it('expands wildcard global restore agents to all global-capable agents', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock({
+        syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+      })
+    );
+
+    await runInstallFromLock(['-g', '--agent', '*']);
+
+    const allGlobalCapableAgents = (
+      Object.entries(agentsModule.agents) as Array<
+        [AgentType, (typeof agentsModule.agents)[AgentType]]
+      >
+    )
+      .filter(([, agent]) => agent.globalSkillsDir !== undefined)
+      .map(([agent]) => agent);
+
+    expect(runAdd).toHaveBeenCalledWith(['https://example.com/repo-one.git'], {
+      global: true,
+      skill: ['syncedSkill'],
+      agent: allGlobalCapableAgents,
+      yes: true,
+    });
+  });
+
+  it('rejects invalid explicit agents', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock({
+        syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+      })
+    );
+
+    await expect(runInstallFromLock(['-g', '--agent', 'invalid-agent'])).rejects.toThrow(
+      'process.exit'
+    );
+
+    expect(promptLog.error).toHaveBeenCalledWith('Invalid agents: invalid-agent');
+    expect(promptLog.info).toHaveBeenCalledWith(expect.stringContaining('Valid agents:'));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(runAdd).not.toHaveBeenCalled();
+  });
+
+  it('prefers detected global agents over saved project history', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock(
+        {
+          syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+        },
+        { lastSelectedAgents: ['codex'] }
+      )
+    );
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['codex', 'claude-code']);
+
+    await runInstallFromLock(['-g']);
+
+    expect(runAdd).toHaveBeenCalledWith(['https://example.com/repo-one.git'], {
+      global: true,
+      skill: ['syncedSkill'],
+      agent: ['codex', 'claude-code'],
+      yes: true,
+    });
+  });
+
+  it('falls back from stale saved agents to detected global agents', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock(
+        {
+          syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+        },
+        { lastSelectedGlobalAgents: ['openclaw'] }
+      )
+    );
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['codex']);
+
+    await runInstallFromLock(['-g']);
+
+    expect(runAdd).toHaveBeenCalledWith(['https://example.com/repo-one.git'], {
+      global: true,
+      skill: ['syncedSkill'],
+      agent: ['codex'],
+      yes: true,
+    });
+  });
+
+  it('falls back to saved global-capable agents when detection finds no agent dirs', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock(
+        {
+          syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+        },
+        { lastSelectedGlobalAgents: ['codex'] }
+      )
+    );
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue([]);
+
+    await runInstallFromLock(['-g']);
+
+    expect(runAdd).toHaveBeenCalledWith(['https://example.com/repo-one.git'], {
+      global: true,
+      skill: ['syncedSkill'],
+      agent: ['codex'],
+      yes: true,
+    });
+  });
+
+  it('ignores saved project history when detection finds no agent dirs', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock(
+        {
+          syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+        },
+        { lastSelectedAgents: ['codex'] }
+      )
+    );
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue([]);
+
+    await expect(runInstallFromLock(['-g'])).rejects.toThrow('process.exit');
+
+    expect(promptLog.warn).toHaveBeenCalledWith('No global-capable installed agents detected.');
+    expect(runAdd).not.toHaveBeenCalled();
+  });
+
+  it('falls back from missing saved agents to detected global agents', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock({
+        syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+      })
+    );
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['codex']);
+
+    await runInstallFromLock(['-g']);
+
+    expect(runAdd).toHaveBeenCalledWith(['https://example.com/repo-one.git'], {
+      global: true,
+      skill: ['syncedSkill'],
+      agent: ['codex'],
+      yes: true,
+    });
+  });
+
+  it('exits when no saved or detected global-capable agents exist', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock({
+        syncedSkill: makeGlobalEntry('repo-one', 'https://example.com/repo-one.git'),
+      })
+    );
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue([]);
+
+    await expect(runInstallFromLock(['-g'])).rejects.toThrow('process.exit');
+
+    expect(promptLog.warn).toHaveBeenCalledWith('No global-capable installed agents detected.');
+    expect(promptLog.info).toHaveBeenCalledWith(
+      expect.stringContaining('skills experimental_install -g --agent <agent>')
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(runAdd).not.toHaveBeenCalled();
+  });
+
+  it('groups global restore entries by replay source', async () => {
+    vi.mocked(readSkillLock).mockResolvedValue(
+      makeGlobalLock(
+        {
+          alpha: makeGlobalEntry('repo-a', 'https://example.com/repo-a.git'),
+          beta: makeGlobalEntry('repo-b', 'https://example.com/repo-a.git'),
+          gamma: makeGlobalEntry('shared-local-source'),
+          delta: makeGlobalEntry('shared-local-source'),
+        },
+        ['codex']
+      )
+    );
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['codex']);
+
+    await runInstallFromLock(['-g']);
+
+    expect(runAdd).toHaveBeenCalledTimes(2);
+    expect(runAdd).toHaveBeenNthCalledWith(1, ['https://example.com/repo-a.git'], {
+      global: true,
+      skill: ['alpha', 'beta'],
+      agent: ['codex'],
+      yes: true,
+    });
+    expect(runAdd).toHaveBeenNthCalledWith(2, ['shared-local-source'], {
+      global: true,
+      skill: ['gamma', 'delta'],
+      agent: ['codex'],
+      yes: true,
+    });
+  });
+});
+
+function makeGlobalEntry(source: string, sourceUrl?: string) {
+  return {
+    source,
+    sourceType: 'github',
+    ...(sourceUrl ? { sourceUrl } : {}),
+    skillFolderHash: '',
+    installedAt: '2026-03-23T00:00:00.000Z',
+    updatedAt: '2026-03-23T00:00:00.000Z',
+  };
+}
+
+function makeGlobalLock(
+  skills: Record<string, ReturnType<typeof makeGlobalEntry>>,
+  selections: {
+    lastSelectedAgents?: string[];
+    lastSelectedGlobalAgents?: string[];
+  } = {}
+) {
+  return {
+    version: 3,
+    skills,
+    dismissed: {},
+    lastSelectedAgents: selections.lastSelectedAgents ?? [],
+    lastSelectedGlobalAgents: selections.lastSelectedGlobalAgents ?? [],
+  };
+}

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,89 +1,238 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
-import { readLocalLock } from './local-lock.ts';
 import { runAdd } from './add.ts';
+import { readLocalLock } from './local-lock.ts';
+import { agents, detectInstalledAgents, getUniversalAgents } from './agents.ts';
+import { readSkillLock } from './skill-lock.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
-import { getUniversalAgents } from './agents.ts';
+import type { AgentType } from './types.ts';
 
-/**
- * Install all skills from the local skills-lock.json.
- * Groups skills by source and calls `runAdd` for each group.
- *
- * Only installs to .agents/skills/ (universal agents) -- the canonical
- * project-level location. Does not install to agent-specific directories.
- *
- * node_modules skills are handled via experimental_sync.
- */
-export async function runInstallFromLock(args: string[]): Promise<void> {
-  const cwd = process.cwd();
-  const lock = await readLocalLock(cwd);
-  const skillEntries = Object.entries(lock.skills);
+interface InstallFromLockOptions {
+  global?: boolean;
+  agent?: string[];
+}
 
-  if (skillEntries.length === 0) {
-    p.log.warn('No project skills found in skills-lock.json');
-    p.log.info(
-      `Add project-level skills with ${pc.cyan('npx skills add <package>')} (without ${pc.cyan('-g')})`
-    );
-    return;
+interface RestoreEntry {
+  source: string;
+  sourceType: string;
+}
+
+export function parseInstallFromLockOptions(args: string[]): InstallFromLockOptions {
+  const options: InstallFromLockOptions = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '-g' || arg === '--global') {
+      options.global = true;
+    } else if (arg === '-a' || arg === '--agent') {
+      options.agent = options.agent || [];
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        options.agent.push(nextArg);
+        i++;
+        nextArg = args[i];
+      }
+      i--;
+    }
   }
 
-  // Only install to .agents/skills/ (universal agents)
-  const universalAgentNames = getUniversalAgents();
+  return options;
+}
 
-  // Separate node_modules skills from remote skills
-  const nodeModuleSkills: string[] = [];
-  const bySource = new Map<string, { sourceType: string; skills: string[] }>();
+function validateAgents(agentNames: string[], global: boolean): AgentType[] {
+  const validAgents = Object.keys(agents) as AgentType[];
+  if (agentNames.includes('*')) {
+    return global
+      ? validAgents.filter((agent) => agents[agent].globalSkillsDir !== undefined)
+      : validAgents;
+  }
+  const invalidAgents = agentNames.filter((agent) => !validAgents.includes(agent as AgentType));
 
-  for (const [skillName, entry] of skillEntries) {
-    if (entry.sourceType === 'node_modules') {
-      nodeModuleSkills.push(skillName);
+  if (invalidAgents.length > 0) {
+    p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
+    p.log.info(`Valid agents: ${validAgents.join(', ')}`);
+    process.exit(1);
+    throw new Error('Unreachable');
+  }
+
+  const targetAgents = agentNames as AgentType[];
+
+  if (global) {
+    const unsupported = targetAgents.filter((agent) => agents[agent].globalSkillsDir === undefined);
+    if (unsupported.length > 0) {
+      p.log.error(`Agents do not support global installs: ${unsupported.join(', ')}`);
+      process.exit(1);
+      throw new Error('Unreachable');
+    }
+  }
+
+  return targetAgents;
+}
+
+async function resolveGlobalRestoreAgents(explicitAgents?: string[]): Promise<AgentType[]> {
+  if (explicitAgents && explicitAgents.length > 0) {
+    return validateAgents(explicitAgents, true);
+  }
+
+  const installedAgents = await detectInstalledAgents();
+  const globalCapableAgents = installedAgents.filter((agent) => agents[agent].globalSkillsDir);
+  const lock = await readSkillLock();
+  const savedAgents = (lock.lastSelectedGlobalAgents || []).filter(
+    (agent): agent is AgentType => agents[agent as AgentType]?.globalSkillsDir !== undefined
+  );
+
+  if (globalCapableAgents.length > 0) {
+    return globalCapableAgents;
+  }
+
+  if (savedAgents.length > 0) {
+    return savedAgents;
+  }
+
+  p.log.warn('No global-capable installed agents detected.');
+  p.log.info(`Re-run with ${pc.cyan('skills experimental_install -g --agent <agent>')}`);
+  process.exit(1);
+  throw new Error('Unreachable');
+}
+
+function groupRestoreEntries(
+  entries: Array<[string, { source: string; sourceType: string; sourceUrl?: string }]>
+): Map<string, { sourceType: string; skills: string[] }> {
+  const grouped = new Map<string, { sourceType: string; skills: string[] }>();
+
+  for (const [skillName, entry] of entries) {
+    const replaySource = entry.sourceUrl || entry.source;
+    const existing = grouped.get(replaySource);
+
+    if (existing) {
+      existing.skills.push(skillName);
       continue;
     }
 
-    const existing = bySource.get(entry.source);
-    if (existing) {
-      existing.skills.push(skillName);
-    } else {
-      bySource.set(entry.source, {
-        sourceType: entry.sourceType,
-        skills: [skillName],
-      });
+    grouped.set(replaySource, {
+      sourceType: entry.sourceType,
+      skills: [skillName],
+    });
+  }
+
+  return grouped;
+}
+
+/**
+ * Install all skills from the appropriate lock file.
+ * Project scope restores from skills-lock.json into project canonical targets.
+ * Global scope restores from the global lock and recreates agent links/copies.
+ *
+ * node_modules skills are handled via experimental_sync for project restores.
+ */
+export async function runInstallFromLock(args: string[]): Promise<void> {
+  const cwd = process.cwd();
+  const options = parseInstallFromLockOptions(args);
+  const isGlobal = options.global === true;
+
+  if (!isGlobal) {
+    const lock = await readLocalLock(cwd);
+    const skillEntries = Object.entries(lock.skills);
+
+    if (skillEntries.length === 0) {
+      p.log.warn('No project skills found in skills-lock.json');
+      p.log.info(
+        `Add project-level skills with ${pc.cyan('npx skills add <package>')} (without ${pc.cyan('-g')})`
+      );
+      return;
     }
+
+    const universalAgentNames = getUniversalAgents();
+    const nodeModuleSkills: string[] = [];
+    const bySource = new Map<string, { sourceType: string; skills: string[] }>();
+
+    for (const [skillName, entry] of skillEntries) {
+      if (entry.sourceType === 'node_modules') {
+        nodeModuleSkills.push(skillName);
+        continue;
+      }
+
+      const existing = bySource.get(entry.source);
+      if (existing) {
+        existing.skills.push(skillName);
+      } else {
+        bySource.set(entry.source, {
+          sourceType: entry.sourceType,
+          skills: [skillName],
+        });
+      }
+    }
+
+    const remoteCount = skillEntries.length - nodeModuleSkills.length;
+    if (remoteCount > 0) {
+      p.log.info(
+        `Restoring ${pc.cyan(String(remoteCount))} skill${remoteCount !== 1 ? 's' : ''} from skills-lock.json into ${pc.dim('.agents/skills/')}`
+      );
+    }
+
+    for (const [source, { skills }] of bySource) {
+      try {
+        await runAdd([source], {
+          skill: skills,
+          agent: universalAgentNames,
+          yes: true,
+        });
+      } catch (error) {
+        p.log.error(
+          `Failed to install from ${pc.cyan(source)}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
+      }
+    }
+
+    if (nodeModuleSkills.length > 0) {
+      p.log.info(
+        `${pc.cyan(String(nodeModuleSkills.length))} skill${nodeModuleSkills.length !== 1 ? 's' : ''} from node_modules`
+      );
+      try {
+        const { options: syncOptions } = parseSyncOptions(args);
+        await runSync(args, { ...syncOptions, yes: true, agent: universalAgentNames });
+      } catch (error) {
+        p.log.error(
+          `Failed to sync node_modules skills: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
+      }
+    }
+
+    return;
   }
 
-  const remoteCount = skillEntries.length - nodeModuleSkills.length;
-  if (remoteCount > 0) {
-    p.log.info(
-      `Restoring ${pc.cyan(String(remoteCount))} skill${remoteCount !== 1 ? 's' : ''} from skills-lock.json into ${pc.dim('.agents/skills/')}`
-    );
+  const lock = await readSkillLock();
+  const skillEntries = Object.entries(lock.skills);
+
+  if (skillEntries.length === 0) {
+    p.log.warn('No global skills found in the global skill lock.');
+    p.log.info(`Add global skills with ${pc.cyan('npx skills add <package> -g')}`);
+    return;
   }
 
-  // Install remote skills grouped by source
+  const targetAgents = await resolveGlobalRestoreAgents(options.agent);
+  const bySource = groupRestoreEntries(skillEntries);
+
+  p.log.info(
+    `Restoring ${pc.cyan(String(skillEntries.length))} skill${skillEntries.length !== 1 ? 's' : ''} from the global skill lock`
+  );
+  p.log.info(
+    `Relinking for: ${targetAgents.map((agent) => pc.cyan(agents[agent].displayName)).join(', ')}`
+  );
+
   for (const [source, { skills }] of bySource) {
     try {
       await runAdd([source], {
+        global: true,
         skill: skills,
-        agent: universalAgentNames,
+        agent: targetAgents,
         yes: true,
       });
     } catch (error) {
       p.log.error(
         `Failed to install from ${pc.cyan(source)}: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
-    }
-  }
-
-  // Handle node_modules skills via sync
-  if (nodeModuleSkills.length > 0) {
-    p.log.info(
-      `${pc.cyan(String(nodeModuleSkills.length))} skill${nodeModuleSkills.length !== 1 ? 's' : ''} from node_modules`
-    );
-    try {
-      const { options: syncOptions } = parseSyncOptions(args);
-      await runSync(args, { ...syncOptions, yes: true, agent: universalAgentNames });
-    } catch (error) {
-      p.log.error(
-        `Failed to sync node_modules skills: ${error instanceof Error ? error.message : 'Unknown error'}`
       );
     }
   }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -73,17 +73,19 @@ export function getCanonicalSkillsDir(global: boolean, cwd?: string): string {
 }
 
 /**
- * Gets the base directory for an agent's skills, respecting universal agents.
- * Universal agents always use the canonical directory, which prevents
- * redundant symlinks and double-listing of skills.
+ * Gets the effective base directory for an agent's skills in the current scope.
+ * Project-scoped installs share the canonical directory for universal agents.
+ * Global installs use the agent's actual global skills dir unless it matches
+ * the canonical global directory.
  */
 export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: string): string {
-  if (isUniversalAgent(agentType)) {
-    return getCanonicalSkillsDir(global, cwd);
-  }
-
   const agent = agents[agentType];
   const baseDir = global ? homedir() : cwd || process.cwd();
+  const canonicalDir = getCanonicalSkillsDir(global, cwd);
+
+  if (!global && isUniversalAgent(agentType)) {
+    return canonicalDir;
+  }
 
   if (global) {
     if (agent.globalSkillsDir === undefined) {
@@ -94,6 +96,14 @@ export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: str
   }
 
   return join(baseDir, agent.skillsDir);
+}
+
+export function sharesCanonicalSkillsDir(
+  agentType: AgentType,
+  global: boolean,
+  cwd?: string
+): boolean {
+  return getAgentBaseDir(agentType, global, cwd) === getCanonicalSkillsDir(global, cwd);
 }
 
 function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
@@ -278,13 +288,10 @@ export async function installSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     await copyDirectory(skill.path, canonicalDir);
 
-    // For universal agents with global install, the skill is already in the canonical
-    // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
-    // (e.g. ~/.copilot/skills) to avoid duplicates.
-    if (isGlobal && isUniversalAgent(agentType)) {
+    if (sharesCanonicalSkillsDir(agentType, isGlobal, cwd)) {
       return {
         success: true,
-        path: canonicalDir,
+        path: agentDir,
         canonicalPath: canonicalDir,
         mode: 'symlink',
       };
@@ -381,19 +388,14 @@ export async function isSkillInstalled(
   agentType: AgentType,
   options: { global?: boolean; cwd?: string } = {}
 ): Promise<boolean> {
-  const agent = agents[agentType];
   const sanitized = sanitizeName(skillName);
 
-  // Agent doesn't support global installation
-  if (options.global && agent.globalSkillsDir === undefined) {
+  const targetBase = getAgentBaseDir(agentType, options.global ?? false, options.cwd);
+  const skillDir = join(targetBase, sanitized);
+
+  if (options.global && agents[agentType].globalSkillsDir === undefined) {
     return false;
   }
-
-  const targetBase = options.global
-    ? agent.globalSkillsDir!
-    : join(options.cwd || process.cwd(), agent.skillsDir);
-
-  const skillDir = join(targetBase, sanitized);
 
   if (!isPathSafe(targetBase, skillDir)) {
     return false;
@@ -412,8 +414,6 @@ export function getInstallPath(
   agentType: AgentType,
   options: { global?: boolean; cwd?: string } = {}
 ): string {
-  const agent = agents[agentType];
-  const cwd = options.cwd || process.cwd();
   const sanitized = sanitizeName(skillName);
 
   const targetBase = getAgentBaseDir(agentType, options.global ?? false, options.cwd);
@@ -519,11 +519,10 @@ export async function installRemoteSkillForAgent(
     const skillMdPath = join(canonicalDir, 'SKILL.md');
     await writeFile(skillMdPath, skill.content, 'utf-8');
 
-    // For universal agents with global install, skip creating agent-specific symlink
-    if (isGlobal && isUniversalAgent(agentType)) {
+    if (sharesCanonicalSkillsDir(agentType, isGlobal, cwd)) {
       return {
         success: true,
-        path: canonicalDir,
+        path: agentDir,
         canonicalPath: canonicalDir,
         mode: 'symlink',
       };
@@ -657,11 +656,10 @@ export async function installWellKnownSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     await writeSkillFiles(canonicalDir);
 
-    // For universal agents with global install, skip creating agent-specific symlink
-    if (isGlobal && isUniversalAgent(agentType)) {
+    if (sharesCanonicalSkillsDir(agentType, isGlobal, cwd)) {
       return {
         success: true,
-        path: canonicalDir,
+        path: agentDir,
         canonicalPath: canonicalDir,
         mode: 'symlink',
       };
@@ -769,7 +767,7 @@ export async function listInstalledSkills(
       if (isGlobal && agent.globalSkillsDir === undefined) {
         continue;
       }
-      const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+      const agentDir = getAgentBaseDir(agentType, isGlobal, cwd);
       // Avoid duplicate paths
       if (!scopes.some((s) => s.path === agentDir && s.global === isGlobal)) {
         scopes.push({ global: isGlobal, path: agentDir, agentType });
@@ -785,7 +783,7 @@ export async function listInstalledSkills(
       if (agentsToCheck.includes(agentType)) continue;
       const agent = agents[agentType];
       if (isGlobal && agent.globalSkillsDir === undefined) continue;
-      const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+      const agentDir = getAgentBaseDir(agentType, isGlobal, cwd);
       if (scopes.some((s) => s.path === agentDir && s.global === isGlobal)) continue;
       if (existsSync(agentDir)) {
         scopes.push({ global: isGlobal, path: agentDir, agentType });
@@ -853,7 +851,7 @@ export async function listInstalledSkills(
             continue;
           }
 
-          const agentBase = scope.global ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+          const agentBase = getAgentBaseDir(agentType, scope.global, cwd);
           let found = false;
 
           // Try exact directory name matches

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -54,7 +54,11 @@ export interface SkillLockFile {
   dismissed?: DismissedPrompts;
   /** Last selected agents for installation */
   lastSelectedAgents?: string[];
+  /** Last selected agents for global installation */
+  lastSelectedGlobalAgents?: string[];
 }
+
+export type AgentSelectionScope = 'project' | 'global';
 
 /**
  * Get the path to the global skill lock file.
@@ -335,16 +339,25 @@ export async function dismissPrompt(promptKey: keyof DismissedPrompts): Promise<
 /**
  * Get the last selected agents.
  */
-export async function getLastSelectedAgents(): Promise<string[] | undefined> {
+export async function getLastSelectedAgents(
+  scope: AgentSelectionScope = 'project'
+): Promise<string[] | undefined> {
   const lock = await readSkillLock();
-  return lock.lastSelectedAgents;
+  return scope === 'global' ? lock.lastSelectedGlobalAgents : lock.lastSelectedAgents;
 }
 
 /**
  * Save the selected agents to the lock file.
  */
-export async function saveSelectedAgents(agents: string[]): Promise<void> {
+export async function saveSelectedAgents(
+  agents: string[],
+  scope: AgentSelectionScope = 'project'
+): Promise<void> {
   const lock = await readSkillLock();
-  lock.lastSelectedAgents = agents;
+  if (scope === 'global') {
+    lock.lastSelectedGlobalAgents = agents;
+  } else {
+    lock.lastSelectedAgents = agents;
+  }
   await writeSkillLock(lock);
 }


### PR DESCRIPTION
## Summary
- add a supported global restore/relink workflow for `experimental_install -g` that reads `~/.agents/.skill-lock.json`, restores canonical global skills, and recreates global agent links
- fix the target-selection/history-scoping bug within that workflow so global restore never reuses project-scoped remembered agents and instead prefers detected global-capable agents before falling back to `lastSelectedGlobalAgents`
- add regression coverage for clean-machine restore, stale project-history contamination, and temp-home global relinking without disturbing project-scoped skills

Fixes #683

## Testing
- `pnpm test` passed locally (`26` files, `399` tests)
- `pnpm build` passed locally
- regression coverage in `src/install.test.ts` proves global restore ignores project-scoped history, prefers detected global-capable agents, and falls back to saved global-only history when needed
- filesystem-backed coverage in `src/add.test.ts` proves temp-home/global-agent relinking works without disturbing overlapping project-scoped skills
- test fixtures create synthetic skills on disk; they do not use real upstream skills
- GitHub Actions is configured to run the matrix on `ubuntu-latest` and `windows-latest`, but this branch has not yet been verified by a real matrix run
