### PR TITLE
fix: remove local skills from skills-lock.json on uninstall

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, runCliWithInput } from './test-utils.js';
@@ -102,6 +102,38 @@ This is a test skill.
       // Verify other skills still exist
       expect(existsSync(join(skillsDir, 'skill-two'))).toBe(true);
       expect(existsSync(join(skillsDir, 'skill-three'))).toBe(true);
+    });
+
+    it('should update skills-lock.json when removing a local skill', () => {
+      writeFileSync(
+        join(testDir, 'skills-lock.json'),
+        JSON.stringify(
+          {
+            version: 1,
+            skills: {
+              'skill-one': {
+                source: 'demo/skill-one',
+                sourceType: 'github',
+                computedHash: 'abc',
+              },
+              'skill-two': {
+                source: 'demo/skill-two',
+                sourceType: 'github',
+                computedHash: 'def',
+              },
+            },
+          },
+          null,
+          2
+        ) + '\n'
+      );
+
+      const result = runCli(['remove', 'skill-one', '-y'], testDir);
+      expect(result.stdout).toContain('Successfully removed');
+
+      const lock = JSON.parse(readFileSync(join(testDir, 'skills-lock.json'), 'utf-8'));
+      expect(lock.skills['skill-one']).toBeUndefined();
+      expect(lock.skills['skill-two']).toBeDefined();
     });
 
     it('should remove multiple skills by name', () => {

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -214,6 +215,8 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);
+      } else {
+        await removeSkillFromLocalLock(skillName, cwd);
       }
 
       results.push({


### PR DESCRIPTION
Fixes #808

Removing a locally installed skill updated filesystem state but left stale entries in `skills-lock.json`. This removes local lock entries during local uninstall and adds regression coverage for lockfile updates.

Greetings, saschabuehrle
