### PR TITLE
fix: version-based fallback when hash algorithm mismatch causes false update positives

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -53,6 +53,7 @@ import {
   dismissPrompt,
   getLastSelectedAgents,
   saveSelectedAgents,
+  extractLocalSkillVersion,
 } from './skill-lock.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
@@ -1510,12 +1511,16 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               if (hash) skillFolderHash = hash;
             }
 
+            // Extract version from SKILL.md frontmatter
+            const version = await extractLocalSkillVersion(skill.path) ?? undefined;
+
             await addSkillToLock(skill.name, {
               source: lockSource || normalizedSource,
               sourceType: parsed.type,
               sourceUrl: parsed.url,
               skillPath: skillPathValue,
               skillFolderHash,
+              version,
               pluginName: skill.pluginName,
             });
           } catch {
@@ -1533,12 +1538,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
             const computedHash = await computeSkillFolderHash(skill.path);
+            // Extract version from SKILL.md frontmatter
+            const version = await extractLocalSkillVersion(skill.path) ?? undefined;
             await addSkillToLocalLock(
               skill.name,
               {
                 source: lockSource || parsed.url,
                 sourceType: parsed.type,
                 computedHash,
+                version,
               },
               cwd
             );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
-import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { fetchSkillFolderHash, fetchRemoteSkillVersion, getGitHubToken } from './skill-lock.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -287,6 +287,8 @@ interface SkillLockEntry {
   skillPath?: string;
   /** GitHub tree SHA for the entire skill folder (v3) */
   skillFolderHash: string;
+  /** Version from SKILL.md frontmatter (e.g., "1.0.0") */
+  version?: string;
   installedAt: string;
   updatedAt: string;
 }
