### PR TITLE
feat: add CodeArts Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Skills can be installed to any of these agents:
 | Claude Code                           | `claude-code`                            | `.claude/skills/`      | `~/.claude/skills/`             |
 | OpenClaw                              | `openclaw`                               | `skills/`              | `~/.openclaw/skills/`           |
 | Cline, Warp                           | `cline`, `warp`                          | `.agents/skills/`      | `~/.agents/skills/`             |
+| CodeArts Agent                        | `codearts-agent`                         | `.codeartsdoer/skills/`| `~/.codeartsdoer/skills/`       |
 | CodeBuddy                             | `codebuddy`                              | `.codebuddy/skills/`   | `~/.codebuddy/skills/`          |
 | Codex                                 | `codex`                                  | `.agents/skills/`      | `~/.codex/skills/`              |
 | Command Code                          | `command-code`                           | `.commandcode/skills/` | `~/.commandcode/skills/`        |
@@ -345,6 +346,7 @@ The CLI searches for skills in these locations within a repository:
 - `.bob/skills/`
 - `.claude/skills/`
 - `./skills/`
+- `.codeartsdoer/skills/`
 - `.codebuddy/skills/`
 - `.commandcode/skills/`
 - `.continue/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -94,6 +94,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.cline'));
     },
   },
+  'codearts-agent': {
+    name: 'codearts-agent',
+    displayName: 'CodeArts Agent',
+    skillsDir: '.codeartsdoer/skills',
+    globalSkillsDir: join(home, '.codeartsdoer/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.codeartsdoer'));
+    },
+  },
   codebuddy: {
     name: 'codebuddy',
     displayName: 'CodeBuddy',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -157,6 +157,7 @@ const PRIORITY_PREFIXES = [
   '.agents/skills/',
   '.claude/skills/',
   '.cline/skills/',
+  '.codeartsdoer/skills/',
   '.codebuddy/skills/',
   '.codex/skills/',
   '.commandcode/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -159,6 +159,7 @@ export async function discoverSkills(
     join(searchPath, '.agents/skills'),
     join(searchPath, '.claude/skills'),
     join(searchPath, '.cline/skills'),
+    join(searchPath, '.codeartsdoer/skills'),
     join(searchPath, '.codebuddy/skills'),
     join(searchPath, '.codex/skills'),
     join(searchPath, '.commandcode/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type AgentType =
   | 'claude-code'
   | 'openclaw'
   | 'cline'
+  | 'codearts-agent'
   | 'codebuddy'
   | 'codex'
   | 'command-code'

--- a/tests/codearts-agent-support.test.ts
+++ b/tests/codearts-agent-support.test.ts
@@ -1,0 +1,50 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { agents } from '../src/agents.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+describe('CodeArts Agent support', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it('registers the expected CodeArts Agent directories', () => {
+    expect(agents['codearts-agent'].displayName).toBe('CodeArts Agent');
+    expect(agents['codearts-agent'].skillsDir).toBe('.codeartsdoer/skills');
+    expect(agents['codearts-agent'].globalSkillsDir).toContain('.codeartsdoer/skills');
+  });
+
+  it('discovers skills from the CodeArts Agent project directory', async () => {
+    const testDir = join(
+      tmpdir(),
+      `skills-codearts-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    tempDirs.push(testDir);
+
+    const skillDir = join(testDir, '.codeartsdoer', 'skills', 'codearts-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: codearts-skill
+description: CodeArts Agent skill
+---
+
+# CodeArts skill
+`
+    );
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.name).toBe('codearts-skill');
+    expect(skills[0]?.path).toBe(skillDir);
+  });
+});


### PR DESCRIPTION
This pull request adds support for the "CodeArts Agent" throughout the codebase. The changes ensure that the agent can be detected, its skills discovered, and its documentation is updated accordingly.

**Support for CodeArts Agent:**

* Added "codearts-agent" as a new `AgentType` in `src/types.ts`.
* Registered "CodeArts Agent" in the `agents` configuration, including detection logic and skills directories in `src/agents.ts`.
* Updated the skills discovery logic to include the `.codeartsdoer/skills` directory in both `src/skills.ts` and `src/blob.ts`.
* Added test coverage for CodeArts Agent directory discovery.

**Documentation update:**

* Added "CodeArts Agent" to the skills installation table in `README.md`.
* Added `.codeartsdoer/skills/` to the documented discovery paths in `README.md`.

**Additional Context about CodeArts Agent:**

* Official website: https://codearts.huaweicloud.com/
* Skills documentation: https://support.huaweicloud.com/usermanual-codeartssnap/codeartsdoer_ug_0024.html

**Testing:**

* `pnpm test tests/codearts-agent-support.test.ts tests/xdg-config-paths.test.ts tests/full-depth-discovery.test.ts`
* `pnpm format:check`

**Acknowledgment:**

* Thanks to the earlier proposal in #672 for helping validate the implementation direction.
