### PR TITLE
fix(prompts): fix agent multiselect spam when lines wrap

### DIFF
--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -1,4 +1,5 @@
 import * as readline from 'readline';
+import { stripVTControlCharacters } from 'node:util';
 import { Writable } from 'stream';
 import pc from 'picocolors';
 
@@ -42,6 +43,88 @@ const S_BAR = pc.dim('│');
 const S_BAR_H = pc.dim('─');
 
 export const cancelSymbol = Symbol('cancel');
+
+/**
+ * Approximate terminal display width (cells) for a string with no ANSI sequences.
+ * Matches common East Asian / emoji double-width behavior used by modern terminals.
+ */
+export function approxStringWidth(plain: string): number {
+  let width = 0;
+  for (const ch of plain) {
+    const code = ch.codePointAt(0)!;
+    if (code === 0) continue;
+    const wide =
+      (code >= 0x1100 && code <= 0x115f) ||
+      (code >= 0x231a && code <= 0x231b) ||
+      (code >= 0x2329 && code <= 0x232a) ||
+      (code >= 0x23e9 && code <= 0x23ec) ||
+      code === 0x23f0 ||
+      code === 0x23f3 ||
+      (code >= 0x25fd && code <= 0x25fe) ||
+      (code >= 0x2614 && code <= 0x2615) ||
+      (code >= 0x2648 && code <= 0x2653) ||
+      (code >= 0x267f && code <= 0x267f) ||
+      (code >= 0x2693 && code <= 0x2693) ||
+      (code >= 0x26a1 && code <= 0x26a1) ||
+      (code >= 0x26aa && code <= 0x26ab) ||
+      (code >= 0x26bd && code <= 0x26be) ||
+      (code >= 0x26c4 && code <= 0x26c5) ||
+      (code >= 0x26ce && code <= 0x26ce) ||
+      (code >= 0x26d4 && code <= 0x26d4) ||
+      (code >= 0x26ea && code <= 0x26ea) ||
+      (code >= 0x26f2 && code <= 0x26f3) ||
+      (code >= 0x26f5 && code <= 0x26f5) ||
+      (code >= 0x26fa && code <= 0x26fa) ||
+      (code >= 0x26fd && code <= 0x26fd) ||
+      (code >= 0x2705 && code <= 0x2705) ||
+      (code >= 0x270a && code <= 0x270b) ||
+      (code >= 0x2728 && code <= 0x2728) ||
+      (code >= 0x274c && code <= 0x274c) ||
+      (code >= 0x274e && code <= 0x274e) ||
+      (code >= 0x2753 && code <= 0x2755) ||
+      (code >= 0x2757 && code <= 0x2757) ||
+      (code >= 0x2795 && code <= 0x2797) ||
+      (code >= 0x27b0 && code <= 0x27b0) ||
+      (code >= 0x27bf && code <= 0x27bf) ||
+      (code >= 0x2b1b && code <= 0x2b1c) ||
+      (code >= 0x2b50 && code <= 0x2b50) ||
+      (code >= 0x2b55 && code <= 0x2b55) ||
+      (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f) ||
+      (code >= 0xa960 && code <= 0xa97c) ||
+      (code >= 0xac00 && code <= 0xd7a3) ||
+      (code >= 0xf900 && code <= 0xfaff) ||
+      (code >= 0xfe10 && code <= 0xfe19) ||
+      (code >= 0xfe30 && code <= 0xfe6f) ||
+      (code >= 0xff00 && code <= 0xff60) ||
+      (code >= 0xffe0 && code <= 0xffe6) ||
+      (code >= 0x1f000 && code <= 0x1f9ff);
+    width += wide ? 2 : 1;
+  }
+  return width;
+}
+
+/**
+ * How many physical terminal rows one logical line occupies after soft-wrapping.
+ */
+export function visualRowsForLine(line: string, columns: number): number {
+  const plain = stripVTControlCharacters(line);
+  const cols = Math.max(1, columns);
+  const w = approxStringWidth(plain);
+  return Math.max(1, Math.ceil(w / cols));
+}
+
+/**
+ * Total physical rows for a block of logical lines (used to erase/redraw TUI output).
+ */
+export function countVisualRowsForLines(lines: string[], columns: number | undefined): number {
+  const cols =
+    columns !== undefined && columns > 0
+      ? columns
+      : process.stdout.columns && process.stdout.columns > 0
+        ? process.stdout.columns
+        : 80;
+  return lines.reduce((sum, line) => sum + visualRowsForLine(line, cols), 0);
+}
 
 /**
  * Interactive search multiselect prompt.
@@ -204,7 +287,10 @@ export async function searchMultiselect<T>(
       }
 
       process.stdout.write(lines.join('\n') + '\n');
-      lastRenderHeight = lines.length;
+      // Use wrapped row count: logical lines can span multiple terminal rows when hints
+      // or labels exceed column width. Using lines.length alone under-counts and breaks
+      // clearRender(), causing the prompt to re-print hundreds of times on each redraw.
+      lastRenderHeight = countVisualRowsForLines(lines, process.stdout.columns);
     };
 
     const cleanup = (): void => {

--- a/tests/search-multiselect-visual-rows.test.ts
+++ b/tests/search-multiselect-visual-rows.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import pc from 'picocolors';
+import {
+  approxStringWidth,
+  countVisualRowsForLines,
+  visualRowsForLine,
+} from '../src/prompts/search-multiselect.ts';
+
+describe('searchMultiselect visual row counting', () => {
+  it('counts ASCII width as one column per character', () => {
+    expect(approxStringWidth('abc')).toBe(3);
+    expect(approxStringWidth('a'.repeat(160))).toBe(160);
+  });
+
+  it('treats common CJK as double-width', () => {
+    expect(approxStringWidth('中')).toBe(2);
+    expect(approxStringWidth('中文')).toBe(4);
+  });
+
+  it('computes wrap rows for long ASCII lines', () => {
+    const line = 'x'.repeat(160);
+    expect(visualRowsForLine(line, 80)).toBe(2);
+    expect(visualRowsForLine(line, 40)).toBe(4);
+  });
+
+  it('strips ANSI before measuring so colors do not affect wrap', () => {
+    const line = pc.bold('z'.repeat(100));
+    expect(visualRowsForLine(line, 80)).toBe(2);
+  });
+
+  it('sums logical lines using explicit column width', () => {
+    const lines = ['short', 'x'.repeat(160)];
+    expect(countVisualRowsForLines(lines, 80)).toBe(1 + 2);
+  });
+
+  it('matches prior behavior when each line fits in one row', () => {
+    const lines = ['a', 'b', 'c'];
+    expect(countVisualRowsForLines(lines, 120)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem
The interactive agent picker (`searchMultiselect`) used `lines.length` as the number of terminal rows to move up when redrawing. When labels or `hint` paths are longer than the terminal width, a single logical line wraps to multiple physical rows. The erase step then under-counted rows, left stale output in place, and every keypress re-printed the prompt (often hundreds of times).

## Fix
- Strip VT sequences and approximate display width (ASCII + common wide CJK / emoji ranges).
- Compute wrapped row count from `process.stdout.columns` (fallback 80).
- Set `lastRenderHeight` to that total so `clearRender()` clears the full visible block.

## Tests
- Added `tests/search-multiselect-visual-rows.test.ts` for wrap / ANSI stripping behavior.

## Verification
`NODE_OPTIONS=--experimental-strip-types pnpm test` — 403 tests passed.

Made with [Cursor](https://cursor.com)