### PR TITLE
feat(list): expose canonical agent IDs in `--json` output

### DIFF
--- a/src/list.ts
+++ b/src/list.ts
@@ -96,7 +96,7 @@ export async function runList(args: string[]): Promise<void> {
       name: skill.name,
       path: skill.canonicalPath,
       scope: skill.scope,
-      agents: skill.agents.map((a) => agents[a].displayName),
+      agents: skill.agents.map((a) => ({ id: a, name: agents[a].displayName })),
     }));
     console.log(JSON.stringify(jsonOutput, null, 2));
     return;


### PR DESCRIPTION
Closes #778. Follow-up to #558 which added `--json` support.

## Summary

The `skills list --json` `agents` array previously contained only display names (e.g. `"Cortex Code"`), but `skills remove -a` expects canonical agent IDs (e.g. `"cortex"`). There was no programmatic way to get the mapping between the two, forcing consumers to maintain a hardcoded lookup table.

This changes the `agents` array from flat strings to objects with both the canonical `id` and the human-readable `name`:

```json
[
  {
    "name": "my-skill",
    "path": "~/.agents/skills/my-skill",
    "scope": "global",
    "agents": [
      { "id": "cortex", "name": "Cortex Code" },
      { "id": "claude-code", "name": "Claude Code" }
    ]
  }
]
```

## Changes

| File          | Change                                                               |
| ------------- | -------------------------------------------------------------------- |
| `src/list.ts` | Map agents to `{ id, name }` objects instead of display-name strings |

# Testing

1. Install a skill globally so there is at least one to list:
   ```
   npx skills install <some-skill>
   ```
2. Run `npx skills list --json` and verify each entry in the `agents` array is an object with `id` and `name` fields (not a plain string).
3. Pick an `id` value from the output and confirm it is accepted by `npx skills remove <skill> -a <id>` (use `--dry-run` if available, or cancel before confirming).
