### PR TITLE
feat(agents): add Iris support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [39 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [40 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -209,45 +209,46 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:start -->
 | Agent | `--agent` | Project Path | Global Path |
 |-------|-----------|--------------|-------------|
-| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
-| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
-| Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
-| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
-| OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline, Warp | `cline`, `warp` | `.agents/skills/` | `~/.agents/skills/` |
-| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
-| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
-| Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
-| Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
-| Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
-| Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
-| Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
-| Deep Agents | `deepagents` | `.agents/skills/` | `~/.deepagents/agent/skills/` |
-| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
-| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
-| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
-| Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
-| Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
-| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
-| Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
-| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
-| Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
-| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
-| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
-| Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
-| OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
-| OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
-| Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
-| Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
-| Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
-| Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
-| Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
-| Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
-| Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
-| Zencoder | `zencoder` | `.zencoder/skills/` | `~/.zencoder/skills/` |
-| Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
-| Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
-| AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
+| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~\.config\agents\skills/` |
+| Antigravity | `antigravity` | `.agents/skills/` | `~\.gemini\antigravity\skills/` |
+| Augment | `augment` | `.augment/skills/` | `~\.augment\skills/` |
+| Claude Code | `claude-code` | `.claude/skills/` | `~\.claude\skills/` |
+| OpenClaw | `openclaw` | `skills/` | `~\.openclaw\skills/` |
+| Cline, Warp | `cline`, `warp` | `.agents/skills/` | `~\.agents\skills/` |
+| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~\.codebuddy\skills/` |
+| Codex | `codex` | `.agents/skills/` | `~\.codex\skills/` |
+| Command Code | `command-code` | `.commandcode/skills/` | `~\.commandcode\skills/` |
+| Continue | `continue` | `.continue/skills/` | `~\.continue\skills/` |
+| Cortex Code | `cortex` | `.cortex/skills/` | `~\.snowflake\cortex\skills/` |
+| Crush | `crush` | `.crush/skills/` | `~\.config\crush\skills/` |
+| Cursor | `cursor` | `.agents/skills/` | `~\.cursor\skills/` |
+| Deep Agents | `deepagents` | `.agents/skills/` | `~\.deepagents\agent\skills/` |
+| Droid | `droid` | `.factory/skills/` | `~\.factory\skills/` |
+| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~\.gemini\skills/` |
+| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~\.copilot\skills/` |
+| Goose | `goose` | `.goose/skills/` | `~\.config\goose\skills/` |
+| Junie | `junie` | `.junie/skills/` | `~\.junie\skills/` |
+| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~\.iflow\skills/` |
+| Iris | `iris` | `.agents/skills/` | `~\.iris\skills/` |
+| Kilo Code | `kilo` | `.kilocode/skills/` | `~\.kilocode\skills/` |
+| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~\.kiro\skills/` |
+| Kode | `kode` | `.kode/skills/` | `~\.kode\skills/` |
+| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~\.mcpjam\skills/` |
+| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~\.vibe\skills/` |
+| Mux | `mux` | `.mux/skills/` | `~\.mux\skills/` |
+| OpenCode | `opencode` | `.agents/skills/` | `~\.config\opencode\skills/` |
+| OpenHands | `openhands` | `.openhands/skills/` | `~\.openhands\skills/` |
+| Pi | `pi` | `.pi/skills/` | `~\.pi\agent\skills/` |
+| Qoder | `qoder` | `.qoder/skills/` | `~\.qoder\skills/` |
+| Qwen Code | `qwen-code` | `.qwen/skills/` | `~\.qwen\skills/` |
+| Roo Code | `roo` | `.roo/skills/` | `~\.roo\skills/` |
+| Trae | `trae` | `.trae/skills/` | `~\.trae\skills/` |
+| Trae CN | `trae-cn` | `.trae/skills/` | `~\.trae-cn\skills/` |
+| Windsurf | `windsurf` | `.windsurf/skills/` | `~\.codeium\windsurf\skills/` |
+| Zencoder | `zencoder` | `.zencoder/skills/` | `~\.zencoder\skills/` |
+| Neovate | `neovate` | `.neovate/skills/` | `~\.neovate\skills/` |
+| Pochi | `pochi` | `.pochi/skills/` | `~\.pochi\skills/` |
+| AdaL | `adal` | `.adal/skills/` | `~\.adal\skills/` |
 <!-- supported-agents:end -->
 
 > [!NOTE]

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "goose",
     "junie",
     "iflow-cli",
+    "iris",
     "kilo",
     "kimi-cli",
     "kiro-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -211,6 +211,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.iflow'));
     },
   },
+  iris: {
+    name: 'iris',
+    displayName: 'Iris',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.iris/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.iris'));
+    },
+  },
   kilo: {
     name: 'kilo',
     displayName: 'Kilo Code',

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type AgentType =
   | 'github-copilot'
   | 'goose'
   | 'iflow-cli'
+  | 'iris'
   | 'junie'
   | 'kilo'
   | 'kimi-cli'


### PR DESCRIPTION
## Description

Add [Iris](https://github.com/Lianues/Iris) as a new supported agent.

Iris is a multi-platform AI agent supporting Console, Web, Discord, Telegram, WeChat, WeCom, Lark, and QQ. It has a built-in skill system that follows the Agent Skills open standard — scanning SKILL.md files with YAML frontmatter from both project-level and global directories.

This PR enables `npx skills add` to auto-detect Iris installations and install skills to the correct location.

---

## Changes

| File | Changes |
| --- | --- |
| `src/types.ts` | Added `'iris'` to `AgentType` |
| `src/agents.ts` | Added Iris agent config |
| `README.md` | Auto-generated via `sync-agents.ts` |
| `package.json` | Auto-generated via `sync-agents.ts` (keywords) |

All changes validated with `validate-agents.ts` and synced with `sync-agents.ts` per AGENTS.md guidelines.

---

## Agent Configuration

| Property | Value |
| --- | --- |
| Agent Name | `iris` |
| Display Name | `Iris` |
| Project Skills Directory | `.agents/skills/` |
| Global Skills Directory | `~/.iris/skills/` |
| Detection Path | `~/.iris` |

---

## How Iris loads skills

Iris's [skill-loader.ts](https://github.com/Lianues/Iris/blob/main/src/config/skill-loader.ts) scans two directories:

1. `~/.iris/skills/<name>/SKILL.md` — global skills
2. `<project>/.agents/skills/<name>/SKILL.md` — project-level skills

It parses YAML frontmatter (`name`, `description`) and uses the Markdown body as skill content, fully compatible with the Agent Skills standard.

---

## Related Links

- [Iris GitHub](https://github.com/Lianues/Iris)
- [Iris Skill Loader source](https://github.com/Lianues/Iris/blob/main/src/config/skill-loader.ts)