### PR TITLE
fix(find): improve well-known install output

### DIFF
--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  formatInstallCommand,
+  formatInstallHint,
+  formatSkillLink,
+  runFind,
+} from './find.ts';
+import { stripAnsi } from './test-utils.ts';
+
+describe('formatInstallCommand', () => {
+  it('uses source@skill for repository sources', () => {
+    expect(
+      formatInstallCommand({
+        name: 'find-skills',
+        slug: 'vercel-labs/skills/find-skills',
+        source: 'vercel-labs/skills',
+      })
+    ).toBe('vercel-labs/skills@find-skills');
+  });
+
+  it('uses add with --skill for URL sources', () => {
+    expect(
+      formatInstallCommand({
+        name: 'skill-name',
+        slug: 'public/skill-name',
+        source: 'http://localhost:9080/registry/public',
+      })
+    ).toBe('npx skills add http://localhost:9080/registry/public --skill skill-name');
+  });
+
+  it('falls back to slug when source is missing', () => {
+    expect(
+      formatInstallCommand({
+        name: 'my-skill',
+        slug: 'owner/repo',
+        source: '',
+      })
+    ).toBe('owner/repo@my-skill');
+  });
+});
+
+describe('formatInstallHint', () => {
+  it('uses a URL-based template for URL sources', () => {
+    expect(
+      formatInstallHint({
+        slug: 'public/skill-name',
+        source: 'http://localhost:9080/registry/public',
+      })
+    ).toBe('npx skills add http://localhost:9080/registry/public --skill skill-name');
+  });
+
+  it('uses the repository template for non-URL sources', () => {
+    expect(
+      formatInstallHint({
+        slug: 'vercel-labs/skills/find-skills',
+        source: 'vercel-labs/skills',
+      })
+    ).toBe('npx skills add <owner/repo@skill>');
+  });
+});
+
+describe('formatSkillLink', () => {
+  it('uses the concrete SKILL.md URL for URL sources', () => {
+    expect(
+      formatSkillLink({
+        name: 'adapt',
+        slug: 'adapt',
+        source: 'http://localhost:9080/registry/public',
+      })
+    ).toBe('http://localhost:9080/registry/public/.well-known/skills/adapt/SKILL.md');
+  });
+
+  it('uses the skills.sh page for repository sources', () => {
+    expect(
+      formatSkillLink({
+        name: 'find-skills',
+        slug: 'vercel-labs/skills/find-skills',
+        source: 'vercel-labs/skills',
+      })
+    ).toBe('https://skills.sh/vercel-labs/skills/find-skills');
+  });
+});
+
+describe('runFind output', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('prints URL-source results with a single install template and concrete SKILL.md links', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        skills: [
+          {
+            id: 'ab-test-setup',
+            name: 'ab-test-setup',
+            installs: 12,
+            source: 'http://localhost:9080/registry/public',
+          },
+          {
+            id: 'webapp-testing',
+            name: 'webapp-testing',
+            installs: 0,
+            source: 'http://localhost:9080/registry/public',
+          },
+        ],
+      }),
+    });
+
+    await runFind(['test']);
+
+    const output = stripAnsi(logSpy.mock.calls.flat().join('\n'));
+    expect(output).toContain(
+      'Install with npx skills add http://localhost:9080/registry/public --skill skill-name'
+    );
+    expect(output).toContain('ab-test-setup');
+    expect(output).toContain('webapp-testing');
+    expect(output).toContain(
+      'http://localhost:9080/registry/public/.well-known/skills/ab-test-setup/SKILL.md'
+    );
+    expect(output).toContain(
+      'http://localhost:9080/registry/public/.well-known/skills/webapp-testing/SKILL.md'
+    );
+    expect(output).not.toContain('http://localhost:9080/registry/public@ab-test-setup');
+    expect(output).not.toContain('npx skills add http://localhost:9080/registry/public --skill ab-test-setup');
+  });
+
+  it('keeps repository-source results in owner/repo@skill format', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        skills: [
+          {
+            id: 'vercel-labs/skills/find-skills',
+            name: 'find-skills',
+            installs: 42,
+            source: 'vercel-labs/skills',
+          },
+        ],
+      }),
+    });
+
+    await runFind(['find']);
+
+    const output = stripAnsi(logSpy.mock.calls.flat().join('\n'));
+    expect(output).toContain('Install with npx skills add <owner/repo@skill>');
+    expect(output).toContain('vercel-labs/skills@find-skills');
+    expect(output).toContain('https://skills.sh/vercel-labs/skills/find-skills');
+  });
+
+  it('falls back to slug-based links when source is missing', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        skills: [
+          {
+            id: 'owner/repo/my-skill',
+            name: 'my-skill',
+            installs: 0,
+            source: '',
+          },
+        ],
+      }),
+    });
+
+    await runFind(['my']);
+
+    const output = stripAnsi(logSpy.mock.calls.flat().join('\n'));
+    expect(output).toContain('owner/repo/my-skill@my-skill');
+    expect(output).toContain('https://skills.sh/owner/repo/my-skill');
+  });
+
+  it('shows a no-results message when search returns nothing', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ skills: [] }),
+    });
+
+    await runFind(['missing']);
+
+    const output = stripAnsi(logSpy.mock.calls.flat().join('\n'));
+    expect(output).toContain('No skills found for "missing"');
+  });
+});

