### PR TITLE
Preserve dotfiles when copying skills

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -327,7 +327,6 @@ const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 
 const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
   if (EXCLUDE_FILES.has(name)) return true;
-  if (name.startsWith('.')) return true;
   if (isDirectory && EXCLUDE_DIRS.has(name)) return true;
   return false;
 };

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { installSkillForAgent } from '../src/installer.ts';
+
+async function makeSkillSource(root: string, name: string): Promise<string> {
+  const dir = join(root, 'source-skill');
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: test\n---\n`, 'utf-8');
+  return dir;
+}
+
+describe('installer copy mode', () => {
+  it('preserves dotfiles while keeping explicit exclusions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'copy-dotfile-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    await writeFile(join(skillDir, '.prettierrc'), '{ "singleQuote": true }\n', 'utf-8');
+    await writeFile(join(skillDir, 'metadata.json'), '{"private":true}\n', 'utf-8');
+    await mkdir(join(skillDir, '.git'), { recursive: true });
+    await writeFile(join(skillDir, '.git', 'config'), '[core]\n', 'utf-8');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedDir = join(projectDir, '.agents/skills', skillName);
+      await expect(readFile(join(installedDir, '.prettierrc'), 'utf-8')).resolves.toBe(
+        '{ "singleQuote": true }\n'
+      );
+      await expect(access(join(installedDir, 'metadata.json'))).rejects.toThrow();
+      await expect(access(join(installedDir, '.git'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- stop excluding every dot-prefixed entry during skill copy installs
- keep the existing explicit exclusions for `metadata.json`, `.git`, `__pycache__`, and `__pypackages__`
- add a regression test that verifies `.prettierrc` is preserved during copy installs

## Root cause
`src/installer.ts` filtered out any entry whose name started with `.` before copying a skill directory. That dropped valid config files like `.prettierrc` even though the installer already had explicit exclusion rules for the entries it actually wanted to skip.

## Background
This came up while installing [`slop-refinery-setup`](https://github.com/HOWMZofficial/slop-refinery/tree/85bd0064d313ddd7b9129ef0c8c6ce77c78ee29b/skills/slop-refinery-setup) from [`HOWMZofficial/slop-refinery`](https://github.com/HOWMZofficial/slop-refinery/tree/85bd0064d313ddd7b9129ef0c8c6ce77c78ee29b).

That skill ships setup templates under `references/templates/typescript/`, including a hidden Prettier config at [`skills/slop-refinery-setup/references/templates/typescript/.prettierrc`](https://github.com/HOWMZofficial/slop-refinery/blob/85bd0064d313ddd7b9129ef0c8c6ce77c78ee29b/skills/slop-refinery-setup/references/templates/typescript/.prettierrc).

Using a local checkout of `slop-refinery` at commit `85bd0064d313ddd7b9129ef0c8c6ce77c78ee29b` and then running `npx -y skills add /path/to/slop-refinery/skills/slop-refinery-setup -y` copied the skill, but silently dropped that dotfile while keeping the adjacent non-hidden templates such as `package.json`, `eslint.config.ts`, and `eslint.format.config.ts`.

Because the installed skill no longer matched the source skill, the failure initially looked like a repo-specific packaging issue in `slop-refinery`. After tracing the install path, the actual problem turned out to be the generic copy-time dotfile exclusion in `skills` itself.

## Verification
- ran `pnpm test`
- confirmed clean upstream `main` already fails `pnpm type-check` in unrelated files: `src/git.ts`, `src/providers/wellknown.ts`, and `src/skills.ts`
- end-to-end check: used the patched CLI to install a temp skill containing `.prettierrc` and `.git/`, and verified the installed skill kept `.prettierrc` while still skipping `.git`
- stable pinned repro check: cloned `HOWMZofficial/slop-refinery`, checked out `85bd0064d313ddd7b9129ef0c8c6ce77c78ee29b`, ran `npx -y skills add /path/to/slop-refinery/skills/slop-refinery-setup -y`, and confirmed `.prettierrc` was missing while `package.json`, `eslint.config.ts`, and `eslint.format.config.ts` were present

## Reproduction
1. Run `git clone https://github.com/HOWMZofficial/slop-refinery.git /tmp/slop-refinery`
2. Run `git -C /tmp/slop-refinery checkout 85bd0064d313ddd7b9129ef0c8c6ce77c78ee29b`
3. Run `mkdir -p /tmp/skills-repro && cd /tmp/skills-repro && npx -y skills add /tmp/slop-refinery/skills/slop-refinery-setup -y`
4. Inspect `.agents/skills/slop-refinery-setup/references/templates/typescript/`
5. Observe that `.prettierrc` is missing even though the source skill contains it and the neighboring non-hidden template files were copied
