### PR TITLE
feat: add `cookiy` source alias for cookiy-ai/cookiy-skill

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -126,6 +126,7 @@ function isLocalPath(input: string): boolean {
 // Source aliases: map common shorthand to canonical source
 const SOURCE_ALIASES: Record<string, string> = {
   'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
+  cookiy: 'cookiy-ai/cookiy-skill',
 };
 
 interface FragmentRefResult {

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -414,6 +414,12 @@ describe('Source aliases', () => {
     expect(result.type).toBe('github');
     expect(result.url).toBe('https://github.com/coinbase/agentic-wallet-skills.git');
   });
+
+  it('resolves cookiy to cookiy-ai/cookiy-skill', () => {
+    const result = parseSource('cookiy');
+    expect(result.type).toBe('github');
+    expect(result.url).toBe('https://github.com/cookiy-ai/cookiy-skill.git');
+  });
 });
 
 describe('Prefix shorthand tests', () => {


### PR DESCRIPTION
## Summary
Adds a `SOURCE_ALIASES` entry so users can run:

```bash
npx skills add cookiy
```

This resolves to the canonical GitHub shorthand `cookiy-ai/cookiy-skill` (https://github.com/cookiy-ai/cookiy-skill).

## Test plan
- [x] `vitest --run tests/source-parser.test.ts` (69 tests)

## Notes
- Mirrors the existing `coinbase/agentWallet` alias pattern (single-token key is supported because alias resolution runs before `owner/repo` shorthand parsing).
- Happy to adjust naming or documentation if you prefer this listed in public docs / skills.sh next to the Coinbase alias table.

Made with [Cursor](https://cursor.com)