### PR TITLE
feat: include skill description in list output

### DIFF
--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -115,6 +115,7 @@ description: A skill for JSON testing
       expect(Array.isArray(parsed)).toBe(true);
       expect(parsed.length).toBe(1);
       expect(parsed[0].name).toBe('json-skill');
+      expect(parsed[0].description).toBe('A skill for JSON testing');
       expect(parsed[0].path).toContain('json-skill');
       expect(parsed[0].scope).toBe('project');
       expect(Array.isArray(parsed[0].agents)).toBe(true);
@@ -173,8 +174,8 @@ This is a test skill.
       const result = runCli(['list'], testDir);
       expect(result.stdout).toContain('test-skill');
       expect(result.stdout).toContain('Project Skills');
-      // Description should not be shown
-      expect(result.stdout).not.toContain('A test skill for listing');
+      // Description should be shown
+      expect(result.stdout).toContain('A test skill for listing');
       expect(result.exitCode).toBe(0);
     });
 

--- a/src/list.ts
+++ b/src/list.ts
@@ -94,6 +94,7 @@ export async function runList(args: string[]): Promise<void> {
   if (options.json) {
     const jsonOutput = installedSkills.map((skill) => ({
       name: skill.name,
+      description: skill.description,
       path: skill.canonicalPath,
       scope: skill.scope,
       agents: skill.agents.map((a) => agents[a].displayName),
@@ -129,6 +130,9 @@ export async function runList(args: string[]): Promise<void> {
     const agentInfo =
       skill.agents.length > 0 ? formatList(agentNames) : `${YELLOW}not linked${RESET}`;
     console.log(`${prefix}${CYAN}${skill.name}${RESET} ${DIM}${shortPath}${RESET}`);
+    if (skill.description) {
+      console.log(`${prefix}  ${TEXT}${skill.description}${RESET}`);
+    }
     console.log(`${prefix}  ${DIM}Agents:${RESET} ${agentInfo}`);
   }
 


### PR DESCRIPTION
## Summary

- Adds the `description` field to both human-readable and `--json` output of the `list` command
- Previously, descriptions were parsed from SKILL.md frontmatter but never displayed — this makes it easier to identify skills at a glance
- Human-readable output shows the description between the skill name/path and agent attribution lines
- JSON output now includes a `description` field in each skill object

## Example

**Before:**
```
my-skill  .agents/skills/my-skill
  Agents: Claude Code
```

**After:**
```
my-skill  .agents/skills/my-skill
  A useful skill that does X
  Agents: Claude Code
```

**JSON (`--json`) before:**
```json
[{ "name": "my-skill", "path": "...", "scope": "project", "agents": ["Claude Code"] }]
```

**JSON (`--json`) after:**
```json
[{ "name": "my-skill", "description": "A useful skill that does X", "path": "...", "scope": "project", "agents": ["Claude Code"] }]
```

## Test plan

- [x] Updated existing test that asserted description was NOT shown → now asserts it IS shown
- [x] Added `description` assertion to the JSON output test
- [x] All `parseListOptions` unit tests pass
- [x] `listInstalledSkills` unit tests pass (description field already populated)
- [x] Pre-existing CLI integration test failures (Node.js can't execute `.ts` directly) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)