### PR TITLE
Sync with upstream v1.5.0, rename to @zot24/skills

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,153 +1,31 @@
-name: Publish
+name: Publish to npm
 
 on:
   push:
-    branches: [main]
     tags:
       - 'v*'
-    paths-ignore:
-      - '**/*.md'
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
-          cache: pnpm
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - run: npm install -g npm@latest
 
-      - name: Build
-        run: pnpm build
+      - run: npm ci
 
-      - name: Determine version bump type
-        id: version
-        run: |
-          # If tag push, skip version bump (already versioned)
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "bump=skip" >> $GITHUB_OUTPUT
-            echo "Tag push - skipping version bump, will publish directly"
-            exit 0
-          fi
+      - run: npm run build
 
-          # If manually triggered, use the input value
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "bump=${{ inputs.bump }}" >> $GITHUB_OUTPUT
-            echo "Manual trigger - will bump ${{ inputs.bump }} version"
-            exit 0
-          fi
-
-          # Get the latest version tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_TAG" ]; then
-            # No tags found, use all commits
-            COMMITS=$(git log --format=%s)
-          else
-            # Get commits since the latest tag
-            COMMITS=$(git log ${LATEST_TAG}..HEAD --format=%s)
-          fi
-
-          echo "Commits since last tag:"
-          echo "$COMMITS"
-
-          # Check for explicit version bump markers
-          if echo "$COMMITS" | grep -q "\[minor\]"; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
-            echo "Found [minor] - will bump minor version"
-          elif echo "$COMMITS" | grep -q "\[patch\]"; then
-            echo "bump=patch" >> $GITHUB_OUTPUT
-            echo "Found [patch] - will bump patch version"
-          else
-            echo "bump=none" >> $GITHUB_OUTPUT
-            echo "No version marker found - skipping release"
-          fi
-
-      - name: Configure git
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Reset generated files
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
-        run: |
-          # Reset any changes to generated files (e.g., ThirdPartyNoticeText.txt)
-          # that may differ between local and CI builds
-          git checkout -- ThirdPartyNoticeText.txt || true
-
-      - name: Bump version
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
-        run: |
-          npm version ${{ steps.version.outputs.bump }} -m "v%s"
-
-      - name: Push changes
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
-        run: |
-          git push
-          git push --tags
-
-      - name: Publish to npm
-        id: publish
-        if: steps.version.outputs.bump != 'none'
-        run: npm publish --provenance --access public
+      - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release
-        if: steps.publish.outcome == 'success'
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-
-          # Get changelog from merged PRs since last tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          if [ -z "$LATEST_TAG" ]; then
-            SINCE=""
-          else
-            SINCE=$(git log -1 --format=%cI ${LATEST_TAG})
-          fi
-
-          # Fetch merged PRs and format as changelog
-          if [ -z "$SINCE" ]; then
-            PRS=$(gh pr list --state merged --json number,title,author --limit 100)
-          else
-            PRS=$(gh pr list --state merged --search "merged:>=${SINCE}" --json number,title,author --limit 100)
-          fi
-
-          CHANGELOG=$(echo "$PRS" | jq -r '.[] | "- \(.title) (#\(.number))"')
-          CONTRIBUTORS=$(echo "$PRS" | jq -r '.[].author.login' | sort -u | sed 's/^/@/' | paste -sd ', ' -)
-
-          # Generate release notes from template
-          export VERSION CHANGELOG CONTRIBUTORS
-          envsubst < .github/RELEASE_TEMPLATE.md > release-notes.md
-
-          gh release create "v${VERSION}" --notes-file release-notes.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,109 @@
+# Fork: @zot24/skills
+
+This is a fork of [vercel-labs/skills](https://github.com/vercel-labs/skills/) (upstream package: `skills`).
+
+## Installation
+
+```bash
+npx @zot24/skills add vercel-labs/agent-skills
+```
+
+## Why This Fork?
+
+This fork adds declarative batch skill installation via TOML manifests, enabling:
+- Team-wide skill synchronization
+- Reproducible skill installations in CI/CD
+- Multi-location installation for monorepos
+
+It also changes telemetry from opt-out to opt-in (set `ENABLE_TELEMETRY=1` to enable).
+
+## Fork Features
+
+### Manifest Files (`--from-file`)
+
+Install multiple skills from a TOML manifest file:
+
+```bash
+npx @zot24/skills add --from-file skills.toml
+npx @zot24/skills add -f skills.toml -g -y
+```
+
+#### Manifest Format
+
+Create a `skills.toml` file:
+
+```toml
+[[skills]]
+source = "vercel-labs/agent-skills"
+name = "frontend-design"
+version = "1.0.0"
+
+[[skills]]
+source = "vercel-labs/agent-skills"
+name = "code-review"
+
+[[skills]]
+source = "other-org/custom-skills"
+name = "my-skill"
+version = "2.0.0"
+```
+
+Each `[[skills]]` entry requires:
+- `source`: Repository in `owner/repo` format or full git URL
+- `name`: Name of the skill to install
+
+Optional fields:
+- `version`: Semantic version (e.g., `1.0.0`) - defaults to latest
+- `locations`: Array of installation locations (see below)
+
+### Multi-Location Installation
+
+The `locations` array allows installing a skill to multiple directories:
+
+```toml
+[[skills]]
+source = "vercel-labs/agent-skills"
+name = "frontend-design"
+locations = ["global", "packages/frontend", "packages/admin"]
+```
+
+Supported values:
+- `"global"` - Install to user home directory
+- `"project"` - Install to current working directory
+- Custom relative paths (e.g., `"packages/my-app"`)
+
+When `locations` is not specified, falls back to `--global` flag or interactive prompt.
+
+### Lock File
+
+A `-lock.toml` file is generated alongside the manifest (e.g., `skills-lock.toml`):
+
+```toml
+lockVersion = 1
+
+[[skills]]
+source = "vercel-labs/agent-skills"
+name = "frontend-design"
+version = "1.0.0"
+resolvedRef = "a1b2c3d4e5f6789abc0123456789def012345678"
+installedAt = "2026-01-16T12:00:00.000Z"
+```
+
+Use `--no-lock` to skip lock file generation.
+
+### Reproducible Installations (`--frozen`)
+
+```bash
+# First, generate a lock file
+npx @zot24/skills add --from-file skills.toml
+
+# Then use --frozen for exact reproducibility
+npx @zot24/skills add --from-file skills.toml --frozen
+```
+
+Frozen mode:
+- Uses exact commit SHAs from the lock file
+- Fails if any manifest skill is missing from the lock file
+- Does not update the lock file
+
+Useful for CI/CD pipelines and ensuring identical skill versions across machines.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# skills
+# @zot24/skills
+
+> Fork of [vercel-labs/skills](https://github.com/vercel-labs/skills) with TOML manifest-based batch installation, frozen mode, and opt-in telemetry. See [FORK.md](FORK.md) for fork-specific features.
 
 The CLI for the open agent skills ecosystem.
 

--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,6 +9,23 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
+Package: @clack/core@0.5.0
+License: MIT
+Repository: https://github.com/bombshell-dev/clack
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -55,6 +72,35 @@ Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+Package: sisteransi@1.0.5
+License: MIT
+Repository: https://github.com/terkelg/sisteransi
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "skills",
+  "name": "@zot24/skills",
   "version": "1.5.0",
   "description": "The open agent skills ecosystem",
   "type": "module",
@@ -84,11 +84,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel-labs/skills.git"
+    "url": "git+https://github.com/zot24/add-skill.git"
   },
-  "homepage": "https://github.com/vercel-labs/skills#readme",
+  "homepage": "https://github.com/zot24/add-skill#readme",
   "bugs": {
-    "url": "https://github.com/vercel-labs/skills/issues"
+    "url": "https://github.com/zot24/add-skill/issues"
   },
   "author": "",
   "license": "MIT",
@@ -111,6 +111,7 @@
   },
   "packageManager": "pnpm@10.17.1",
   "dependencies": {
+    "smol-toml": "^1.3.1",
     "yaml": "^2.8.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import {
   buildLocalUpdateSource,
   formatSourceInput,
 } from './update-source.ts';
