### PR TITLE
fix #769: use .opencode/skills as skillsDir for opencode agent

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -277,7 +277,7 @@ export const agents: Record<AgentType, AgentConfig> = {
   opencode: {
     name: 'opencode',
     displayName: 'OpenCode',
-    skillsDir: '.agents/skills',
+    skillsDir: '.opencode/skills',
     globalSkillsDir: join(configHome, 'opencode/skills'),
     detectInstalled: async () => {
       return existsSync(join(configHome, 'opencode'));

--- a/tests/agents-opencode.test.ts
+++ b/tests/agents-opencode.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, lstat, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { installSkillForAgent } from '../src/installer.ts';
+import { agents, isUniversalAgent } from '../src/agents.ts';
+
+describe('opencode agent configuration', () => {
+  it('opencode should not be a universal agent', () => {
+    expect(isUniversalAgent('opencode')).toBe(false);
+  });
+
+  it('opencode should have correct skillsDir', () => {
+    expect(agents.opencode.skillsDir).toBe('.opencode/skills');
+  });
+
+  it('opencode skillsDir should differ from universal .agents/skills', () => {
+    expect(agents.opencode.skillsDir).not.toBe('.agents/skills');
+  });
+
+  it('opencode globalSkillsDir should end with opencode/skills', () => {
+    expect(agents.opencode.globalSkillsDir).toContain('opencode/skills');
+  });
+});
+
+describe('opencode project-level installation', () => {
+  it('creates symlink at .opencode/skills/<skill>', async () => {
+    // Setup: create temp project dir and skill source
+    const root = await mkdtemp(join(tmpdir(), 'opencode-test-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillDir = join(root, 'source');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: proj-skill\ndescription: test\n---', 'utf-8');
+
+    try {
+      // Install skill for opencode in project directory (non-global)
+      const result = await installSkillForAgent(
+        { name: 'proj-skill', description: 'test', path: skillDir },
+        'opencode',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      // Verify: symlink exists at .opencode/skills/<skill>
+      const symlinkPath = join(projectDir, '.opencode/skills/proj-skill');
+      const stats = await lstat(symlinkPath);
+      expect(stats.isSymbolicLink()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('copy mode installs directly without symlink', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencode-copy-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillDir = join(root, 'source');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: copy-skill\ndescription: test\n---', 'utf-8');
+
+    try {
+      // Copy mode: no symlinks, direct copy to agent dir
+      const result = await installSkillForAgent(
+        { name: 'copy-skill', description: 'test', path: skillDir },
+        'opencode',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('copy');
+
+      // Verify: no symlink, real directory at .opencode/skills/<skill>
+      const skillPath = join(projectDir, '.opencode/skills/copy-skill');
+      const stats = await lstat(skillPath);
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('opencode global-level installation', () => {
+  it('installs to ~/.config/opencode/skills/', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencode-global-'));
+    const homeDir = join(root, 'home');
+    await mkdir(homeDir, { recursive: true });
+
+    const skillDir = join(root, 'source');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: global-skill\ndescription: test\n---', 'utf-8');
+
+    try {
+      // Global install for opencode
+      const result = await installSkillForAgent(
+        { name: 'global-skill', description: 'test', path: skillDir },
+        'opencode',
+        { mode: 'symlink', global: true }
+      );
+
+      expect(result.success).toBe(true);
+
+      // Verify: skill is accessible at globalSkillsDir
+      expect(result.path).toContain('.config/opencode/skills/global-skill');
+      expect(result.canonicalPath).toContain('.agents/skills/global-skill');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -187,4 +187,36 @@ describe('installer symlink regression', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  // Regression test for OpenCode: should use .opencode/skills, not .agents/skills
+  it('installs opencode skills to agent-specific directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'opencode-test-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'opencode',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBeUndefined();
+
+      // Skill should be accessible via .opencode/skills
+      const agentPath = join(projectDir, '.opencode/skills', skillName);
+      const agentStats = await lstat(agentPath);
+      expect(agentStats.isSymbolicLink()).toBe(true);
+
+      // Content should be correct
+      const contents = await readFile(join(agentPath, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
OpenCode expects skills in ~/.config/opencode/skills (global) and .opencode/skills (project), not in the shared .agents/skills directory.

This change marks OpenCode as a non-universal agent, so skills are installed to the correct location instead of ~/.agents/skills/.

Previously, skills installed globally with 'npx skills -g -a opencode' would end up in ~/.agents/skills/ and show as 'not linked' because OpenCode doesn't read from that directory.

Closes #769 