### PR TITLE
fix: hand off tty for interactive ssh clone prompts

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -21,7 +21,14 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   }
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
-import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
+import {
+  cloneRepo,
+  cloneRepoInteractive,
+  cleanupTempDir,
+  GitCloneError,
+  GitInteractiveSshPromptRequiredError,
+  getInteractiveSshRetryMessage,
+} from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
   installSkillForAgent,
@@ -66,6 +73,30 @@ import {
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
   setVersion(version);
+}
+
+async function cloneRepoWithPromptHandling(
+  spinner: ReturnType<typeof p.spinner>,
+  url: string,
+  ref?: string
+): Promise<string> {
+  spinner.start('Cloning repository...');
+
+  try {
+    const tempDir = await cloneRepo(url, ref);
+    spinner.stop('Repository cloned');
+    return tempDir;
+  } catch (error) {
+    if (error instanceof GitInteractiveSshPromptRequiredError) {
+      spinner.stop(pc.dim('SSH authentication requires terminal interaction...'));
+      p.log.message(pc.dim(getInteractiveSshRetryMessage(url, error.sshPromptIssue)));
+      const tempDir = await cloneRepoInteractive(url, ref);
+      p.log.step('Repository cloned');
+      return tempDir;
+    }
+
+    throw error;
+  }
 }
 
 // ─── Security Advisory ───
