### PR TITLE
fix: add --source-type flag to override URL classification (#737)

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -389,6 +389,32 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse --source-type git', () => {
+    const result = parseAddOptions(['source', '--source-type', 'git']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.sourceType).toBe('git');
+  });
+
+  it('should parse --source-type well-known', () => {
+    const result = parseAddOptions(['source', '--source-type', 'well-known']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.sourceType).toBe('well-known');
+  });
+
+  it('should ignore invalid --source-type values', () => {
+    const result = parseAddOptions(['source', '--source-type', 'invalid']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.sourceType).toBeUndefined();
+  });
+
+  it('should parse --source-type with other flags', () => {
+    const result = parseAddOptions(['source', '--source-type', 'git', '-g', '-y']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.sourceType).toBe('git');
+    expect(result.options.global).toBe(true);
+    expect(result.options.yes).toBe(true);
+  });
 });
 
 describe('openclaw source blocking', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -424,6 +424,7 @@ export interface AddOptions {
   fullDepth?: boolean;
   copy?: boolean;
   dangerouslyAcceptOpenclawRisks?: boolean;
+  sourceType?: 'git' | 'well-known';
 }
 
 /**
@@ -938,6 +939,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     spinner.start('Parsing source...');
     const parsed = parseSource(source);
+
+    // Allow CLI override of auto-detected source type
+    if (options.sourceType) {
+      parsed.type = options.sourceType;
+    }
+
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
@@ -1901,6 +1908,11 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.copy = true;
     } else if (arg === '--dangerously-accept-openclaw-risks') {
       options.dangerouslyAcceptOpenclawRisks = true;
+    } else if (arg === '--source-type') {
+      const value = args[++i];
+      if (value === 'git' || value === 'well-known') {
+        options.sourceType = value;
+      }
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/git.ts
+++ b/src/git.ts
@@ -23,7 +23,13 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const git = simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: '0',
+      // Prevent Git Credential Manager from opening interactive GUI prompts
+      // that block indefinitely when git is spawned as a child process.
+      GCM_INTERACTIVE: 'never',
+    },
   });
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -63,6 +63,19 @@ describe('source-parser', () => {
       expect(result.url).toBe('https://google.com/search/result');
     });
 
+    it('Azure DevOps HTTPS URL without .git suffix falls through to well-known (use --source-type git to override)', () => {
+      const result = parseSource('https://dev.azure.com/ORG/PROJECT/_git/REPO');
+      // Without .git suffix, Azure DevOps URLs are classified as well-known.
+      // Users can use --source-type git to force git handling.
+      expect(result.type).toBe('well-known');
+    });
+
+    it('Azure DevOps HTTPS URL with .git suffix is detected as git source', () => {
+      const result = parseSource('https://dev.azure.com/ORG/PROJECT/_git/REPO.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://dev.azure.com/ORG/PROJECT/_git/REPO.git');
+    });
+
     it('retains official gitlab.com parsing for convenience', () => {
       const result = parseSource('https://gitlab.com/owner/repo');
       expect(result).toEqual({


### PR DESCRIPTION
Azure DevOps HTTPS URLs are misclassified as well-known sources instead of git repos, causing 'No skills found' errors.

This adds a --source-type flag (git | well-known) to let users override the auto-detected source type:

  npx skills add https://dev.azure.com/ORG/PROJECT/_git/REPO --source-type git

Also sets GCM_INTERACTIVE=never to prevent Git Credential Manager from opening interactive GUI prompts that hang indefinitely when git is spawned as a child process.