### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -274,6 +274,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.mcpjam'));
     },
   },
+  'minimax-cli': {
+    name: 'minimax-cli',
+    displayName: 'MiniMax CLI',
+    skillsDir: '.mmx/skills',
+    globalSkillsDir: join(home, '.mmx/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.mmx'));
+    },
+  },
   'mistral-vibe': {
     name: 'mistral-vibe',
     displayName: 'Mistral Vibe',

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type AgentType =
   | 'kiro-cli'
   | 'kode'
   | 'mcpjam'
+  | 'minimax-cli'
   | 'mistral-vibe'
   | 'mux'
   | 'neovate'


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `src/agents.ts` so the MiniMax CLI is a first-class supported agent in the skills ecosystem
- Users can install skills to MiniMax CLI via `npx skills add <repo> -a minimax-cli`
- Detection: checks for `~/.mmx` directory (MiniMax CLI config home)
- Skills directory: `.mmx/skills/` (project) and `~/.mmx/skills/` (global)

**10 lines changed across 2 files, 0 new files.**

## What is MiniMax CLI?

[mmx-cli](https://github.com/MiniMax-AI/cli) is the official CLI for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard.

## Test plan

- `npx skills add vercel-labs/agent-skills -a minimax-cli` installs to `.mmx/skills/`
- `npx skills add vercel-labs/agent-skills -a minimax-cli -g` installs to `~/.mmx/skills/`
- Existing agent detection and installation flows are unaffected