### PR TITLE
fix: compute skillFolderHash for non-GitHub git sources

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { sep } from 'path';
+import { sep, join, dirname } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
@@ -1600,6 +1600,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 token,
                 parsed.ref
               );
+              if (hash) skillFolderHash = hash;
+            } else if (skillPathValue && tempDir) {
+              // Non-GitHub git source (Bitbucket, GitLab, Azure DevOps, self-hosted, etc.):
+              // compute hash from local clone — no platform API needed
+              const skillDir = join(tempDir, dirname(skillPathValue));
+              const hash = await computeSkillFolderHash(skillDir);
               if (hash) skillFolderHash = hash;
             }
 


### PR DESCRIPTION
Fixes #655 

`skillFolderHash` is left as an empty string for any non-GitHub git source (Bitbucket, GitLab, Azure DevOps, self-hosted, etc.) because the hash computation was gated on `parsed.type === 'github'` and used the GitHub Trees API.

`local-lock.ts` already has `computeSkillFolderHash()` which computes a SHA-256 from local file contents — no platform API needed. This PR wires it up as a catch-all for any source that has a local clone but isn't a GitHub blob or GitHub clone path.

The existing GitHub branches are untouched to preserve backward compatibility.
