### PR TITLE
feat: merge skills-npm features into experimental_sync

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "npm-next-next-compile": {
+      "source": "next",
+      "sourceType": "node_modules",
+      "computedHash": "281a6bf7bfa8a5ad7c88e340fdbfc5ae7e240b370be83a61dad0afdbaccda88f"
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -149,8 +149,16 @@ ${BOLD}Remove Options:${RESET}
   --all                  Shorthand for --skill '*' --agent '*' -y
   
 ${BOLD}Experimental Sync Options:${RESET}
+  -s, --source <source>  Source: "node_modules" | "package.json" (default: "package.json")
+  -r, --recursive        Scan monorepo workspace packages
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
   -y, --yes              Skip confirmation prompts
+  -f, --force            Ignore lock, force full rescan + reinstall
+  --include <patterns>   Only include matching packages
+  --exclude <patterns>   Exclude matching packages
+  --dry-run              Show what would be done without making changes
+  --no-cleanup           Don't remove stale npm-* skills
+  --no-gitignore         Don't update .gitignore
 
 ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
@@ -182,6 +190,9 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills init my-skill
   ${DIM}$${RESET} skills experimental_sync              ${DIM}# sync from node_modules${RESET}
   ${DIM}$${RESET} skills experimental_sync -y           ${DIM}# sync without prompts${RESET}
+  ${DIM}$${RESET} skills experimental_sync -r           ${DIM}# sync monorepo recursively${RESET}
+  ${DIM}$${RESET} skills experimental_sync --dry-run    ${DIM}# preview sync changes${RESET}
+  ${DIM}$${RESET} skills experimental_sync -s node_modules ${DIM}# scan all packages${RESET}
 
 Discover more skills at ${TEXT}https://skills.sh/${RESET}
 `);

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -1,0 +1,58 @@
+import { access, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+const GITIGNORE_PATTERN = '**/skills/npm-*';
+const LEGACY_GITIGNORE_PATTERN = 'skills/npm-*';
+const GITIGNORE_COMMENT = '# Agent skills from npm packages (managed by skills)';
+
+export async function hasGitignorePattern(cwd: string): Promise<boolean> {
+  try {
+    const content = await readFile(join(cwd, '.gitignore'), 'utf-8');
+    return content.includes(GITIGNORE_PATTERN);
+  } catch {
+    return false;
+  }
+}
+
+export async function updateGitignore(
+  cwd: string,
+  dryRun: boolean = false
+): Promise<{ updated: boolean; created: boolean }> {
+  const gitignorePath = join(cwd, '.gitignore');
+
+  if (await hasGitignorePattern(cwd)) {
+    return { updated: false, created: false };
+  }
+
+  let exists = true;
+  try {
+    await access(gitignorePath);
+  } catch {
+    exists = false;
+  }
+
+  if (dryRun) {
+    return { updated: true, created: !exists };
+  }
+
+  if (!exists) {
+    await writeFile(gitignorePath, `${GITIGNORE_COMMENT}\n${GITIGNORE_PATTERN}\n`, 'utf-8');
+    return { updated: true, created: true };
+  }
+
+  const content = await readFile(gitignorePath, 'utf-8');
+
+  if (content.includes(LEGACY_GITIGNORE_PATTERN)) {
+    const newContent = content.replace(LEGACY_GITIGNORE_PATTERN, GITIGNORE_PATTERN);
+    await writeFile(gitignorePath, newContent, 'utf-8');
+    return { updated: true, created: false };
+  }
+
+  const separator = content.endsWith('\n') ? '\n' : '\n\n';
+  await writeFile(
+    gitignorePath,
+    `${content}${separator}${GITIGNORE_COMMENT}\n${GITIGNORE_PATTERN}\n`,
+    'utf-8'
+  );
+  return { updated: true, created: false };
+}

--- a/src/sync-utils.ts
+++ b/src/sync-utils.ts
@@ -1,0 +1,251 @@
+import { readFile, readdir, lstat, readlink, rm, mkdir, symlink } from 'fs/promises';
+import { existsSync, readFileSync } from 'fs';
+import { join, dirname, relative, resolve } from 'path';
+import { platform } from 'os';
+
+export interface NpmSkill {
+  packageName: string;
+  skillName: string;
+  skillPath: string;
+  targetName: string;
+  name: string;
+  description: string;
+}
+
+export function sanitizePackageName(packageName: string): string {
+  return packageName.replace(/^@/, '').replace(/\//g, '-').toLowerCase();
+}
+
+export function createTargetName(packageName: string, skillName?: string): string {
+  const sanitized = sanitizePackageName(packageName);
+  return skillName ? `npm-${sanitized}-${skillName}` : `npm-${sanitized}`;
+}
+
+// --- Package dependency reading ---
+
+export async function getPackageDeps(cwd: string): Promise<string[] | null> {
+  try {
+    const content = await readFile(join(cwd, 'package.json'), 'utf-8');
+    const data = JSON.parse(content);
+    return Object.keys({ ...data.dependencies, ...data.devDependencies });
+  } catch {
+    return null;
+  }
+}
+
+// --- Workspace support ---
+
+export function searchForWorkspaceRoot(current: string): string {
+  const ROOT_FILES = ['pnpm-workspace.yaml', 'lerna.json'];
+
+  let dir = current;
+  while (true) {
+    if (ROOT_FILES.some((f) => existsSync(join(dir, f)))) return dir;
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+      if (pkg.workspaces) return dir;
+    } catch {
+      // no package.json or invalid JSON
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return current;
+    dir = parent;
+  }
+}
+
+export async function getWorkspacePackageRoots(root: string): Promise<string[]> {
+  const patterns: string[] = [];
+
+  try {
+    const content = await readFile(join(root, 'pnpm-workspace.yaml'), 'utf-8');
+    const { parse } = await import('yaml');
+    const data = parse(content);
+    if (Array.isArray(data?.packages)) {
+      patterns.push(...data.packages);
+    }
+  } catch {
+    // no pnpm-workspace.yaml
+  }
+
+  try {
+    const content = await readFile(join(root, 'package.json'), 'utf-8');
+    const data = JSON.parse(content);
+    if (Array.isArray(data.workspaces)) {
+      patterns.push(...data.workspaces);
+    }
+  } catch {
+    // no package.json
+  }
+
+  if (patterns.length === 0) return [];
+
+  const results: string[] = [];
+  for (const pattern of patterns) {
+    if (pattern.startsWith('!')) continue;
+
+    const cleanPattern = pattern.replace(/\/\*{1,2}$/, '');
+    const parentDir = join(root, cleanPattern);
+
+    if (cleanPattern === pattern) {
+      if (existsSync(parentDir)) results.push(parentDir);
+    } else {
+      try {
+        const entries = await readdir(parentDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory() && !entry.name.startsWith('.')) {
+            results.push(join(parentDir, entry.name));
+          }
+        }
+      } catch {
+        // directory doesn't exist
+      }
+    }
+  }
+
+  return results;
+}
+
+// --- Pattern matching for include/exclude ---
+
+const patternCache = new Map<string, RegExp>();
+
+function escapeRegexChar(char: string): string {
+  return char.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function getPatternRegex(pattern: string): RegExp {
+  const cached = patternCache.get(pattern);
+  if (cached) return cached;
+
+  let source = '^';
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]!;
+    if (char === '*') {
+      if (pattern[i + 1] === '*') {
+        source += '.*';
+        i++;
+      } else {
+        source += '[^/]*';
+      }
+    } else if (char === '?') {
+      source += '[^/]';
+    } else {
+      source += escapeRegexChar(char);
+    }
+  }
+  source += '$';
+
+  const regex = new RegExp(source);
+  patternCache.set(pattern, regex);
+  return regex;
+}
+
+export function matchesPattern(name: string, pattern: string): boolean {
+  if (!pattern.includes('*') && !pattern.includes('?')) return name === pattern;
+  return getPatternRegex(pattern).test(name);
+}
+
+export function filterNpmSkills(
+  skills: NpmSkill[],
+  include?: string[],
+  exclude?: string[]
+): { skills: NpmSkill[]; excludedCount: number } {
+  let result = skills;
+
+  if (include && include.length > 0) {
+    result = result.filter((skill) =>
+      include.some((pattern) => matchesPattern(skill.packageName, pattern))
+    );
+  }
+
+  if (exclude && exclude.length > 0) {
+    result = result.filter(
+      (skill) => !exclude.some((pattern) => matchesPattern(skill.packageName, pattern))
+    );
+  }
+
+  return { skills: result, excludedCount: skills.length - result.length };
+}
+
+// --- Symlink helpers ---
+
+export async function createSkillSymlink(target: string, linkPath: string): Promise<boolean> {
+  try {
+    const resolvedTarget = resolve(target);
+    const resolvedLinkPath = resolve(linkPath);
+
+    if (resolvedTarget === resolvedLinkPath) return true;
+
+    try {
+      const stats = await lstat(linkPath);
+      if (stats.isSymbolicLink()) {
+        const existingTarget = await readlink(linkPath);
+        const resolvedExisting = resolve(dirname(linkPath), existingTarget);
+        if (resolvedExisting === resolvedTarget) return true;
+        await rm(linkPath);
+      } else {
+        await rm(linkPath, { recursive: true });
+      }
+    } catch (err: unknown) {
+      if (
+        err &&
+        typeof err === 'object' &&
+        'code' in err &&
+        (err as { code: string }).code === 'ELOOP'
+      ) {
+        try {
+          await rm(linkPath, { force: true });
+        } catch {
+          // if we can't remove it, symlink creation will fail below
+        }
+      }
+    }
+
+    const linkDir = dirname(linkPath);
+    await mkdir(linkDir, { recursive: true });
+
+    const relativePath = relative(linkDir, target);
+    const symlinkType = platform() === 'win32' ? 'junction' : undefined;
+    await symlink(relativePath, linkPath, symlinkType);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// --- Stale cleanup ---
+
+export async function cleanupStaleNpmSkills(
+  skillsDir: string,
+  validTargetNames: Set<string>,
+  dryRun: boolean = false
+): Promise<Array<{ targetName: string; path: string; success: boolean }>> {
+  const results: Array<{ targetName: string; path: string; success: boolean }> = [];
+
+  let entries: string[];
+  try {
+    entries = await readdir(skillsDir);
+  } catch {
+    return results;
+  }
+
+  const staleEntries = entries.filter(
+    (entry) => entry.startsWith('npm-') && !validTargetNames.has(entry)
+  );
+
+  for (const entry of staleEntries) {
+    const entryPath = join(skillsDir, entry);
+    if (dryRun) {
+      results.push({ targetName: entry, path: entryPath, success: true });
+      continue;
+    }
+    try {
+      await rm(entryPath, { recursive: true, force: true });
+      results.push({ targetName: entry, path: entryPath, success: true });
+    } catch {
+      results.push({ targetName: entry, path: entryPath, success: false });
+    }
+  }
+
+  return results;
+}

--- a/src/sync-utils.ts
+++ b/src/sync-utils.ts
@@ -5,11 +5,20 @@ import { platform } from 'os';
 
 export interface NpmSkill {
   packageName: string;
+  packageVersion?: string;
   skillName: string;
   skillPath: string;
   targetName: string;
   name: string;
   description: string;
+}
+
+export interface NpmSyncTelemetryPackage {
+  skill: string;
+  package: string;
+  ecosystem: 'npm';
+  registry: 'npm';
+  version?: string;
 }
 
 export function sanitizePackageName(packageName: string): string {
@@ -165,6 +174,18 @@ export function filterNpmSkills(
   }
 
   return { skills: result, excludedCount: skills.length - result.length };
+}
+
+export function buildNpmSyncTelemetryPackages(skills: NpmSkill[]): NpmSyncTelemetryPackage[] {
+  return skills
+    .filter((skill) => skill.packageName && skill.packageVersion)
+    .map((skill) => ({
+      skill: skill.name,
+      package: skill.packageName,
+      ecosystem: 'npm' as const,
+      registry: 'npm' as const,
+      version: skill.packageVersion,
+    }));
 }
 
 // --- Symlink helpers ---

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4,7 +4,6 @@ import { readdir, stat } from 'fs/promises';
 import { join, sep } from 'path';
 import { homedir } from 'os';
 import { parseSkillMd } from './skills.ts';
-import { installSkillForAgent, getCanonicalPath } from './installer.ts';
 import {
   detectInstalledAgents,
   agents,
@@ -13,8 +12,20 @@ import {
 } from './agents.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
-import type { Skill, AgentType } from './types.ts';
+import type { AgentType } from './types.ts';
 import { track } from './telemetry.ts';
+import {
+  type NpmSkill,
+  createTargetName,
+  sanitizePackageName,
+  getPackageDeps,
+  searchForWorkspaceRoot,
+  getWorkspacePackageRoots,
+  filterNpmSkills,
+  createSkillSymlink,
+  cleanupStaleNpmSkills,
+} from './sync-utils.ts';
+import { updateGitignore } from './gitignore.ts';
 
 const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
 
@@ -22,11 +33,15 @@ export interface SyncOptions {
   agent?: string[];
   yes?: boolean;
   force?: boolean;
+  source?: 'node_modules' | 'package.json';
+  recursive?: boolean;
+  include?: string[];
+  exclude?: string[];
+  dryRun?: boolean;
+  cleanup?: boolean;
+  gitignore?: boolean;
 }
 
-/**
- * Shortens a path for display: replaces homedir with ~ and cwd with .
- */
 function shortenPath(fullPath: string, cwd: string): string {
   const home = homedir();
   if (fullPath === home || fullPath.startsWith(home + sep)) {
@@ -39,15 +54,20 @@ function shortenPath(fullPath: string, cwd: string): string {
 }
 
 /**
- * Crawl node_modules for SKILL.md files.
- * Searches both top-level packages and scoped packages (@org/pkg).
- * Returns discovered skills with their source package name.
+ * Scan a single node_modules directory for skills.
+ * For each package, checks:
+ *   1. SKILL.md at package root (single-skill package, skips subdirectory scan)
+ *   2. Subdirectories of: package root, skills/, dist/skills/, .agents/skills/
  */
-async function discoverNodeModuleSkills(
-  cwd: string
-): Promise<Array<Skill & { packageName: string }>> {
+async function scanNodeModulesDir(
+  cwd: string,
+  source: 'node_modules' | 'package.json' = 'package.json'
+): Promise<NpmSkill[]> {
   const nodeModulesDir = join(cwd, 'node_modules');
-  const skills: Array<Skill & { packageName: string }> = [];
+  const skills: NpmSkill[] = [];
+  const seenTargetNames = new Set<string>();
+
+  const packageDeps = source === 'package.json' ? await getPackageDeps(cwd) : null;
 
   let topNames: string[];
   try {
@@ -56,16 +76,35 @@ async function discoverNodeModuleSkills(
     return skills;
   }
 
+  const addSkill = (skill: NpmSkill) => {
+    if (!seenTargetNames.has(skill.targetName)) {
+      seenTargetNames.add(skill.targetName);
+      skills.push(skill);
+    }
+  };
+
   const processPackageDir = async (pkgDir: string, packageName: string) => {
-    // Check for SKILL.md at package root
+    // 1. Check for SKILL.md at package root (simple single-skill package)
     const rootSkill = await parseSkillMd(join(pkgDir, 'SKILL.md'));
     if (rootSkill) {
-      skills.push({ ...rootSkill, packageName });
+      addSkill({
+        packageName,
+        skillName: sanitizePackageName(packageName),
+        skillPath: rootSkill.path,
+        targetName: createTargetName(packageName),
+        name: rootSkill.name,
+        description: rootSkill.description,
+      });
       return;
     }
 
-    // Check common skill locations within the package
-    const searchDirs = [pkgDir, join(pkgDir, 'skills'), join(pkgDir, '.agents', 'skills')];
+    // 2. Scan subdirectories of common skill locations
+    const searchDirs = [
+      pkgDir,
+      join(pkgDir, 'skills'),
+      join(pkgDir, 'dist', 'skills'),
+      join(pkgDir, '.agents', 'skills'),
+    ];
 
     for (const searchDir of searchDirs) {
       try {
@@ -80,7 +119,14 @@ async function discoverNodeModuleSkills(
           }
           const skill = await parseSkillMd(join(skillDir, 'SKILL.md'));
           if (skill) {
-            skills.push({ ...skill, packageName });
+            addSkill({
+              packageName,
+              skillName: name,
+              skillPath: skill.path,
+              targetName: createTargetName(packageName, name),
+              name: skill.name,
+              description: skill.description,
+            });
           }
         }
       } catch {
@@ -102,25 +148,29 @@ async function discoverNodeModuleSkills(
       }
 
       if (name.startsWith('@')) {
-        // Scoped package: read @org/* entries
         try {
           const scopeNames = await readdir(fullPath);
           await Promise.all(
             scopeNames.map(async (scopedName) => {
               const scopedPath = join(fullPath, scopedName);
+              const fullPackageName = `${name}/${scopedName}`;
+
+              if (packageDeps && !packageDeps.includes(fullPackageName)) return;
+
               try {
                 const s = await stat(scopedPath);
                 if (!s.isDirectory()) return;
               } catch {
                 return;
               }
-              await processPackageDir(scopedPath, `${name}/${scopedName}`);
+              await processPackageDir(scopedPath, fullPackageName);
             })
           );
         } catch {
           // Scope directory not readable
         }
       } else {
+        if (packageDeps && !packageDeps.includes(name)) return;
         await processPackageDir(fullPath, name);
       }
     })
@@ -129,7 +179,40 @@ async function discoverNodeModuleSkills(
   return skills;
 }
 
-export async function runSync(args: string[], options: SyncOptions = {}): Promise<void> {
+/**
+ * Discover npm skills from node_modules.
+ * Supports --source filtering and --recursive monorepo scanning.
+ */
+async function discoverNodeModuleSkills(
+  cwd: string,
+  options: { source?: 'node_modules' | 'package.json'; recursive?: boolean } = {}
+): Promise<NpmSkill[]> {
+  const source = options.source || 'package.json';
+
+  if (!options.recursive) {
+    return scanNodeModulesDir(cwd, source);
+  }
+
+  // Recursive mode: find workspace root and scan all package roots
+  const workspaceRoot = searchForWorkspaceRoot(cwd);
+  const packageRoots = await getWorkspacePackageRoots(workspaceRoot);
+  const allRoots = [workspaceRoot, ...packageRoots];
+
+  const allSkills = new Map<string, NpmSkill>();
+
+  for (const root of allRoots) {
+    const skills = await scanNodeModulesDir(root, source);
+    for (const skill of skills) {
+      if (!allSkills.has(skill.targetName)) {
+        allSkills.set(skill.targetName, skill);
+      }
+    }
+  }
+
+  return Array.from(allSkills.values());
+}
+
+export async function runSync(_args: string[], options: SyncOptions = {}): Promise<void> {
   const cwd = process.cwd();
 
   console.log();
@@ -139,7 +222,10 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
 
   // 1. Discover skills from node_modules
   spinner.start('Scanning node_modules for skills...');
-  const discoveredSkills = await discoverNodeModuleSkills(cwd);
+  let discoveredSkills = await discoverNodeModuleSkills(cwd, {
+    source: options.source,
+    recursive: options.recursive,
+  });
 
   if (discoveredSkills.length === 0) {
     spinner.stop(pc.yellow('No skills found'));
@@ -147,11 +233,26 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     return;
   }
 
-  spinner.stop(
-    `Found ${pc.green(String(discoveredSkills.length))} skill${discoveredSkills.length > 1 ? 's' : ''} in node_modules`
+  // 2. Apply include/exclude filters
+  const { skills: filteredSkills, excludedCount } = filterNpmSkills(
+    discoveredSkills,
+    options.include,
+    options.exclude
   );
 
-  // Show discovered skills
+  if (filteredSkills.length === 0) {
+    spinner.stop(pc.yellow(`No skills found (${excludedCount} filtered)`));
+    p.outro(pc.dim('All discovered skills were filtered out.'));
+    return;
+  }
+
+  discoveredSkills = filteredSkills;
+
+  const filterMsg = excludedCount > 0 ? ` (${excludedCount} filtered)` : '';
+  spinner.stop(
+    `Found ${pc.green(String(discoveredSkills.length))} skill${discoveredSkills.length > 1 ? 's' : ''} in node_modules${filterMsg}`
+  );
+
   for (const skill of discoveredSkills) {
     p.log.info(`${pc.cyan(skill.name)} ${pc.dim(`from ${skill.packageName}`)}`);
     if (skill.description) {
@@ -159,9 +260,9 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     }
   }
 
-  // 2. Check which skills are already up-to-date via local lock
+  // 3. Check which skills are already up-to-date via local lock
   const localLock = await readLocalLock(cwd);
-  const toInstall: Array<Skill & { packageName: string }> = [];
+  const toInstall: NpmSkill[] = [];
   const upToDate: string[] = [];
 
   if (options.force) {
@@ -169,10 +270,9 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     p.log.info(pc.dim('Force mode: reinstalling all skills'));
   } else {
     for (const skill of discoveredSkills) {
-      const existingEntry = localLock.skills[skill.name];
+      const existingEntry = localLock.skills[skill.targetName];
       if (existingEntry) {
-        // Compute current hash and compare
-        const currentHash = await computeSkillFolderHash(skill.path);
+        const currentHash = await computeSkillFolderHash(skill.skillPath);
         if (currentHash === existingEntry.computedHash) {
           upToDate.push(skill.name);
           continue;
@@ -186,17 +286,26 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         pc.dim(`${upToDate.length} skill${upToDate.length !== 1 ? 's' : ''} already up to date`)
       );
     }
+  }
 
-    if (toInstall.length === 0) {
-      console.log();
-      p.outro(pc.green('All skills are up to date.'));
-      return;
+  const hasWorkToDo = toInstall.length > 0;
+
+  if (!hasWorkToDo) {
+    // Even if nothing to install, still run cleanup if enabled
+    if (options.cleanup !== false) {
+      await runCleanup(cwd, discoveredSkills, options);
     }
+    if (options.gitignore !== false) {
+      await runGitignoreUpdate(cwd, options);
+    }
+    console.log();
+    p.outro(pc.green('All skills are up to date.'));
+    return;
   }
 
   p.log.info(`${toInstall.length} skill${toInstall.length !== 1 ? 's' : ''} to install/update`);
 
-  // 3. Select agents
+  // 4. Select agents
   let targetAgents: AgentType[];
   const validAgents = Object.keys(agents);
   const universalAgents = getUniversalAgents();
@@ -252,7 +361,6 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         targetAgents = selected as AgentType[];
       }
     } else if (installedAgents.length === 1 || options.yes) {
-      // Ensure universal agents are included
       targetAgents = [...installedAgents];
       for (const ua of universalAgents) {
         if (!targetAgents.includes(ua)) {
@@ -290,19 +398,21 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     }
   }
 
-  // 4. Build summary
+  // 5. Build summary
   const summaryLines: string[] = [];
   for (const skill of toInstall) {
-    const canonicalPath = getCanonicalPath(skill.name, { global: false });
-    const shortCanonical = shortenPath(canonicalPath, cwd);
     summaryLines.push(`${pc.cyan(skill.name)} ${pc.dim(`← ${skill.packageName}`)}`);
-    summaryLines.push(`  ${pc.dim(shortCanonical)}`);
+    summaryLines.push(`  ${pc.dim(skill.targetName)}`);
   }
 
   console.log();
   p.note(summaryLines.join('\n'), 'Sync Summary');
 
-  if (!options.yes) {
+  if (options.dryRun) {
+    p.log.info(pc.yellow('Dry run mode: no changes will be made'));
+  }
+
+  if (!options.yes && !options.dryRun) {
     const confirmed = await p.confirm({ message: 'Proceed with sync?' });
 
     if (p.isCancel(confirmed) || !confirmed) {
@@ -311,90 +421,113 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     }
   }
 
-  // 5. Install skills (always project-scoped, always symlink)
+  // 6. Create symlinks
+  // Deduplicate agent skillsDirs to avoid redundant symlinks
+  const uniqueSkillsDirs = [...new Set(targetAgents.map((a) => agents[a].skillsDir))];
+
   spinner.start('Syncing skills...');
 
   const results: Array<{
     skill: string;
+    targetName: string;
     packageName: string;
-    agent: string;
+    skillsDir: string;
     success: boolean;
-    path: string;
-    canonicalPath?: string;
     error?: string;
   }> = [];
 
   for (const skill of toInstall) {
-    for (const agent of targetAgents) {
-      const result = await installSkillForAgent(skill, agent, {
-        global: false,
-        cwd,
-        mode: 'symlink',
-      });
+    for (const skillsDir of uniqueSkillsDirs) {
+      const linkPath = join(cwd, skillsDir, skill.targetName);
+
+      if (options.dryRun) {
+        results.push({
+          skill: skill.name,
+          targetName: skill.targetName,
+          packageName: skill.packageName,
+          skillsDir,
+          success: true,
+        });
+        continue;
+      }
+
+      const success = await createSkillSymlink(skill.skillPath, linkPath);
       results.push({
         skill: skill.name,
+        targetName: skill.targetName,
         packageName: skill.packageName,
-        agent: agents[agent].displayName,
-        success: result.success,
-        path: result.path,
-        canonicalPath: result.canonicalPath,
-        error: result.error,
+        skillsDir,
+        success,
+        error: success ? undefined : 'Failed to create symlink',
       });
     }
   }
 
   spinner.stop('Sync complete');
 
-  // 6. Update local lock file
-  const successful = results.filter((r) => r.success);
-  const failed = results.filter((r) => !r.success);
-  const successfulSkillNames = new Set(successful.map((r) => r.skill));
+  // 7. Cleanup stale npm-* entries
+  if (options.cleanup !== false) {
+    await runCleanup(cwd, discoveredSkills, options, uniqueSkillsDirs);
+  }
 
-  for (const skill of toInstall) {
-    if (successfulSkillNames.has(skill.name)) {
-      try {
-        const computedHash = await computeSkillFolderHash(skill.path);
-        await addSkillToLocalLock(
-          skill.name,
-          {
-            source: skill.packageName,
-            sourceType: 'node_modules',
-            computedHash,
-          },
-          cwd
-        );
-      } catch {
-        // Don't fail sync if lock file update fails
+  // 8. Update .gitignore
+  if (options.gitignore !== false) {
+    await runGitignoreUpdate(cwd, options);
+  }
+
+  // 9. Update local lock file
+  if (!options.dryRun) {
+    const successfulTargetNames = new Set(
+      results.filter((r) => r.success).map((r) => r.targetName)
+    );
+
+    for (const skill of toInstall) {
+      if (successfulTargetNames.has(skill.targetName)) {
+        try {
+          const computedHash = await computeSkillFolderHash(skill.skillPath);
+          await addSkillToLocalLock(
+            skill.targetName,
+            {
+              source: skill.packageName,
+              sourceType: 'node_modules',
+              computedHash,
+            },
+            cwd
+          );
+        } catch {
+          // Don't fail sync if lock file update fails
+        }
       }
     }
   }
 
-  // 7. Display results
+  // 10. Display results
   console.log();
 
+  const successful = results.filter((r) => r.success);
+  const failed = results.filter((r) => !r.success);
+
   if (successful.length > 0) {
-    const bySkill = new Map<string, typeof results>();
+    const bySkill = new Map<string, (typeof results)[number][]>();
     for (const r of successful) {
-      const skillResults = bySkill.get(r.skill) || [];
+      const skillResults = bySkill.get(r.targetName) || [];
       skillResults.push(r);
-      bySkill.set(r.skill, skillResults);
+      bySkill.set(r.targetName, skillResults);
     }
 
     const resultLines: string[] = [];
-    for (const [skillName, skillResults] of bySkill) {
+    for (const [, skillResults] of bySkill) {
       const firstResult = skillResults[0]!;
-      const pkg = toInstall.find((s) => s.name === skillName)?.packageName;
-      if (firstResult.canonicalPath) {
-        const shortPath = shortenPath(firstResult.canonicalPath, cwd);
-        resultLines.push(`${pc.green('✓')} ${skillName} ${pc.dim(`← ${pkg}`)}`);
-        resultLines.push(`  ${pc.dim(shortPath)}`);
-      } else {
-        resultLines.push(`${pc.green('✓')} ${skillName} ${pc.dim(`← ${pkg}`)}`);
-      }
+      const shortPath = shortenPath(join(cwd, firstResult.skillsDir, firstResult.targetName), cwd);
+      resultLines.push(
+        `${pc.green('✓')} ${firstResult.skill} ${pc.dim(`← ${firstResult.packageName}`)}`
+      );
+      resultLines.push(`  ${pc.dim(shortPath)}`);
     }
 
+    const action = options.dryRun ? 'Would sync' : 'Synced';
     const skillCount = bySkill.size;
-    const title = pc.green(`Synced ${skillCount} skill${skillCount !== 1 ? 's' : ''}`);
+    const title = pc.green(`${action} ${skillCount} skill${skillCount !== 1 ? 's' : ''}`);
     p.note(resultLines.join('\n'), title);
   }
 
@@ -402,7 +535,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     console.log();
     p.log.error(pc.red(`Failed to install ${failed.length}`));
     for (const r of failed) {
-      p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
+      p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.skillsDir}: ${pc.dim(r.error)}`);
     }
   }
 