@@ -415,13 +417,33 @@ async function runCheck(args: string[] = []): Promise<void> {
       try {
         const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token);
 
-        if (!latestHash) {
-          errors.push({ name, source, error: 'Could not fetch from GitHub' });
-          continue;
+        if (latestHash) {
+          // Hash comparison: only trust if both are the same algorithm
+          // (both 40-char git SHA-1 or both 64-char SHA-256)
+          if (latestHash.length === entry.skillFolderHash.length) {
+            if (latestHash !== entry.skillFolderHash) {
+              updates.push({ name, source });
+            }
+            continue;
+          }
+          // Hash length mismatch (e.g., git SHA-1 vs local SHA-256)
+          // Fall through to version-based check
         }
 
-        if (latestHash !== entry.skillFolderHash) {
-          updates.push({ name, source });
+        // Fallback: version-based check using SKILL.md frontmatter
+        if (entry.version) {
+          const remoteVersion = await fetchRemoteSkillVersion(source, entry.skillPath!, token);
+          if (remoteVersion && remoteVersion !== entry.version) {
+            updates.push({ name, source });
+          } else if (!remoteVersion) {
+            errors.push({ name, source, error: 'Could not fetch version from GitHub' });
+          }
+          // If versions match, skill is up to date
+        } else if (!latestHash) {
+          errors.push({ name, source, error: 'Could not fetch from GitHub' });
+        } else {
+          // Hash length mismatch and no version stored — can't reliably compare
+          errors.push({ name, source, error: 'Hash type mismatch, reinstall to fix' });
         }
       } catch (err) {
         errors.push({
@@ -496,16 +518,30 @@ async function runUpdate(): Promise<void> {
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    // Only check skills with folder hash and skill path
-    if (!entry.skillFolderHash || !entry.skillPath) {
+    // Need either hash+skillPath or version+skillPath to check for updates
+    if (!entry.skillPath || (!entry.skillFolderHash && !entry.version)) {
       skipped.push({ name: skillName, reason: getSkipReason(entry), sourceUrl: entry.sourceUrl });
       continue;
     }
 
     try {
+      let hasUpdate = false;
       const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
 
-      if (latestHash && latestHash !== entry.skillFolderHash) {
+      if (latestHash && entry.skillFolderHash && latestHash.length === entry.skillFolderHash.length) {
+        // Same hash algorithm — direct comparison is reliable
+        hasUpdate = latestHash !== entry.skillFolderHash;
+      } else if (entry.version) {
+        // Fallback: version-based check
+        const remoteVersion = await fetchRemoteSkillVersion(entry.source, entry.skillPath, token);
+        if (remoteVersion) {
+          hasUpdate = remoteVersion !== entry.version;
+        }
+      } else if (latestHash && entry.skillFolderHash) {
+        // Hash length mismatch, no version — skip (unreliable)
+      }
+
+      if (hasUpdate) {
         updates.push({ name: skillName, source: entry.source, entry });
       }
     } catch {

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -23,6 +23,11 @@ export interface LocalSkillLockEntry {
    * computes the hash from actual file contents on disk.
    */
   computedHash: string;
+  /**
+   * Version string from the skill's SKILL.md frontmatter (e.g., "1.0.0").
+   * Used for reliable update checks via simple version comparison.
+   */
+  version?: string;
 }
 
 /**

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -26,6 +26,12 @@ export interface SkillLockEntry {
    * Fetched via GitHub Trees API by the telemetry server.
    */
   skillFolderHash: string;
+  /**
+   * Version string from the skill's SKILL.md frontmatter (e.g., "1.0.0").
+   * Used as a reliable fallback for update checks when hash comparison
+   * is unreliable (e.g., hash algorithm mismatch between local and remote).
+   */
+  version?: string;
   /** ISO timestamp when the skill was first installed */
   installedAt: string;
   /** ISO timestamp when the skill was last updated */
@@ -223,6 +229,98 @@ export async function fetchSkillFolderHash(
     } catch {
       continue;
     }
+  }
+
+  return null;
+}
+
+/**
+ * Fetch the version string from a remote skill's SKILL.md frontmatter.
+ * Uses raw.githubusercontent.com to fetch the file content, then parses
+ * the YAML frontmatter to extract the `version` field.
+ *
+ * This is a lightweight alternative to fetchSkillFolderHash that only
+ * requires fetching a single file instead of the entire repo tree.
+ *
+ * @param ownerRepo - GitHub owner/repo (e.g., "vercel-labs/agent-skills")
+ * @param skillPath - Path to skill folder or SKILL.md (e.g., "skills/my-skill/SKILL.md")
+ * @param token - Optional GitHub token for private repos
+ * @returns The version string, or null if not found
+ */
+export async function fetchRemoteSkillVersion(
+  ownerRepo: string,
+  skillPath: string,
+  token?: string | null
+): Promise<string | null> {
+  // Normalize to get the SKILL.md path
+  let mdPath = skillPath.replace(/\\/g, '/');
+  if (!mdPath.endsWith('SKILL.md')) {
+    if (mdPath.endsWith('/')) {
+      mdPath += 'SKILL.md';
+    } else {
+      mdPath += '/SKILL.md';
+    }
+  }
+
+  const branches = ['main', 'master'];
+
+  for (const branch of branches) {
+    try {
+      const url = `https://raw.githubusercontent.com/${ownerRepo}/${branch}/${mdPath}`;
+      const headers: Record<string, string> = {
+        'User-Agent': 'skills-cli',
+      };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      const response = await fetch(url, { headers });
+
+      if (!response.ok) continue;
+
+      const content = await response.text();
+
+      // Parse YAML frontmatter (between --- delimiters)
+      const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+      if (!match) continue;
+
+      // Extract version field from frontmatter
+      const versionMatch = match[1].match(/^version:\s*['"]?([^\s'"]+)['"]?\s*$/m);
+      if (versionMatch && versionMatch[1]) {
+        return versionMatch[1];
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract the version string from a local SKILL.md file's frontmatter.
+ *
+ * @param skillDir - Path to the skill directory containing SKILL.md
+ * @returns The version string, or null if not found
+ */
+export async function extractLocalSkillVersion(
+  skillDir: string
+): Promise<string | null> {
+  try {
+    const { readFile } = await import('fs/promises');
+    const { join } = await import('path');
+    const skillMdPath = join(skillDir, 'SKILL.md');
+    const content = await readFile(skillMdPath, 'utf-8');
+
+    const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+    if (!match) return null;
+
+    const versionMatch = match[1].match(/^version:\s*['"]?([^\s'"]+)['"]?\s*$/m);
+    if (versionMatch && versionMatch[1]) {
+      return versionMatch[1];
+    }
+  } catch {
+    // SKILL.md not found or not readable
   }
 
   return null;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -13,6 +13,7 @@ import {
 } from './agents.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
+import { extractLocalSkillVersion } from './skill-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import { track } from './telemetry.ts';
 
@@ -354,12 +355,14 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     if (successfulSkillNames.has(skill.name)) {
       try {
         const computedHash = await computeSkillFolderHash(skill.path);
+        const version = await extractLocalSkillVersion(skill.path) ?? undefined;
         await addSkillToLocalLock(
           skill.name,
           {
             source: skill.packageName,
             sourceType: 'node_modules',
             computedHash,
+            version,
           },
           cwd
         );


### PR DESCRIPTION
## Problem

`npx skills check` reports all officially installed skills as having updates on every run, even when nothing has changed.

**Root cause: hash algorithm mismatch**

- When installing with `--agent` (project-scoped), `computeSkillFolderHash()` stores a **SHA-256** (64-char) hash in the lock file
- When `skills check` runs, `fetchSkillFolderHash()` returns a **Git tree SHA-1** (40-char) hash from the GitHub Trees API
- These two hashes can never match → every skill always appears outdated

## Solution

Add **version-based update checking** as a fallback when hash comparison is unreliable (i.e. hash length mismatch).

### Changes (5 files, +159 lines)

| File | Change |
|------|--------|
| `src/skill-lock.ts` | Add `fetchRemoteSkillVersion()` and `extractLocalSkillVersion()` — read version field from SKILL.md frontmatter |
| `src/local-lock.ts` | Add `version?: string` to `LocalSkillLockEntry` |
| `src/add.ts` | Store version from SKILL.md into lock on install |
| `src/sync.ts` | Store version from SKILL.md into lock on sync |
| `src/cli.ts` | Fallback to version comparison when hash lengths differ |

### Fallback logic

```
skills check →
  hash lengths match?  → compare hashes (existing behavior)
  hash lengths differ? → compare version from SKILL.md frontmatter
    remote version > local version → has update
    versions equal                 → up to date
    version unavailable            → skip with warning
```

### Why version instead of fixing the hash?

Fixing the hash would require either:
1. Re-fetching the GitHub tree SHA on every install (still rate-limited), or  
2. Changing `skills check` to re-compute local SHA-256 and compare against remote file contents (heavy — requires downloading all files)

Version comparison is lightweight (single file fetch of SKILL.md) and doesn't depend on GitHub Trees API rate limits.

## Testing

Before: 14/14 official skills reported as having updates on every check  
After: 0/14 false positives — all skills correctly reported as up to date
