### PR TITLE
feat: add Tabnine CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [41 more](#available-agents).
-
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [42 more](#available-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -225,51 +223,50 @@ Discover skills at **[skills.sh](https://skills.sh)**
 Skills can be installed to any of these agents:
 
 <!-- supported-agents:start -->
-
-| Agent                                 | `--agent`                                | Project Path           | Global Path                     |
-| ------------------------------------- | ---------------------------------------- | ---------------------- | ------------------------------- |
-| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/`      | `~/.config/agents/skills/`      |
-| Antigravity                           | `antigravity`                            | `.agents/skills/`      | `~/.gemini/antigravity/skills/` |
-| Augment                               | `augment`                                | `.augment/skills/`     | `~/.augment/skills/`            |
-| IBM Bob                               | `bob`                                    | `.bob/skills/`         | `~/.bob/skills/`                |
-| Claude Code                           | `claude-code`                            | `.claude/skills/`      | `~/.claude/skills/`             |
-| OpenClaw                              | `openclaw`                               | `skills/`              | `~/.openclaw/skills/`           |
-| Cline, Warp                           | `cline`, `warp`                          | `.agents/skills/`      | `~/.agents/skills/`             |
-| CodeBuddy                             | `codebuddy`                              | `.codebuddy/skills/`   | `~/.codebuddy/skills/`          |
-| Codex                                 | `codex`                                  | `.agents/skills/`      | `~/.codex/skills/`              |
-| Command Code                          | `command-code`                           | `.commandcode/skills/` | `~/.commandcode/skills/`        |
-| Continue                              | `continue`                               | `.continue/skills/`    | `~/.continue/skills/`           |
-| Cortex Code                           | `cortex`                                 | `.cortex/skills/`      | `~/.snowflake/cortex/skills/`   |
-| Crush                                 | `crush`                                  | `.crush/skills/`       | `~/.config/crush/skills/`       |
-| Cursor                                | `cursor`                                 | `.agents/skills/`      | `~/.cursor/skills/`             |
-| Deep Agents                           | `deepagents`                             | `.agents/skills/`      | `~/.deepagents/agent/skills/`   |
-| Droid                                 | `droid`                                  | `.factory/skills/`     | `~/.factory/skills/`            |
-| Firebender                            | `firebender`                             | `.agents/skills/`      | `~/.firebender/skills/`         |
-| Gemini CLI                            | `gemini-cli`                             | `.agents/skills/`      | `~/.gemini/skills/`             |
-| GitHub Copilot                        | `github-copilot`                         | `.agents/skills/`      | `~/.copilot/skills/`            |
-| Goose                                 | `goose`                                  | `.goose/skills/`       | `~/.config/goose/skills/`       |
-| Junie                                 | `junie`                                  | `.junie/skills/`       | `~/.junie/skills/`              |
-| iFlow CLI                             | `iflow-cli`                              | `.iflow/skills/`       | `~/.iflow/skills/`              |
-| Kilo Code                             | `kilo`                                   | `.kilocode/skills/`    | `~/.kilocode/skills/`           |
-| Kiro CLI                              | `kiro-cli`                               | `.kiro/skills/`        | `~/.kiro/skills/`               |
-| Kode                                  | `kode`                                   | `.kode/skills/`        | `~/.kode/skills/`               |
-| MCPJam                                | `mcpjam`                                 | `.mcpjam/skills/`      | `~/.mcpjam/skills/`             |
-| Mistral Vibe                          | `mistral-vibe`                           | `.vibe/skills/`        | `~/.vibe/skills/`               |
-| Mux                                   | `mux`                                    | `.mux/skills/`         | `~/.mux/skills/`                |
-| OpenCode                              | `opencode`                               | `.agents/skills/`      | `~/.config/opencode/skills/`    |
-| OpenHands                             | `openhands`                              | `.openhands/skills/`   | `~/.openhands/skills/`          |
-| Pi                                    | `pi`                                     | `.pi/skills/`          | `~/.pi/agent/skills/`           |
-| Qoder                                 | `qoder`                                  | `.qoder/skills/`       | `~/.qoder/skills/`              |
-| Qwen Code                             | `qwen-code`                              | `.qwen/skills/`        | `~/.qwen/skills/`               |
-| Roo Code                              | `roo`                                    | `.roo/skills/`         | `~/.roo/skills/`                |
-| Trae                                  | `trae`                                   | `.trae/skills/`        | `~/.trae/skills/`               |
-| Trae CN                               | `trae-cn`                                | `.trae/skills/`        | `~/.trae-cn/skills/`            |
-| Windsurf                              | `windsurf`                               | `.windsurf/skills/`    | `~/.codeium/windsurf/skills/`   |
-| Zencoder                              | `zencoder`                               | `.zencoder/skills/`    | `~/.zencoder/skills/`           |
-| Neovate                               | `neovate`                                | `.neovate/skills/`     | `~/.neovate/skills/`            |
-| Pochi                                 | `pochi`                                  | `.pochi/skills/`       | `~/.pochi/skills/`              |
-| AdaL                                  | `adal`                                   | `.adal/skills/`        | `~/.adal/skills/`               |
-
+| Agent | `--agent` | Project Path | Global Path |
+|-------|-----------|--------------|-------------|
+| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
+| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
+| Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
+| IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
+| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
+| OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
+| Cline, Warp | `cline`, `warp` | `.agents/skills/` | `~/.agents/skills/` |
+| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
+| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
+| Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
+| Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
+| Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
+| Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
+| Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
+| Deep Agents | `deepagents` | `.agents/skills/` | `~/.deepagents/agent/skills/` |
+| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
+| Firebender | `firebender` | `.agents/skills/` | `~/.firebender/skills/` |
+| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
+| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
+| Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
+| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
+| Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
+| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
+| Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
+| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
+| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
+| Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
+| OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
+| OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
+| Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
+| Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
+| Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
+| Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
+| Tabnine CLI | `tabnine-cli` | `.tabnine/agent/skills/` | `~/.tabnine/agent/skills/` |
+| Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
+| Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
+| Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| Zencoder | `zencoder` | `.zencoder/skills/` | `~/.zencoder/skills/` |
+| Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
+| Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
+| AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
 <!-- supported-agents:end -->
 
 > [!NOTE]
@@ -334,7 +331,6 @@ metadata:
 The CLI searches for skills in these locations within a repository:
 
 <!-- skill-discovery:start -->
-
 - Root directory (if it contains `SKILL.md`)
 - `skills/`
 - `skills/.curated/`
@@ -365,6 +361,7 @@ The CLI searches for skills in these locations within a repository:
 - `.qoder/skills/`
 - `.qwen/skills/`
 - `.roo/skills/`
+- `.tabnine/agent/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`
 - `.zencoder/skills/`
@@ -471,6 +468,7 @@ Telemetry is automatically disabled in CI environments.
 - [Qoder Skills Documentation](https://docs.qoder.com/cli/Skills)
 - [Replit Skills Documentation](https://docs.replit.com/replitai/skills)
 - [Roo Code Skills Documentation](https://docs.roocode.com/features/skills)
+- [Tabnine CLI Skills Documentation](https://docs.tabnine.com/main/getting-started/tabnine-cli/features/agent-skills)
 - [Trae Skills Documentation](https://docs.trae.ai/ide/skills)
 - [Vercel Agent Skills Repository](https://github.com/vercel-labs/agent-skills)
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "qwen-code",
     "replit",
     "roo",
+    "tabnine-cli",
     "trae",
     "trae-cn",
     "warp",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -356,6 +356,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.roo'));
     },
   },
+  'tabnine-cli': {
+    name: 'tabnine-cli',
+    displayName: 'Tabnine CLI',
+    skillsDir: '.tabnine/agent/skills',
+    globalSkillsDir: join(home, '.tabnine/agent/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.tabnine'));
+    },
+  },
   trae: {
     name: 'trae',
     displayName: 'Trae',

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type AgentType =
   | 'qwen-code'
   | 'replit'
   | 'roo'
+  | 'tabnine-cli'
   | 'trae'
   | 'trae-cn'
   | 'warp'


### PR DESCRIPTION
## Summary

Adds support for [Tabnine CLI](https://docs.tabnine.com/main/getting-started/tabnine-cli/features/agent-skills) (Gemini CLI–based) as an installation target.

- Project path: `.tabnine/agent/skills/`
- Global path: `~/.tabnine/agent/skills/`
- Detection: `~/.tabnine`

Per `AGENTS.md` "Adding a New Agent": added entry to `src/agents.ts`, ran `validate-agents.ts`, and ran `sync-agents.ts` to update `README.md` and `package.json` keywords.

## Test plan

- [x] `pnpm test` — 402/402 pass
- [x] `pnpm format:check`
- [x] `pnpm build` (type-check)
- [x] `node scripts/validate-agents.ts`
- [x] Verified end-to-end against a real Tabnine CLI install (`~/.tabnine/agent/` present): auto-detection, global install → `~/.tabnine/agent/skills/<skill>`, project install → `./.tabnine/agent/skills/<skill>`, `skills list` associates skills with Tabnine CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)