### PR TITLE
feat: add 'scandit' source alias for Scandit/skills

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -126,6 +126,7 @@ function isLocalPath(input: string): boolean {
 // Source aliases: map common shorthand to canonical source
 const SOURCE_ALIASES: Record<string, string> = {
   'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
+  scandit: 'Scandit/scandit-sdk-skills',
 };
 
 interface FragmentRefResult {

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -126,7 +126,7 @@ function isLocalPath(input: string): boolean {
 // Source aliases: map common shorthand to canonical source
 const SOURCE_ALIASES: Record<string, string> = {
   'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
-  scandit: 'Scandit/scandit-sdk-skills',
+  scandit: 'Scandit/skills',
 };
 
 interface FragmentRefResult {

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -415,10 +415,10 @@ describe('Source aliases', () => {
     expect(result.url).toBe('https://github.com/coinbase/agentic-wallet-skills.git');
   });
 
-  it('resolves scandit to Scandit/scandit-sdk-skills', () => {
+  it('resolves scandit to Scandit/skills', () => {
     const result = parseSource('scandit');
     expect(result.type).toBe('github');
-    expect(result.url).toBe('https://github.com/Scandit/scandit-sdk-skills.git');
+    expect(result.url).toBe('https://github.com/Scandit/skills.git');
   });
 });
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -414,6 +414,12 @@ describe('Source aliases', () => {
     expect(result.type).toBe('github');
     expect(result.url).toBe('https://github.com/coinbase/agentic-wallet-skills.git');
   });
+
+  it('resolves scandit to Scandit/scandit-sdk-skills', () => {
+    const result = parseSource('scandit');
+    expect(result.type).toBe('github');
+    expect(result.url).toBe('https://github.com/Scandit/scandit-sdk-skills.git');
+  });
 });
 
 describe('Prefix shorthand tests', () => {


### PR DESCRIPTION
## Summary

Adds a source alias so users can install Scandit skills with:

```
npx skills add scandit
```

This resolves to the canonical GitHub shorthand `Scandit/skills` ([repo](https://github.com/Scandit/skills)).

> **Note:** The repo was previously named `Scandit/scandit-sdk-skills` and has been renamed to `Scandit/skills`. GitHub redirects keep the old URL working, but the alias now points at the canonical name. The PR was originally opened against the old name and has been updated to match.

## Test plan

- [x] `vitest --run tests/source-parser.test.ts` — all 69 tests pass