--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -7,6 +7,8 @@ import {
 } from './find.ts';
 import { stripAnsi } from './test-utils.ts';
 
+const EXAMPLE_REGISTRY_URL = 'https://registry.example.com/catalog';
+
 describe('formatInstallCommand', () => {
   it('uses source@skill for repository sources', () => {
     expect(
@@ -23,9 +25,9 @@ describe('formatInstallCommand', () => {
       formatInstallCommand({
         name: 'skill-name',
         slug: 'public/skill-name',
-        source: 'http://localhost:9080/registry/public',
+        source: EXAMPLE_REGISTRY_URL,
       })
-    ).toBe('npx skills add http://localhost:9080/registry/public --skill skill-name');
+    ).toBe(`npx skills add ${EXAMPLE_REGISTRY_URL} --skill skill-name`);
   });
 
   it('falls back to slug when source is missing', () => {
@@ -44,9 +46,9 @@ describe('formatInstallHint', () => {
     expect(
       formatInstallHint({
         slug: 'public/skill-name',
-        source: 'http://localhost:9080/registry/public',
+        source: EXAMPLE_REGISTRY_URL,
       })
-    ).toBe('npx skills add http://localhost:9080/registry/public --skill skill-name');
+    ).toBe(`npx skills add ${EXAMPLE_REGISTRY_URL} --skill skill-name`);
   });
 
   it('uses the repository template for non-URL sources', () => {
@@ -60,24 +62,44 @@ describe('formatInstallHint', () => {
 });
 
 describe('formatSkillLink', () => {
-  it('uses the concrete SKILL.md URL for URL sources', () => {
-    expect(
+  it('uses registry-resolved well-known paths for URL sources', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (url === `${EXAMPLE_REGISTRY_URL}/.well-known/agent-skills/index.json`) {
+          return { ok: false };
+        }
+
+        if (url === `${EXAMPLE_REGISTRY_URL}/.well-known/skills/index.json`) {
+          return {
+            ok: true,
+            json: async () => ({
+              skills: [{ name: 'adapt', description: 'Test skill', files: ['SKILL.md'] }],
+            }),
+          };
+        }
+
+        throw new Error(`Unexpected URL: ${url}`);
+      })
+    );
+
+    await expect(
       formatSkillLink({
         name: 'adapt',
         slug: 'adapt',
-        source: 'http://localhost:9080/registry/public',
+        source: EXAMPLE_REGISTRY_URL,
       })
-    ).toBe('http://localhost:9080/registry/public/.well-known/skills/adapt/SKILL.md');
+    ).resolves.toBe(`${EXAMPLE_REGISTRY_URL}/.well-known/skills/adapt/SKILL.md`);
   });
 
-  it('uses the skills.sh page for repository sources', () => {
-    expect(
+  it('uses the skills.sh page for repository sources', async () => {
+    await expect(
       formatSkillLink({
         name: 'find-skills',
         slug: 'vercel-labs/skills/find-skills',
         source: 'vercel-labs/skills',
       })
-    ).toBe('https://skills.sh/vercel-labs/skills/find-skills');
+    ).resolves.toBe('https://skills.sh/vercel-labs/skills/find-skills');
   });
 });
 
@@ -97,57 +119,79 @@ describe('runFind output', () => {
   });
 
   it('prints URL-source results with a single install template and concrete SKILL.md links', async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        skills: [
-          {
-            id: 'ab-test-setup',
-            name: 'ab-test-setup',
-            installs: 12,
-            source: 'http://localhost:9080/registry/public',
-          },
-          {
-            id: 'webapp-testing',
-            name: 'webapp-testing',
-            installs: 0,
-            source: 'http://localhost:9080/registry/public',
-          },
-        ],
-      }),
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://skills.sh/api/search?q=test&limit=10') {
+        return {
+          ok: true,
+          json: async () => ({
+            skills: [
+              {
+                id: 'ab-test-setup',
+                name: 'ab-test-setup',
+                installs: 12,
+                source: EXAMPLE_REGISTRY_URL,
+              },
+              {
+                id: 'webapp-testing',
+                name: 'webapp-testing',
+                installs: 0,
+                source: EXAMPLE_REGISTRY_URL,
+              },
+            ],
+          }),
+        };
+      }
+
+      if (url === `${EXAMPLE_REGISTRY_URL}/.well-known/agent-skills/index.json`) {
+        return { ok: false };
+      }
+
+      if (url === `${EXAMPLE_REGISTRY_URL}/.well-known/skills/index.json`) {
+        return {
+          ok: true,
+          json: async () => ({
+            skills: [
+              { name: 'ab-test-setup', description: 'A', files: ['SKILL.md'] },
+              { name: 'webapp-testing', description: 'B', files: ['SKILL.md'] },
+            ],
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
     });
 
     await runFind(['test']);
 
     const output = stripAnsi(logSpy.mock.calls.flat().join('\n'));
-    expect(output).toContain(
-      'Install with npx skills add http://localhost:9080/registry/public --skill skill-name'
-    );
+    expect(output).toContain(`Install with npx skills add ${EXAMPLE_REGISTRY_URL} --skill skill-name`);
     expect(output).toContain('ab-test-setup');
     expect(output).toContain('webapp-testing');
-    expect(output).toContain(
-      'http://localhost:9080/registry/public/.well-known/skills/ab-test-setup/SKILL.md'
-    );
-    expect(output).toContain(
-      'http://localhost:9080/registry/public/.well-known/skills/webapp-testing/SKILL.md'
-    );
-    expect(output).not.toContain('http://localhost:9080/registry/public@ab-test-setup');
-    expect(output).not.toContain('npx skills add http://localhost:9080/registry/public --skill ab-test-setup');
+    expect(output).toContain(`${EXAMPLE_REGISTRY_URL}/.well-known/skills/ab-test-setup/SKILL.md`);
+    expect(output).toContain(`${EXAMPLE_REGISTRY_URL}/.well-known/skills/webapp-testing/SKILL.md`);
+    expect(output).not.toContain(`${EXAMPLE_REGISTRY_URL}@ab-test-setup`);
+    expect(output).not.toContain(`npx skills add ${EXAMPLE_REGISTRY_URL} --skill ab-test-setup`);
   });
 
   it('keeps repository-source results in owner/repo@skill format', async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        skills: [
-          {
-            id: 'vercel-labs/skills/find-skills',
-            name: 'find-skills',
-            installs: 42,
-            source: 'vercel-labs/skills',
-          },
-        ],
-      }),
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://skills.sh/api/search?q=find&limit=10') {
+        return {
+          ok: true,
+          json: async () => ({
+            skills: [
+              {
+                id: 'vercel-labs/skills/find-skills',
+                name: 'find-skills',
+                installs: 42,
+                source: 'vercel-labs/skills',
+              },
+            ],
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
     });
 
     await runFind(['find']);
@@ -159,18 +203,24 @@ describe('runFind output', () => {
   });
 
   it('falls back to slug-based links when source is missing', async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        skills: [
-          {
-            id: 'owner/repo/my-skill',
-            name: 'my-skill',
-            installs: 0,
-            source: '',
-          },
-        ],
-      }),
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://skills.sh/api/search?q=my&limit=10') {
+        return {
+          ok: true,
+          json: async () => ({
+            skills: [
+              {
+                id: 'owner/repo/my-skill',
+                name: 'my-skill',
+                installs: 0,
+                source: '',
+              },
+            ],
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
     });
 
     await runFind(['my']);
@@ -181,9 +231,15 @@ describe('runFind output', () => {
   });
 
   it('shows a no-results message when search returns nothing', async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({ skills: [] }),
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'https://skills.sh/api/search?q=missing&limit=10') {
+        return {
+          ok: true,
+          json: async () => ({ skills: [] }),
+        };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
     });
 
     await runFind(['missing']);

--- a/src/find.ts
+++ b/src/find.ts
@@ -28,6 +28,36 @@ export interface SearchSkill {
   installs: number;
 }
 
+export function formatInstallCommand(skill: Pick<SearchSkill, 'name' | 'slug' | 'source'>): string {
+  const pkg = skill.source || skill.slug;
+
+  if (/^https?:\/\//i.test(pkg)) {
+    return `npx skills add ${pkg} --skill ${skill.name}`;
+  }
+
+  return `${pkg}@${skill.name}`;
+}
+
+export function formatInstallHint(skill: Pick<SearchSkill, 'slug' | 'source'>): string {
+  const pkg = skill.source || skill.slug;
+
+  if (/^https?:\/\//i.test(pkg)) {
+    return `npx skills add ${pkg} --skill skill-name`;
+  }
+
+  return 'npx skills add <owner/repo@skill>';
+}
+
+export function formatSkillLink(skill: Pick<SearchSkill, 'name' | 'slug' | 'source'>): string {
+  const pkg = skill.source || skill.slug;
+
+  if (/^https?:\/\//i.test(pkg)) {
+    return `${pkg.replace(/\/$/, '')}/.well-known/skills/${skill.name}/SKILL.md`;
+  }
+
+  return `https://skills.sh/${skill.slug}`;
+}
+
 // Search via API
 export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
   try {
@@ -289,16 +319,21 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
       return;
     }
 
-    console.log(`${DIM}Install with${RESET} npx skills add <owner/repo@skill>`);
+    console.log(`${DIM}Install with${RESET} ${formatInstallHint(results[0]!)}`);
     console.log();
 
     for (const skill of results.slice(0, 6)) {
-      const pkg = skill.source || skill.slug;
       const installs = formatInstalls(skill.installs);
-      console.log(
-        `${TEXT}${pkg}@${skill.name}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`
-      );
-      console.log(`${DIM}└ https://skills.sh/${skill.slug}${RESET}`);
+      if (/^https?:\/\//i.test(skill.source || skill.slug)) {
+        console.log(`${TEXT}${skill.name}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`);
+        console.log(`${DIM}└ ${formatSkillLink(skill)}${RESET}`);
+      } else {
+        const installCommand = formatInstallCommand(skill);
+        console.log(
+          `${TEXT}${installCommand}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`
+        );
+        console.log(`${DIM}└ ${formatSkillLink(skill)}${RESET}`);
+      }
       console.log();
     }
     return;

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,5 +1,6 @@
 import * as readline from 'readline';
 import { runAdd, parseAddOptions } from './add.ts';
+import { wellKnownProvider } from './providers/index.ts';
 import { track } from './telemetry.ts';
 import { isRepoPrivate } from './source-parser.ts';
 
@@ -28,6 +29,13 @@ export interface SearchSkill {
   installs: number;
 }
 
+type WellKnownSourceResolution = {
+  resolvedBaseUrl: string;
+  resolvedWellKnownPath: string;
+};
+
+const wellKnownSourceResolutionCache = new Map<string, Promise<WellKnownSourceResolution | null>>();
+
 export function formatInstallCommand(skill: Pick<SearchSkill, 'name' | 'slug' | 'source'>): string {
   const pkg = skill.source || skill.slug;
 
@@ -48,11 +56,39 @@ export function formatInstallHint(skill: Pick<SearchSkill, 'slug' | 'source'>): 
   return 'npx skills add <owner/repo@skill>';
 }
 
-export function formatSkillLink(skill: Pick<SearchSkill, 'name' | 'slug' | 'source'>): string {
+async function resolveWellKnownSource(
+  source: string
+): Promise<WellKnownSourceResolution | null> {
+  let cached = wellKnownSourceResolutionCache.get(source);
+  if (!cached) {
+    cached = wellKnownProvider.fetchIndex(source).then((result) => {
+      if (!result) {
+        return null;
+      }
+
+      return {
+        resolvedBaseUrl: result.resolvedBaseUrl,
+        resolvedWellKnownPath: result.resolvedWellKnownPath,
+      };
+    });
+    wellKnownSourceResolutionCache.set(source, cached);
+  }
+
+  return cached;
+}
+
+export async function formatSkillLink(
+  skill: Pick<SearchSkill, 'name' | 'slug' | 'source'>
+): Promise<string> {
   const pkg = skill.source || skill.slug;
 
   if (/^https?:\/\//i.test(pkg)) {
-    return `${pkg.replace(/\/$/, '')}/.well-known/skills/${skill.name}/SKILL.md`;
+    const resolved = await resolveWellKnownSource(pkg);
+    if (resolved) {
+      return `${resolved.resolvedBaseUrl.replace(/\/$/, '')}/${resolved.resolvedWellKnownPath}/${skill.name}/SKILL.md`;
+    }
+
+    return pkg;
   }
 
   return `https://skills.sh/${skill.slug}`;
@@ -325,14 +361,16 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
     for (const skill of results.slice(0, 6)) {
       const installs = formatInstalls(skill.installs);
       if (/^https?:\/\//i.test(skill.source || skill.slug)) {
+        const skillLink = await formatSkillLink(skill);
         console.log(`${TEXT}${skill.name}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`);
-        console.log(`${DIM}└ ${formatSkillLink(skill)}${RESET}`);
+        console.log(`${DIM}└ ${skillLink}${RESET}`);
       } else {
         const installCommand = formatInstallCommand(skill);
+        const skillLink = await formatSkillLink(skill);
         console.log(
           `${TEXT}${installCommand}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`
         );
-        console.log(`${DIM}└ ${formatSkillLink(skill)}${RESET}`);
+        console.log(`${DIM}└ ${skillLink}${RESET}`);
       }
       console.log();
     }


### PR DESCRIPTION
Fix  #790  `skills find` output for well-known registry sources so the suggested install command can be copied directly into `skills add`.

Previously, `find` rendered all results as `<source>@<skill>`. That works for repository sources, but it does not work for well-known registry sources, where `add` expects `<source> --skill <name>`.

This PR updates `find` so URL-backed/custom registry sources render as a reusable `add` command, while preserving the existing repository-backed behavior.

**What changed**

- For repository-backed results, keep the existing output format:
  ```bash
  owner/repo@skill
  ```
- For custom registry / well-known URL results:
  - show a single install hint at the top:
    ```bash
    npx skills add custom-registry --skill skill-name
    ```
  - show each result row as:
    - skill name
    - concrete skill URL:
      ```bash
      custom-registry/.well-known/skills/test/SKILL.md
      ```

**Before**

```text
Install with npx skills add <owner/repo@skill>

custom-registry@test
└ https://skills.sh/test
```

**After**

```text
Install with npx skills add custom-registry --skill skill-name

test
└ custom-registry/.well-known/skills/test/SKILL.md
```

**Why**

`find` should print commands that users can copy and run directly.

For well-known registry sources, the old `<source>@<skill>` output was misleading because it looked installable but was not accepted by `skills add`.

**Scope**

This change is limited to `find` output formatting.

It does not change:

- `add` parsing behavior
- well-known provider resolution
- install logic
- repository-backed flows

**Tests**

Added/updated tests to cover:

- URL-backed/custom registry output formatting
- repository-backed output formatting remains unchanged
- concrete `SKILL.md` link rendering for custom registry results
- no-results behavior
- helper formatting functions used by `find`

**Validation**

Relevant regression suite passed:

```bash
npx vitest run src/find.test.ts src/cli.test.ts src/add.test.ts src/source-parser.test.ts tests/wellknown-provider.test.ts
```