### PR TITLE
feat: add Code Studio as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [40 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [41 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -216,6 +216,7 @@ Skills can be installed to any of these agents:
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
 | Cline, Warp | `cline`, `warp` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
+| Code Studio | `codestudio` | `.codestudio/skills/` | `~/.codestudio/skills/` |
 | Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
@@ -323,6 +324,7 @@ The CLI searches for skills in these locations within a repository:
 - `.claude/skills/`
 - `./skills/`
 - `.codebuddy/skills/`
+- `.codestudio/skills/`
 - `.commandcode/skills/`
 - `.continue/skills/`
 - `.cortex/skills/`
@@ -377,12 +379,12 @@ If no skills are found in standard locations, a recursive search is performed.
 Skills are generally compatible across agents since they follow a
 shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
-| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
-| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
-| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
-| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Code Studio | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
+| --------------- | -------- | --------- | ----------- | ----- | --------- | ----------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
+| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes         | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
+| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes         | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
+| `context: fork` | No       | No        | Yes         | No    | No        | No          | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Hooks           | No       | No        | Yes         | Yes   | No        | No          | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
 
 ## Troubleshooting
 
@@ -430,6 +432,7 @@ Telemetry is automatically disabled in CI environments.
 - [OpenClaw Skills Documentation](https://docs.openclaw.ai/tools/skills)
 - [Cline Skills Documentation](https://docs.cline.bot/features/skills)
 - [CodeBuddy Skills Documentation](https://www.codebuddy.ai/docs/ide/Features/Skills)
+- [Code Studio Skills Documentation](https://help.syncfusion.com/code-studio/reference/configure-properties/skills)
 - [Codex Skills Documentation](https://developers.openai.com/codex/skills)
 - [Command Code Skills Documentation](https://commandcode.ai/docs/skills)
 - [Crush Skills Documentation](https://github.com/charmbracelet/crush?tab=readme-ov-file#agent-skills)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "openclaw",
     "cline",
     "codebuddy",
+    "codestudio",
     "codex",
     "command-code",
     "continue",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -94,6 +94,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(process.cwd(), '.codebuddy')) || existsSync(join(home, '.codebuddy'));
     },
   },
+  codestudio: {
+    name: 'codestudio',
+    displayName: 'Code Studio',
+    skillsDir: '.codestudio/skills',
+    globalSkillsDir: join(home, '.codestudio/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.codestudio')) || existsSync(join(home, '.codestudio'));
+    },
+  },
   codex: {
     name: 'codex',
     displayName: 'Codex',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -160,6 +160,7 @@ export async function discoverSkills(
     join(searchPath, '.claude/skills'),
     join(searchPath, '.cline/skills'),
     join(searchPath, '.codebuddy/skills'),
+    join(searchPath, '.codestudio/skills'),
     join(searchPath, '.codex/skills'),
     join(searchPath, '.commandcode/skills'),
     join(searchPath, '.continue/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type AgentType =
   | 'openclaw'
   | 'cline'
   | 'codebuddy'
+  | 'codestudio'
   | 'codex'
   | 'command-code'
   | 'continue'


### PR DESCRIPTION
## feat: add Code Studio support

Add [Code Studio](https://www.syncfusion.com/code-studio/) as a new supported agent.

Code Studio is Syncfusion's AI-powered coding assistant, supports the Agent Skills specification through SKILL.md files with YAML frontmatter, scanning both project-level and global skill directories.

This PR enables `npx skills add` to auto-detect Code Studio installations and install skills to the correct location.

### Changes

| File | Change |
|------|--------|
| types.ts | Added `'codestudio'` to `AgentType` union |
| agents.ts | Added Code Studio agent config (`skillsDir: '.codestudio/skills'`, `globalSkillsDir: '~/.codestudio/skills'`, detection via project or home directory) |
| skills.ts | Added `.codestudio/skills/` to skill discovery paths |
| README.md | Updated supported agents table and agent count (auto-generated) |
| package.json | Added `"codestudio"` to keywords (auto-generated) |

All changes validated with `validate-agents.ts` and synced with `sync-agents.ts` per AGENTS.md guidelines.

### Agent Configuration

| Field | Value |
|-------|-------|
| Agent Name | `codestudio` |
| Display Name | Code Studio |
| --agent flag | `codestudio` |
| Project Skills Directory | `.codestudio/skills/` |
| Global Skills Directory | `~/.codestudio/skills/` |
| Detection | `.codestudio` directory (project or home) |
| Docs | https://help.syncfusion.com/code-studio/reference/configure-properties/skills |

### Verification

- ✅ `pnpm run -C scripts validate-agents.ts` — All agents valid
- ✅ `pnpm run -C scripts sync-agents.ts` — README and package.json updated
- ✅ `pnpm build` — Build successful
- ✅ `pnpm format` — Code properly formatted
- ✅ Compatibility table updated with Code Studio features

### Related Links

- [Code Studio Documentation](https://help.syncfusion.com/code-studio)
- [Code Studio Skills Reference](https://help.syncfusion.com/code-studio/reference/configure-properties/skills)