### PR TITLE
feat(agents): add Atlassian Rovo Dev support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ package-lock.json
 .opencode/
 .qoder/
 .qwen/
+.rovodev/
 .trae/
 .vscode/
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [41 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [42 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -243,6 +243,7 @@ Skills can be installed to any of these agents:
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
+| Rovo Dev | `rovodev` | `.rovodev/skills/` | `~/.rovodev/skills/` |
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
 | Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
 | Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
@@ -344,6 +345,7 @@ The CLI searches for skills in these locations within a repository:
 - `.qoder/skills/`
 - `.qwen/skills/`
 - `.roo/skills/`
+- `.rovodev/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`
 - `.zencoder/skills/`
@@ -379,12 +381,12 @@ If no skills are found in standard locations, a recursive search is performed.
 Skills are generally compatible across agents since they follow a
 shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
 
-| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
-| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
-| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
-| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
-| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Rovo Dev | Zencoder |
+| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- | -------- |
+| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      | Yes      |
+| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      | No       |
+| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       | No       |
+| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       | No       |
 
 ## Troubleshooting
 
@@ -450,6 +452,7 @@ Telemetry is automatically disabled in CI environments.
 - [Qoder Skills Documentation](https://docs.qoder.com/cli/Skills)
 - [Replit Skills Documentation](https://docs.replit.com/replitai/skills)
 - [Roo Code Skills Documentation](https://docs.roocode.com/features/skills)
+- [Rovo Skills Documentation](https://support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills/)
 - [Trae Skills Documentation](https://docs.trae.ai/ide/skills)
 - [Vercel Agent Skills Repository](https://github.com/vercel-labs/agent-skills)
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "qwen-code",
     "replit",
     "roo",
+    "rovodev",
     "trae",
     "trae-cn",
     "warp",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -356,6 +356,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.roo'));
     },
   },
+  rovodev: {
+    name: 'rovodev',
+    displayName: 'Rovo Dev',
+    skillsDir: '.rovodev/skills',
+    globalSkillsDir: join(home, '.rovodev/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.rovodev'));
+    },
+  },
   trae: {
     name: 'trae',
     displayName: 'Trae',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -174,6 +174,7 @@ const PRIORITY_PREFIXES = [
   '.pi/skills/',
   '.qoder/skills/',
   '.roo/skills/',
+  '.rovodev/skills/',
   '.trae/skills/',
   '.windsurf/skills/',
   '.zencoder/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -177,6 +177,7 @@ export async function discoverSkills(
     join(searchPath, '.pi/skills'),
     join(searchPath, '.qoder/skills'),
     join(searchPath, '.roo/skills'),
+    join(searchPath, '.rovodev/skills'),
     join(searchPath, '.trae/skills'),
     join(searchPath, '.windsurf/skills'),
     join(searchPath, '.zencoder/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type AgentType =
   | 'qwen-code'
   | 'replit'
   | 'roo'
+  | 'rovodev'
   | 'trae'
   | 'trae-cn'
   | 'warp'


### PR DESCRIPTION
[Rovo Dev](https://www.atlassian.com/blog/announcements/rovo-dev-command-line-interface) is Atlassian's AI agent available as a CLI. It too can be [extended with skills](https://support.atlassian.com/rovo/docs/extend-rovo-dev-cli-with-agent-skills/), and thus would benefit from support in this package.

Note that while Rovo Dev supports multiple locations for retrieving skills:

 - `{~/,}.rovodev/skills`
 - `{~/,}.agents/skills`

We choose the former when installing skills to allow consumers to explicitly install skills just for Rovo Dev (and acts as future-proofing in case Atlassian wants to create skills only Rovo Dev can read).