@@ -1025,9 +1056,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         spinner.stop(`Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
       } else {
         // Blob failed — fall back to git clone
-        spinner.start('Cloning repository...');
-        tempDir = await cloneRepo(parsed.url, parsed.ref);
-        spinner.stop('Repository cloned');
+        tempDir = await cloneRepoWithPromptHandling(spinner, parsed.url, parsed.ref);
 
         spinner.start('Discovering skills...');
         skills = await discoverSkills(tempDir, parsed.subpath, {
@@ -1037,9 +1066,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     } else {
       // GitLab, git URL, or --full-depth: always clone
-      spinner.start('Cloning repository...');
-      tempDir = await cloneRepo(parsed.url, parsed.ref);
-      spinner.stop('Repository cloned');
+      tempDir = await cloneRepoWithPromptHandling(spinner, parsed.url, parsed.ref);
 
       spinner.start('Discovering skills...');
       skills = await discoverSkills(tempDir, parsed.subpath, {

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -3,9 +3,11 @@ import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { promisify } from 'util';
+import { EventEmitter } from 'events';
 
 const simpleGitMock = vi.hoisted(() => vi.fn());
 const execFileAsyncMock = vi.hoisted(() => vi.fn());
+const spawnMock = vi.hoisted(() => vi.fn());
 
 vi.mock('simple-git', () => ({
   default: simpleGitMock,
@@ -20,18 +22,24 @@ vi.mock('child_process', async () => {
   return {
     ...actual,
     execFile,
+    spawn: spawnMock,
   };
 });
 
 import {
   GitCloneError,
+  GitInteractiveSshPromptRequiredError,
   cloneRepo,
+  cloneRepoInteractive,
   detectSshPassphrasePromptIssue,
   parseSshCloneUrl,
 } from './git.ts';
 
 function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
-  return { clone };
+  return {
+    clone,
+    env: vi.fn().mockReturnThis(),
+  };
 }
 
 function mockExecFileSuccess(stdout = '', stderr = '') {
@@ -44,12 +52,19 @@ function mockExecFileError(message: string) {
   );
 }
 
+function createSpawnChild() {
+  const child = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+  child.kill = vi.fn();
+  return child;
+}
+
 describe('git ssh passphrase handling', () => {
   const createdDirs: string[] = [];
 
   beforeEach(() => {
     simpleGitMock.mockReset();
     execFileAsyncMock.mockReset();
+    spawnMock.mockReset();
     execFileAsyncMock.mockRejectedValue(
       Object.assign(new Error('unexpected execFile call'), {
         code: 1,
@@ -117,6 +132,8 @@ describe('git ssh passphrase handling', () => {
 
     const originalIsTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    const clone = vi.fn().mockRejectedValue(new Error('Permission denied (publickey).'));
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(clone));
 
     try {
       await cloneRepo('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git');
@@ -133,6 +150,84 @@ describe('git ssh passphrase handling', () => {
       });
     }
 
-    expect(simpleGitMock.mock.results[0]?.value?.clone).toBeUndefined();
+    expect(clone).toHaveBeenCalledWith(
+      'git@github-passphrase-giphy:Giphy/giphy-codex-skills.git',
+      expect.any(String),
+      ['--depth', '1']
+    );
+    expect(simpleGitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeout: { block: 60000 },
+      })
+    );
+    expect(simpleGitMock.mock.results[0]?.value?.env).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GIT_TERMINAL_PROMPT: '0',
+        GIT_SSH_COMMAND: expect.stringContaining('BatchMode=yes'),
+      })
+    );
+  });
+
+  it('requests an interactive retry for SSH auth failures in a TTY', async () => {
+    const sshDir = join(tmpdir(), `skills-git-test-${Date.now()}`);
+    const identityFile = join(sshDir, 'id_rsa_github_passphrase_giphy');
+    mkdirSync(sshDir, { recursive: true });
+    writeFileSync(identityFile, 'private');
+    writeFileSync(`${identityFile}.pub`, 'public');
+    createdDirs.push(sshDir);
+
+    mockExecFileSuccess(
+      `host github-passphrase-giphy\nidentitiesonly yes\nidentityfile ${identityFile}\n`
+    );
+    mockExecFileError('incorrect passphrase supplied to decrypt private key');
+    mockExecFileError('The agent has no identities.');
+
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+
+    const clone = vi.fn().mockRejectedValue(new Error('Permission denied (publickey).'));
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(clone));
+
+    try {
+      await cloneRepo('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git');
+      throw new Error('Expected cloneRepo to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(GitInteractiveSshPromptRequiredError);
+      expect((error as Error).message).toMatch(/needs terminal interaction/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    }
+  });
+
+  it('runs interactive git clone with inherited stdio', async () => {
+    const child = createSpawnChild();
+    spawnMock.mockImplementationOnce(() => {
+      setImmediate(() => {
+        child.emit('exit', 0, null);
+      });
+      return child;
+    });
+
+    const tempDir = await cloneRepoInteractive(
+      'git@github-passphrase-giphy:Giphy/giphy-codex-skills.git'
+    );
+    createdDirs.push(tempDir);
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'git',
+      [
+        'clone',
+        '--depth',
+        '1',
+        'git@github-passphrase-giphy:Giphy/giphy-codex-skills.git',
+        tempDir,
+      ],
+      expect.objectContaining({
+        stdio: 'inherit',
+      })
+    );
   });
 });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { promisify } from 'util';
+
+const simpleGitMock = vi.hoisted(() => vi.fn());
+const execFileAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('simple-git', () => ({
+  default: simpleGitMock,
+}));
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  const execFile = vi.fn();
+  Object.defineProperty(execFile, promisify.custom, {
+    value: execFileAsyncMock,
+  });
+  return {
+    ...actual,
+    execFile,
+  };
+});
+
+import {
+  GitCloneError,
+  cloneRepo,
+  detectSshPassphrasePromptIssue,
+  parseSshCloneUrl,
+} from './git.ts';
+
+function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
+  return { clone };
+}
+
+function mockExecFileSuccess(stdout = '', stderr = '') {
+  execFileAsyncMock.mockResolvedValueOnce({ stdout, stderr });
+}
+
+function mockExecFileError(message: string) {
+  execFileAsyncMock.mockRejectedValueOnce(
+    Object.assign(new Error(message), { code: 1, stdout: '', stderr: message })
+  );
+}
+
+describe('git ssh passphrase handling', () => {
+  const createdDirs: string[] = [];
+
+  beforeEach(() => {
+    simpleGitMock.mockReset();
+    execFileAsyncMock.mockReset();
+    execFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('unexpected execFile call'), {
+        code: 1,
+        stdout: '',
+        stderr: 'unexpected execFile call',
+      })
+    );
+  });
+
+  afterEach(() => {
+    for (const dir of createdDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses SSH clone URLs and host aliases', () => {
+    expect(parseSshCloneUrl('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git')).toEqual({
+      user: 'git',
+      host: 'github-passphrase-giphy',
+    });
+
+    expect(
+      parseSshCloneUrl('ssh://git@github-passphrase-giphy/Giphy/giphy-codex-skills.git')
+    ).toEqual({
+      user: 'git',
+      host: 'github-passphrase-giphy',
+    });
+  });
+
+  it('detects passphrase-protected SSH identities that are not usable through agent', async () => {
+    const sshDir = join(tmpdir(), `skills-git-test-${Date.now()}`);
+    const identityFile = join(sshDir, 'id_rsa_github_passphrase_giphy');
+    mkdirSync(sshDir, { recursive: true });
+    writeFileSync(identityFile, 'private');
+    writeFileSync(`${identityFile}.pub`, 'public');
+    createdDirs.push(sshDir);
+
+    mockExecFileSuccess(
+      `host github-passphrase-giphy\nidentitiesonly yes\nidentityfile ${identityFile}\n`
+    );
+    mockExecFileError('incorrect passphrase supplied to decrypt private key');
+    mockExecFileError('The agent has no identities.');
+
+    await expect(
+      detectSshPassphrasePromptIssue('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git')
+    ).resolves.toEqual({
+      host: 'github-passphrase-giphy',
+      identityFile,
+    });
+  });
+
+  it('fails fast with a targeted message for SSH passphrase prompt dead-ends', async () => {
+    const sshDir = join(tmpdir(), `skills-git-test-${Date.now()}`);
+    const identityFile = join(sshDir, 'id_rsa_github_passphrase_giphy');
+    mkdirSync(sshDir, { recursive: true });
+    writeFileSync(identityFile, 'private');
+    writeFileSync(`${identityFile}.pub`, 'public');
+    createdDirs.push(sshDir);
+
+    mockExecFileSuccess(
+      `host github-passphrase-giphy\nidentitiesonly yes\nidentityfile ${identityFile}\n`
+    );
+    mockExecFileError('incorrect passphrase supplied to decrypt private key');
+    mockExecFileError('The agent has no identities.');
+
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    try {
+      await cloneRepo('git@github-passphrase-giphy:Giphy/giphy-codex-skills.git');
+      throw new Error('Expected cloneRepo to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(GitCloneError);
+      expect((error as Error).message).toMatch(/requires unlocking the passphrase-protected key/);
+      expect((error as Error).message).toMatch(/cannot prompt for that passphrase/);
+      expect((error as Error).message).toMatch(/ssh-add/);
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
+    }
+
+    expect(simpleGitMock.mock.results[0]?.value?.clone).toBeUndefined();
+  });
+});

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,7 +3,7 @@ import { join, normalize, resolve, sep } from 'path';
 import { mkdtemp, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
-import { execFile } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 
 const CLONE_TIMEOUT_MS = 60000; // 60 seconds
@@ -24,6 +24,10 @@ interface SshPassphrasePromptIssue {
   identityFile: string;
 }
 
+interface CloneRepoOptions {
+  allowInteractiveSshPrompt?: boolean;
+}
+
 export class GitCloneError extends Error {
   readonly url: string;
   readonly isTimeout: boolean;
@@ -35,6 +39,23 @@ export class GitCloneError extends Error {
     this.url = url;
     this.isTimeout = isTimeout;
     this.isAuthError = isAuthError;
+  }
+}
+
+export class GitInteractiveSshPromptRequiredError extends GitCloneError {
+  readonly sshPromptIssue: SshPassphrasePromptIssue | null;
+
+  constructor(url: string, sshPromptIssue: SshPassphrasePromptIssue | null) {
+    super(
+      sshPromptIssue
+        ? `SSH authentication for ${url} needs terminal interaction to unlock ${sshPromptIssue.identityFile}.`
+        : `SSH authentication for ${url} needs terminal interaction.`,
+      url,
+      false,
+      true
+    );
+    this.name = 'GitInteractiveSshPromptRequiredError';
+    this.sshPromptIssue = sshPromptIssue;
   }
 }
 
@@ -186,26 +207,75 @@ function buildSshPassphrasePromptError(
   );
 }
 
-export async function cloneRepo(url: string, ref?: string): Promise<string> {
-  const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const git = simpleGit({
+function buildSshInteractiveRetryMessage(
+  url: string,
+  issue: SshPassphrasePromptIssue | null
+): string {
+  if (issue) {
+    return (
+      `SSH clone for ${url} requires terminal interaction to unlock ${issue.identityFile}.\n` +
+      `  skills will retry without the spinner so git and ssh can prompt directly.\n` +
+      `  - Host alias involved: ${issue.host}`
+    );
+  }
+
+  return (
+    `SSH clone for ${url} requires terminal interaction.\n` +
+    `  skills will retry without the spinner so git and ssh can prompt directly.`
+  );
+}
+
+function buildNonInteractiveSshAuthError(
+  url: string,
+  issue: SshPassphrasePromptIssue | null
+): string {
+  if (issue) {
+    return buildSshPassphrasePromptError(url, issue, false);
+  }
+
+  const sshClone = parseSshCloneUrl(url);
+  const aliasLine = sshClone ? `\n  - Host alias involved: ${sshClone.host}` : '';
+
+  return (
+    `SSH authentication for ${url} could not complete without terminal interaction.\n` +
+    `  - If you use an SSH agent, unlock or approve the key there and retry\n` +
+    `  - Otherwise load the key first with ssh-add${aliasLine}`
+  );
+}
+
+function buildBatchModeSshCommand(command?: string): string {
+  if (!command || command.trim() === '') {
+    return 'ssh -o BatchMode=yes';
+  }
+
+  if (/BatchMode\s*=\s*yes/i.test(command) || /-o\s+BatchMode=yes/i.test(command)) {
+    return command;
+  }
+
+  return `${command} -o BatchMode=yes`;
+}
+
+function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
+  return simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-  });
+  }).env({ ...process.env, GIT_TERMINAL_PROMPT: '0', ...extraEnv });
+}
+
+export async function cloneRepo(
+  url: string,
+  ref?: string,
+  options: CloneRepoOptions = {}
+): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
+  const sshClone = parseSshCloneUrl(url);
+  const git = createGitClient(
+    sshClone
+      ? { GIT_SSH_COMMAND: buildBatchModeSshCommand(process.env.GIT_SSH_COMMAND) }
+      : undefined
+  );
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 
   try {
-    const sshPromptIssue = await detectSshPassphrasePromptIssue(url);
-    if (sshPromptIssue) {
-      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
-      throw new GitCloneError(
-        buildSshPassphrasePromptError(url, sshPromptIssue, !!process.stdin.isTTY),
-        url,
-        false,
-        true
-      );
-    }
-
     await git.clone(url, tempDir, cloneOptions);
     return tempDir;
   } catch (error) {
@@ -232,6 +302,21 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       );
     }
 
+    if (sshClone && isAuthError) {
+      const sshPromptIssue = await detectSshPassphrasePromptIssue(url);
+
+      if (process.stdin.isTTY && options.allowInteractiveSshPrompt !== false) {
+        throw new GitInteractiveSshPromptRequiredError(url, sshPromptIssue);
+      }
+
+      throw new GitCloneError(
+        buildNonInteractiveSshAuthError(url, sshPromptIssue),
+        url,
+        false,
+        true
+      );
+    }
+
     if (isAuthError) {
       throw new GitCloneError(
         `Authentication failed for ${url}.\n` +
@@ -246,6 +331,68 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
     throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);
   }
+}
+
+export async function cloneRepoInteractive(url: string, ref?: string): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
+  const cloneArgs = ref
+    ? ['clone', '--depth', '1', '--branch', ref, url, tempDir]
+    : ['clone', '--depth', '1', url, tempDir];
+
+  try {
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      const child = spawn('git', cloneArgs, {
+        stdio: 'inherit',
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      });
+
+      const forwardSigint = () => {
+        child.kill('SIGINT');
+      };
+
+      process.once('SIGINT', forwardSigint);
+
+      child.once('error', (spawnError) => {
+        process.removeListener('SIGINT', forwardSigint);
+        rejectPromise(spawnError);
+      });
+
+      child.once('exit', (code, signal) => {
+        process.removeListener('SIGINT', forwardSigint);
+
+        if (code === 0) {
+          resolvePromise();
+          return;
+        }
+
+        if (signal === 'SIGINT' || code === 130) {
+          rejectPromise(new GitCloneError('Clone canceled.', url, false, false));
+          return;
+        }
+
+        rejectPromise(
+          new GitCloneError(
+            `Failed to clone ${url}: interactive git clone exited with code ${code ?? 'unknown'}`,
+            url,
+            false,
+            false
+          )
+        );
+      });
+    });
+
+    return tempDir;
+  } catch (error) {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+export function getInteractiveSshRetryMessage(
+  url: string,
+  issue: SshPassphrasePromptIssue | null
+): string {
+  return buildSshInteractiveRetryMessage(url, issue);
 }
 
 export async function cleanupTempDir(dir: string): Promise<void> {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,9 +1,28 @@
 import simpleGit from 'simple-git';
 import { join, normalize, resolve, sep } from 'path';
 import { mkdtemp, rm } from 'fs/promises';
+import { existsSync } from 'fs';
 import { tmpdir } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 const CLONE_TIMEOUT_MS = 60000; // 60 seconds
+const execFileAsync = promisify(execFile);
+
+interface SshCloneInfo {
+  host: string;
+  user: string;
+}
+
+interface SshHostConfig {
+  identitiesOnly: boolean;
+  identityFiles: string[];
+}
+
+interface SshPassphrasePromptIssue {
+  host: string;
+  identityFile: string;
+}
 
 export class GitCloneError extends Error {
   readonly url: string;
@@ -19,6 +38,154 @@ export class GitCloneError extends Error {
   }
 }
 
+export function parseSshCloneUrl(url: string): SshCloneInfo | null {
+  const scpStyleMatch = url.match(/^([^@]+)@([^:]+):(.+)$/);
+  if (scpStyleMatch) {
+    return {
+      user: scpStyleMatch[1]!,
+      host: scpStyleMatch[2]!,
+    };
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'ssh:' || !parsed.hostname) return null;
+    return {
+      user: parsed.username || 'git',
+      host: parsed.hostname,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function getSshHostConfig(host: string): Promise<SshHostConfig | null> {
+  try {
+    const { stdout } = await execFileAsync('ssh', ['-G', host], {
+      timeout: 5000,
+      env: process.env,
+    });
+
+    const config: SshHostConfig = {
+      identitiesOnly: false,
+      identityFiles: [],
+    };
+
+    for (const rawLine of stdout.split('\n')) {
+      const line = rawLine.trim();
+      if (!line) continue;
+
+      if (line.startsWith('identitiesonly ')) {
+        config.identitiesOnly = line.slice('identitiesonly '.length).trim() === 'yes';
+      } else if (line.startsWith('identityfile ')) {
+        config.identityFiles.push(line.slice('identityfile '.length).trim());
+      }
+    }
+
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+async function isPassphraseProtectedKey(identityFile: string): Promise<boolean | null> {
+  if (!existsSync(identityFile)) {
+    return null;
+  }
+
+  try {
+    await execFileAsync('ssh-keygen', ['-y', '-P', '', '-f', identityFile], {
+      timeout: 5000,
+      env: process.env,
+    });
+    return false;
+  } catch (error) {
+    const message =
+      error && typeof error === 'object' && 'stderr' in error
+        ? String((error as { stderr?: string }).stderr || '')
+        : '';
+    const combined = message.toLowerCase();
+
+    if (
+      combined.includes('incorrect passphrase') ||
+      combined.includes('bad passphrase') ||
+      combined.includes('passphrase')
+    ) {
+      return true;
+    }
+
+    return null;
+  }
+}
+
+async function isIdentityUsableThroughAgent(identityFile: string): Promise<boolean | null> {
+  const publicKeyPath = `${identityFile}.pub`;
+  if (!existsSync(publicKeyPath)) {
+    return null;
+  }
+
+  try {
+    await execFileAsync('ssh-add', ['-T', publicKeyPath], {
+      timeout: 5000,
+      env: process.env,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectSshPassphrasePromptIssue(
+  url: string
+): Promise<SshPassphrasePromptIssue | null> {
+  const sshClone = parseSshCloneUrl(url);
+  if (!sshClone) return null;
+
+  const config = await getSshHostConfig(sshClone.host);
+  if (!config || !config.identitiesOnly || config.identityFiles.length === 0) {
+    return null;
+  }
+
+  for (const identityFile of config.identityFiles) {
+    const isProtected = await isPassphraseProtectedKey(identityFile);
+    if (isProtected !== true) continue;
+
+    const agentUsable = await isIdentityUsableThroughAgent(identityFile);
+    if (agentUsable === false) {
+      return {
+        host: sshClone.host,
+        identityFile,
+      };
+    }
+  }
+
+  return null;
+}
+
+function buildSshPassphrasePromptError(
+  url: string,
+  issue: SshPassphrasePromptIssue,
+  interactive: boolean
+): string {
+  if (interactive) {
+    return (
+      `SSH clone for ${url} requires unlocking the passphrase-protected key ${issue.identityFile}, ` +
+      `but the current clone flow does not allow SSH to prompt for that passphrase.\n` +
+      `  - Load the key first: ssh-add ${issue.identityFile}\n` +
+      `  - Then rerun: npx skills add --list ${url}\n` +
+      `  - Host alias involved: ${issue.host}`
+    );
+  }
+
+  return (
+    `SSH clone for ${url} requires unlocking the passphrase-protected key ${issue.identityFile}, ` +
+    `but this session is non-interactive and cannot prompt for that passphrase.\n` +
+    `  - Load the key first: ssh-add ${issue.identityFile}\n` +
+    `  - Then rerun: npx skills add --list ${url}\n` +
+    `  - Host alias involved: ${issue.host}`
+  );
+}
+
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const git = simpleGit({
@@ -28,6 +195,17 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 
   try {
+    const sshPromptIssue = await detectSshPassphrasePromptIssue(url);
+    if (sshPromptIssue) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      throw new GitCloneError(
+        buildSshPassphrasePromptError(url, sshPromptIssue, !!process.stdin.isTTY),
+        url,
+        false,
+        true
+      );
+    }
+
     await git.clone(url, tempDir, cloneOptions);
     return tempDir;
   } catch (error) {


### PR DESCRIPTION
## Summary
This PR is the interactive follow-up to #910.

It includes the same fail-fast base commit from #910 and adds a second commit that handles the TTY case correctly:
- first attempt SSH clone in batch mode so non-interactive auth either succeeds quickly or fails quickly
- if SSH auth fails and a TTY is available, stop the spinner and retry with `git` attached directly to the terminal
- let native SSH / agent prompts and `Ctrl-C` work instead of hiding them behind the spinner

Once #910 merges, this PR should collapse down to just the interactive retry commit.

## What Changed
In `src/git.ts`:
- keep the fail-fast SSH passphrase detection from #910
- add `GitInteractiveSshPromptRequiredError` for SSH auth failures that need terminal interaction
- use a batch-mode first attempt for SSH clone URLs by applying `BatchMode=yes` through `GIT_SSH_COMMAND`
- add `cloneRepoInteractive()` which runs `git clone` with inherited stdio so SSH and external agents can prompt directly in the terminal

In `src/add.ts`:
- wrap clone operations in a helper that:
  - starts the spinner for the non-interactive attempt
  - stops the spinner when terminal interaction is required
  - prints a short note explaining that `git` / `ssh` are taking over the terminal
  - retries interactively

In `src/git.test.ts`:
- keep the fail-fast non-interactive regression
- add coverage for interactive-retry signaling in TTY mode
- add coverage for the interactive clone path using inherited stdio

## Verification
Automated:
- `pnpm test src/git.test.ts`
- `pnpm format:check`

Manual:
- forced no-agent path to validate the TTY handoff:
  - `GIT_SSH_COMMAND='ssh -o IdentityAgent=none' pnpm dev add --list git@github-passphrase-giphy:Giphy/giphy-codex-skills.git`
  - observed behavior:
    - spinner starts
    - spinner stops with `SSH authentication requires terminal interaction`
    - terminal is handed to `git`
    - SSH shows `Enter passphrase for key ...`
    - `Ctrl-C` exits instead of trapping the user behind the spinner
- agent-backed path was previously validated manually with:
  - `pnpm dev add --list git@github-1p-giphy:Giphy/giphy-codex-skills.git`
  - `npx skills add --list git@github-1p-giphy:Giphy/giphy-codex-skills.git`

Sanitized SSH config snippets used for validation:

```sshconfig
Host github-passphrase-giphy
    HostName github.com
    User git
    IdentityFile ~/.ssh/id_rsa_github_passphrase_giphy
    IdentitiesOnly yes
```

```sshconfig
Host github-1p-giphy
    HostName github.com
    User git
    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
    IdentityFile ~/.ssh/id_rsa_github_passphrase_giphy.pub
    IdentitiesOnly yes
```

## Design Notes
- `GIT_TERMINAL_PROMPT=0` does not suppress SSH passphrase prompts; it only affects Git's own credential prompting
- `BatchMode=yes` is the key to making the first SSH attempt fail fast instead of blocking on hidden terminal input
- the interactive retry does not proxy or collect the passphrase in Node; it lets `git` / `ssh` handle prompts directly