### PR TITLE
fix: complete OpenCode skills path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Skills can be installed to any of these agents:
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
-| OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
+| OpenCode | `opencode` | `.opencode/skills/` | `~/.config/opencode/skills/` |
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
@@ -339,6 +339,7 @@ The CLI searches for skills in these locations within a repository:
 - `.mcpjam/skills/`
 - `.vibe/skills/`
 - `.mux/skills/`
+- `.opencode/skills/`
 - `.openhands/skills/`
 - `.pi/skills/`
 - `.qoder/skills/`

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -90,6 +90,31 @@ Instructions here.
     expect(result.exitCode).toBe(0);
   });
 
+  it('should show opencode project path in summary for copy installs', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+# My Skill
+
+Instructions here.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(['add', testDir, '-y', '--agent', 'opencode'], targetDir);
+    expect(result.stdout).toContain('.opencode/skills/my-skill');
+    expect(result.stdout).not.toContain('.agents/skills/my-skill');
+    expect(result.exitCode).toBe(0);
+  });
+
   it('should filter skills by name with --skill flag', () => {
     // Create multiple test skills
     const skill1Dir = join(testDir, 'skills', 'skill-one');

--- a/src/add.ts
+++ b/src/add.ts
@@ -28,6 +28,7 @@ import {
   installBlobSkillForAgent,
   isSkillInstalled,
   getCanonicalPath,
+  getInstallPath,
   installWellKnownSkillForAgent,
   type InstallMode,
 } from './installer.ts';
@@ -227,6 +228,26 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
 }
 
 /**
+ * Builds the summary path shown before installation.
+ * In copy mode, the real target path is agent-specific.
+ * In symlink mode, the canonical .agents/skills path is used.
+ */
+function getSummaryPath(
+  skillName: string,
+  targetAgents: AgentType[],
+  installGlobally: boolean,
+  installMode: InstallMode,
+  cwd: string
+): string {
+  const path =
+    installMode === 'copy'
+      ? getInstallPath(skillName, targetAgents[0]!, { global: installGlobally, cwd })
+      : getCanonicalPath(skillName, { global: installGlobally, cwd });
+
+  return shortenPath(path, cwd);
+}
+
+/**
  * Ensures universal agents are always included in the target agents list.
  * Used when -y flag is passed or when auto-selecting agents.
  */
@@ -386,11 +407,19 @@ async function selectAgentsInteractive(options: {
     // Silently ignore errors
   }
 
-  const initialSelected = lastSelected
-    ? (lastSelected.filter(
-        (a) => otherAgents.includes(a as AgentType) && !universalAgents.includes(a as AgentType)
-      ) as AgentType[])
+  let detectedOther: AgentType[] = [];
+  try {
+    const detected = await detectInstalledAgents();
+    detectedOther = detected.filter((a) => otherAgents.includes(a));
+  } catch {
+    // Silently ignore errors
+  }
+
+  const lastOther = lastSelected
+    ? (lastSelected.filter((a) => otherAgents.includes(a as AgentType)) as AgentType[])
     : [];
+
+  const initialSelected = [...new Set([...lastOther, ...detectedOther])];
 
   const selected = await searchMultiselect({
     message: 'Which agents do you want to install to?',
@@ -690,9 +719,14 @@ async function handleWellKnownSkills(
   for (const skill of selectedSkills) {
     if (summaryLines.length > 0) summaryLines.push('');
 
-    const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
-    const shortCanonical = shortenPath(canonicalPath, cwd);
-    summaryLines.push(`${pc.cyan(shortCanonical)}`);
+    const summaryPath = getSummaryPath(
+      skill.installName,
+      targetAgents,
+      installGlobally,
+      installMode,
+      cwd
+    );
+    summaryLines.push(`${pc.cyan(summaryPath)}`);
     summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
@@ -1373,9 +1407,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       for (const skill of skills) {
         if (summaryLines.length > 0) summaryLines.push('');
 
-        const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally });
-        const shortCanonical = shortenPath(canonicalPath, cwd);
-        summaryLines.push(`${pc.cyan(shortCanonical)}`);
+        const summaryPath = getSummaryPath(
+          skill.name,
+          targetAgents,
+          installGlobally,
+          installMode,
+          cwd
+        );
+        summaryLines.push(`${pc.cyan(summaryPath)}`);
         summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
 
         const skillOverwrites = overwriteStatus.get(skill.name);

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -295,7 +295,7 @@ export const agents: Record<AgentType, AgentConfig> = {
   opencode: {
     name: 'opencode',
     displayName: 'OpenCode',
-    skillsDir: '.agents/skills',
+    skillsDir: '.opencode/skills',
     globalSkillsDir: join(configHome, 'opencode/skills'),
     detectInstalled: async () => {
       return existsSync(join(configHome, 'opencode'));

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -187,4 +187,33 @@ describe('installer symlink regression', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('installs opencode skills to .opencode/skills for project installs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'opencode-test-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'opencode',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const opencodePath = join(projectDir, '.opencode/skills', skillName);
+      const opencodeStats = await lstat(opencodePath);
+      expect(opencodeStats.isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(opencodePath, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -16,12 +16,18 @@
 import { describe, it, expect } from 'vitest';
 import { homedir } from 'os';
 import { join } from 'path';
-import { agents } from '../src/agents.ts';
+import { agents, getUniversalAgents, isUniversalAgent } from '../src/agents.ts';
 
 describe('XDG config paths', () => {
   const home = homedir();
 
   describe('OpenCode', () => {
+    it('uses .opencode/skills for project skills (not .agents/skills)', () => {
+      expect(agents.opencode.skillsDir).toBe('.opencode/skills');
+      expect(isUniversalAgent('opencode')).toBe(false);
+      expect(getUniversalAgents()).not.toContain('opencode');
+    });
+
     it('uses ~/.config/opencode/skills for global skills (not ~/Library/Preferences)', () => {
       const expected = join(home, '.config', 'opencode', 'skills');
       expect(agents.opencode.globalSkillsDir).toBe(expected);


### PR DESCRIPTION
## Summary

Follow-up to #770 for #769.

PR #770 fixed OpenCode's `skillsDir`, but there were still two related gaps in `skills add` behavior and docs.
This PR closes those gaps so OpenCode consistently uses `.opencode/skills` (project) and `~/.config/opencode/skills` (global), including in selection/summary UX.

## Changes

- keep OpenCode non-universal by using `.opencode/skills` in agent config
- fix interactive preselection to merge saved non-universal agents with currently detected non-universal agents (so detected OpenCode is preselected reliably)
- fix install summary path output in copy mode to show the real agent target path instead of always the canonical `.agents/skills` path
- update README supported agents and discovery paths for OpenCode
- add test coverage for OpenCode path/universal classification

## Why this follow-up is needed

Without these additions, users can still see misleading summary paths and suboptimal agent preselection even after the base OpenCode directory fix.

## Verification

- `pnpm format`
- `pnpm test`

All tests pass locally.

## Related

- Issue: #769
- Prior PR: #770
