### PR TITLE
feat: add Azure DevOps repo support to add command

### DIFF
--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -72,6 +72,57 @@ describe('source-parser', () => {
     });
   });
 
+  describe('Azure DevOps Support', () => {
+    it('parses modern dev.azure.com URL', () => {
+      const result = parseSource('https://dev.azure.com/myorg/myproject/_git/myrepo');
+      expect(result).toEqual({
+        type: 'azure-devops',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+        ref: undefined,
+        subpath: undefined,
+      });
+    });
+
+    it('parses dev.azure.com URL with branch (GB prefix)', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?version=GBmain'
+      );
+      expect(result).toMatchObject({
+        type: 'azure-devops',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+        ref: 'main',
+      });
+    });
+
+    it('parses dev.azure.com URL with path and branch', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?path=/skills&version=GBmain'
+      );
+      expect(result).toMatchObject({
+        type: 'azure-devops',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+        ref: 'main',
+        subpath: 'skills',
+      });
+    });
+
+    it('parses legacy visualstudio.com URL', () => {
+      const result = parseSource('https://myorg.visualstudio.com/myproject/_git/myrepo');
+      expect(result).toMatchObject({
+        type: 'azure-devops',
+        url: 'https://myorg.visualstudio.com/myproject/_git/myrepo',
+      });
+    });
+
+    it('parses azdo: shorthand', () => {
+      const result = parseSource('azdo:myorg/myproject/myrepo');
+      expect(result).toEqual({
+        type: 'azure-devops',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+      });
+    });
+  });
+
   describe('Existing GitHub Support', () => {
     it('parses github shorthand', () => {
       const result = parseSource('vercel-labs/agent-skills');

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -148,6 +148,16 @@ export function parseSource(input: string): ParsedSource {
     return parseSource(`https://gitlab.com/${gitlabPrefixMatch[1]!}`);
   }
 
+  // Prefix shorthand: azdo:org/project/repo -> https://dev.azure.com/org/project/_git/repo
+  const azdoPrefixMatch = input.match(/^azdo:([^/]+)\/([^/]+)\/(.+)$/);
+  if (azdoPrefixMatch) {
+    const [, org, project, repo] = azdoPrefixMatch;
+    return {
+      type: 'azure-devops',
+      url: `https://dev.azure.com/${org}/${project}/_git/${repo}`,
+    };
+  }
+
   // Local path: absolute, relative, or current directory
   if (isLocalPath(input)) {
     const resolvedPath = resolve(input);
@@ -239,6 +249,34 @@ export function parseSource(input: string): ParsedSource {
     }
   }
 
+  // Azure DevOps modern URL: https://dev.azure.com/org/project/_git/repo
+  const azdoMatch = input.match(/^(https?):\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/?#]+)/);
+  if (azdoMatch) {
+    const [, protocol, org, project, repo] = azdoMatch;
+    const cloneUrl = `${protocol}://dev.azure.com/${org}/${project}/_git/${repo}`;
+    const parsedUrl = new URL(input);
+    const version = parsedUrl.searchParams.get('version'); // e.g. "GBmain"
+    const path = parsedUrl.searchParams.get('path'); // e.g. "/skills"
+    const ref = version?.startsWith('GB') ? version.slice(2) : undefined;
+    const subpath = path ? sanitizeSubpath(path.replace(/^\//, '')) : undefined;
+    return { type: 'azure-devops', url: cloneUrl, ref, subpath };
+  }
+
+  // Azure DevOps legacy URL: https://org.visualstudio.com/project/_git/repo
+  const azdoLegacyMatch = input.match(
+    /^(https?):\/\/([^.]+)\.visualstudio\.com\/([^/]+)\/_git\/([^/?#]+)/
+  );
+  if (azdoLegacyMatch) {
+    const [, protocol, org, project, repo] = azdoLegacyMatch;
+    const cloneUrl = `${protocol}://${org}.visualstudio.com/${project}/_git/${repo}`;
+    const parsedUrl = new URL(input);
+    const version = parsedUrl.searchParams.get('version');
+    const path = parsedUrl.searchParams.get('path');
+    const ref = version?.startsWith('GB') ? version.slice(2) : undefined;
+    const subpath = path ? sanitizeSubpath(path.replace(/^\//, '')) : undefined;
+    return { type: 'azure-devops', url: cloneUrl, ref, subpath };
+  }
+
   // GitHub shorthand: owner/repo, owner/repo/path/to/skill, or owner/repo@skill-name
   // Exclude paths that start with . or / to avoid matching local paths
   // First check for @skill syntax: owner/repo@skill-name
@@ -293,8 +331,16 @@ function isWellKnownUrl(input: string): boolean {
     const parsed = new URL(input);
 
     // Exclude known git hosts that have their own handling
-    const excludedHosts = ['github.com', 'gitlab.com', 'raw.githubusercontent.com'];
+    const excludedHosts = [
+      'github.com',
+      'gitlab.com',
+      'raw.githubusercontent.com',
+      'dev.azure.com',
+    ];
     if (excludedHosts.includes(parsed.hostname)) {
+      return false;
+    }
+    if (parsed.hostname.endsWith('.visualstudio.com')) {
       return false;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known';
+  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known' | 'azure-devops';
   url: string;
   subpath?: string;
   localPath?: string;

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -191,6 +191,42 @@ describe('parseSource', () => {
     });
   });
 
+  describe('Azure DevOps URL tests', () => {
+    it('Azure DevOps - modern dev.azure.com URL', () => {
+      const result = parseSource('https://dev.azure.com/myorg/myproject/_git/myrepo');
+      expect(result.type).toBe('azure-devops');
+      expect(result.url).toBe('https://dev.azure.com/myorg/myproject/_git/myrepo');
+      expect(result.ref).toBeUndefined();
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('Azure DevOps - URL with branch (GB prefix)', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?version=GBmain'
+      );
+      expect(result.type).toBe('azure-devops');
+      expect(result.url).toBe('https://dev.azure.com/myorg/myproject/_git/myrepo');
+      expect(result.ref).toBe('main');
+    });
+
+    it('Azure DevOps - URL with path and branch', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?path=/skills&version=GBmain'
+      );
+      expect(result.type).toBe('azure-devops');
+      expect(result.url).toBe('https://dev.azure.com/myorg/myproject/_git/myrepo');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('skills');
+    });
+
+    it('Azure DevOps - legacy visualstudio.com URL', () => {
+      const result = parseSource('https://myorg.visualstudio.com/myproject/_git/myrepo');
+      expect(result.type).toBe('azure-devops');
+      expect(result.url).toBe('https://myorg.visualstudio.com/myproject/_git/myrepo');
+      expect(result.ref).toBeUndefined();
+    });
+  });
+
   describe('Git URL fallback tests', () => {
     it('Git URL - SSH format', () => {
       const result = parseSource('git@github.com:owner/repo.git');
@@ -384,6 +420,14 @@ describe('Prefix shorthand tests', () => {
       const result = parseSource('github:googleworkspace/cli');
       expect(result.type).toBe('github');
       expect(result.url).toBe('https://github.com/googleworkspace/cli.git');
+    });
+  });
+
+  describe('azdo: prefix', () => {
+    it('azdo:org/project/repo - basic', () => {
+      const result = parseSource('azdo:myorg/myproject/myrepo');
+      expect(result.type).toBe('azure-devops');
+      expect(result.url).toBe('https://dev.azure.com/myorg/myproject/_git/myrepo');
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds URL parsing for `dev.azure.com` and legacy `visualstudio.com` Azure DevOps repository URLs
- Supports branch extraction from `?version=GB*` query params and path extraction from `?path=` query params
- Adds `azdo:` shorthand prefix for Azure DevOps repos

## Test plan

- [ ] Verify `dev.azure.com` URLs are parsed correctly with branch and path query params
- [ ] Verify legacy `visualstudio.com` URLs are parsed correctly
- [ ] Verify `azdo:` shorthand prefix resolves to the correct repo
- [ ] Run existing test suite: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)