+import { installFromManifest, type ManifestInstallOptions } from './manifest-install.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -140,6 +141,9 @@ ${BOLD}Add Options:${RESET}
   --copy                 Copy files instead of symlinking to agent directories
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
+  -f, --from-file <path> Install skills from a TOML manifest file
+  --no-lock              Skip lock file generation (with --from-file)
+  --frozen               Use exact versions from lock file (with --from-file)
 
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope
@@ -872,8 +876,35 @@ async function main(): Promise<void> {
     case 'a':
     case 'add': {
       showLogo();
-      const { source: addSource, options: addOpts } = parseAddOptions(restArgs);
-      await runAdd(addSource, addOpts);
+      // Check for --from-file flag (manifest mode)
+      const fromFileIdx = restArgs.findIndex((a) => a === '-f' || a === '--from-file');
+      if (fromFileIdx !== -1) {
+        const manifestPath = restArgs[fromFileIdx + 1];
+        if (!manifestPath) {
+          console.log(`${TEXT}Error:${RESET} --from-file requires a path argument`);
+          process.exit(1);
+        }
+        const manifestOpts: ManifestInstallOptions = {};
+        for (const arg of restArgs) {
+          if (arg === '-g' || arg === '--global') manifestOpts.global = true;
+          if (arg === '-y' || arg === '--yes') manifestOpts.yes = true;
+          if (arg === '--no-lock') manifestOpts.noLock = true;
+          if (arg === '--frozen') manifestOpts.frozen = true;
+          if (arg === '-a' || arg === '--agent') {
+            manifestOpts.agent = manifestOpts.agent || [];
+            const agentIdx = restArgs.indexOf(arg);
+            let j = agentIdx + 1;
+            while (j < restArgs.length && restArgs[j] && !restArgs[j]!.startsWith('-')) {
+              manifestOpts.agent.push(restArgs[j]!);
+              j++;
+            }
+          }
+        }
+        await installFromManifest(manifestPath, manifestOpts);
+      } else {
+        const { source: addSource, options: addOpts } = parseAddOptions(restArgs);
+        await runAdd(addSource, addOpts);
+      }
       break;
     }
     case 'remove':

--- a/src/manifest-install.ts
+++ b/src/manifest-install.ts
@@ -1,0 +1,537 @@
+/**
+ * Manifest-based batch skill installation (fork feature).
+ *
+ * Installs multiple skills from a TOML manifest file with support for:
+ * - Version pinning and resolution
+ * - Multi-location installation (global/project/custom paths)
+ * - Frozen mode for reproducible installs via lock file
+ */
+
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { join } from 'path';
+import { homedir } from 'os';
+import { parseSource, getOwnerRepo } from './source-parser.ts';
+import { cloneRepo, cleanupTempDir } from './git.ts';
+import { discoverSkills, getSkillDisplayName } from './skills.ts';
+import {
+  installSkillForAgent,
+  isSkillInstalled,
+  getInstallPath,
+  getCanonicalSkillsDir,
+  getAgentBaseDir,
+  sanitizeName,
+} from './installer.ts';
+import { detectInstalledAgents, agents } from './agents.ts';
+import { track } from './telemetry.ts';
+import { addSkillToLock } from './skill-lock.ts';
+import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
+import {
+  parseManifestFile,
+  groupSkillsBySource,
+  groupSkillsBySourceAndRef,
+  getLockFilePath,
+  readLockFile,
+  writeLockFile,
+  ManifestParseError,
+  SkillNotFoundError,
+} from './manifest.ts';
+import type { Skill, AgentType, ManifestSkillEntry, ManifestLockEntry } from './types.ts';
+
+export interface ManifestInstallOptions {
+  global?: boolean;
+  agent?: string[];
+  yes?: boolean;
+  noLock?: boolean;
+  frozen?: boolean;
+}
+
+/**
+ * Resolves a location string to an actual install path for a given agent.
+ */
+function resolveLocationPath(
+  skillName: string,
+  agentType: AgentType,
+  location: string,
+  cwd: string
+): string {
+  const sanitized = sanitizeName(skillName);
+
+  if (location === 'global') {
+    return join(getAgentBaseDir(agentType, true), sanitized);
+  }
+
+  if (location === 'project') {
+    return join(getAgentBaseDir(agentType, false, cwd), sanitized);
+  }
+
+  // Custom relative path
+  const customCwd = join(cwd, location);
+  return join(getAgentBaseDir(agentType, false, customCwd), sanitized);
+}
+
+function getLocationLabel(location: string): string {
+  if (location === 'global') return '[global]';
+  if (location === 'project') return '[project]';
+  return `[${location}]`;
+}
+
+export async function installFromManifest(
+  manifestPath: string,
+  options: ManifestInstallOptions
+): Promise<void> {
+  console.log();
+  p.intro(pc.bgCyan(pc.black(' add-skill ')) + pc.dim(' (manifest mode)'));
+
+  const tempDirs: string[] = [];
+  const cwd = process.cwd();
+
+  try {
+    const spinner = p.spinner();
+
+    if (options.frozen && options.noLock) {
+      p.log.error('Cannot use --frozen with --no-lock. Frozen mode requires a lock file.');
+      process.exit(1);
+    }
+
+    // Parse manifest file
+    spinner.start('Parsing manifest file...');
+    let manifest;
+    try {
+      manifest = await parseManifestFile(manifestPath);
+    } catch (error) {
+      spinner.stop(pc.red('Failed to parse manifest'));
+      if (error instanceof ManifestParseError) {
+        p.log.error(error.message);
+      } else {
+        p.log.error((error as Error).message);
+      }
+      process.exit(1);
+    }
+    spinner.stop(
+      `Found ${pc.green(String(manifest.skills.length))} skill${manifest.skills.length !== 1 ? 's' : ''} in manifest`
+    );
+
+    // Read lock file if in frozen mode
+    const lockPath = getLockFilePath(manifestPath);
+    let lockFile: Awaited<ReturnType<typeof readLockFile>> = null;
+
+    if (options.frozen) {
+      spinner.start('Reading lock file...');
+      lockFile = await readLockFile(lockPath);
+
+      if (!lockFile) {
+        spinner.stop(pc.red('Lock file not found'));
+        p.log.error(
+          'Frozen mode requires a lock file. Run without --frozen first to generate one.'
+        );
+        p.log.info(`Expected lock file: ${lockPath}`);
+        process.exit(1);
+      }
+
+      spinner.stop(`Lock file loaded (${pc.green(String(lockFile.skills.length))} entries)`);
+    }
+
+    // In frozen mode, validate all manifest skills exist in lock file
+    if (options.frozen && lockFile) {
+      for (const entry of manifest.skills) {
+        const lockEntry = lockFile.skills.find(
+          (l) => l.source === entry.source && l.name.toLowerCase() === entry.name.toLowerCase()
+        );
+        if (!lockEntry) {
+          p.log.error(`Skill "${entry.name}" from "${entry.source}" not found in lock file.`);
+          p.log.info('Run without --frozen to update the lock file with new skills.');
+          process.exit(1);
+        }
+      }
+    }
+
+    // Group skills by source (and ref in frozen mode)
+    const skillsBySource =
+      options.frozen && lockFile
+        ? groupSkillsBySourceAndRef(manifest.skills, lockFile.skills)
+        : groupSkillsBySource(manifest.skills);
+    p.log.info(
+      `From ${pc.cyan(String(skillsBySource.size))} source${skillsBySource.size !== 1 ? 's' : ''}`
+    );
+
+    // Collect all skills to install
+    const skillsToInstall: Array<{
+      skill: Skill;
+      entry: ManifestSkillEntry;
+      resolvedRef: string;
+      locations: string[];
+    }> = [];
+    const lockEntries: ManifestLockEntry[] = [];
+
+    // Process each source
+    for (const [_sourceKey, entries] of skillsBySource) {
+      const firstEntry = entries[0]!;
+      const source = firstEntry.source;
+      const version = firstEntry.version;
+
+      const parsed = parseSource(source);
+      let tempDir: string;
+      let resolvedRef: string;
+
+      if (options.frozen && lockFile) {
+        const lockEntry = lockFile.skills.find(
+          (l) => l.source === source && l.name.toLowerCase() === firstEntry.name.toLowerCase()
+        )!;
+        const ref = lockEntry.resolvedRef;
+
+        spinner.start(`Cloning ${pc.cyan(source)} @ ${pc.dim(ref.slice(0, 7))} (frozen)...`);
+
+        tempDir = await cloneRepo(parsed.url, ref);
+        resolvedRef = ref;
+      } else {
+        spinner.start(`Cloning ${pc.cyan(source)}${version ? ` @ ${version}` : ''}...`);
+
+        // Clone at version tag if specified, otherwise HEAD
+        const ref = version ? `v${version}` : undefined;
+        tempDir = await cloneRepo(parsed.url, ref);
+
+        // Get the resolved ref (HEAD of the cloned repo)
+        const { execSync } = await import('child_process');
+        resolvedRef = execSync('git rev-parse HEAD', {
+          cwd: tempDir,
+          encoding: 'utf-8',
+        }).trim();
+      }
+
+      tempDirs.push(tempDir);
+      spinner.stop(`Cloned ${pc.cyan(source)} (${pc.dim(resolvedRef.slice(0, 7))})`);
+
+      spinner.start('Discovering skills...');
+      const discoveredSkills = await discoverSkills(tempDir, parsed.subpath);
+      spinner.stop(
+        `Found ${discoveredSkills.length} skill${discoveredSkills.length !== 1 ? 's' : ''}`
+      );
+
+      // Match requested skills
+      for (const entry of entries) {
+        const skill = discoveredSkills.find(
+          (s) => s.name.toLowerCase() === entry.name.toLowerCase()
+        );
+
+        if (!skill) {
+          throw new SkillNotFoundError(
+            entry.name,
+            entry.source,
+            discoveredSkills.map((s) => s.name)
+          );
+        }
+
+        // Determine locations for this skill
+        const entryLocations = entry.locations && entry.locations.length > 0 ? entry.locations : [];
+
+        skillsToInstall.push({ skill, entry, resolvedRef, locations: entryLocations });
+      }
+    }
+
+    // Determine target agents
+    let targetAgents: AgentType[];
+
+    if (options.agent && options.agent.length > 0) {
+      const validAgentNames = Object.keys(agents);
+      const invalidAgents = options.agent.filter((a) => !validAgentNames.includes(a));
+
+      if (invalidAgents.length > 0) {
+        p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
+        p.log.info(`Valid agents: ${validAgentNames.join(', ')}`);
+        await cleanupAll(tempDirs);
+        process.exit(1);
+      }
+
+      targetAgents = options.agent as AgentType[];
+    } else {
+      spinner.start('Detecting installed agents...');
+      const installedAgents = await detectInstalledAgents();
+      spinner.stop(
+        `Detected ${installedAgents.length} agent${installedAgents.length !== 1 ? 's' : ''}`
+      );
+
+      if (installedAgents.length === 0) {
+        if (options.yes) {
+          targetAgents = Object.keys(agents) as AgentType[];
+          p.log.info('Installing to all agents (none detected)');
+        } else {
+          p.log.warn('No coding agents detected. You can still install skills.');
+
+          const allAgentChoices = Object.entries(agents).map(([key, config]) => ({
+            value: key as AgentType,
+            label: config.displayName,
+          }));
+
+          const selected = await p.multiselect({
+            message: 'Select agents to install skills to',
+            options: allAgentChoices,
+            required: true,
+          });
+
+          if (p.isCancel(selected)) {
+            p.cancel('Installation cancelled');
+            await cleanupAll(tempDirs);
+            process.exit(0);
+          }
+
+          targetAgents = selected as AgentType[];
+        }
+      } else if (installedAgents.length === 1 || options.yes) {
+        targetAgents = installedAgents;
+        p.log.info(
+          `Installing to: ${targetAgents.map((a) => pc.cyan(agents[a].displayName)).join(', ')}`
+        );
+      } else {
+        const agentChoices = installedAgents.map((a) => ({
+          value: a,
+          label: agents[a].displayName,
+          hint: `${options.global ? agents[a].globalSkillsDir : agents[a].skillsDir}`,
+        }));
+
+        const selected = await p.multiselect({
+          message: 'Select agents to install skills to',
+          options: agentChoices,
+          required: true,
+          initialValues: installedAgents,
+        });
+
+        if (p.isCancel(selected)) {
+          p.cancel('Installation cancelled');
+          await cleanupAll(tempDirs);
+          process.exit(0);
+        }
+
+        targetAgents = selected as AgentType[];
+      }
+    }
+
+    // Determine default location for skills without explicit locations
+    let defaultLocation: string | null = null;
+    const skillsNeedingLocation = skillsToInstall.filter((s) => s.locations.length === 0);
+
+    if (skillsNeedingLocation.length > 0) {
+      if (options.global !== undefined) {
+        defaultLocation = options.global ? 'global' : 'project';
+      } else if (options.yes) {
+        defaultLocation = 'project';
+      } else {
+        const scope = await p.select({
+          message: 'Installation scope (for skills without explicit locations)',
+          options: [
+            { value: 'project', label: 'Project', hint: 'Install in current directory' },
+            { value: 'global', label: 'Global', hint: 'Install in home directory' },
+          ],
+        });
+
+        if (p.isCancel(scope)) {
+          p.cancel('Installation cancelled');
+          await cleanupAll(tempDirs);
+          process.exit(0);
+        }
+
+        defaultLocation = scope as string;
+      }
+
+      for (const item of skillsNeedingLocation) {
+        item.locations = [defaultLocation];
+      }
+    }
+
+    // Display summary
+    console.log();
+    p.log.step(pc.bold('Installation Summary'));
+
+    for (const { skill, entry, locations } of skillsToInstall) {
+      const versionStr = entry.version ? ` @ ${entry.version}` : '';
+      p.log.message(`  ${pc.cyan(getSkillDisplayName(skill))}${pc.dim(versionStr)}`);
+      p.log.message(`    ${pc.dim('from')} ${entry.source}`);
+      for (const location of locations) {
+        const locationLabel = getLocationLabel(location);
+        for (const agent of targetAgents) {
+          const path = resolveLocationPath(skill.name, agent, location, cwd);
+          const installed = await isSkillInstalled(skill.name, agent, {
+            global: location === 'global',
+            cwd: location !== 'global' && location !== 'project' ? join(cwd, location) : cwd,
+          });
+          const status = installed ? pc.yellow(' (will overwrite)') : '';
+          p.log.message(
+            `    ${pc.dim('→')} ${agents[agent].displayName} ${pc.blue(locationLabel)}: ${pc.dim(path)}${status}`
+          );
+        }
+      }
+    }
+    console.log();
+
+    // Confirm installation
+    if (!options.yes) {
+      const confirmed = await p.confirm({ message: 'Proceed with installation?' });
+
+      if (p.isCancel(confirmed) || !confirmed) {
+        p.cancel('Installation cancelled');
+        await cleanupAll(tempDirs);
+        process.exit(0);
+      }
+    }
+
+    // Install skills
+    spinner.start('Installing skills...');
+
+    const results: {
+      skill: string;
+      agent: string;
+      location: string;
+      success: boolean;
+      path: string;
+      error?: string;
+    }[] = [];
+
+    for (const { skill, entry, resolvedRef, locations } of skillsToInstall) {
+      for (const location of locations) {
+        for (const agent of targetAgents) {
+          const isGlobal = location === 'global';
+          const installCwd =
+            location !== 'global' && location !== 'project' ? join(cwd, location) : cwd;
+
+          const result = await installSkillForAgent(skill, agent, {
+            global: isGlobal,
+            cwd: installCwd,
+          });
+
+          results.push({
+            skill: getSkillDisplayName(skill),
+            agent: agents[agent].displayName,
+            location,
+            ...result,
+          });
+
+          // Register in upstream's global lock for update tracking
+          if (result.success) {
+            const ownerRepo = getOwnerRepo(parseSource(entry.source));
+            if (ownerRepo) {
+              try {
+                await addSkillToLock(skill.name, {
+                  source: ownerRepo,
+                  sourceType: parseSource(entry.source).type,
+                  sourceUrl: parseSource(entry.source).url,
+                  ref: entry.version ? `v${entry.version}` : undefined,
+                  skillFolderHash: '',
+                });
+              } catch {
+                // Non-critical: don't fail install if lock update fails
+              }
+            }
+
+            // Register in local lock for project-scope installs
+            if (!isGlobal) {
+              try {
+                const hash = await computeSkillFolderHash(result.path);
+                await addSkillToLocalLock(
+                  skill.name,
+                  {
+                    source: ownerRepo || entry.source,
+                    sourceType: parseSource(entry.source).type,
+                    ref: entry.version ? `v${entry.version}` : undefined,
+                    computedHash: hash,
+                  },
+                  installCwd
+                );
+              } catch {
+                // Non-critical
+              }
+            }
+          }
+
+          // Prepare manifest lock entry
+          if (!options.frozen && result.success) {
+            lockEntries.push({
+              source: entry.source,
+              name: entry.name,
+              version: entry.version || 'latest',
+              resolvedRef,
+              installedAt: new Date().toISOString(),
+              location,
+            });
+          }
+        }
+      }
+    }
+
+    spinner.stop('Installation complete');
+
+    // Write manifest lock file
+    if (!options.noLock && !options.frozen && lockEntries.length > 0) {
+      await writeLockFile(lockPath, lockEntries);
+      p.log.info(`Lock file written to ${pc.dim(lockPath)}`);
+    }
+
+    // Report results
+    console.log();
+    const successful = results.filter((r) => r.success);
+    const failed = results.filter((r) => !r.success);
+
+    // Track installation
+    const hasGlobalLocation = skillsToInstall.some((s) => s.locations.includes('global'));
+    track({
+      event: 'install',
+      source: `manifest:${manifest.skills.length}`,
+      skills: skillsToInstall.map((s) => s.skill.name).join(','),
+      agents: targetAgents.join(','),
+      ...(hasGlobalLocation && { global: '1' }),
+    });
+
+    if (successful.length > 0) {
+      p.log.success(
+        pc.green(
+          `Successfully installed ${successful.length} skill${successful.length !== 1 ? 's' : ''}`
+        )
+      );
+      for (const r of successful) {
+        const locationLabel = getLocationLabel(r.location);
+        p.log.message(`  ${pc.green('✓')} ${r.skill} → ${r.agent} ${pc.blue(locationLabel)}`);
+        p.log.message(`    ${pc.dim(r.path)}`);
+      }
+    }
+
+    if (failed.length > 0) {
+      console.log();
+      p.log.error(
+        pc.red(`Failed to install ${failed.length} skill${failed.length !== 1 ? 's' : ''}`)
+      );
+      for (const r of failed) {
+        const locationLabel = getLocationLabel(r.location);
+        p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent} ${pc.blue(locationLabel)}`);
+        p.log.message(`    ${pc.dim(r.error)}`);
+      }
+    }
+
+    console.log();
+    p.outro(pc.green('Done!'));
+  } catch (error) {
+    if (error instanceof SkillNotFoundError) {
+      p.log.error(error.message);
+      if (error.availableSkills.length > 0) {
+        p.log.info('Available skills:');
+        for (const name of error.availableSkills) {
+          p.log.message(`  - ${name}`);
+        }
+      }
+    } else {
+      p.log.error(error instanceof Error ? error.message : 'Unknown error occurred');
+    }
+    p.outro(pc.red('Installation failed'));
+    process.exit(1);
+  } finally {
+    await cleanupAll(tempDirs);
+  }
+}
+
+async function cleanupAll(tempDirs: string[]) {
+  for (const dir of tempDirs) {
+    try {
+      await cleanupTempDir(dir);
+    } catch {
+      // Best effort cleanup
+    }
+  }
+}

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,0 +1,327 @@
+import { readFile, writeFile } from 'fs/promises';
+import { dirname } from 'path';
+import { parse, stringify } from 'smol-toml';
+import type {
+  ManifestSkillEntry,
+  SkillManifest,
+  ManifestLockEntry,
+  ManifestLockFile,
+} from './types.ts';
+
+export class ManifestParseError extends Error {
+  filePath: string;
+  constructor(message: string, filePath: string) {
+    super(message);
+    this.name = 'ManifestParseError';
+    this.filePath = filePath;
+  }
+}
+
+export class VersionNotFoundError extends Error {
+  source: string;
+  version: string;
+  availableVersions: string[];
+  constructor(source: string, version: string, availableVersions: string[]) {
+    super(
+      `Version ${version} not found for ${source}. Available: ${availableVersions.join(', ') || 'none'}`
+    );
+    this.name = 'VersionNotFoundError';
+    this.source = source;
+    this.version = version;
+    this.availableVersions = availableVersions;
+  }
+}
+
+export class SkillNotFoundError extends Error {
+  skillName: string;
+  source: string;
+  availableSkills: string[];
+  constructor(skillName: string, source: string, availableSkills: string[]) {
+    super(
+      `Skill "${skillName}" not found in ${source}. Available: ${availableSkills.join(', ') || 'none'}`
+    );
+    this.name = 'SkillNotFoundError';
+    this.skillName = skillName;
+    this.source = source;
+    this.availableSkills = availableSkills;
+  }
+}
+
+export class LocationValidationError extends Error {
+  location: string;
+  constructor(message: string, location: string) {
+    super(message);
+    this.name = 'LocationValidationError';
+    this.location = location;
+  }
+}
+
+/**
+ * Validates a location string for security and correctness.
+ * Accepts: "global", "project", or relative paths (no absolute paths, no "..")
+ */
+export function validateLocation(location: string): void {
+  if (location === 'global' || location === 'project') {
+    return;
+  }
+
+  if (!location || location.trim() === '') {
+    throw new LocationValidationError('Location cannot be empty', location);
+  }
+
+  if (location.startsWith('/') || location.startsWith('~')) {
+    throw new LocationValidationError(
+      `Location "${location}" must be a relative path. Absolute paths starting with "/" or "~" are not allowed.`,
+      location
+    );
+  }
+
+  if (/^[A-Za-z]:/.test(location)) {
+    throw new LocationValidationError(
+      `Location "${location}" must be a relative path. Windows absolute paths are not allowed.`,
+      location
+    );
+  }
+
+  if (location.includes('..')) {
+    throw new LocationValidationError(
+      `Location "${location}" contains ".." which is not allowed for security reasons.`,
+      location
+    );
+  }
+
+  if (/[\x00]/.test(location)) {
+    throw new LocationValidationError(
+      `Location "${location}" contains invalid characters.`,
+      location
+    );
+  }
+}
+
+interface TomlSkillEntry {
+  source: string;
+  name: string;
+  version?: string;
+  locations?: string[];
+}
+
+interface TomlManifest {
+  skills?: TomlSkillEntry[];
+}
+
+interface TomlLockEntry {
+  source: string;
+  name: string;
+  version: string;
+  resolvedRef: string;
+  installedAt: string;
+  location?: string;
+}
+
+interface TomlLockFile {
+  lockVersion?: number;
+  skills?: TomlLockEntry[];
+}
+
+export async function parseManifestFile(filePath: string): Promise<SkillManifest> {
+  let content: string;
+
+  try {
+    content = await readFile(filePath, 'utf-8');
+  } catch (error) {
+    throw new ManifestParseError(
+      `Could not read manifest file: ${(error as Error).message}`,
+      filePath
+    );
+  }
+
+  let parsed: TomlManifest;
+  try {
+    parsed = parse(content) as TomlManifest;
+  } catch (error) {
+    throw new ManifestParseError(`Invalid TOML: ${(error as Error).message}`, filePath);
+  }
+
+  if (!parsed.skills || !Array.isArray(parsed.skills)) {
+    throw new ManifestParseError('Manifest must contain a [[skills]] array', filePath);
+  }
+
+  const skills: ManifestSkillEntry[] = [];
+
+  for (let i = 0; i < parsed.skills.length; i++) {
+    const entry = parsed.skills[i];
+
+    if (!entry || typeof entry !== 'object') {
+      throw new ManifestParseError(`Invalid skill entry at index ${i}`, filePath);
+    }
+
+    if (!entry.source || typeof entry.source !== 'string') {
+      throw new ManifestParseError(`Skill entry ${i} missing required "source" field`, filePath);
+    }
+
+    if (!entry.name || typeof entry.name !== 'string') {
+      throw new ManifestParseError(`Skill entry ${i} missing required "name" field`, filePath);
+    }
+
+    const manifestEntry: ManifestSkillEntry = {
+      source: entry.source,
+      name: entry.name,
+    };
+
+    if (entry.version && typeof entry.version === 'string') {
+      manifestEntry.version = entry.version;
+    }
+
+    if (entry.locations) {
+      if (!Array.isArray(entry.locations)) {
+        throw new ManifestParseError(`Skill entry ${i} "locations" must be an array`, filePath);
+      }
+
+      for (const loc of entry.locations) {
+        if (typeof loc !== 'string') {
+          throw new ManifestParseError(
+            `Skill entry ${i} "locations" must contain only strings`,
+            filePath
+          );
+        }
+        try {
+          validateLocation(loc);
+        } catch (error) {
+          if (error instanceof LocationValidationError) {
+            throw new ManifestParseError(`Skill entry ${i}: ${error.message}`, filePath);
+          }
+          throw error;
+        }
+      }
+
+      if (entry.locations.length > 0) {
+        manifestEntry.locations = [...new Set(entry.locations)];
+      }
+    }
+
+    validateManifestEntry(manifestEntry);
+    skills.push(manifestEntry);
+  }
+
+  if (skills.length === 0) {
+    throw new ManifestParseError('Manifest file contains no skill entries', filePath);
+  }
+
+  return { skills };
+}
+
+export function validateManifestEntry(entry: ManifestSkillEntry): void {
+  const isShorthand = /^[^/]+\/[^/]+$/.test(entry.source);
+  const isUrl = entry.source.includes('://') || entry.source.startsWith('git@');
+
+  if (!isShorthand && !isUrl) {
+    throw new Error(`Invalid source "${entry.source}". Use "owner/repo" or a full git URL.`);
+  }
+
+  if (entry.version && entry.version !== 'latest') {
+    const semverRegex = /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/;
+    if (!semverRegex.test(entry.version)) {
+      throw new Error(
+        `Invalid version "${entry.version}" for skill "${entry.name}". Use semantic versioning (e.g., 1.0.0) or "latest".`
+      );
+    }
+  }
+}
+
+export function getLockFilePath(manifestPath: string): string {
+  const baseName = manifestPath.replace(/\.toml$/, '');
+  return `${baseName}-lock.toml`;
+}
+
+export async function readLockFile(lockPath: string): Promise<ManifestLockFile | null> {
+  try {
+    const content = await readFile(lockPath, 'utf-8');
+    const parsed = parse(content) as TomlLockFile;
+
+    if (!parsed.lockVersion || typeof parsed.lockVersion !== 'number') {
+      return null;
+    }
+
+    if (!parsed.skills || !Array.isArray(parsed.skills)) {
+      return { lockVersion: parsed.lockVersion, skills: [] };
+    }
+
+    const skills: ManifestLockEntry[] = parsed.skills.map((entry) => {
+      const lockEntry: ManifestLockEntry = {
+        source: entry.source,
+        name: entry.name,
+        version: entry.version,
+        resolvedRef: entry.resolvedRef,
+        installedAt: entry.installedAt,
+      };
+      if (entry.location) {
+        lockEntry.location = entry.location;
+      }
+      return lockEntry;
+    });
+
+    return { lockVersion: parsed.lockVersion, skills };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeLockFile(lockPath: string, entries: ManifestLockEntry[]): Promise<void> {
+  const lockFile: TomlLockFile = {
+    lockVersion: 1,
+    skills: entries.map((entry) => {
+      const tomlEntry: TomlLockEntry = {
+        source: entry.source,
+        name: entry.name,
+        version: entry.version,
+        resolvedRef: entry.resolvedRef,
+        installedAt: entry.installedAt,
+      };
+      if (entry.location) {
+        tomlEntry.location = entry.location;
+      }
+      return tomlEntry;
+    }),
+  };
+
+  const tomlContent = stringify(lockFile);
+  await writeFile(lockPath, tomlContent, 'utf-8');
+}
+
+/** Group manifest entries by source for efficient cloning */
+export function groupSkillsBySource(
+  skills: ManifestSkillEntry[]
+): Map<string, ManifestSkillEntry[]> {
+  const grouped = new Map<string, ManifestSkillEntry[]>();
+
+  for (const skill of skills) {
+    const key = skill.version ? `${skill.source}@${skill.version}` : skill.source;
+    const existing = grouped.get(key) || [];
+    existing.push(skill);
+    grouped.set(key, existing);
+  }
+
+  return grouped;
+}
+
+/** Group manifest entries by source and resolved ref (for frozen mode) */
+export function groupSkillsBySourceAndRef(
+  skills: ManifestSkillEntry[],
+  lockEntries: ManifestLockEntry[]
+): Map<string, ManifestSkillEntry[]> {
+  const grouped = new Map<string, ManifestSkillEntry[]>();
+
+  for (const skill of skills) {
+    const lockEntry = lockEntries.find(
+      (l) => l.source === skill.source && l.name.toLowerCase() === skill.name.toLowerCase()
+    );
+
+    const key = lockEntry ? `${skill.source}@${lockEntry.resolvedRef}` : skill.source;
+
+    const existing = grouped.get(key) || [];
+    existing.push(skill);
+    grouped.set(key, existing);
+  }
+
+  return grouped;
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -71,7 +71,7 @@ function isCI(): boolean {
 }
 
 function isEnabled(): boolean {
-  return !process.env.DISABLE_TELEMETRY && !process.env.DO_NOT_TRACK;
+  return !!process.env.ENABLE_TELEMETRY;
 }
 
 export function setVersion(version: string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,37 @@ export interface ParsedSource {
 /**
  * Represents a skill fetched from a remote host provider.
  */
+// ─── Manifest types (fork feature: TOML-based batch installation) ───
+
+/** Entry in a TOML manifest file */
+export interface ManifestSkillEntry {
+  source: string; // "owner/repo" or full git URL
+  name: string; // Skill name to install
+  version?: string; // Optional: requested version
+  locations?: string[]; // Optional: ["global", "project", "packages/app"]
+}
+
+/** Parsed manifest file */
+export interface SkillManifest {
+  skills: ManifestSkillEntry[];
+}
+
+/** Entry in the manifest lock file */
+export interface ManifestLockEntry {
+  source: string;
+  name: string;
+  version: string;
+  resolvedRef: string; // Actual git commit SHA used
+  installedAt: string; // ISO timestamp
+  location?: string; // Which location this entry was installed to
+}
+
+/** Manifest lock file structure */
+export interface ManifestLockFile {
+  lockVersion: number;
+  skills: ManifestLockEntry[];
+}
+
 export interface RemoteSkill {
   /** Display name of the skill (from frontmatter) */
   name: string;


### PR DESCRIPTION
## Summary
- Rebases fork onto upstream vercel-labs/skills v1.5.0 (220 commits), gaining 45+ agents, symlink installs, blob fast-path, security audits, find/remove/list/update/sync commands, and dual lock files
- Preserves fork-unique features (TOML manifest `--from-file`, `--frozen` mode, multi-location installs, opt-in telemetry) adapted to upstream's new architecture
- Renames package from `@zot24/add-skill` to `@zot24/skills` to align with upstream's rename

## Test plan
- [x] `npm run build` passes
- [x] All 402 upstream tests pass
- [ ] Manual test: `npx @zot24/skills add vercel-labs/agent-skills --list`
- [ ] Manual test: `npx @zot24/skills add --from-file skills.toml -y`
- [ ] Manual test: `npx @zot24/skills add --from-file skills.toml --frozen -y`
- [ ] Verify telemetry is opt-in (no requests without `ENABLE_TELEMETRY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)