### PR TITLE
fix: GitHub auth fallback for org repos (`gh` CLI if available, else try `ssh`)

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -16,7 +16,13 @@ vi.mock('child_process', async () => {
   };
 });
 
-import { GitCloneError, cloneRepo, isGitHubSsoAuthError, parseGitHubRepoUrl } from './git.ts';
+import {
+  GitCloneError,
+  cloneRepo,
+  isGitHubHttpsCloneUrl,
+  isGitHubSsoAuthError,
+  parseGitHubRepoUrl,
+} from './git.ts';
 
 function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
   return {
@@ -77,6 +83,13 @@ describe('git clone fallbacks', () => {
       isGitHubSsoAuthError("remote: The 'Giphy' organization has enabled or enforced SAML SSO.")
     ).toBe(true);
     expect(isGitHubSsoAuthError('fatal: Authentication failed')).toBe(false);
+  });
+
+  it('only enables automatic auth fallback for GitHub HTTPS clone URLs', () => {
+    expect(isGitHubHttpsCloneUrl('https://github.com/Giphy/giphy-codex-skills.git')).toBe(true);
+    expect(isGitHubHttpsCloneUrl('http://github.com/Giphy/giphy-codex-skills.git')).toBe(false);
+    expect(isGitHubHttpsCloneUrl('git@github.com:Giphy/giphy-codex-skills.git')).toBe(false);
+    expect(isGitHubHttpsCloneUrl('https://gitlab.com/Giphy/giphy-codex-skills.git')).toBe(false);
   });
 
   it('falls back to gh repo clone for GitHub HTTPS auth failures', async () => {
@@ -155,5 +168,31 @@ describe('git clone fallbacks', () => {
       expect((error as Error).message).toMatch(/SAML SSO/);
       expect((error as Error).message).toMatch(/git@github\.com:Giphy\/giphy-codex-skills\.git/);
     }
+  });
+
+  it('does not try gh fallback for GitLab clone URLs', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error('fatal: unable to access repo: The requested URL returned error: 403')
+      );
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/Giphy/giphy-codex-skills.git')).rejects.toThrow(
+      GitCloneError
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('does not try gh fallback for GitHub SSH clone URLs', async () => {
+    const primaryClone = vi.fn().mockRejectedValue(new Error('Permission denied (publickey).'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('git@github.com:Giphy/giphy-codex-skills.git')).rejects.toThrow(
+      GitCloneError
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rmSync } from 'fs';
+
+const simpleGitMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock('simple-git', () => ({
+  default: simpleGitMock,
+}));
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    execFile: execFileMock,
+  };
+});
+
+import { GitCloneError, cloneRepo, isGitHubSsoAuthError, parseGitHubRepoUrl } from './git.ts';
+
+function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
+  return {
+    clone,
+    env: vi.fn().mockReturnThis(),
+  };
+}
+
+function mockExecFileSuccess(stdout = '', stderr = '') {
+  execFileMock.mockImplementationOnce(
+    (_file: string, _args: string[], _options: unknown, callback: (...args: unknown[]) => void) => {
+      callback(null, stdout, stderr);
+    }
+  );
+}
+
+function mockExecFileError(message: string) {
+  execFileMock.mockImplementationOnce(
+    (_file: string, _args: string[], _options: unknown, callback: (...args: unknown[]) => void) => {
+      const error = Object.assign(new Error(message), { code: 1 });
+      callback(error, '', message);
+    }
+  );
+}
+
+describe('git clone fallbacks', () => {
+  const createdDirs: string[] = [];
+
+  beforeEach(() => {
+    simpleGitMock.mockReset();
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    for (const dir of createdDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses GitHub HTTPS and SSH clone URLs', () => {
+    expect(parseGitHubRepoUrl('https://github.com/Giphy/giphy-codex-skills.git')).toEqual({
+      owner: 'Giphy',
+      repo: 'giphy-codex-skills',
+      slug: 'Giphy/giphy-codex-skills',
+      sshUrl: 'git@github.com:Giphy/giphy-codex-skills.git',
+    });
+
+    expect(parseGitHubRepoUrl('git@github.com:Giphy/giphy-codex-skills.git')).toEqual({
+      owner: 'Giphy',
+      repo: 'giphy-codex-skills',
+      slug: 'Giphy/giphy-codex-skills',
+      sshUrl: 'git@github.com:Giphy/giphy-codex-skills.git',
+    });
+  });
+
+  it('detects GitHub SAML SSO clone failures', () => {
+    expect(
+      isGitHubSsoAuthError("remote: The 'Giphy' organization has enabled or enforced SAML SSO.")
+    ).toBe(true);
+    expect(isGitHubSsoAuthError('fatal: Authentication failed')).toBe(false);
+  });
+
+  it('falls back to gh repo clone for GitHub HTTPS auth failures', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "remote: The 'Giphy' organization has enabled or enforced SAML SSO.\n" +
+            "fatal: unable to access 'https://github.com/Giphy/giphy-codex-skills.git/': The requested URL returned error: 403"
+        )
+      );
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+    mockExecFileSuccess('Git operations protocol: https\n');
+    mockExecFileSuccess();
+
+    const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+    createdDirs.push(tempDir);
+
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      1,
+      'gh',
+      ['auth', 'status', '-h', 'github.com'],
+      expect.any(Object),
+      expect.any(Function)
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'gh',
+      ['repo', 'clone', 'Giphy/giphy-codex-skills', tempDir, '--', '--depth=1'],
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  it('falls back to SSH when gh clone is unavailable or fails', async () => {
+    const primaryClone = vi.fn().mockRejectedValue(new Error('fatal: Authentication failed'));
+    const sshClone = vi.fn().mockResolvedValue(undefined);
+
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(createGitClientMock(sshClone));
+    mockExecFileSuccess('Git operations protocol: ssh\n');
+    mockExecFileError('gh repo clone failed');
+
+    const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+    createdDirs.push(tempDir);
+
+    expect(sshClone).toHaveBeenCalledWith('git@github.com:Giphy/giphy-codex-skills.git', tempDir, [
+      '--depth',
+      '1',
+    ]);
+  });
+
+  it('surfaces a targeted SAML SSO message when all fallbacks fail', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "remote: The 'Giphy' organization has enabled or enforced SAML SSO.\n" +
+            "fatal: unable to access 'https://github.com/Giphy/giphy-codex-skills.git/': The requested URL returned error: 403"
+        )
+      );
+    const sshClone = vi.fn().mockRejectedValue(new Error('Permission denied (publickey).'));
+
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(createGitClientMock(sshClone));
+    mockExecFileError('gh auth unavailable');
+
+    try {
+      await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+      throw new Error('Expected cloneRepo to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(GitCloneError);
+      expect((error as Error).message).toMatch(/SAML SSO/);
+      expect((error as Error).message).toMatch(/git@github\.com:Giphy\/giphy-codex-skills\.git/);
+    }
+  });
+});

