### PR TITLE
Add Hermes Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [41 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [42 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -229,6 +229,7 @@ Skills can be installed to any of these agents:
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Hermes Agent | `hermes` | `.hermes/skills/` | `~/.hermes/skills/` |
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
@@ -331,6 +332,7 @@ The CLI searches for skills in these locations within a repository:
 - `.crush/skills/`
 - `.factory/skills/`
 - `.goose/skills/`
+- `.hermes/skills/`
 - `.junie/skills/`
 - `.iflow/skills/`
 - `.kilocode/skills/`

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gemini-cli",
     "github-copilot",
     "goose",
+    "hermes",
     "junie",
     "iflow-cli",
     "kilo",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -211,6 +211,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(configHome, 'goose'));
     },
   },
+  hermes: {
+    name: 'hermes',
+    displayName: 'Hermes Agent',
+    skillsDir: '.hermes/skills',
+    globalSkillsDir: join(home, '.hermes/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.hermes'));
+    },
+  },
   junie: {
     name: 'junie',
     displayName: 'Junie',

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type AgentType =
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'
+  | 'hermes'
   | 'iflow-cli'
   | 'junie'
   | 'kilo'


### PR DESCRIPTION
Adds [Hermes Agent](https://github.com/nicepkg/hermes) to the supported agents list.

- Adds `hermes` to `AgentType`
- Adds hermes agent config with:
  - `skillsDir`: `.hermes/skills`
  - `globalSkillsDir`: `~/.hermes/skills`
  - `detectInstalled`: checks for `~/.hermes` directory existence
- Syncs `README.md` and `package.json` keywords via `sync-agents.ts`
- Validated with `validate-agents.ts`
- All 402 tests pass