### PR TITLE
docs: fix Kiro CLI skills note and hooks compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:end -->
 
 > [!NOTE]
-> **Kiro CLI users:** After installing skills, manually add them to your custom agent's `resources` in
-> `.kiro/agents/<agent>.json`:
+> **Kiro CLI users:** The default agent automatically loads skills from `.kiro/skills/` and `~/.kiro/skills/` — no
+> configuration needed. If you use a **custom agent**, add skills to its `resources` in `.kiro/agents/<agent>.json`:
 >
 > ```json
 > {
@@ -384,7 +384,7 @@ shared [Agent Skills specification](https://agentskills.io). However, some featu
 | Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
 | `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
 | `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
+| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | Yes      | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Changes

Two documentation fixes for Kiro CLI in the README:

1. **Fix the Kiro CLI note** — The current note implies all Kiro CLI users must manually add skills to a custom agent's `resources` config. Per [Kiro CLI skills docs](https://kiro.dev/docs/cli/skills/#default-agent), the default agent automatically loads skills from `.kiro/skills/` and `~/.kiro/skills/` with no configuration. The manual `resources` step is only needed for custom agents.

2. **Fix compatibility table** — Kiro CLI is marked as not supporting hooks. Per the [configuration reference](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#hooks-field), Kiro CLI supports `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop` hooks.