### PR TITLE
fix: remove the wrong path in skill-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,6 @@ The CLI searches for skills in these locations within a repository:
 - `.augment/skills/`
 - `.bob/skills/`
 - `.claude/skills/`
-- `./skills/`
 - `.codebuddy/skills/`
 - `.commandcode/skills/`
 - `.continue/skills/`

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -72,7 +72,7 @@ function generateSkillDiscoveryPaths(): string {
 
   const agentPaths = [...new Set(Object.values(agents).map((a) => a.skillsDir))]
     .filter((p) => p !== 'skills') // Filter out the standard `skills/` path
-    .map((p) => `- \`.${p.startsWith('.') ? p.slice(1) : '/' + p}/\``);
+    .map((p) => `- \`${p}/\``);
 
   return [...standardPaths, ...agentPaths].join('\n');
 }

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -70,9 +70,9 @@ function generateSkillDiscoveryPaths(): string {
     '- `skills/.system/`',
   ];
 
-  const agentPaths = [...new Set(Object.values(agents).map((a) => a.skillsDir))].map(
-    (p) => `- \`.${p.startsWith('.') ? p.slice(1) : '/' + p}/\``
-  );
+  const agentPaths = [...new Set(Object.values(agents).map((a) => a.skillsDir))]
+    .filter((p) => p !== 'skills') // Filter out the standard `skills/` path
+    .map((p) => `- \`.${p.startsWith('.') ? p.slice(1) : '/' + p}/\``);
 
   return [...standardPaths, ...agentPaths].join('\n');
 }


### PR DESCRIPTION
This PR fixes a tiny bug, `./skills/` is the same as `skills/`.