### PR TITLE
feat: support #branch syntax for installing from specific branches

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1506,7 +1506,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             const skillPathValue = skillFiles[skill.name];
             if (parsed.type === 'github' && skillPathValue) {
               const token = getGitHubToken();
-              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token);
+              const hash = await fetchSkillFolderHash(normalizedSource, skillPathValue, token, parsed.ref);
               if (hash) skillFolderHash = hash;
             }
 
@@ -1517,6 +1517,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
+              ref: parsed.ref,
             });
           } catch {
             // Don't fail installation if lock file update fails

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -413,7 +413,7 @@ async function runCheck(args: string[] = []): Promise<void> {
   for (const [source, skills] of skillsBySource) {
     for (const { name, entry } of skills) {
       try {
-        const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token);
+        const latestHash = await fetchSkillFolderHash(source, entry.skillPath!, token, entry.ref);
 
         if (!latestHash) {
           errors.push({ name, source, error: 'Could not fetch from GitHub' });
@@ -503,7 +503,7 @@ async function runUpdate(): Promise<void> {
     }
 
     try {
-      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token);
+      const latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath, token, entry.ref);
 
       if (latestHash && latestHash !== entry.skillFolderHash) {
         updates.push({ name: skillName, source: entry.source, entry });
@@ -555,7 +555,8 @@ async function runUpdate(): Promise<void> {
       // Convert git URL to tree URL with path
       // https://github.com/owner/repo.git -> https://github.com/owner/repo/tree/main/path
       installUrl = update.entry.sourceUrl.replace(/\.git$/, '').replace(/\/$/, '');
-      installUrl = `${installUrl}/tree/main/${skillFolder}`;
+      const branch = update.entry.ref || 'main';
+      installUrl = `${installUrl}/tree/${branch}/${skillFolder}`;
     }
 
     // Reinstall using the current CLI entrypoint directly (avoid nested npm exec/npx)

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -32,6 +32,8 @@ export interface SkillLockEntry {
   updatedAt: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  /** Git ref (branch/tag) to track for updates. If unset, defaults to main/master. */
+  ref?: string;
 }
 
 /**
@@ -168,7 +170,8 @@ export function getGitHubToken(): string | null {
 export async function fetchSkillFolderHash(
   ownerRepo: string,
   skillPath: string,
-  token?: string | null
+  token?: string | null,
+  ref?: string
 ): Promise<string | null> {
   // Normalize to forward slashes first (for GitHub API compatibility)
   let folderPath = skillPath.replace(/\\/g, '/');
@@ -185,7 +188,7 @@ export async function fetchSkillFolderHash(
     folderPath = folderPath.slice(0, -1);
   }
 
-  const branches = ['main', 'master'];
+  const branches = ref ? [ref] : ['main', 'master'];
 
   for (const branch of branches) {
     try {

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -135,17 +135,30 @@ export function parseSource(input: string): ParsedSource {
     input = alias;
   }
 
+  // Extract #ref fragment from input (e.g., owner/repo#branch, github:owner/repo#branch)
+  // Only for non-URL, non-local inputs — full URLs encode branch in /tree/branch
+  let fragmentRef: string | undefined;
+  const hashIndex = input.indexOf('#');
+  if (hashIndex !== -1 && !isLocalPath(input) && !input.startsWith('http')) {
+    fragmentRef = input.slice(hashIndex + 1);
+    input = input.slice(0, hashIndex);
+  }
+
   // Prefix shorthand: github:owner/repo -> owner/repo (handled by existing shorthand logic)
   // Also supports github:owner/repo/subpath and github:owner/repo@skill
   const githubPrefixMatch = input.match(/^github:(.+)$/);
   if (githubPrefixMatch) {
-    return parseSource(githubPrefixMatch[1]!);
+    const result = parseSource(githubPrefixMatch[1]!);
+    if (fragmentRef && !result.ref) result.ref = fragmentRef;
+    return result;
   }
 
   // Prefix shorthand: gitlab:owner/repo -> https://gitlab.com/owner/repo
   const gitlabPrefixMatch = input.match(/^gitlab:(.+)$/);
   if (gitlabPrefixMatch) {
-    return parseSource(`https://gitlab.com/${gitlabPrefixMatch[1]!}`);
+    const result = parseSource(`https://gitlab.com/${gitlabPrefixMatch[1]!}`);
+    if (fragmentRef && !result.ref) result.ref = fragmentRef;
+    return result;
   }
 
   // Local path: absolute, relative, or current directory
@@ -249,6 +262,7 @@ export function parseSource(input: string): ParsedSource {
       type: 'github',
       url: `https://github.com/${owner}/${repo}.git`,
       skillFilter,
+      ref: fragmentRef,
     };
   }
 
@@ -259,6 +273,7 @@ export function parseSource(input: string): ParsedSource {
       type: 'github',
       url: `https://github.com/${owner}/${repo}.git`,
       subpath: subpath ? sanitizeSubpath(subpath) : subpath,
+      ref: fragmentRef,
     };
   }
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -163,6 +163,51 @@ describe('parseSource', () => {
     });
   });
 
+  describe('Branch ref with # syntax', () => {
+    it('GitHub shorthand - owner/repo#branch', () => {
+      const result = parseSource('owner/repo#feature-branch');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.com/owner/repo.git');
+      expect(result.ref).toBe('feature-branch');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('GitHub shorthand - owner/repo/subpath#branch', () => {
+      const result = parseSource('owner/repo/skills/my-skill#develop');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.com/owner/repo.git');
+      expect(result.ref).toBe('develop');
+      expect(result.subpath).toBe('skills/my-skill');
+    });
+
+    it('GitHub shorthand - owner/repo@skill#branch', () => {
+      const result = parseSource('owner/repo@my-skill#v2');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.com/owner/repo.git');
+      expect(result.skillFilter).toBe('my-skill');
+      expect(result.ref).toBe('v2');
+    });
+
+    it('github: prefix with #branch', () => {
+      const result = parseSource('github:owner/repo#staging');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.com/owner/repo.git');
+      expect(result.ref).toBe('staging');
+    });
+
+    it('gitlab: prefix with #branch', () => {
+      const result = parseSource('gitlab:owner/repo#staging');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/owner/repo.git');
+      expect(result.ref).toBe('staging');
+    });
+
+    it('no # means ref is undefined', () => {
+      const result = parseSource('owner/repo');
+      expect(result.ref).toBeUndefined();
+    });
+  });
+
   describe('Local path tests', () => {
     it('Local path - relative with ./', () => {
       const result = parseSource('./my-skills');


### PR DESCRIPTION
Add `#branch` fragment syntax for specifying a git ref (e.g., `owner/repo#develop`). Ref is stored in the lock file and used by `check`/`update`.

```bash
npx skills add owner/repo#feature-branch
npx skills add owner/repo@skill-name#v2
npx skills add github:owner/repo#staging
```

Uses `#` to avoid conflict with `@skill-name` filter syntax. Sticky — reinstall without `#` to switch back to default branch.

Related: #373, #11, #722