### PR TITLE
feat(well-known): selective skill fetch when --skill is specified

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -429,16 +429,31 @@ async function handleWellKnownSkills(
   options: AddOptions,
   spinner: ReturnType<typeof p.spinner>
 ): Promise<void> {
-  spinner.start('Discovering skills from well-known endpoint...');
+  // When specific skills are requested (not wildcard, not --list),
+  // use selective fetch to only download the requested skills.
+  // This avoids unnecessary network requests for all other skills.
+  const useSelectiveFetch =
+    options.skill && options.skill.length > 0 && !options.skill.includes('*') && !options.list;
 
-  // Fetch all skills from the well-known endpoint
-  const skills = await wellKnownProvider.fetchAllSkills(url);
+  let skills: WellKnownSkill[];
+
+  if (useSelectiveFetch) {
+    spinner.start(
+      `Fetching ${options.skill!.length} skill${options.skill!.length > 1 ? 's' : ''} from well-known endpoint...`
+    );
+    skills = await wellKnownProvider.fetchSkillsByNames(url, options.skill!);
+  } else {
+    spinner.start('Discovering skills from well-known endpoint...');
+    skills = await wellKnownProvider.fetchAllSkills(url);
+  }
 
   if (skills.length === 0) {
     spinner.stop(pc.red('No skills found'));
     p.outro(
       pc.red(
-        'No skills found at this URL. Make sure the server has a /.well-known/agent-skills/index.json or /.well-known/skills/index.json file.'
+        useSelectiveFetch
+          ? `No matching skills found for: ${options.skill!.join(', ')}. Verify the skill names exist in the source index.`
+          : 'No skills found at this URL. Make sure the server has a /.well-known/agent-skills/index.json or /.well-known/skills/index.json file.'
       )
     );
     process.exit(1);
@@ -470,10 +485,16 @@ async function handleWellKnownSkills(
     process.exit(0);
   }
 
-  // Filter skills if --skill option is provided
+  // Filter/select skills based on --skill option
   let selectedSkills: WellKnownSkill[];
 
-  if (options.skill?.includes('*')) {
+  if (useSelectiveFetch) {
+    // Skills were already selectively fetched — use them directly
+    selectedSkills = skills;
+    p.log.info(
+      `Selected ${skills.length} skill${skills.length !== 1 ? 's' : ''}: ${skills.map((s) => pc.cyan(s.installName)).join(', ')}`
+    );
+  } else if (options.skill?.includes('*')) {
     // --skill '*' selects all skills
     selectedSkills = skills;
     p.log.info(`Installing all ${skills.length} skills`);

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -324,6 +324,46 @@ export class WellKnownProvider implements HostProvider {
   }
 
   /**
+   * Fetch specific skills by name from a well-known endpoint.
+   * Only downloads the index and the requested skills, avoiding unnecessary
+   * network requests for skills that won't be installed.
+   *
+   * @param url - The well-known endpoint URL
+   * @param skillNames - Array of skill names to fetch (case-insensitive)
+   * @returns Array of fetched skills (only those matching the requested names)
+   */
+  async fetchSkillsByNames(url: string, skillNames: string[]): Promise<WellKnownSkill[]> {
+    try {
+      const result = await this.fetchIndex(url);
+      if (!result) {
+        return [];
+      }
+
+      const { index, resolvedBaseUrl, resolvedWellKnownPath } = result;
+
+      // Filter index entries to only the requested skill names
+      const lowerNames = new Set(skillNames.map((n) => n.toLowerCase()));
+      const matchedEntries = index.skills.filter((entry: WellKnownSkillEntry) =>
+        lowerNames.has(entry.name.toLowerCase())
+      );
+
+      if (matchedEntries.length === 0) {
+        return [];
+      }
+
+      // Only fetch the matched skills in parallel
+      const skillPromises = matchedEntries.map((entry: WellKnownSkillEntry) =>
+        this.fetchSkillByEntry(resolvedBaseUrl, entry, resolvedWellKnownPath)
+      );
+      const results = await Promise.all(skillPromises);
+
+      return results.filter((s: WellKnownSkill | null): s is WellKnownSkill => s !== null);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
    * Fetch all skills from a well-known endpoint.
    */
   async fetchAllSkills(url: string): Promise<WellKnownSkill[]> {

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WellKnownProvider } from '../src/providers/wellknown.ts';
 
 describe('WellKnownProvider', () => {
@@ -109,6 +109,115 @@ describe('WellKnownProvider', () => {
     it('provider should have display name "Well-Known Skills"', () => {
       expect(provider.displayName).toBe('Well-Known Skills');
     });
+  });
+});
+
+describe('WellKnownProvider.fetchSkillsByNames', () => {
+  const provider = new WellKnownProvider();
+
+  // Mock index.json and SKILL.md responses
+  const mockIndex = {
+    skills: [
+      { name: 'skill-a', description: 'Skill A desc', files: ['SKILL.md'] },
+      { name: 'skill-b', description: 'Skill B desc', files: ['SKILL.md', 'refs/data.md'] },
+      { name: 'skill-c', description: 'Skill C desc', files: ['SKILL.md'] },
+    ],
+  };
+
+  const skillMdContent = (name: string) =>
+    `---\nname: ${name}\ndescription: ${name} description\n---\n# ${name}`;
+
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function mockFetchResponses() {
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+
+      if (url.includes('index.json')) {
+        return new Response(JSON.stringify(mockIndex), { status: 200 });
+      }
+
+      // Match SKILL.md requests like /.well-known/agent-skills/skill-a/SKILL.md
+      const skillMatch = url.match(/\/([a-z-]+)\/SKILL\.md$/);
+      if (skillMatch && skillMatch[1]) {
+        const name = skillMatch[1];
+        if (['skill-a', 'skill-b', 'skill-c'].includes(name)) {
+          return new Response(skillMdContent(name), { status: 200 });
+        }
+      }
+
+      // Match other files like refs/data.md
+      if (url.includes('/refs/data.md')) {
+        return new Response('reference data', { status: 200 });
+      }
+
+      return new Response('Not found', { status: 404 });
+    });
+  }
+
+  it('should only fetch requested skills, not all skills', async () => {
+    mockFetchResponses();
+
+    const results = await provider.fetchSkillsByNames('https://example.com', ['skill-b']);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.installName).toBe('skill-b');
+
+    // Verify: should NOT have fetched skill-a or skill-c SKILL.md
+    const fetchedUrls = fetchSpy.mock.calls.map((call) => {
+      const input = call[0];
+      return typeof input === 'string' ? input : input!.toString();
+    });
+
+    expect(fetchedUrls.some((u) => u.includes('/skill-a/SKILL.md'))).toBe(false);
+    expect(fetchedUrls.some((u) => u.includes('/skill-c/SKILL.md'))).toBe(false);
+    expect(fetchedUrls.some((u) => u.includes('/skill-b/SKILL.md'))).toBe(true);
+  });
+
+  it('should handle case-insensitive skill name matching', async () => {
+    mockFetchResponses();
+
+    const results = await provider.fetchSkillsByNames('https://example.com', ['Skill-A']);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.installName).toBe('skill-a');
+  });
+
+  it('should fetch multiple requested skills', async () => {
+    mockFetchResponses();
+
+    const results = await provider.fetchSkillsByNames('https://example.com', [
+      'skill-a',
+      'skill-c',
+    ]);
+
+    expect(results).toHaveLength(2);
+    const names = results.map((r) => r.installName).sort();
+    expect(names).toEqual(['skill-a', 'skill-c']);
+  });
+
+  it('should return empty array for non-existent skill names', async () => {
+    mockFetchResponses();
+
+    const results = await provider.fetchSkillsByNames('https://example.com', ['non-existent']);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should return empty array when index fetch fails', async () => {
+    fetchSpy.mockImplementation(async () => new Response('Not found', { status: 404 }));
+
+    const results = await provider.fetchSkillsByNames('https://example.com', ['skill-a']);
+
+    expect(results).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary                                                                                                                                                  
                                                                                                                                                              
  - When `--skill` specifies concrete skill names, only fetch index.json + the requested skills instead of downloading all skills from the source             
  - Add `fetchSkillsByNames()` to `WellKnownProvider` with case-insensitive name matching
  - Fallback to `fetchAllSkills()` for `--skill '*'`, `--list`, or interactive selection
 
## Motivation                                                                                                                                               
                                                                                                                                                              
  The current `handleWellKnownSkills` always calls `fetchAllSkills()`, which downloads every SKILL.md and associated file from the index — even when the user 
  only wants one skill via `--skill`. This causes:
                                                                                                                                                              
  1. **Unnecessary network overhead**: a source with 20 skills triggers 20× more HTTP requests than needed, slowing down installation                         
  2. **Behavior inconsistent with user intent**: `--skill foo` means "I only want foo", but the CLI fetches everything then filters locally
  3. As a side benefit, well-known servers can now distinguish per-skill downloads from HTTP access logs

## Changes                                                
                                                                                                                                                              
  | File | Change |                                         
  |------|--------|
  | `src/providers/wellknown.ts` | Add `fetchSkillsByNames(url, skillNames)` — fetches index, filters entries by name, downloads only matched skills |
  | `src/add.ts` | Route to `fetchSkillsByNames` when `--skill` has concrete names (not `*`, not `--list`) |                                                  
  | `tests/wellknown-provider.test.ts` | 5 new tests: selective fetch, case-insensitive match, multi-skill, non-existent names, index failure |               
                                                                                                                                                              
  ## Test plan                                                                                                                                                
                                                                                                                                                              
  - [x] 5 new unit tests for `fetchSkillsByNames` (mock fetch, verify only requested URLs are called)                                                         
  - [x] All 383 existing tests pass (1 pre-existing flaky test in `remove.test.ts` under parallel execution)                                                  
  - [ ] Manual: `npx skills install <well-known-url> --skill <name>` fetches only the specified skill