@@ -410,7 +543,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   track({
     event: 'experimental_sync',
     skillCount: String(toInstall.length),
-    successCount: String(successfulSkillNames.size),
+    successCount: String(new Set(successful.map((r) => r.targetName)).size),
     agents: targetAgents.join(','),
   });
 
@@ -420,8 +553,55 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   );
 }
 
+async function runCleanup(
+  cwd: string,
+  allSkills: NpmSkill[],
+  options: SyncOptions,
+  skillsDirs?: string[]
+): Promise<void> {
+  const validTargetNames = new Set(allSkills.map((s) => s.targetName));
+  const dirs = skillsDirs || [...new Set(Object.values(agents).map((a) => a.skillsDir))];
+
+  let totalCleaned = 0;
+  for (const skillsDir of dirs) {
+    const results = await cleanupStaleNpmSkills(
+      join(cwd, skillsDir),
+      validTargetNames,
+      options.dryRun
+    );
+    const cleaned = results.filter((r) => r.success);
+    totalCleaned += cleaned.length;
+
+    if (cleaned.length > 0) {
+      const action = options.dryRun ? 'Would remove' : 'Removed';
+      for (const r of cleaned) {
+        p.log.info(
+          `${action} stale ${pc.dim(r.targetName)} from ${pc.dim(shortenPath(r.path, cwd))}`
+        );
+      }
+    }
+  }
+
+  if (totalCleaned > 0) {
+    const action = options.dryRun ? 'Would clean up' : 'Cleaned up';
+    p.log.success(`${action} ${totalCleaned} stale skill${totalCleaned !== 1 ? 's' : ''}`);
+  }
+}
+
+async function runGitignoreUpdate(cwd: string, options: SyncOptions): Promise<void> {
+  const { updated, created } = await updateGitignore(cwd, options.dryRun);
+  if (updated) {
+    const prefix = options.dryRun ? 'Would update' : 'Updated';
+    const msg = created ? `${prefix} .gitignore (created)` : `${prefix} .gitignore`;
+    p.log.success(msg);
+  }
+}
+
 export function parseSyncOptions(args: string[]): { options: SyncOptions } {
-  const options: SyncOptions = {};
+  const options: SyncOptions = {
+    cleanup: true,
+    gitignore: true,
+  };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -430,12 +610,46 @@ export function parseSyncOptions(args: string[]): { options: SyncOptions } {
       options.yes = true;
     } else if (arg === '-f' || arg === '--force') {
       options.force = true;
+    } else if (arg === '-r' || arg === '--recursive') {
+      options.recursive = true;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--no-cleanup') {
+      options.cleanup = false;
+    } else if (arg === '--no-gitignore') {
+      options.gitignore = false;
+    } else if (arg === '-s' || arg === '--source') {
+      i++;
+      const val = args[i];
+      if (val === 'node_modules' || val === 'package.json') {
+        options.source = val;
+      }
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
         options.agent.push(nextArg);
+        i++;
+        nextArg = args[i];
+      }
+      i--;
+    } else if (arg === '--include') {
+      options.include = options.include || [];
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        options.include.push(nextArg);
+        i++;
+        nextArg = args[i];
+      }
+      i--;
+    } else if (arg === '--exclude') {
+      options.exclude = options.exclude || [];
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        options.exclude.push(nextArg);
         i++;
         nextArg = args[i];
       }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -14,6 +14,7 @@ import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import { track } from './telemetry.ts';