--- a/src/git.ts
+++ b/src/git.ts
@@ -62,6 +62,15 @@ export function parseGitHubRepoUrl(url: string): GitHubRepoInfo | null {
   }
 }
 
+export function isGitHubHttpsCloneUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' && parsed.hostname === 'github.com';
+  } catch {
+    return false;
+  }
+}
+
 export function isGitHubSsoAuthError(message: string): boolean {
   const lower = message.toLowerCase();
   return (
@@ -172,7 +181,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       );
     }
 
-    if (isAuthError && repo && url.startsWith('https://github.com/')) {
+    if (isAuthError && repo && isGitHubHttpsCloneUrl(url)) {
       try {
         await resetTempDir(tempDir);
         if (await tryGhClone(repo, tempDir, ref)) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,9 +1,19 @@
 import simpleGit from 'simple-git';
 import { join, normalize, resolve, sep } from 'path';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp, mkdir, rm } from 'fs/promises';
 import { tmpdir } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 const CLONE_TIMEOUT_MS = 60000; // 60 seconds
+const execFileAsync = promisify(execFile);
+
+interface GitHubRepoInfo {
+  owner: string;
+  repo: string;
+  slug: string;
+  sshUrl: string;
+}
 
 export class GitCloneError extends Error {
   readonly url: string;
@@ -19,30 +29,138 @@ export class GitCloneError extends Error {
   }
 }
 
-export async function cloneRepo(url: string, ref?: string): Promise<string> {
-  const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const git = simpleGit({
-    timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-  });
-  const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+export function parseGitHubRepoUrl(url: string): GitHubRepoInfo | null {
+  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  if (sshMatch) {
+    const owner = sshMatch[1]!;
+    const repo = sshMatch[2]!;
+    return {
+      owner,
+      repo,
+      slug: `${owner}/${repo}`,
+      sshUrl: `git@github.com:${owner}/${repo}.git`,
+    };
+  }
 
   try {
-    await git.clone(url, tempDir, cloneOptions);
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'github.com') return null;
+
+    const match = parsed.pathname.match(/^\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+    if (!match) return null;
+
+    const owner = match[1]!;
+    const repo = match[2]!;
+    return {
+      owner,
+      repo,
+      slug: `${owner}/${repo}`,
+      sshUrl: `git@github.com:${owner}/${repo}.git`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isGitHubSsoAuthError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('saml sso') ||
+    lower.includes('enforced sso') ||
+    lower.includes('enabled or enforced saml') ||
+    lower.includes('re-authorize the oauth application')
+  );
+}
+
+function isAuthFailure(message: string): boolean {
+  return (
+    message.includes('Authentication failed') ||
+    message.includes('could not read Username') ||
+    message.includes('Permission denied') ||
+    message.includes('Repository not found') ||
+    message.includes('requested URL returned error: 403') ||
+    isGitHubSsoAuthError(message)
+  );
+}
+
+function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
+  return simpleGit({
+    timeout: { block: CLONE_TIMEOUT_MS },
+  }).env({ ...process.env, GIT_TERMINAL_PROMPT: '0', ...extraEnv });
+}
+
+async function resetTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true }).catch(() => {});
+  await mkdir(dir, { recursive: true });
+}
+
+async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): Promise<boolean> {
+  let cloneTarget = repo.slug;
+
+  try {
+    const { stdout, stderr } = await execFileAsync('gh', ['auth', 'status', '-h', 'github.com'], {
+      timeout: 5000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    const statusOutput = `${stdout}${stderr}`;
+    if (/Git operations protocol:\s+ssh/i.test(statusOutput)) {
+      cloneTarget = repo.sshUrl;
+    }
+  } catch {
+    return false;
+  }
+
+  const gitFlags = ref ? ['--depth=1', '--branch', ref] : ['--depth=1'];
+  await execFileAsync('gh', ['repo', 'clone', cloneTarget, tempDir, '--', ...gitFlags], {
+    timeout: CLONE_TIMEOUT_MS,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return true;
+}
+
+function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message: string): string {
+  if (repo && isGitHubSsoAuthError(message)) {
+    return (
+      `GitHub blocked HTTPS access to ${url} because the organization enforces SAML SSO.\n` +
+      `  skills tried your existing git credentials and available fallbacks, but none succeeded.\n` +
+      `  - Re-authorize your GitHub credentials/app for that org's SSO policy\n` +
+      `  - Or rerun with SSH: npx skills add ${repo.sshUrl}\n` +
+      `  - Verify access with: gh auth status -h github.com or ssh -T git@github.com`
+    );
+  }
+
+  if (repo) {
+    return (
+      `Authentication failed for ${url}.\n` +
+      `  - For private repos, ensure you have access\n` +
+      `  - Retry with SSH: npx skills add ${repo.sshUrl}\n` +
+      `  - Check access with: gh auth status -h github.com or ssh -T git@github.com`
+    );
+  }
+
+  return (
+    `Authentication failed for ${url}.\n` +
+    `  - For private repos, ensure you have access\n` +
+    `  - For SSH: Check your keys with 'ssh -T git@github.com'\n` +
+    `  - For HTTPS: Run 'gh auth login' or configure git credentials`
+  );
+}
+
+export async function cloneRepo(url: string, ref?: string): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
+  const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const repo = parseGitHubRepoUrl(url);
+
+  try {
+    await createGitClient().clone(url, tempDir, cloneOptions);
     return tempDir;
   } catch (error) {
-    // Clean up temp dir on failure
-    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
-
     const errorMessage = error instanceof Error ? error.message : String(error);
     const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
-    const isAuthError =
-      errorMessage.includes('Authentication failed') ||
-      errorMessage.includes('could not read Username') ||
-      errorMessage.includes('Permission denied') ||
-      errorMessage.includes('Repository not found');
+    const isAuthError = isAuthFailure(errorMessage);
 
     if (isTimeout) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
       throw new GitCloneError(
         `Clone timed out after 60s. This often happens with private repos that require authentication.\n` +
           `  Ensure you have access and your SSH keys or credentials are configured:\n` +
@@ -54,16 +172,31 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       );
     }
 
+    if (isAuthError && repo && url.startsWith('https://github.com/')) {
+      try {
+        await resetTempDir(tempDir);
+        if (await tryGhClone(repo, tempDir, ref)) {
+          return tempDir;
+        }
+      } catch {
+        // Fall through to SSH retry.
+      }
+
+      try {
+        await resetTempDir(tempDir);
+        await createGitClient({
+          GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
+        }).clone(repo.sshUrl, tempDir, cloneOptions);
+        return tempDir;
+      } catch {
+        // Fall through to the targeted auth error below.
+      }
+    }
+
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+
     if (isAuthError) {
-      throw new GitCloneError(
-        `Authentication failed for ${url}.\n` +
-          `  - For private repos, ensure you have access\n` +
-          `  - For SSH: Check your keys with 'ssh -T git@github.com'\n` +
-          `  - For HTTPS: Run 'gh auth login' or configure git credentials`,
-        url,
-        false,
-        true
-      );
+      throw new GitCloneError(buildGitHubAuthError(url, repo, errorMessage), url, false, true);
     }
 
     throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);


### PR DESCRIPTION
## Issue

Private repos, particularly those in orgs, cannot be cloned with unauth'd HTTPS and copying/pasting SSH URLs is, frankly, annoying. An improved user experience would be to try the other two methods that may be available instead of asking the user to think about this when the problem can actually be solved automagically.

## Summary
- retry GitHub HTTPS clone auth failures through `gh repo clone` when GitHub CLI auth is available
- fall back to the derived GitHub SSH remote for org/private repos that reject HTTPS auth
- replace raw SAML/SSO clone failures with targeted remediation text and add coverage for the fallback paths
- explicitly lock the `gh` fallback to GitHub HTTPS clone URLs; GitLab, generic `git` URLs, and GitHub SSH URLs skip it

## Related

- Fixes #12
- Fixes #381
- Benefits from #78
- Benefits From #162
- Benefits From - Actually... it looks like the most important part of this may be fixed on main already - #379

## Possible Issues

- [x] GitLab and non-GitHub clone sources skip `gh` CLI fallback attempts
- [ ] #78 fixes prompting for a passphrase if the SSH key has one
- [ ] #379 fixes issues with unauthenticated API calls resulting in later bustage

## Design Decision

We considered retrying GitHub HTTPS clones with a token from `getGitHubToken()`, since that helper already reads `GITHUB_TOKEN`, `GH_TOKEN`, and `gh auth token` for GitHub API calls.

We did not take that route here because the clone path shells out to `git`, and token-backed HTTPS retry would require passing credentials into that subprocess somehow. That increases the risk of leaking or persisting the token through process arguments, command traces, debug logs, shell history, or git credential/config state.

Using `gh repo clone` when GitHub CLI auth is already configured, then falling back to SSH, avoids introducing a new token-handling path in the clone flow while still solving the user-facing org/private-repo failure mode.

## Testing

### List

#### After - Falling back to `gh cli`

<img width="1156" height="602" alt="image" src="https://github.com/user-attachments/assets/d59b8a27-c193-4b09-8289-ad027d1aa15a" />

#### Before - Fails with cryptic error

<img width="1196" height="747" alt="image" src="https://github.com/user-attachments/assets/57618072-11a1-418c-98b6-f6c52326583f" />

### Install

### After - Succeeds

<img width="1066" height="933" alt="image" src="https://github.com/user-attachments/assets/8132751d-2a4e-4464-8fa3-1fd4dd26b3ea" />

### Before - Fails with cryptic error

<img width="1201" height="739" alt="image" src="https://github.com/user-attachments/assets/b0ccd420-e54d-4d1a-a289-52f4b6d90c43" />

### Automated

- `pnpm test src/git.test.ts`
- `pnpm test src/add.test.ts`
- `pnpm test src/git.test.ts src/update-source.test.ts src/source-parser.test.ts`
- `pnpm format:check`

## Notes
- `pnpm type-check` still fails on pre-existing errors in `src/providers/wellknown.ts` and `src/skills.ts`
