### PR TITLE
Add source alias for resemble-ai/detect

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -126,6 +126,7 @@ function isLocalPath(input: string): boolean {
 // Source aliases: map common shorthand to canonical source
 const SOURCE_ALIASES: Record<string, string> = {
   'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
+  'resemble-ai/detect': 'resemble-ai/detect-skill',
 };
 
 interface FragmentRefResult {

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -414,6 +414,12 @@ describe('Source aliases', () => {
     expect(result.type).toBe('github');
     expect(result.url).toBe('https://github.com/coinbase/agentic-wallet-skills.git');
   });
+
+  it('resolves resemble-ai/detect to resemble-ai/detect-skill', () => {
+    const result = parseSource('resemble-ai/detect');
+    expect(result.type).toBe('github');
+    expect(result.url).toBe('https://github.com/resemble-ai/detect-skill.git');
+  });
 });
 
 describe('Prefix shorthand tests', () => {


### PR DESCRIPTION
## Summary

- Adds a source alias mapping `resemble-ai/detect` → `resemble-ai/detect-skill` so users can install with the shorter name:
  ```bash
  npx skills add resemble-ai/detect
  ```
- Adds corresponding test case in `source-parser.test.ts`

**Skill repo:** https://github.com/resemble-ai/detect-skill

Related: #891