+import { getLastSelectedAgents, saveSelectedAgents } from './skill-lock.ts';
 import {
   type NpmSkill,
   createTargetName,
@@ -327,6 +328,14 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
     const totalAgents = Object.keys(agents).length;
     spinner.stop(`${totalAgents} agents`);
 
+    // Load last selected agents for initial selection
+    let lastSelected: string[] | undefined;
+    try {
+      lastSelected = await getLastSelectedAgents();
+    } catch {
+      // Silently ignore errors
+    }
+
     if (installedAgents.length === 0) {
       if (options.yes) {
         targetAgents = universalAgents;
@@ -340,10 +349,17 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
           hint: agents[a].skillsDir,
         }));
 
+        const initialSelected = lastSelected
+          ? (lastSelected.filter(
+              (a) =>
+                otherAgents.includes(a as AgentType) && !universalAgents.includes(a as AgentType)
+            ) as AgentType[])
+          : [];
+
         const selected = await searchMultiselect({
           message: 'Which agents do you want to install to?',
           items: otherChoices,
-          initialSelected: [],
+          initialSelected,
           lockedSection: {
             title: 'Universal (.agents/skills)',
             items: universalAgents.map((a) => ({
@@ -359,6 +375,13 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
         }
 
         targetAgents = selected as AgentType[];
+
+        // Save selection for next time
+        try {
+          await saveSelectedAgents(targetAgents as string[]);
+        } catch {
+          // Silently ignore errors
+        }
       }
     } else if (installedAgents.length === 1 || options.yes) {
       targetAgents = [...installedAgents];
@@ -376,10 +399,17 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
         hint: agents[a].skillsDir,
       }));
 
+      // Use last saved selection if available, otherwise fall back to all installed
+      const initialSelected = lastSelected
+        ? (lastSelected.filter(
+            (a) => otherAgents.includes(a as AgentType) && !universalAgents.includes(a as AgentType)
+          ) as AgentType[])
+        : (installedAgents.filter((a) => !universalAgents.includes(a)) as AgentType[]);
+
       const selected = await searchMultiselect({
         message: 'Which agents do you want to install to?',
         items: otherChoices,
-        initialSelected: installedAgents.filter((a) => !universalAgents.includes(a)),
+        initialSelected,
         lockedSection: {
           title: 'Universal (.agents/skills)',
           items: universalAgents.map((a) => ({
@@ -395,6 +425,13 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
       }
 
       targetAgents = selected as AgentType[];
+
+      // Save selection for next time
+      try {
+        await saveSelectedAgents(targetAgents as string[]);
+      } catch {
+        // Silently ignore errors
+      }
     }
   }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,6 +1,6 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
-import { readdir, stat } from 'fs/promises';
+import { readFile, readdir, stat } from 'fs/promises';
 import { join, sep } from 'path';
 import { homedir } from 'os';
 import { parseSkillMd } from './skills.ts';
@@ -23,6 +23,7 @@ import {
   searchForWorkspaceRoot,
   getWorkspacePackageRoots,
   filterNpmSkills,
+  buildNpmSyncTelemetryPackages,
   createSkillSymlink,
   cleanupStaleNpmSkills,
 } from './sync-utils.ts';
@@ -85,11 +86,22 @@ async function scanNodeModulesDir(
   };
 
   const processPackageDir = async (pkgDir: string, packageName: string) => {
+    let packageVersion: string | undefined;
+    try {
+      const pkgJson = JSON.parse(await readFile(join(pkgDir, 'package.json'), 'utf-8'));
+      if (typeof pkgJson.version === 'string' && pkgJson.version.trim()) {
+        packageVersion = pkgJson.version.trim();
+      }
+    } catch {
+      // package.json is optional for local test fixtures and unusual installs.
+    }
+
     // 1. Check for SKILL.md at package root (simple single-skill package)
     const rootSkill = await parseSkillMd(join(pkgDir, 'SKILL.md'));
     if (rootSkill) {
       addSkill({
         packageName,
+        packageVersion,
         skillName: sanitizePackageName(packageName),
         skillPath: rootSkill.path,
         targetName: createTargetName(packageName),
@@ -122,6 +134,7 @@ async function scanNodeModulesDir(
           if (skill) {
             addSkill({
               packageName,
+              packageVersion,
               skillName: name,
               skillPath: skill.path,
               targetName: createTargetName(packageName, name),
@@ -255,7 +268,10 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
   );
 
   for (const skill of discoveredSkills) {
-    p.log.info(`${pc.cyan(skill.name)} ${pc.dim(`from ${skill.packageName}`)}`);
+    const packageLabel = skill.packageVersion
+      ? `${skill.packageName}@${skill.packageVersion}`
+      : skill.packageName;
+    p.log.info(`${pc.cyan(skill.name)} ${pc.dim(`from ${packageLabel}`)}`);
     if (skill.description) {
       p.log.message(pc.dim(`  ${skill.description}`));
     }
@@ -299,6 +315,12 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
     if (options.gitignore !== false) {
       await runGitignoreUpdate(cwd, options);
     }
+    trackSyncTelemetry({
+      observedSkills: discoveredSkills,
+      skillCount: 0,
+      successCount: 0,
+      agents: options.agent ?? [],
+    });
     console.log();
     p.outro(pc.green('All skills are up to date.'));
     return;
@@ -438,7 +460,10 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
   // 5. Build summary
   const summaryLines: string[] = [];
   for (const skill of toInstall) {
-    summaryLines.push(`${pc.cyan(skill.name)} ${pc.dim(`← ${skill.packageName}`)}`);
+    const packageLabel = skill.packageVersion
+      ? `${skill.packageName}@${skill.packageVersion}`
+      : skill.packageName;
+    summaryLines.push(`${pc.cyan(skill.name)} ${pc.dim(`← ${packageLabel}`)}`);
     summaryLines.push(`  ${pc.dim(skill.targetName)}`);
   }
 
@@ -468,6 +493,7 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
     skill: string;
     targetName: string;
     packageName: string;
+    packageVersion?: string;
     skillsDir: string;
     success: boolean;
     error?: string;
@@ -482,6 +508,7 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
           skill: skill.name,
           targetName: skill.targetName,
           packageName: skill.packageName,
+          packageVersion: skill.packageVersion,
           skillsDir,
           success: true,
         });
@@ -493,6 +520,7 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
         skill: skill.name,
         targetName: skill.targetName,
         packageName: skill.packageName,
+        packageVersion: skill.packageVersion,
         skillsDir,
         success,
         error: success ? undefined : 'Failed to create symlink',
@@ -556,9 +584,10 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
     for (const [, skillResults] of bySkill) {
       const firstResult = skillResults[0]!;
       const shortPath = shortenPath(join(cwd, firstResult.skillsDir, firstResult.targetName), cwd);
-      resultLines.push(
-        `${pc.green('✓')} ${firstResult.skill} ${pc.dim(`← ${firstResult.packageName}`)}`
-      );
+      const packageLabel = firstResult.packageVersion
+        ? `${firstResult.packageName}@${firstResult.packageVersion}`
+        : firstResult.packageName;
+      resultLines.push(`${pc.green('✓')} ${firstResult.skill} ${pc.dim(`← ${packageLabel}`)}`);
       resultLines.push(`  ${pc.dim(shortPath)}`);
     }
 
@@ -576,18 +605,39 @@ export async function runSync(_args: string[], options: SyncOptions = {}): Promi
     }
   }
 
-  // Track telemetry
-  track({
-    event: 'experimental_sync',
-    skillCount: String(toInstall.length),
-    successCount: String(new Set(successful.map((r) => r.targetName)).size),
-    agents: targetAgents.join(','),
+  trackSyncTelemetry({
+    observedSkills: discoveredSkills,
+    skillCount: toInstall.length,
+    successCount: new Set(successful.map((r) => r.targetName)).size,
+    agents: targetAgents,
   });
 
   console.log();
   p.outro(
     pc.green('Done!') + pc.dim('  Review skills before use; they run with full agent permissions.')
   );
+}
+
+function trackSyncTelemetry({
+  observedSkills,
+  skillCount,
+  successCount,
+  agents,
+}: {
+  observedSkills: NpmSkill[];
+  skillCount: number;
+  successCount: number;
+  agents: string[];
+}): void {
+  const packages = buildNpmSyncTelemetryPackages(observedSkills);
+
+  track({
+    event: 'experimental_sync',
+    skillCount: String(skillCount),
+    successCount: String(successCount),
+    agents: agents.join(','),
+    ...(packages.length > 0 && { packages: JSON.stringify(packages) }),
+  });
 }
 
 async function runCleanup(

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -46,6 +46,13 @@ interface SyncTelemetryData {
   skillCount: string;
   successCount: string;
   agents: string;
+  /**
+   * JSON array of package manager skills observed during sync.
+   * Each entry includes npm package/version context so the telemetry server can
+   * verify and index the published registry artifact without trusting local
+   * node_modules contents.
+   */
+  packages?: string;
 }
 
 type TelemetryData =

--- a/tests/gitignore.test.ts
+++ b/tests/gitignore.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { hasGitignorePattern, updateGitignore } from '../src/gitignore.ts';
+
+describe('gitignore', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-gitignore-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('hasGitignorePattern', () => {
+    it('returns false when .gitignore does not exist', async () => {
+      expect(await hasGitignorePattern(testDir)).toBe(false);
+    });
+
+    it('returns false when pattern is not present', async () => {
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules\n');
+      expect(await hasGitignorePattern(testDir)).toBe(false);
+    });
+
+    it('returns true when pattern is present', async () => {
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules\n**/skills/npm-*\n');
+      expect(await hasGitignorePattern(testDir)).toBe(true);
+    });
+  });
+
+  describe('updateGitignore', () => {
+    it('creates .gitignore when it does not exist', async () => {
+      const result = await updateGitignore(testDir);
+      expect(result).toEqual({ updated: true, created: true });
+
+      const content = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(content).toContain('**/skills/npm-*');
+      expect(content).toContain('# Agent skills from npm packages');
+    });
+
+    it('appends pattern to existing .gitignore', async () => {
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules\n');
+
+      const result = await updateGitignore(testDir);
+      expect(result).toEqual({ updated: true, created: false });
+
+      const content = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(content).toContain('node_modules');
+      expect(content).toContain('**/skills/npm-*');
+    });
+
+    it('does not modify when pattern already exists', async () => {
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules\n**/skills/npm-*\n');
+
+      const result = await updateGitignore(testDir);
+      expect(result).toEqual({ updated: false, created: false });
+    });
+
+    it('replaces legacy pattern', async () => {
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules\nskills/npm-*\n');
+
+      const result = await updateGitignore(testDir);
+      expect(result).toEqual({ updated: true, created: false });
+
+      const content = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(content).toContain('**/skills/npm-*');
+      expect(content).not.toMatch(/^skills\/npm-\*/m);
+    });
+
+    it('does not write in dry-run mode', async () => {
+      const result = await updateGitignore(testDir, true);
+      expect(result).toEqual({ updated: true, created: true });
+      expect(existsSync(join(testDir, '.gitignore'))).toBe(false);
+    });
+  });
+});

--- a/tests/sync-utils.test.ts
+++ b/tests/sync-utils.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizePackageName,
+  createTargetName,
+  matchesPattern,
+  filterNpmSkills,
+  type NpmSkill,
+} from '../src/sync-utils.ts';
+
+describe('sanitizePackageName', () => {
+  it('strips leading @', () => {
+    expect(sanitizePackageName('@vercel/ai-sdk')).toBe('vercel-ai-sdk');
+  });
+
+  it('replaces / with -', () => {
+    expect(sanitizePackageName('@scope/pkg')).toBe('scope-pkg');
+  });
+
+  it('lowercases the result', () => {
+    expect(sanitizePackageName('MyPackage')).toBe('mypackage');
+  });
+
+  it('handles unscoped packages', () => {
+    expect(sanitizePackageName('my-lib')).toBe('my-lib');
+  });
+});
+
+describe('createTargetName', () => {
+  it('creates npm-<pkg> for root skills', () => {
+    expect(createTargetName('my-pkg')).toBe('npm-my-pkg');
+  });
+
+  it('creates npm-<pkg>-<skill> for subdir skills', () => {
+    expect(createTargetName('my-lib', 'coding')).toBe('npm-my-lib-coding');
+  });
+
+  it('handles scoped packages for root skills', () => {
+    expect(createTargetName('@vercel/ai-sdk')).toBe('npm-vercel-ai-sdk');
+  });
+
+  it('handles scoped packages for subdir skills', () => {
+    expect(createTargetName('@vercel/ai-sdk', 'coding')).toBe('npm-vercel-ai-sdk-coding');
+  });
+});
+
+describe('matchesPattern', () => {
+  it('matches exact names', () => {
+    expect(matchesPattern('pkg-a', 'pkg-a')).toBe(true);
+    expect(matchesPattern('pkg-a', 'pkg-b')).toBe(false);
+  });
+
+  it('matches wildcard patterns', () => {
+    expect(matchesPattern('@scope/foo', '@scope/*')).toBe(true);
+    expect(matchesPattern('@scope/bar', '@scope/*')).toBe(true);
+    expect(matchesPattern('@other/foo', '@scope/*')).toBe(false);
+  });
+
+  it('matches ** patterns', () => {
+    expect(matchesPattern('@scope/sub/pkg', '@scope/**')).toBe(true);
+  });
+
+  it('matches ? patterns', () => {
+    expect(matchesPattern('pkg-a', 'pkg-?')).toBe(true);
+    expect(matchesPattern('pkg-ab', 'pkg-?')).toBe(false);
+  });
+
+  it('matches suffix wildcards', () => {
+    expect(matchesPattern('my-skills', '*-skills')).toBe(true);
+    expect(matchesPattern('my-tools', '*-skills')).toBe(false);
+  });
+});
+
+describe('filterNpmSkills', () => {
+  const mockSkills: NpmSkill[] = [
+    {
+      packageName: 'pkg-a',
+      skillName: 'skill1',
+      skillPath: '/a/skill1',
+      targetName: 'npm-pkg-a-skill1',
+      name: 'Skill 1',
+      description: 'Desc 1',
+    },
+    {
+      packageName: 'pkg-b',
+      skillName: 'skill2',
+      skillPath: '/b/skill2',
+      targetName: 'npm-pkg-b-skill2',
+      name: 'Skill 2',
+      description: 'Desc 2',
+    },
+    {
+      packageName: '@scope/foo',
+      skillName: 'integration',
+      skillPath: '/scope/foo/integration',
+      targetName: 'npm-scope-foo-integration',
+      name: 'Foo Integration',
+      description: 'Desc 3',
+    },
+    {
+      packageName: '@scope/bar',
+      skillName: 'guide',
+      skillPath: '/scope/bar/guide',
+      targetName: 'npm-scope-bar-guide',
+      name: 'Bar Guide',
+      description: 'Desc 4',
+    },
+  ];
+
+  it('returns all skills with no filters', () => {
+    const { skills, excludedCount } = filterNpmSkills(mockSkills);
+    expect(skills).toHaveLength(4);
+    expect(excludedCount).toBe(0);
+  });
+
+  it('includes only matching packages', () => {
+    const { skills, excludedCount } = filterNpmSkills(mockSkills, ['pkg-a']);
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.packageName).toBe('pkg-a');
+    expect(excludedCount).toBe(3);
+  });
+
+  it('excludes matching packages', () => {
+    const { skills } = filterNpmSkills(mockSkills, undefined, ['pkg-a']);
+    expect(skills).toHaveLength(3);
+    expect(skills.every((s) => s.packageName !== 'pkg-a')).toBe(true);
+  });
+
+  it('handles wildcard include patterns', () => {
+    const { skills } = filterNpmSkills(mockSkills, ['@scope/*']);
+    expect(skills).toHaveLength(2);
+    expect(skills.every((s) => s.packageName.startsWith('@scope/'))).toBe(true);
+  });
+
+  it('handles wildcard exclude patterns', () => {
+    const { skills } = filterNpmSkills(mockSkills, undefined, ['@scope/*']);
+    expect(skills).toHaveLength(2);
+    expect(skills.every((s) => !s.packageName.startsWith('@scope/'))).toBe(true);
+  });
+
+  it('applies both include and exclude', () => {
+    const { skills, excludedCount } = filterNpmSkills(mockSkills, ['pkg-a', 'pkg-b'], ['pkg-b']);
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.packageName).toBe('pkg-a');
+    expect(excludedCount).toBe(3);
+  });
+});

--- a/tests/sync-utils.test.ts
+++ b/tests/sync-utils.test.ts
@@ -4,6 +4,7 @@ import {
   createTargetName,
   matchesPattern,
   filterNpmSkills,
+  buildNpmSyncTelemetryPackages,
   type NpmSkill,
 } from '../src/sync-utils.ts';
 
@@ -40,6 +41,63 @@ describe('createTargetName', () => {
 
   it('handles scoped packages for subdir skills', () => {
     expect(createTargetName('@vercel/ai-sdk', 'coding')).toBe('npm-vercel-ai-sdk-coding');
+  });
+});
+
+describe('buildNpmSyncTelemetryPackages', () => {
+  it('builds npm package observations for versioned package skills', () => {
+    const skills: NpmSkill[] = [
+      {
+        packageName: 'next',
+        packageVersion: '16.2.1',
+        skillName: 'next',
+        skillPath: '/repo/node_modules/next/dist/skills/next/SKILL.md',
+        targetName: 'npm-next-next',
+        name: 'Next.js',
+        description: 'Next.js skill',
+      },
+      {
+        packageName: '@vercel/ai-sdk',
+        packageVersion: '6.0.0',
+        skillName: 'coding',
+        skillPath: '/repo/node_modules/@vercel/ai-sdk/skills/coding/SKILL.md',
+        targetName: 'npm-vercel-ai-sdk-coding',
+        name: 'AI SDK Coding',
+        description: 'AI SDK skill',
+      },
+    ];
+
+    expect(buildNpmSyncTelemetryPackages(skills)).toEqual([
+      {
+        skill: 'Next.js',
+        package: 'next',
+        ecosystem: 'npm',
+        registry: 'npm',
+        version: '16.2.1',
+      },
+      {
+        skill: 'AI SDK Coding',
+        package: '@vercel/ai-sdk',
+        ecosystem: 'npm',
+        registry: 'npm',
+        version: '6.0.0',
+      },
+    ]);
+  });
+
+  it('omits skills when package version is unavailable', () => {
+    const skills: NpmSkill[] = [
+      {
+        packageName: 'fixture-pkg',
+        skillName: 'skill',
+        skillPath: '/fixture/SKILL.md',
+        targetName: 'npm-fixture-pkg',
+        name: 'Fixture Skill',
+        description: 'No package.json version',
+      },
+    ];
+
+    expect(buildNpmSyncTelemetryPackages(skills)).toEqual([]);
   });
 });
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from '../src/test-utils.ts';
+
+function writeSkillMd(dir: string, name: string, description: string) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+Instructions.
+`
+  );
+}
 
 describe('experimental_sync command', () => {
   let testDir: string;
@@ -20,19 +35,10 @@ describe('experimental_sync command', () => {
 
   describe('node_modules discovery', () => {
     it('should find SKILL.md at package root', () => {
-      // Create a package with SKILL.md at root
-      const pkgDir = join(testDir, 'node_modules', 'my-skill-pkg');
-      mkdirSync(pkgDir, { recursive: true });
-      writeFileSync(
-        join(pkgDir, 'SKILL.md'),
-        `---
-name: root-skill
-description: A skill at package root
----
-
-# Root Skill
-Instructions.
-`
+      writeSkillMd(
+        join(testDir, 'node_modules', 'my-skill-pkg'),
+        'root-skill',
+        'A skill at package root'
       );
 
       const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
@@ -41,18 +47,10 @@ Instructions.
     });
 
     it('should find skills in skills/ subdirectory', () => {
-      const skillDir = join(testDir, 'node_modules', 'my-lib', 'skills', 'helper-skill');
-      mkdirSync(skillDir, { recursive: true });
-      writeFileSync(
-        join(skillDir, 'SKILL.md'),
-        `---
-name: helper-skill
-description: A helper skill in skills/ dir
----
-
-# Helper
-Instructions.
-`
+      writeSkillMd(
+        join(testDir, 'node_modules', 'my-lib', 'skills', 'helper-skill'),
+        'helper-skill',
+        'A helper skill in skills/ dir'
       );
 
       const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
@@ -60,19 +58,23 @@ Instructions.
       expect(result.stdout).toContain('my-lib');
     });
 
-    it('should find skills in scoped packages', () => {
-      const pkgDir = join(testDir, 'node_modules', '@acme', 'tools');
-      mkdirSync(pkgDir, { recursive: true });
-      writeFileSync(
-        join(pkgDir, 'SKILL.md'),
-        `---
-name: acme-tool
-description: A skill from a scoped package
----
+    it('should find skills in dist/skills/ subdirectory', () => {
+      writeSkillMd(
+        join(testDir, 'node_modules', 'my-lib', 'dist', 'skills', 'built-skill'),
+        'built-skill',
+        'A skill built to dist/'
+      );
 
-# Acme Tool
-Instructions.
-`
+      const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+      expect(result.stdout).toContain('built-skill');
+      expect(result.stdout).toContain('my-lib');
+    });
+
+    it('should find skills in scoped packages', () => {
+      writeSkillMd(
+        join(testDir, 'node_modules', '@acme', 'tools'),
+        'acme-tool',
+        'A skill from a scoped package'
       );
 
       const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
@@ -94,19 +96,11 @@ Instructions.
   });
 
   describe('skills-lock.json', () => {
-    it('should write skills-lock.json after sync', () => {
-      const pkgDir = join(testDir, 'node_modules', 'my-pkg');
-      mkdirSync(pkgDir, { recursive: true });
-      writeFileSync(
-        join(pkgDir, 'SKILL.md'),
-        `---
-name: lock-test-skill
-description: Test lock file writing
----
-
-# Lock Test
-Instructions.
-`
+    it('should write skills-lock.json after sync using targetName as key', () => {
+      writeSkillMd(
+        join(testDir, 'node_modules', 'my-pkg'),
+        'lock-test-skill',
+        'Test lock file writing'
       );
 
       runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
@@ -116,101 +110,274 @@ Instructions.
 
       const lock = JSON.parse(readFileSync(lockPath, 'utf-8'));
       expect(lock.version).toBe(1);
-      expect(lock.skills['lock-test-skill']).toBeDefined();
-      expect(lock.skills['lock-test-skill'].source).toBe('my-pkg');
-      expect(lock.skills['lock-test-skill'].sourceType).toBe('node_modules');
-      expect(lock.skills['lock-test-skill'].computedHash).toMatch(/^[a-f0-9]{64}$/);
+      // Key should be targetName (npm-my-pkg), not skill name
+      expect(lock.skills['npm-my-pkg']).toBeDefined();
+      expect(lock.skills['npm-my-pkg'].source).toBe('my-pkg');
+      expect(lock.skills['npm-my-pkg'].sourceType).toBe('node_modules');
+      expect(lock.skills['npm-my-pkg'].computedHash).toMatch(/^[a-f0-9]{64}$/);
     });
 
-    it('should not have timestamps in lock entries', () => {
-      const pkgDir = join(testDir, 'node_modules', 'my-pkg');
-      mkdirSync(pkgDir, { recursive: true });
-      writeFileSync(
-        join(pkgDir, 'SKILL.md'),
-        `---
-name: no-timestamp-skill
-description: No timestamps
----
-
-# Test
-`
+    it('should use targetName with skill dir name for subdir skills', () => {
+      writeSkillMd(
+        join(testDir, 'node_modules', 'my-lib', 'skills', 'my-skill'),
+        'my-skill',
+        'Test subdir lock'
       );
 
       runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
 
       const lock = JSON.parse(readFileSync(join(testDir, 'skills-lock.json'), 'utf-8'));
-      const entry = lock.skills['no-timestamp-skill'];
+      expect(lock.skills['npm-my-lib-my-skill']).toBeDefined();
+      expect(lock.skills['npm-my-lib-my-skill'].source).toBe('my-lib');
+    });
+
+    it('should not have timestamps in lock entries', () => {
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'no-timestamp-skill', 'No timestamps');
+
+      runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+
+      const lock = JSON.parse(readFileSync(join(testDir, 'skills-lock.json'), 'utf-8'));
+      const entry = lock.skills['npm-my-pkg'];
       expect(entry.installedAt).toBeUndefined();
       expect(entry.updatedAt).toBeUndefined();
     });
 
     it('should sort skills alphabetically in lock file', () => {
-      // Create three packages in reverse order
       for (const name of ['zebra-skill', 'alpha-skill', 'mid-skill']) {
-        const pkgDir = join(testDir, 'node_modules', name);
-        mkdirSync(pkgDir, { recursive: true });
-        writeFileSync(
-          join(pkgDir, 'SKILL.md'),
-          `---
-name: ${name}
-description: ${name} description
----
-
-# ${name}
-`
-        );
+        writeSkillMd(join(testDir, 'node_modules', name), name, `${name} description`);
       }
 
       runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
 
       const raw = readFileSync(join(testDir, 'skills-lock.json'), 'utf-8');
       const keys = Object.keys(JSON.parse(raw).skills);
-      expect(keys).toEqual(['alpha-skill', 'mid-skill', 'zebra-skill']);
+      expect(keys).toEqual(['npm-alpha-skill', 'npm-mid-skill', 'npm-zebra-skill']);
     });
 
     it('should skip unchanged skills on second sync', () => {
-      const pkgDir = join(testDir, 'node_modules', 'my-pkg');
-      mkdirSync(pkgDir, { recursive: true });
-      writeFileSync(
-        join(pkgDir, 'SKILL.md'),
-        `---
-name: cached-skill
-description: Test caching
----
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'cached-skill', 'Test caching');
 
-# Cached
-`
-      );
-
-      // First sync
       runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
 
-      // Second sync - should say up to date
       const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
       expect(result.stdout).toContain('up to date');
     });
 
     it('should reinstall when --force is used', () => {
-      const pkgDir = join(testDir, 'node_modules', 'my-pkg');
-      mkdirSync(pkgDir, { recursive: true });
-      writeFileSync(
-        join(pkgDir, 'SKILL.md'),
-        `---
-name: force-skill
-description: Test force
----
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'force-skill', 'Test force');
 
-# Force
-`
-      );
-
-      // First sync
       runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
 
-      // Second sync with --force should reinstall
       const result = runCli(['experimental_sync', '-y', '-a', 'claude-code', '--force'], testDir);
       expect(result.stdout).toContain('force-skill');
       expect(result.stdout).not.toContain('All skills are up to date');
+    });
+  });
+
+  describe('npm-* symlink naming', () => {
+    it('should create symlinks with npm- prefix for root SKILL.md', () => {
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'my-skill', 'Test symlink naming');
+
+      runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+
+      expect(existsSync(join(testDir, '.claude', 'skills', 'npm-my-pkg'))).toBe(true);
+    });
+
+    it('should create symlinks with npm-<pkg>-<skill> for subdir skills', () => {
+      writeSkillMd(
+        join(testDir, 'node_modules', 'my-lib', 'skills', 'coding'),
+        'coding',
+        'Test subdir symlink naming'
+      );
+
+      runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+
+      expect(existsSync(join(testDir, '.claude', 'skills', 'npm-my-lib-coding'))).toBe(true);
+    });
+
+    it('should handle scoped packages in symlink names', () => {
+      writeSkillMd(
+        join(testDir, 'node_modules', '@vercel', 'ai-sdk', 'skills', 'coding'),
+        'coding',
+        'Test scoped symlink'
+      );
+
+      runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+
+      expect(existsSync(join(testDir, '.claude', 'skills', 'npm-vercel-ai-sdk-coding'))).toBe(true);
+    });
+  });
+
+  describe('--source option', () => {
+    it('should filter to package.json deps by default', () => {
+      writeFileSync(
+        join(testDir, 'package.json'),
+        JSON.stringify({
+          dependencies: { 'dep-pkg': '^1.0.0' },
+        })
+      );
+      writeSkillMd(join(testDir, 'node_modules', 'dep-pkg'), 'dep-skill', 'From dependency');
+      writeSkillMd(
+        join(testDir, 'node_modules', 'not-dep-pkg'),
+        'not-dep-skill',
+        'Not a dependency'
+      );
+
+      const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+      expect(result.stdout).toContain('dep-skill');
+      expect(result.stdout).not.toContain('not-dep-skill');
+    });
+
+    it('should scan all packages with --source node_modules', () => {
+      writeFileSync(
+        join(testDir, 'package.json'),
+        JSON.stringify({
+          dependencies: { 'dep-pkg': '^1.0.0' },
+        })
+      );
+      writeSkillMd(join(testDir, 'node_modules', 'dep-pkg'), 'dep-skill', 'From dependency');
+      writeSkillMd(
+        join(testDir, 'node_modules', 'not-dep-pkg'),
+        'not-dep-skill',
+        'Not a dependency'
+      );
+
+      const result = runCli(
+        ['experimental_sync', '-y', '-a', 'claude-code', '-s', 'node_modules'],
+        testDir
+      );
+      expect(result.stdout).toContain('dep-skill');
+      expect(result.stdout).toContain('not-dep-skill');
+    });
+  });
+
+  describe('--include / --exclude', () => {
+    it('should include only matching packages', () => {
+      writeSkillMd(join(testDir, 'node_modules', 'pkg-a'), 'skill-a', 'Skill A');
+      writeSkillMd(join(testDir, 'node_modules', 'pkg-b'), 'skill-b', 'Skill B');
+
+      const result = runCli(
+        [
+          'experimental_sync',
+          '-y',
+          '-a',
+          'claude-code',
+          '-s',
+          'node_modules',
+          '--include',
+          'pkg-a',
+        ],
+        testDir
+      );
+      expect(result.stdout).toContain('skill-a');
+      expect(result.stdout).not.toContain('skill-b');
+    });
+
+    it('should exclude matching packages', () => {
+      writeSkillMd(join(testDir, 'node_modules', 'pkg-a'), 'skill-a', 'Skill A');
+      writeSkillMd(join(testDir, 'node_modules', 'pkg-b'), 'skill-b', 'Skill B');
+
+      const result = runCli(
+        [
+          'experimental_sync',
+          '-y',
+          '-a',
+          'claude-code',
+          '-s',
+          'node_modules',
+          '--exclude',
+          'pkg-a',
+        ],
+        testDir
+      );
+      expect(result.stdout).not.toContain('skill-a');
+      expect(result.stdout).toContain('skill-b');
+    });
+  });
+
+  describe('--dry-run', () => {
+    it('should not create symlinks in dry-run mode', () => {
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'dry-skill', 'Test dry run');
+
+      const result = runCli(
+        ['experimental_sync', '-y', '-a', 'claude-code', '--dry-run', '-s', 'node_modules'],
+        testDir
+      );
+      expect(result.stdout).toContain('dry-skill');
+      expect(result.stdout).toContain('Dry run');
+      expect(existsSync(join(testDir, '.claude', 'skills', 'npm-my-pkg'))).toBe(false);
+    });
+
+    it('should not write skills-lock.json in dry-run mode', () => {
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'dry-lock-skill', 'Test dry run lock');
+
+      runCli(
+        ['experimental_sync', '-y', '-a', 'claude-code', '--dry-run', '-s', 'node_modules'],
+        testDir
+      );
+      expect(existsSync(join(testDir, 'skills-lock.json'))).toBe(false);
+    });
+  });
+
+  describe('stale cleanup', () => {
+    it('should remove stale npm-* symlinks', () => {
+      // Create a stale symlink manually
+      const skillsDir = join(testDir, '.claude', 'skills');
+      mkdirSync(skillsDir, { recursive: true });
+      mkdirSync(join(testDir, 'node_modules', 'stale-target'), { recursive: true });
+      symlinkSync(join(testDir, 'node_modules', 'stale-target'), join(skillsDir, 'npm-stale-old'));
+
+      // Create a real skill
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'real-skill', 'Real skill');
+
+      runCli(['experimental_sync', '-y', '-a', 'claude-code', '-s', 'node_modules'], testDir);
+
+      // Stale symlink should be removed
+      expect(existsSync(join(skillsDir, 'npm-stale-old'))).toBe(false);
+      // Real skill should exist
+      expect(existsSync(join(skillsDir, 'npm-my-pkg'))).toBe(true);
+    });
+
+    it('should not remove stale skills with --no-cleanup', () => {
+      const skillsDir = join(testDir, '.claude', 'skills');
+      mkdirSync(skillsDir, { recursive: true });
+      mkdirSync(join(testDir, 'node_modules', 'stale-target'), { recursive: true });
+      symlinkSync(join(testDir, 'node_modules', 'stale-target'), join(skillsDir, 'npm-stale-old'));
+
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'real-skill', 'Real skill');
+
+      runCli(
+        ['experimental_sync', '-y', '-a', 'claude-code', '-s', 'node_modules', '--no-cleanup'],
+        testDir
+      );
+
+      // Stale symlink should still exist
+      expect(existsSync(join(skillsDir, 'npm-stale-old'))).toBe(true);
+    });
+  });
+
+  describe('gitignore', () => {
+    it('should add npm-* pattern to .gitignore', () => {
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules\n');
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'gitignore-skill', 'Test gitignore');
+
+      runCli(['experimental_sync', '-y', '-a', 'claude-code', '-s', 'node_modules'], testDir);
+
+      const gitignore = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(gitignore).toContain('**/skills/npm-*');
+    });
+
+    it('should not modify .gitignore with --no-gitignore', () => {
+      writeFileSync(join(testDir, '.gitignore'), 'node_modules\n');
+      writeSkillMd(join(testDir, 'node_modules', 'my-pkg'), 'gitignore-skill', 'Test no gitignore');
+
+      runCli(
+        ['experimental_sync', '-y', '-a', 'claude-code', '-s', 'node_modules', '--no-gitignore'],
+        testDir
+      );
+
+      const gitignore = readFileSync(join(testDir, '.gitignore'), 'utf-8');
+      expect(gitignore).not.toContain('**/skills/npm-*');
     });
   });
 
@@ -230,21 +397,13 @@ description: Test force
     it('should discover multiple skills in skills/ subdirectory', () => {
       const pkg = join(testDir, 'node_modules', 'multi-skill-pkg');
       for (const name of ['skill-one', 'skill-two']) {
-        const dir = join(pkg, 'skills', name);
-        mkdirSync(dir, { recursive: true });
-        writeFileSync(
-          join(dir, 'SKILL.md'),
-          `---
-name: ${name}
-description: ${name} from multi package
----
-
-# ${name}
-`
-        );
+        writeSkillMd(join(pkg, 'skills', name), name, `${name} from multi package`);
       }
 
-      const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+      const result = runCli(
+        ['experimental_sync', '-y', '-a', 'claude-code', '-s', 'node_modules'],
+        testDir
+      );
       expect(result.stdout).toContain('skill-one');
       expect(result.stdout).toContain('skill-two');
       expect(result.stdout).toContain('multi-skill-pkg');

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -46,6 +46,17 @@ describe('experimental_sync command', () => {
       expect(result.stdout).toContain('my-skill-pkg');
     });
 
+    it('should read package version from package.json', () => {
+      const packageDir = join(testDir, 'node_modules', 'versioned-pkg');
+      mkdirSync(packageDir, { recursive: true });
+      writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ version: '1.2.3' }));
+      writeSkillMd(packageDir, 'versioned-skill', 'A skill with package version');
+
+      const result = runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+      expect(result.stdout).toContain('versioned-skill');
+      expect(result.stdout).toContain('versioned-pkg@1.2.3');
+    });
+
     it('should find skills in skills/ subdirectory', () => {
       writeSkillMd(
         join(testDir, 'node_modules', 'my-lib', 'skills', 'helper-skill'),


### PR DESCRIPTION
Port key features from the standalone [skills-npm](https://github.com/antfu/skills-npm) package into the existing experimental_sync command:

- Discovery: add `dist/skills/` as a scan location alongside `skills/`, `.agents/skills/`, and package root `SKILL.md`
- Symlinks: switch from copy-then-symlink to direct symlinks with `npm-*` naming convention
- Source filtering: `--source package.json` (default) limits scanning to declared dependencies; `--source node_modules` scans everything in node_modules 
- Monorepo: `--recursive` scans workspace package node_modules
- Include/exclude: `--include` and `--exclude` with wildcard patterns to filter packages by name
- Cleanup: automatically removes stale npm-* symlinks (`--no-cleanup` to disable)
- Gitignore: auto-adds `**/skills/npm-*` to .gitignore (`--no-gitignore` to disable)
- Dry run: `--dry-run` previews changes without writing
- Lock: `skills-lock.json` entries keyed by targetName with sourceType 'node_modules' for npm-synced skills

Things to be discussed:
- [ ] Should we automatically append `.gitignore`? I did that in `skills-npm` as I think it would provide better DX and give users a clear sign that we want them to not commit the links
- [ ] About the `npm-*` prefix, I am not sure if it's a better fit. Consider also `local-` `package-`?
- [ ] `skills-npm` as a configuration system `skills-npm.config.ts`, I didn't include it in this PR, but I wonder if we want to introduce the config system for the CLI as a whole for later.
- [ ] I am not sure if we need the `source` option, or if we can simplify things to only support the `package.json` mode (only scanning packages declared in package.json)