### PR TITLE
feat: add "Devin for Terminal" as a supported agent in skills CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-
 Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [42 more](#available-agents).
-
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -225,52 +223,50 @@ Discover skills at **[skills.sh](https://skills.sh)**
 Skills can be installed to any of these agents:
 
 <!-- supported-agents:start -->
-
-| Agent                                 | `--agent`                                | Project Path           | Global Path                     |
-| ------------------------------------- | ---------------------------------------- | ---------------------- | ------------------------------- |
-| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/`      | `~/.config/agents/skills/`      |
-| Antigravity                           | `antigravity`                            | `.agents/skills/`      | `~/.gemini/antigravity/skills/` |
-| Augment                               | `augment`                                | `.augment/skills/`     | `~/.augment/skills/`            |
-| IBM Bob                               | `bob`                                    | `.bob/skills/`         | `~/.bob/skills/`                |
-| Claude Code                           | `claude-code`                            | `.claude/skills/`      | `~/.claude/skills/`             |
-| OpenClaw                              | `openclaw`                               | `skills/`              | `~/.openclaw/skills/`           |
-| Cline, Warp                           | `cline`, `warp`                          | `.agents/skills/`      | `~/.agents/skills/`             |
-| CodeBuddy                             | `codebuddy`                              | `.codebuddy/skills/`   | `~/.codebuddy/skills/`          |
-| Codex                                 | `codex`                                  | `.agents/skills/`      | `~/.codex/skills/`              |
-| Command Code                          | `command-code`                           | `.commandcode/skills/` | `~/.commandcode/skills/`        |
-| Continue                              | `continue`                               | `.continue/skills/`    | `~/.continue/skills/`           |
-| Cortex Code                           | `cortex`                                 | `.cortex/skills/`      | `~/.snowflake/cortex/skills/`   |
-| Crush                                 | `crush`                                  | `.crush/skills/`       | `~/.config/crush/skills/`       |
-| Cursor                                | `cursor`                                 | `.agents/skills/`      | `~/.cursor/skills/`             |
-| Deep Agents                           | `deepagents`                             | `.agents/skills/`      | `~/.deepagents/agent/skills/`   |
-| Devin for Terminal                    | `devin`                                  | `.devin/skills/`       | `~/.config/devin/skills/`       |
-| Droid                                 | `droid`                                  | `.factory/skills/`     | `~/.factory/skills/`            |
-| Firebender                            | `firebender`                             | `.agents/skills/`      | `~/.firebender/skills/`         |
-| Gemini CLI                            | `gemini-cli`                             | `.agents/skills/`      | `~/.gemini/skills/`             |
-| GitHub Copilot                        | `github-copilot`                         | `.agents/skills/`      | `~/.copilot/skills/`            |
-| Goose                                 | `goose`                                  | `.goose/skills/`       | `~/.config/goose/skills/`       |
-| Junie                                 | `junie`                                  | `.junie/skills/`       | `~/.junie/skills/`              |
-| iFlow CLI                             | `iflow-cli`                              | `.iflow/skills/`       | `~/.iflow/skills/`              |
-| Kilo Code                             | `kilo`                                   | `.kilocode/skills/`    | `~/.kilocode/skills/`           |
-| Kiro CLI                              | `kiro-cli`                               | `.kiro/skills/`        | `~/.kiro/skills/`               |
-| Kode                                  | `kode`                                   | `.kode/skills/`        | `~/.kode/skills/`               |
-| MCPJam                                | `mcpjam`                                 | `.mcpjam/skills/`      | `~/.mcpjam/skills/`             |
-| Mistral Vibe                          | `mistral-vibe`                           | `.vibe/skills/`        | `~/.vibe/skills/`               |
-| Mux                                   | `mux`                                    | `.mux/skills/`         | `~/.mux/skills/`                |
-| OpenCode                              | `opencode`                               | `.agents/skills/`      | `~/.config/opencode/skills/`    |
-| OpenHands                             | `openhands`                              | `.openhands/skills/`   | `~/.openhands/skills/`          |
-| Pi                                    | `pi`                                     | `.pi/skills/`          | `~/.pi/agent/skills/`           |
-| Qoder                                 | `qoder`                                  | `.qoder/skills/`       | `~/.qoder/skills/`              |
-| Qwen Code                             | `qwen-code`                              | `.qwen/skills/`        | `~/.qwen/skills/`               |
-| Roo Code                              | `roo`                                    | `.roo/skills/`         | `~/.roo/skills/`                |
-| Trae                                  | `trae`                                   | `.trae/skills/`        | `~/.trae/skills/`               |
-| Trae CN                               | `trae-cn`                                | `.trae/skills/`        | `~/.trae-cn/skills/`            |
-| Windsurf                              | `windsurf`                               | `.windsurf/skills/`    | `~/.codeium/windsurf/skills/`   |
-| Zencoder                              | `zencoder`                               | `.zencoder/skills/`    | `~/.zencoder/skills/`           |
-| Neovate                               | `neovate`                                | `.neovate/skills/`     | `~/.neovate/skills/`            |
-| Pochi                                 | `pochi`                                  | `.pochi/skills/`       | `~/.pochi/skills/`              |
-| AdaL                                  | `adal`                                   | `.adal/skills/`        | `~/.adal/skills/`               |
-
+| Agent | `--agent` | Project Path | Global Path |
+|-------|-----------|--------------|-------------|
+| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
+| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
+| Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
+| IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
+| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
+| OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
+| Cline, Warp | `cline`, `warp` | `.agents/skills/` | `~/.agents/skills/` |
+| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
+| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
+| Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
+| Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
+| Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
+| Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
+| Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
+| Deep Agents | `deepagents` | `.agents/skills/` | `~/.deepagents/agent/skills/` |
+| Devin for Terminal | `devin` | `.devin/skills/` | `~/.config/devin/skills/` |
+| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
+| Firebender | `firebender` | `.agents/skills/` | `~/.firebender/skills/` |
+| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
+| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
+| Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
+| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
+| Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
+| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
+| Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
+| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
+| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
+| Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
+| OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
+| OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
+| Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
+| Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
+| Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
+| Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
+| Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
+| Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
+| Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| Zencoder | `zencoder` | `.zencoder/skills/` | `~/.zencoder/skills/` |
+| Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
+| Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
+| AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
 <!-- supported-agents:end -->
 
 > [!NOTE]
@@ -335,7 +331,6 @@ metadata:
 The CLI searches for skills in these locations within a repository:
 
 <!-- skill-discovery:start -->
-
 - Root directory (if it contains `SKILL.md`)
 - `skills/`
 - `skills/.curated/`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [41 more](#available-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [42 more](#available-agents).
 
 <!-- agent-list:end -->
 
@@ -243,6 +243,7 @@ Skills can be installed to any of these agents:
 | Crush                                 | `crush`                                  | `.crush/skills/`       | `~/.config/crush/skills/`       |
 | Cursor                                | `cursor`                                 | `.agents/skills/`      | `~/.cursor/skills/`             |
 | Deep Agents                           | `deepagents`                             | `.agents/skills/`      | `~/.deepagents/agent/skills/`   |
+| Devin for Terminal                    | `devin`                                  | `.devin/skills/`       | `~/.config/devin/skills/`       |
 | Droid                                 | `droid`                                  | `.factory/skills/`     | `~/.factory/skills/`            |
 | Firebender                            | `firebender`                             | `.agents/skills/`      | `~/.firebender/skills/`         |
 | Gemini CLI                            | `gemini-cli`                             | `.agents/skills/`      | `~/.gemini/skills/`             |
@@ -350,6 +351,7 @@ The CLI searches for skills in these locations within a repository:
 - `.continue/skills/`
 - `.cortex/skills/`
 - `.crush/skills/`
+- `.devin/skills/`
 - `.factory/skills/`
 - `.goose/skills/`
 - `.junie/skills/`

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "crush",
     "cursor",
     "deepagents",
+    "devin",
     "droid",
     "firebender",
     "gemini-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -166,6 +166,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.deepagents'));
     },
   },
+  devin: {
+    name: 'devin',
+    displayName: 'Devin for Terminal',
+    skillsDir: '.devin/skills',
+    globalSkillsDir: join(configHome, 'devin/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(configHome, 'devin'));
+    },
+  },
   droid: {
     name: 'droid',
     displayName: 'Droid',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -163,7 +163,7 @@ export async function discoverSkills(
     join(searchPath, '.codex/skills'),
     join(searchPath, '.commandcode/skills'),
     join(searchPath, '.continue/skills'),
-
+    join(searchPath, '.devin/skills'),
     join(searchPath, '.github/skills'),
     join(searchPath, '.goose/skills'),
     join(searchPath, '.iflow/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type AgentType =
   | 'crush'
   | 'cursor'
   | 'deepagents'
+  | 'devin'
   | 'droid'
   | 'firebender'
   | 'gemini-cli'

--- a/tests/devin-agent.test.ts
+++ b/tests/devin-agent.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for Devin for Terminal agent registration and config.
+ *
+ * Verifies:
+ * - 'devin' exists in agents record (type correctness)
+ * - Config fields: name, displayName, skillsDir, globalSkillsDir
+ * - Detection logic (both branches: directory exists / does not exist)
+ * - Non-universal classification (isUniversalAgent, getNonUniversalAgents)
+ * - No duplicate names or conflicting directories
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// Create a controllable mock for existsSync, hoisted before all imports
+const mockExistsSync = vi.hoisted(() => vi.fn(() => false));
+
+// Mock the 'fs' module so agents.ts uses our mock existsSync
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+  };
+});
+
+import {
+  agents,
+  getAgentConfig,
+  getNonUniversalAgents,
+  getUniversalAgents,
+  isUniversalAgent,
+} from '../src/agents.ts';
+
+const home = homedir();
+const configHome = process.env.XDG_CONFIG_HOME || join(home, '.config');
+
+describe('Devin agent config', () => {
+  it('exists in agents record', () => {
+    expect(agents).toHaveProperty('devin');
+    expect(agents.devin).toBeDefined();
+  });
+
+  it('has correct name', () => {
+    expect(agents.devin.name).toBe('devin');
+  });
+
+  it('has correct displayName', () => {
+    expect(agents.devin.displayName).toBe('Devin for Terminal');
+  });
+
+  it('has correct skillsDir', () => {
+    expect(agents.devin.skillsDir).toBe('.devin/skills');
+  });
+
+  it('has correct globalSkillsDir (XDG-style)', () => {
+    const expected = join(configHome, 'devin', 'skills');
+    expect(agents.devin.globalSkillsDir).toBe(expected);
+  });
+
+  it('does NOT use platform-specific paths for globalSkillsDir', () => {
+    expect(agents.devin.globalSkillsDir).not.toContain('Library');
+    expect(agents.devin.globalSkillsDir).not.toContain('Preferences');
+    expect(agents.devin.globalSkillsDir).not.toContain('AppData');
+  });
+
+  it('has a detectInstalled function', () => {
+    expect(typeof agents.devin.detectInstalled).toBe('function');
+  });
+
+  it('is accessible via getAgentConfig', () => {
+    const config = getAgentConfig('devin');
+    expect(config.name).toBe('devin');
+    expect(config.displayName).toBe('Devin for Terminal');
+  });
+});
+
+describe('Devin detection logic', () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset();
+  });
+
+  it('returns true when ~/.config/devin exists', async () => {
+    mockExistsSync.mockImplementation((p: any) => {
+      return String(p) === join(configHome, 'devin');
+    });
+    const result = await agents.devin.detectInstalled();
+    expect(result).toBe(true);
+  });
+
+  it('returns false when ~/.config/devin does not exist', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = await agents.devin.detectInstalled();
+    expect(result).toBe(false);
+  });
+});
+
+describe('Devin non-universal classification', () => {
+  it('isUniversalAgent returns false for devin', () => {
+    expect(isUniversalAgent('devin')).toBe(false);
+  });
+
+  it('is included in getNonUniversalAgents', () => {
+    const nonUniversal = getNonUniversalAgents();
+    expect(nonUniversal).toContain('devin');
+  });
+
+  it('is NOT included in getUniversalAgents', () => {
+    const universal = getUniversalAgents();
+    expect(universal).not.toContain('devin');
+  });
+});
+
+describe('Devin no duplicates', () => {
+  it('devin appears exactly once as a key in agents record', () => {
+    const keys = Object.keys(agents);
+    const devinCount = keys.filter((k) => k === 'devin').length;
+    expect(devinCount).toBe(1);
+  });
+
+  it('displayName "Devin for Terminal" is unique across all agents', () => {
+    const displayNames = Object.values(agents).map((a) => a.displayName);
+    const devinDisplayCount = displayNames.filter((d) => d === 'Devin for Terminal').length;
+    expect(devinDisplayCount).toBe(1);
+  });
+
+  it('skillsDir ".devin/skills" is unique across all agents', () => {
+    const skillsDirs = Object.values(agents).map((a) => a.skillsDir);
+    const devinDirCount = skillsDirs.filter((d) => d === '.devin/skills').length;
+    expect(devinDirCount).toBe(1);
+  });
+
+  it('globalSkillsDir is unique across all agents', () => {
+    const globalDirs = Object.values(agents)
+      .map((a) => a.globalSkillsDir)
+      .filter(Boolean);
+    const devinGlobalDir = agents.devin.globalSkillsDir;
+    const count = globalDirs.filter((d) => d === devinGlobalDir).length;
+    expect(count).toBe(1);
+  });
+});

--- a/tests/devin-discovery.test.ts
+++ b/tests/devin-discovery.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for Devin skill discovery via .devin/skills/ directory.
+ *
+ * Verifies:
+ * - discoverSkills() finds skills placed in .devin/skills/<name>/SKILL.md
+ * - '.devin/skills' is included in prioritySearchDirs (via grep verification)
+ * - Skills in .devin/skills/ are found alongside skills in other agent directories
+ *
+ * Fulfills: VAL-INT-001
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { discoverSkills } from '../src/skills.ts';
+
+describe('discoverSkills finds skills in .devin/skills/', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-devin-discovery-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('should discover a skill in .devin/skills/ directory', async () => {
+    // Create a skill inside .devin/skills/
+    mkdirSync(join(testDir, '.devin', 'skills', 'my-devin-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.devin', 'skills', 'my-devin-skill', 'SKILL.md'),
+      `---
+name: my-devin-skill
+description: A skill installed for Devin
+---
+
+# My Devin Skill
+`
+    );
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('my-devin-skill');
+    expect(skills[0].description).toBe('A skill installed for Devin');
+  });
+
+  it('should discover multiple skills in .devin/skills/ directory', async () => {
+    // Create multiple skills inside .devin/skills/
+    mkdirSync(join(testDir, '.devin', 'skills', 'devin-skill-a'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.devin', 'skills', 'devin-skill-a', 'SKILL.md'),
+      `---
+name: devin-skill-a
+description: Devin skill A
+---
+
+# Devin Skill A
+`
+    );
+
+    mkdirSync(join(testDir, '.devin', 'skills', 'devin-skill-b'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.devin', 'skills', 'devin-skill-b', 'SKILL.md'),
+      `---
+name: devin-skill-b
+description: Devin skill B
+---
+
+# Devin Skill B
+`
+    );
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(2);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(['devin-skill-a', 'devin-skill-b']);
+  });
+
+  it('should discover .devin/skills/ alongside other agent skill directories', async () => {
+    // Create a skill in .devin/skills/
+    mkdirSync(join(testDir, '.devin', 'skills', 'devin-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.devin', 'skills', 'devin-skill', 'SKILL.md'),
+      `---
+name: devin-skill
+description: Skill for Devin
+---
+
+# Devin Skill
+`
+    );
+
+    // Create a skill in .claude/skills/
+    mkdirSync(join(testDir, '.claude', 'skills', 'claude-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.claude', 'skills', 'claude-skill', 'SKILL.md'),
+      `---
+name: claude-skill
+description: Skill for Claude
+---
+
+# Claude Skill
+`
+    );
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(2);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(['claude-skill', 'devin-skill']);
+  });
+
+  it('should not duplicate skills found in .devin/skills/ and another location', async () => {
+    // Same skill name in both .devin/skills/ and .agents/skills/
+    mkdirSync(join(testDir, '.agents', 'skills', 'shared-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.agents', 'skills', 'shared-skill', 'SKILL.md'),
+      `---
+name: shared-skill
+description: Shared skill in agents
+---
+
+# Shared Skill
+`
+    );
+
+    mkdirSync(join(testDir, '.devin', 'skills', 'shared-skill'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.devin', 'skills', 'shared-skill', 'SKILL.md'),
+      `---
+name: shared-skill
+description: Shared skill in devin
+---
+
+# Shared Skill
+`
+    );
+
+    const skills = await discoverSkills(testDir);
+
+    // Should deduplicate by name — only one instance
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('shared-skill');
+  });
+});
+
+describe('prioritySearchDirs includes .devin/skills', () => {
+  it('src/skills.ts contains .devin/skills in prioritySearchDirs', () => {
+    const skillsSource = readFileSync(join(__dirname, '..', 'src', 'skills.ts'), 'utf-8');
+    // Verify that .devin/skills appears in the prioritySearchDirs section
+    expect(skillsSource).toContain("join(searchPath, '.devin/skills')");
+  });
+});

--- a/tests/devin-installer.test.ts
+++ b/tests/devin-installer.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Integration tests for Devin skill installation.
+ *
+ * Verifies:
+ * - Symlink install creates .agents/skills/<name> + symlink at .devin/skills/<name>
+ * - Copy install writes directly to .devin/skills/<name>
+ * - Global install resolves to ~/.config/devin/skills
+ * - listInstalledSkills finds skills in .devin/skills/
+ * - 'devin' is accepted as a valid agent (no "Invalid agents" error)
+ * - End-to-end config + installer + discovery consistency
+ *
+ * Fulfills: VAL-INT-002, VAL-INT-003, VAL-INT-004, VAL-INT-005, VAL-INT-008, VAL-CROSS-001
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile, lstat, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import {
+  installSkillForAgent,
+  getAgentBaseDir,
+  getCanonicalSkillsDir,
+  listInstalledSkills,
+  isSkillInstalled,
+} from '../src/installer.ts';
+import { agents, isUniversalAgent } from '../src/agents.ts';
+import * as agentsModule from '../src/agents.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+/** Creates a temporary skill source directory with a valid SKILL.md */
+async function makeSkillSource(root: string, name: string): Promise<string> {
+  const dir = join(root, 'source-skill');
+  await mkdir(dir, { recursive: true });
+  const skillMd = `---\nname: ${name}\ndescription: A test skill for ${name}\n---\n\n# ${name}\n`;
+  await writeFile(join(dir, 'SKILL.md'), skillMd, 'utf-8');
+  return dir;
+}
+
+// ─── VAL-INT-002: Symlink installation for Devin ────────────────────────────
+
+describe('Devin symlink installation (VAL-INT-002)', () => {
+  it('copies skill to .agents/skills/<name> and symlinks from .devin/skills/<name>', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-symlink-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'devin-test-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      // Result assertions
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('symlink');
+
+      // Canonical directory should contain the skill as a real directory
+      const canonicalPath = join(projectDir, '.agents', 'skills', skillName);
+      const canonicalStats = await lstat(canonicalPath);
+      expect(canonicalStats.isDirectory()).toBe(true);
+      expect(canonicalStats.isSymbolicLink()).toBe(false);
+
+      // Verify SKILL.md contents in canonical location
+      const canonicalContent = await readFile(join(canonicalPath, 'SKILL.md'), 'utf-8');
+      expect(canonicalContent).toContain(`name: ${skillName}`);
+
+      // Agent-specific path should be a symlink
+      const agentPath = join(projectDir, '.devin', 'skills', skillName);
+      const agentStats = await lstat(agentPath);
+      expect(agentStats.isSymbolicLink()).toBe(true);
+
+      // Symlink should resolve to the canonical location
+      const symlinkContent = await readFile(join(agentPath, 'SKILL.md'), 'utf-8');
+      expect(symlinkContent).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns canonicalPath pointing to .agents/skills/<name>', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-symlink-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'devin-canonical-test';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.canonicalPath).toBe(join(projectDir, '.agents', 'skills', skillName));
+      expect(result.path).toBe(join(projectDir, '.devin', 'skills', skillName));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── VAL-INT-003: Copy installation for Devin ───────────────────────────────
+
+describe('Devin copy installation (VAL-INT-003)', () => {
+  it('writes directly to .devin/skills/<name> without canonical directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-copy-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'devin-copy-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      // Result assertions
+      expect(result.success).toBe(true);
+      expect(result.mode).toBe('copy');
+
+      // Skill should be written directly to .devin/skills/<name>
+      const agentPath = join(projectDir, '.devin', 'skills', skillName);
+      const agentStats = await lstat(agentPath);
+      expect(agentStats.isDirectory()).toBe(true);
+      expect(agentStats.isSymbolicLink()).toBe(false);
+
+      // Verify SKILL.md exists and has correct content
+      const content = await readFile(join(agentPath, 'SKILL.md'), 'utf-8');
+      expect(content).toContain(`name: ${skillName}`);
+
+      // Canonical .agents/skills/<name> should NOT exist for copy mode
+      const canonicalPath = join(projectDir, '.agents', 'skills', skillName);
+      await expect(lstat(canonicalPath)).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns undefined canonicalPath for copy mode', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-copy-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'devin-copy-no-canonical';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.canonicalPath).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── VAL-INT-004: Global installation paths ─────────────────────────────────
+
+describe('Devin global installation paths (VAL-INT-004)', () => {
+  it('getAgentBaseDir returns ~/.config/devin/skills for global', () => {
+    const home = homedir();
+    const configHome = process.env.XDG_CONFIG_HOME || join(home, '.config');
+    const expected = join(configHome, 'devin', 'skills');
+
+    const result = getAgentBaseDir('devin', true);
+    expect(result).toBe(expected);
+  });
+
+  it('agents.devin.globalSkillsDir is defined (supports global install)', () => {
+    expect(agents.devin.globalSkillsDir).toBeDefined();
+    expect(typeof agents.devin.globalSkillsDir).toBe('string');
+  });
+
+  it('getAgentBaseDir returns <cwd>/.devin/skills for project-level', () => {
+    const cwd = '/tmp/test-project';
+    const expected = join(cwd, '.devin', 'skills');
+
+    const result = getAgentBaseDir('devin', false, cwd);
+    expect(result).toBe(expected);
+  });
+
+  it('devin is not a universal agent so getAgentBaseDir does not return canonical path', () => {
+    expect(isUniversalAgent('devin')).toBe(false);
+
+    const cwd = '/tmp/test-project';
+    const agentDir = getAgentBaseDir('devin', false, cwd);
+    const canonicalDir = getCanonicalSkillsDir(false, cwd);
+
+    // Non-universal agents have different paths
+    expect(agentDir).not.toBe(canonicalDir);
+    expect(agentDir).toBe(join(cwd, '.devin', 'skills'));
+    expect(canonicalDir).toBe(join(cwd, '.agents', 'skills'));
+  });
+});
+
+// ─── VAL-INT-005: CLI accepts -a devin ──────────────────────────────────────
+
+describe('Devin agent recognition (VAL-INT-005)', () => {
+  it("'devin' is a key in the agents record", () => {
+    const agentKeys = Object.keys(agents);
+    expect(agentKeys).toContain('devin');
+  });
+
+  it('installSkillForAgent accepts devin without error', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-accept-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'devin-accept-test';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      // This should not throw or return an "Invalid agents" error
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('isSkillInstalled works with devin agent type', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-installed-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'devin-check-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      // Before install: not installed
+      const beforeCheck = await isSkillInstalled(skillName, 'devin', {
+        cwd: projectDir,
+      });
+      expect(beforeCheck).toBe(false);
+
+      // Install
+      await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      // After install: installed
+      const afterCheck = await isSkillInstalled(skillName, 'devin', {
+        cwd: projectDir,
+      });
+      expect(afterCheck).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── VAL-INT-008: listInstalledSkills finds Devin skills ────────────────────
+
+describe('listInstalledSkills with Devin (VAL-INT-008)', () => {
+  it('finds skills in .devin/skills/ and attributes them to devin', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-list-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    // Mock: devin is detected as installed
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['devin']);
+
+    try {
+      // Create a skill directly in .devin/skills/
+      const devinSkillDir = join(projectDir, '.devin', 'skills', 'listed-skill');
+      await mkdir(devinSkillDir, { recursive: true });
+      await writeFile(
+        join(devinSkillDir, 'SKILL.md'),
+        `---\nname: listed-skill\ndescription: A skill found by list\n---\n\n# listed-skill\n`,
+        'utf-8'
+      );
+
+      const skills = await listInstalledSkills({
+        global: false,
+        cwd: projectDir,
+      });
+
+      expect(skills.length).toBeGreaterThanOrEqual(1);
+      const listedSkill = skills.find((s) => s.name === 'listed-skill');
+      expect(listedSkill).toBeDefined();
+      expect(listedSkill!.agents).toContain('devin');
+    } finally {
+      vi.restoreAllMocks();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('finds symlink-installed skills via listInstalledSkills', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-list-sym-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    // Mock: devin is detected as installed
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['devin']);
+
+    const skillName = 'symlink-listed-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      // Install via symlink mode
+      const installResult = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+      expect(installResult.success).toBe(true);
+
+      const skills = await listInstalledSkills({
+        global: false,
+        cwd: projectDir,
+      });
+
+      expect(skills.length).toBeGreaterThanOrEqual(1);
+      const found = skills.find((s) => s.name === skillName);
+      expect(found).toBeDefined();
+      expect(found!.agents).toContain('devin');
+    } finally {
+      vi.restoreAllMocks();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── VAL-CROSS-001: End-to-end consistency ──────────────────────────────────
+
+describe('End-to-end config + installer + discovery consistency (VAL-CROSS-001)', () => {
+  it('agents.devin.skillsDir matches getAgentBaseDir path', () => {
+    const cwd = '/tmp/cross-test';
+    const agentBaseDir = getAgentBaseDir('devin', false, cwd);
+    const expected = join(cwd, agents.devin.skillsDir);
+    expect(agentBaseDir).toBe(expected);
+  });
+
+  it('after symlink install, discoverSkills finds the skill in .devin/skills/', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-cross-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'cross-discover-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+      expect(result.success).toBe(true);
+
+      // discoverSkills should find it (via .devin/skills/ or .agents/skills/)
+      const discovered = await discoverSkills(projectDir);
+      const found = discovered.find((s) => s.name === skillName);
+      expect(found).toBeDefined();
+      expect(found!.description).toContain('test skill');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('after symlink install, listInstalledSkills finds the skill', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-cross-list-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['devin']);
+
+    const skillName = 'cross-list-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+      expect(result.success).toBe(true);
+
+      const installed = await listInstalledSkills({
+        global: false,
+        cwd: projectDir,
+      });
+      const found = installed.find((s) => s.name === skillName);
+      expect(found).toBeDefined();
+      expect(found!.agents).toContain('devin');
+    } finally {
+      vi.restoreAllMocks();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('after install, both discoverSkills and listInstalledSkills find the same skill', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'devin-both-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['devin']);
+
+    const skillName = 'unified-find-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'devin',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+      expect(result.success).toBe(true);
+
+      // Both should find it
+      const discovered = await discoverSkills(projectDir);
+      const installed = await listInstalledSkills({
+        global: false,
+        cwd: projectDir,
+      });
+
+      const discoveredSkill = discovered.find((s) => s.name === skillName);
+      const installedSkill = installed.find((s) => s.name === skillName);
+
+      expect(discoveredSkill).toBeDefined();
+      expect(installedSkill).toBeDefined();
+      expect(discoveredSkill!.name).toBe(installedSkill!.name);
+    } finally {
+      vi.restoreAllMocks();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Register "Devin for Terminal" (https://cli.devin.ai/docs) as the 42nd supported non-universal agent in the skills CLI, enabling `skills add <repo> -a devin` and all related commands (list, remove, sync, etc.).

Agent configuration:
- AgentType union: added 'devin' literal to src/types.ts
- Agent config: name 'devin', displayName 'Devin for Terminal', skillsDir `.devin/skills` (project-level), globalSkillsDir `~/.config/devin/skills` (XDG-style global), detectInstalled via `existsSync(~/.config/devin)`
- Follows the goose pattern (non-universal agent + XDG config paths)

Skill discovery:
- Added `.devin/skills` to prioritySearchDirs in src/skills.ts so discoverSkills() finds skills placed in `.devin/skills/<name>/`

Tests added (39 new tests, 441 total passing):
- tests/devin-agent.test.ts: 17 unit tests covering config fields, detection logic (both branches), non-universal classification, and uniqueness guards (no duplicate names/dirs)
- tests/devin-discovery.test.ts: 5 tests for skill discovery in `.devin/skills/`, cross-agent discovery, and deduplication
- tests/devin-installer.test.ts: 17 integration tests for symlink install, copy install, global path resolution, agent recognition, listInstalledSkills attribution, and end-to-end consistency

Documentation & metadata:
- README.md: agent table updated (42 agents), discovery paths include `.devin/skills/`, generated via `bun scripts/sync-agents.ts`
- package.json: 'devin' keyword added via sync script
- `bun scripts/validate-agents.ts`: passes ("All agents valid.")

Verification: 441 tests pass, 6 pre-existing type errors (no new), Prettier formatting clean, validate-agents.ts passes.

<img width="722" height="994" alt="截屏2026-04-13 22 32 28" src="https://github.com/user-attachments/assets/e193ad35-175d-4662-941a-621643b464ed" />
<img width="854" height="270" alt="截屏2026-04-13 22 41 12" src="https://github.com/user-attachments/assets/92dec427-a4ec-41ee-a9c9-1375ed19d68e" />


