### PR TITLE
feat: add Dexto as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,12 +400,12 @@ If no skills are found in standard locations, a recursive search is performed.
 Skills are generally compatible across agents since they follow a
 shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
-| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
-| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
-| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
-| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Dexto | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
+| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
+| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
+| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
+| `context: fork` | No       | No        | Yes         | No    | No        | Yes   | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [41 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [42 more](#available-agents).
 
 <!-- agent-list:end -->
 
@@ -234,7 +234,7 @@ Skills can be installed to any of these agents:
 | IBM Bob                               | `bob`                                    | `.bob/skills/`         | `~/.bob/skills/`                |
 | Claude Code                           | `claude-code`                            | `.claude/skills/`      | `~/.claude/skills/`             |
 | OpenClaw                              | `openclaw`                               | `skills/`              | `~/.openclaw/skills/`           |
-| Cline, Warp                           | `cline`, `warp`                          | `.agents/skills/`      | `~/.agents/skills/`             |
+| Cline, Dexto, Warp                    | `cline`, `dexto`, `warp`                 | `.agents/skills/`      | `~/.agents/skills/`             |
 | CodeBuddy                             | `codebuddy`                              | `.codebuddy/skills/`   | `~/.codebuddy/skills/`          |
 | Codex                                 | `codex`                                  | `.agents/skills/`      | `~/.codex/skills/`              |
 | Command Code                          | `command-code`                           | `.commandcode/skills/` | `~/.commandcode/skills/`        |

--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ Skills can be installed to any of these agents:
 | Neovate                               | `neovate`                                | `.neovate/skills/`     | `~/.neovate/skills/`            |
 | Pochi                                 | `pochi`                                  | `.pochi/skills/`       | `~/.pochi/skills/`              |
 | AdaL                                  | `adal`                                   | `.adal/skills/`        | `~/.adal/skills/`               |
-
 <!-- supported-agents:end -->
 
 > [!NOTE]

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "crush",
     "cursor",
     "deepagents",
+    "dexto",
     "droid",
     "firebender",
     "gemini-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -166,6 +166,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.deepagents'));
     },
   },
+  dexto: {
+    name: 'dexto',
+    displayName: 'Dexto',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.dexto/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.dexto'));
+    },
+  },
   droid: {
     name: 'droid',
     displayName: 'Droid',

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -170,7 +170,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'dexto',
     displayName: 'Dexto',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.dexto/skills'),
+    globalSkillsDir: join(home, '.agents/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.dexto'));
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type AgentType =
   | 'crush'
   | 'cursor'
   | 'deepagents'
+  | 'dexto'
   | 'droid'
   | 'firebender'
   | 'gemini-cli'


### PR DESCRIPTION
Add **Dexto** as a new supported agent.

[Dexto](https://dexto.ai) is an open-source agent harness for AI applications built by [Truffle AI](https://github.com/truffle-ai/dexto). It ships with a production-ready coding agent and supports a skills system for extending agent behaviour via SKILL.md files. This PR enables users to install and manage skills for Dexto through the skills CLI.

## Changes

### Core Changes

- Add `dexto` agent configuration in `src/agents.ts`
  - Project-level skills directory: `.agents/skills/`
  - Global skills directory: `~/.agents/skills/`
  - Detection: checks for `~/.dexto` directory existence
- Add `'dexto'` to the `AgentType` union in `src/types.ts`

### Documentation

- Update `README.md` with Dexto in the supported agents table and bump agent count
- Add Dexto to the compatibility feature table — notably it supports both `allowed-tools` and `context: fork` (spawns an isolated subagent), joining Claude Code as one of the few agents that implement fork execution
- Add `dexto` to `package.json` keywords

## Verification

Paths and feature support were verified directly against Dexto's source:

- Skill paths: [`packages/agent-management/src/plugins/discover-skills.ts`](https://github.com/truffle-ai/dexto/blob/main/packages/agent-management/src/plugins/discover-skills.ts)
- `allowed-tools` + `context: fork`: [`packages/core/src/prompts/schemas.ts`](https://github.com/truffle-ai/dexto/blob/main/packages/core/src/prompts/schemas.ts)
- Fork implementation (spawns isolated subagent): [`packages/tools-builtins/src/implementations/invoke-skill-tool.ts`](https://github.com/truffle-ai/dexto/blob/main/packages/tools-builtins/src/implementations/invoke-skill-tool.ts)
- Hooks explicitly unsupported (security risk): [`packages/agent-management/src/plugins/load-plugin.ts`](https://github.com/truffle-ai/dexto/blob/main/packages/agent-management/src/plugins/load-plugin.ts)

## Testing

```bash
# Install a skill targeting Dexto
npx skills add vercel-labs/agent-skills -a dexto -y

# Verify the skill appears
npx skills ls -a dexto
```

The skill is installed into `.agents/skills/` locally or `~/.agents/skills/` globally and picked up by the Dexto CLI automatically.