### PR TITLE
fix: fail fast on ssh passphrase - instead of 60 second hang

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { rmSync } from 'fs';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { promisify } from 'util';
 
 const simpleGitMock = vi.hoisted(() => vi.fn());
-const execFileMock = vi.hoisted(() => vi.fn());
+const execFileAsyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock('simple-git', () => ({
   default: simpleGitMock,
@@ -10,18 +13,24 @@ vi.mock('simple-git', () => ({
 
 vi.mock('child_process', async () => {
   const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  const execFile = vi.fn();
+  Object.defineProperty(execFile, promisify.custom, {
+    value: execFileAsyncMock,
+  });
   return {
     ...actual,
-    execFile: execFileMock,
+    execFile,
   };
 });
 
 import {
   GitCloneError,
   cloneRepo,
+  detectSshPassphrasePromptIssue,
   isGitHubHttpsCloneUrl,
   isGitHubSsoAuthError,
   parseGitHubRepoUrl,
+  parseSshCloneUrl,
 } from './git.ts';
 
 function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
@@ -31,19 +40,12 @@ function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
 }
 
 function mockExecFileSuccess(stdout = '', stderr = '') {
-  execFileMock.mockImplementationOnce(
-    (_file: string, _args: string[], _options: unknown, callback: (...args: unknown[]) => void) => {
-      callback(null, stdout, stderr);
-    }
-  );
+  execFileAsyncMock.mockResolvedValueOnce({ stdout, stderr });
 }
 
 function mockExecFileError(message: string) {
-  execFileMock.mockImplementationOnce(
-    (_file: string, _args: string[], _options: unknown, callback: (...args: unknown[]) => void) => {
-      const error = Object.assign(new Error(message), { code: 1 });
-      callback(error, '', message);
-    }
+  execFileAsyncMock.mockRejectedValueOnce(
+    Object.assign(new Error(message), { code: 1, stdout: '', stderr: message })
   );
 }
 
@@ -52,7 +54,14 @@ describe('git clone fallbacks', () => {
 
   beforeEach(() => {
     simpleGitMock.mockReset();
-    execFileMock.mockReset();
+    execFileAsyncMock.mockReset();
+    execFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('unexpected execFile call'), {
+        code: 1,
+        stdout: '',
+        stderr: 'unexpected execFile call',
+      })
+    );
   });
 
   afterEach(() => {
@@ -74,6 +83,20 @@ describe('git clone fallbacks', () => {
       repo: 'giphy-codex-skills',
       slug: 'Giphy/giphy-codex-skills',
       sshUrl: 'git@github.com:Giphy/giphy-codex-skills.git',
+    });
+  });
+
+  it('parses SSH clone URLs and host aliases', () => {
+    expect(parseSshCloneUrl('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git')).toEqual({
+      user: 'git',
+      host: 'github-passphrase-giphy',
+    });
+
+    expect(
+      parseSshCloneUrl('ssh://git@github-passphrase-giphy/Giphy/giphy-codex-skills.git')
+    ).toEqual({
+      user: 'git',
+      host: 'github-passphrase-giphy',
     });
   });
 
@@ -108,19 +131,17 @@ describe('git clone fallbacks', () => {
     const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
     createdDirs.push(tempDir);
 
-    expect(execFileMock).toHaveBeenNthCalledWith(
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
       1,
       'gh',
       ['auth', 'status', '-h', 'github.com'],
-      expect.any(Object),
-      expect.any(Function)
+      expect.any(Object)
     );
-    expect(execFileMock).toHaveBeenNthCalledWith(
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
       2,
       'gh',
       ['repo', 'clone', 'Giphy/giphy-codex-skills', tempDir, '--', '--depth=1'],
-      expect.any(Object),
-      expect.any(Function)
+      expect.any(Object)
     );
   });
 
@@ -181,7 +202,7 @@ describe('git clone fallbacks', () => {
     await expect(cloneRepo('https://gitlab.com/Giphy/giphy-codex-skills.git')).rejects.toThrow(
       GitCloneError
     );
-    expect(execFileMock).not.toHaveBeenCalled();
+    expect(execFileAsyncMock).not.toHaveBeenCalled();
   });
 
   it('does not try gh fallback for GitHub SSH clone URLs', async () => {
@@ -192,6 +213,63 @@ describe('git clone fallbacks', () => {
     await expect(cloneRepo('git@github.com:Giphy/giphy-codex-skills.git')).rejects.toThrow(
       GitCloneError
     );
-    expect(execFileMock).not.toHaveBeenCalled();
+    expect(execFileAsyncMock).toHaveBeenCalledWith('ssh', ['-G', 'github.com'], expect.any(Object));
+  });
+
+  it('detects passphrase-protected SSH identities that are not usable through agent', async () => {
+    const sshDir = join(tmpdir(), `skills-git-test-${Date.now()}`);
+    const identityFile = join(sshDir, 'id_rsa_github_passphrase_giphy');
+    mkdirSync(sshDir, { recursive: true });
+    writeFileSync(identityFile, 'private');
+    writeFileSync(`${identityFile}.pub`, 'public');
+    createdDirs.push(sshDir);
+
+    mockExecFileSuccess(
+      `host github-passphrase-giphy\nidentitiesonly yes\nidentityfile ${identityFile}\n`
+    );
+    mockExecFileError('incorrect passphrase supplied to decrypt private key');
+    mockExecFileError('The agent has no identities.');
+
+    await expect(
+      detectSshPassphrasePromptIssue('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git')
+    ).resolves.toEqual({
+      host: 'github-passphrase-giphy',
+      identityFile,
+    });
+  });
+
+  it('fails fast with a targeted message for SSH passphrase prompt dead-ends', async () => {
+    const sshDir = join(tmpdir(), `skills-git-test-${Date.now()}`);
+    const identityFile = join(sshDir, 'id_rsa_github_passphrase_giphy');
+    mkdirSync(sshDir, { recursive: true });
+    writeFileSync(identityFile, 'private');
+    writeFileSync(`${identityFile}.pub`, 'public');
+    createdDirs.push(sshDir);
+
+    mockExecFileSuccess(
+      `host github-passphrase-giphy\nidentitiesonly yes\nidentityfile ${identityFile}\n`
+    );
+    mockExecFileError('incorrect passphrase supplied to decrypt private key');
+    mockExecFileError('The agent has no identities.');
+
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    try {
+      await cloneRepo('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git');
+      throw new Error('Expected cloneRepo to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(GitCloneError);
+      expect((error as Error).message).toMatch(/requires unlocking the passphrase-protected key/);
+      expect((error as Error).message).toMatch(/cannot prompt for that passphrase/);
+      expect((error as Error).message).toMatch(/ssh-add/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    }
+
+    expect(simpleGitMock.mock.results[0]?.value?.clone).toBeUndefined();
   });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,7 @@
 import simpleGit from 'simple-git';
 import { join, normalize, resolve, sep } from 'path';
 import { mkdtemp, mkdir, rm } from 'fs/promises';
+import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -21,6 +22,21 @@ interface GitHubRepoInfo {
   sshUrl: string;
 }
 
+interface SshCloneInfo {
+  host: string;
+  user: string;
+}
+
+interface SshHostConfig {
+  identitiesOnly: boolean;
+  identityFiles: string[];
+}
+
+interface SshPassphrasePromptIssue {
+  host: string;
+  identityFile: string;
+}
+
 export class GitCloneError extends Error {
   readonly url: string;
   readonly isTimeout: boolean;
@@ -32,6 +48,27 @@ export class GitCloneError extends Error {
     this.url = url;
     this.isTimeout = isTimeout;
     this.isAuthError = isAuthError;
+  }
+}
+
+export function parseSshCloneUrl(url: string): SshCloneInfo | null {
+  const scpStyleMatch = url.match(/^([^@]+)@([^:]+):(.+)$/);
+  if (scpStyleMatch) {
+    return {
+      user: scpStyleMatch[1]!,
+      host: scpStyleMatch[2]!,
+    };
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'ssh:' || !parsed.hostname) return null;
+    return {
+      user: parsed.username || 'git',
+      host: parsed.hostname,
+    };
+  } catch {
+    return null;
   }
 }
 
@@ -109,7 +146,7 @@ function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
       GIT_LFS_SKIP_SMUDGE: '1',
       ...extraEnv,
     },
-    // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect —
+    // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect -
     // git sees `filter=lfs` in .gitattributes, tries to run
     // `git-lfs filter-process`, and aborts the checkout with:
     //   git-lfs filter-process: git-lfs: command not found
@@ -119,7 +156,7 @@ function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
     // entirely for this clone, so checkout succeeds regardless of whether
     // git-lfs is installed. LFS-tracked files are left as ~130-byte
     // pointer files, which the skills installer doesn't read anyway
-    // (skills are plain text — HTML/MD/JSON — never LFS-tracked).
+    // (skills are plain text - HTML/MD/JSON - never LFS-tracked).
     //
     // Reported downstream: heygen-com/hyperframes#407.
     config: [
@@ -129,6 +166,109 @@ function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
       'filter.lfs.process=',
     ],
   });
+}
+
+async function getSshHostConfig(host: string): Promise<SshHostConfig | null> {
+  try {
+    const { stdout } = await execFileAsync('ssh', ['-G', host], {
+      timeout: 5000,
+      env: process.env,
+    });
+
+    const config: SshHostConfig = {
+      identitiesOnly: false,
+      identityFiles: [],
+    };
+
+    for (const rawLine of stdout.split('\n')) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      if (line.startsWith('identitiesonly ')) {
+        config.identitiesOnly = line.slice('identitiesonly '.length).trim() === 'yes';
+      } else if (line.startsWith('identityfile ')) {
+        config.identityFiles.push(line.slice('identityfile '.length).trim());
+      }
+    }
+
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+async function isPassphraseProtectedKey(identityFile: string): Promise<boolean | null> {
+  if (!existsSync(identityFile)) {
+    return null;
+  }
+
+  try {
+    await execFileAsync('ssh-keygen', ['-y', '-P', '', '-f', identityFile], {
+      timeout: 5000,
+      env: process.env,
+    });
+    return false;
+  } catch (error) {
+    const message =
+      error && typeof error === 'object' && 'stderr' in error
+        ? String((error as { stderr?: string }).stderr || '')
+        : '';
+    const combined = message.toLowerCase();
+
+    if (
+      combined.includes('incorrect passphrase') ||
+      combined.includes('bad passphrase') ||
+      combined.includes('passphrase')
+    ) {
+      return true;
+    }
+
+    return null;
+  }
+}
+
+async function isIdentityUsableThroughAgent(identityFile: string): Promise<boolean | null> {
+  const publicKeyPath = `${identityFile}.pub`;
+  if (!existsSync(publicKeyPath)) {
+    return null;
+  }
+
+  try {
+    await execFileAsync('ssh-add', ['-T', publicKeyPath], {
+      timeout: 5000,
+      env: process.env,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectSshPassphrasePromptIssue(
+  url: string
+): Promise<SshPassphrasePromptIssue | null> {
+  const sshClone = parseSshCloneUrl(url);
+  if (!sshClone) return null;
+
+  const config = await getSshHostConfig(sshClone.host);
+  if (!config || !config.identitiesOnly || config.identityFiles.length === 0) {
+    return null;
+  }
+
+  for (const identityFile of config.identityFiles) {
+    const isProtected = await isPassphraseProtectedKey(identityFile);
+    if (isProtected !== true) continue;
+
+    const agentUsable = await isIdentityUsableThroughAgent(identityFile);
+    if (agentUsable === false) {
+      return {
+        host: sshClone.host,
+        identityFile,
+      };
+    }
+  }
+
+  return null;
 }
 
 async function resetTempDir(dir: string): Promise<void> {
@@ -188,12 +328,47 @@ function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message:
   );
 }
 
+function buildSshPassphrasePromptError(
+  url: string,
+  issue: SshPassphrasePromptIssue,
+  interactive: boolean
+): string {
+  if (interactive) {
+    return (
+      `SSH clone for ${url} requires unlocking the passphrase-protected key ${issue.identityFile}, ` +
+      `but the current clone flow does not allow SSH to prompt for that passphrase.\n` +
+      `  - Load the key first: ssh-add ${issue.identityFile}\n` +
+      `  - Then rerun: npx skills add --list ${url}\n` +
+      `  - Host alias involved: ${issue.host}`
+    );
+  }
+
+  return (
+    `SSH clone for ${url} requires unlocking the passphrase-protected key ${issue.identityFile}, ` +
+    `but this session is non-interactive and cannot prompt for that passphrase.\n` +
+    `  - Load the key first: ssh-add ${issue.identityFile}\n` +
+    `  - Then rerun: npx skills add --list ${url}\n` +
+    `  - Host alias involved: ${issue.host}`
+  );
+}
+
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
   const repo = parseGitHubRepoUrl(url);
 
   try {
+    const sshPromptIssue = await detectSshPassphrasePromptIssue(url);
+    if (sshPromptIssue) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      throw new GitCloneError(
+        buildSshPassphrasePromptError(url, sshPromptIssue, !!process.stdin.isTTY),
+        url,
+        false,
+        true
+      );
+    }
+
     await createGitClient().clone(url, tempDir, cloneOptions);
     return tempDir;
   } catch (error) {


### PR DESCRIPTION
## Summary
- detect SSH clone aliases whose configured identity is passphrase-protected and not currently usable through the active SSH agent path
- fail before the 60s clone timeout instead of leaving users on `Cloning repository...` with a generic private-repo timeout
- add focused regression coverage for SSH alias parsing and passphrase dead-end detection
- This is intended to go before #911 
   - The second PR actually fixes the ability to prompt for the password

## What Changed
This patch adds a lightweight SSH preflight in `src/git.ts` before `git clone` starts:
- parse SSH clone URLs and host aliases
- inspect `ssh -G <host>` to resolve `IdentityFile` and `IdentitiesOnly`
- detect passphrase-protected private keys with `ssh-keygen -y -P '' -f <identity>`
- probe whether the identity is already usable through the current agent path via `ssh-add -T <identity>.pub`
- if the key is passphrase-protected and not agent-usable, surface a targeted `GitCloneError` immediately

This branch does not implement the interactive retry yet. It only removes the dead-end where a non-interactive SSH clone sits behind the spinner until the 60s timeout.

## Verification
Automated:
- `pnpm test src/git.test.ts`
- `pnpm format:check`

Manual validation performed while developing this fix:
- no-agent passphrase alias:
  - `npx skills add --list git@github-passphrase-giphy:Giphy/giphy-codex-skills.git`
  - current branch behavior: immediate targeted SSH/passphrase error instead of the old 60s timeout path
- 1Password agent alias:
  - `npx skills add --list git@github-1p-giphy:Giphy/giphy-codex-skills.git`
  - agent-backed auth still works when the key is available through 1Password

Sanitized SSH config snippets used for repro:

```sshconfig
Host github-passphrase-giphy
    HostName github.com
    User git
    IdentityFile ~/.ssh/id_rsa_github_passphrase_giphy
    IdentitiesOnly yes
```

```sshconfig
Host github-1p-giphy
    HostName github.com
    User git
    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
    IdentityFile ~/.ssh/id_rsa_github_passphrase_giphy.pub
    IdentitiesOnly yes
```

### SSH with Passphrase - No SSH Agent

#### Before - Hangs for 60 Seconds

<img width="886" height="617" alt="image" src="https://github.com/user-attachments/assets/fe049f79-41aa-4309-8a8a-be508205543f" />

#### After - SSH with Passphrase - Fast Fails (< 1 second)

<img width="849" height="608" alt="image" src="https://github.com/user-attachments/assets/cbf225dc-aa3c-4059-b017-c18a33be1c1a" />

## Notes
- `GIT_TERMINAL_PROMPT=0` does not suppress SSH passphrase prompts; it only affects Git's own credential prompting
- the follow-up stacked PR will handle the interactive TTY case by retrying without the spinner so native SSH prompts and `Ctrl-C` work normally