### PR TITLE
Add source filtering to skills remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ npx skills remove --global web-design-guidelines
 # Remove from specific agents only
 npx skills remove --agent claude-code cursor my-skill
 
+# Remove every skill installed from a specific source
+npx skills remove --source get-convex/agent-skills --all
+
 # Remove all installed skills without confirmation
 npx skills remove --all
 
@@ -199,13 +202,14 @@ npx skills remove my-skill --agent '*'
 npx skills rm my-skill
 ```
 
-| Option         | Description                                      |
-| -------------- | ------------------------------------------------ |
-| `-g, --global` | Remove from global scope (~/) instead of project |
-| `-a, --agent`  | Remove from specific agents (use `'*'` for all)  |
-| `-s, --skill`  | Specify skills to remove (use `'*'` for all)     |
-| `-y, --yes`    | Skip confirmation prompts                        |
-| `--all`        | Shorthand for `--skill '*' --agent '*' -y`       |
+| Option         | Description                                       |
+| -------------- | ------------------------------------------------- |
+| `-g, --global` | Remove from global scope (~/) instead of project  |
+| `-a, --agent`  | Remove from specific agents (use `'*'` for all)   |
+| `--source`     | Remove skills from a specific installation source |
+| `-s, --skill`  | Specify skills to remove (use `'*'` for all)      |
+| `-y, --yes`    | Skip confirmation prompts                         |
+| `--all`        | Shorthand for `--skill '*' --agent '*' -y`        |
 
 ## What are Agent Skills?
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -144,6 +144,7 @@ ${BOLD}Add Options:${RESET}
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope
   -a, --agent <agents>   Remove from specific agents (use '*' for all agents)
+  --source <sources>     Remove skills installed from specific sources
   -s, --skill <skills>   Specify skills to remove (use '*' for all skills)
   -y, --yes              Skip confirmation prompts
   --all                  Shorthand for --skill '*' --agent '*' -y
@@ -201,6 +202,7 @@ ${BOLD}Arguments:${RESET}
 ${BOLD}Options:${RESET}
   -g, --global       Remove from global scope (~/) instead of project scope
   -a, --agent        Remove from specific agents (use '*' for all agents)
+  --source           Remove skills from specific sources
   -s, --skill        Specify skills to remove (use '*' for all skills)
   -y, --yes          Skip confirmation prompts
   --all              Shorthand for --skill '*' --agent '*' -y
@@ -211,6 +213,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills remove skill1 skill2 -y           ${DIM}# remove multiple skills${RESET}
   ${DIM}$${RESET} skills remove --global my-skill          ${DIM}# remove from global scope${RESET}
   ${DIM}$${RESET} skills rm --agent claude-code my-skill   ${DIM}# remove from specific agent${RESET}
+  ${DIM}$${RESET} skills remove --source owner/repo --all  ${DIM}# remove all skills from a source${RESET}
   ${DIM}$${RESET} skills remove --all                      ${DIM}# remove all skills${RESET}
   ${DIM}$${RESET} skills remove --skill '*' -a cursor      ${DIM}# remove all skills from cursor${RESET}
 

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, runCliWithInput } from './test-utils.js';
+import { parseRemoveOptions } from './remove.ts';
 
 describe('remove command', { timeout: 30000 }, () => {
   let testDir: string;
@@ -44,6 +45,31 @@ This is a test skill.
     const agentSkillsDir = join(testDir, agentName, 'skills');
     mkdirSync(agentSkillsDir, { recursive: true });
     return agentSkillsDir;
+  }
+
+  function writeProjectLock(skills: Record<string, { source: string; sourceType: string }>) {
+    const lockPath = join(testDir, 'skills-lock.json');
+    const entries = Object.fromEntries(
+      Object.entries(skills).map(([skillName, entry]) => [
+        skillName,
+        {
+          ...entry,
+          computedHash: `${skillName}-hash`,
+        },
+      ])
+    );
+
+    writeFileSync(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 1,
+          skills: entries,
+        },
+        null,
+        2
+      ) + '\n'
+    );
   }
 
   function createSymlink(skillName: string, targetDir: string) {
@@ -125,6 +151,43 @@ This is a test skill.
       expect(existsSync(join(skillsDir, 'skill-one'))).toBe(false);
       expect(existsSync(join(skillsDir, 'skill-two'))).toBe(false);
       expect(existsSync(join(skillsDir, 'skill-three'))).toBe(false);
+    });
+
+    it('should remove only skills from the requested source', () => {
+      writeProjectLock({
+        'skill-one': {
+          source: 'get-convex/agent-skills',
+          sourceType: 'github',
+        },
+        'skill-two': {
+          source: 'get-convex/agent-skills',
+          sourceType: 'github',
+        },
+        'skill-three': {
+          source: 'vercel-labs/skills',
+          sourceType: 'github',
+        },
+      });
+
+      const result = runCli(
+        ['remove', '--source', 'get-convex/agent-skills', '--all', '-y'],
+        testDir
+      );
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.stdout).toContain('2 skill');
+      expect(existsSync(join(skillsDir, 'skill-one'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'skill-two'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'skill-three'))).toBe(true);
+
+      const lock = JSON.parse(readFileSync(join(testDir, 'skills-lock.json'), 'utf-8'));
+      expect(lock.skills).toEqual({
+        'skill-three': {
+          source: 'vercel-labs/skills',
+          sourceType: 'github',
+          computedHash: 'skill-three-hash',
+        },
+      });
     });
 
     it('should show error for non-existent skill name when skills exist', () => {
@@ -275,6 +338,7 @@ This is a test skill.
       expect(result.stdout).toContain('remove');
       expect(result.stdout).toContain('--global');
       expect(result.stdout).toContain('--agent');
+      expect(result.stdout).toContain('--source');
       expect(result.stdout).toContain('--yes');
       expect(result.exitCode).toBe(0);
     });
@@ -313,6 +377,19 @@ This is a test skill.
         testDir
       );
       expect(result.stdout).not.toContain('Invalid agents');
+    });
+
+    it('should parse --source values', () => {
+      const result = parseRemoveOptions([
+        'parse-test-skill',
+        '--source',
+        'get-convex/agent-skills',
+        '--all',
+      ]);
+
+      expect(result.skills).toEqual(['parse-test-skill']);
+      expect(result.options.source).toEqual(['get-convex/agent-skills']);
+      expect(result.options.all).toBe(true);
     });
   });
 });

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -289,7 +289,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);
-      } else {
+      } else if (!isStillUsed) {
         await removeSkillFromLocalLock(skillName, cwd);
       }
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -3,8 +3,10 @@ import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
+import { readLocalLock, removeSkillFromLocalLock } from './local-lock.ts';
 import { track } from './telemetry.ts';
-import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { readSkillLock, removeSkillFromLock } from './skill-lock.ts';
+import { getOwnerRepo, parseSource } from './source-parser.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -18,11 +20,66 @@ export interface RemoveOptions {
   agent?: string[];
   yes?: boolean;
   all?: boolean;
+  source?: string[];
+}
+
+interface RemoveLockEntry {
+  source: string;
+  sourceType: string;
+}
+
+function getSourceFilterValues(sourceFilters: string[]): Set<string> {
+  const values = new Set<string>();
+
+  for (const sourceFilter of sourceFilters) {
+    const trimmedSource = sourceFilter.trim();
+    if (!trimmedSource) {
+      continue;
+    }
+
+    values.add(trimmedSource);
+
+    const parsedSource = parseSource(trimmedSource);
+    const ownerRepo = getOwnerRepo(parsedSource);
+    if (ownerRepo) {
+      values.add(ownerRepo);
+    }
+
+    if (parsedSource.type === 'local' || parsedSource.type === 'git') {
+      values.add(parsedSource.url);
+    }
+
+    if (parsedSource.type === 'well-known') {
+      try {
+        const url = new URL(parsedSource.url);
+        values.add(`wellknown/${url.hostname}`);
+      } catch {
+        values.add(parsedSource.url);
+      }
+    }
+  }
+
+  return values;
+}
+
+function matchesSourceFilter(
+  lockEntry: RemoveLockEntry | undefined,
+  sourceFilters: Set<string>
+): boolean {
+  if (!lockEntry) {
+    return false;
+  }
+
+  return sourceFilters.has(lockEntry.source);
 }
 
 export async function removeCommand(skillNames: string[], options: RemoveOptions) {
   const isGlobal = options.global ?? false;
   const cwd = process.cwd();
+  const globalLock = isGlobal ? await readSkillLock() : null;
+  const localLock = !isGlobal ? await readLocalLock(cwd) : null;
+  const lockEntries = isGlobal ? globalLock?.skills : localLock?.skills;
+  const sourceFilters = options.source ? getSourceFilterValues(options.source) : null;
 
   const spinner = p.spinner();
 
@@ -78,21 +135,39 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
   }
 
+  const availableSkills = sourceFilters
+    ? installedSkills.filter((skillName) =>
+        matchesSourceFilter(lockEntries?.[skillName], sourceFilters)
+      )
+    : installedSkills;
+
+  if (sourceFilters && availableSkills.length === 0) {
+    p.log.error(`No installed skills found for source: ${options.source?.join(', ')}`);
+    return;
+  }
+
   let selectedSkills: string[] = [];
 
   if (options.all) {
-    selectedSkills = installedSkills;
+    selectedSkills = availableSkills;
   } else if (skillNames.length > 0) {
-    selectedSkills = installedSkills.filter((s) =>
+    selectedSkills = availableSkills.filter((s) =>
       skillNames.some((name) => name.toLowerCase() === s.toLowerCase())
     );
 
     if (selectedSkills.length === 0) {
+      if (sourceFilters) {
+        p.log.error(
+          `No matching skills found for: ${skillNames.join(', ')} from source: ${options.source?.join(', ')}`
+        );
+        return;
+      }
+
       p.log.error(`No matching skills found for: ${skillNames.join(', ')}`);
       return;
     }
   } else {
-    const choices = installedSkills.map((s) => ({
+    const choices = availableSkills.map((s) => ({
       value: s,
       label: s,
     }));
@@ -208,12 +283,14 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         await rm(canonicalPath, { recursive: true, force: true });
       }
 
-      const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
+      const lockEntry = lockEntries?.[skillName];
       const effectiveSource = lockEntry?.source || 'local';
       const effectiveSourceType = lockEntry?.sourceType || 'local';
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);
+      } else {
+        await removeSkillFromLocalLock(skillName, cwd);
       }
 
       results.push({
@@ -292,6 +369,16 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
       options.yes = true;
     } else if (arg === '--all') {
       options.all = true;
+    } else if (arg === '--source') {
+      options.source = options.source || [];
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        options.source.push(nextArg);
+        i++;
+        nextArg = args[i];
+      }
+      i--; // Back up one since the loop will increment
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       i++;

--- a/tests/remove-canonical.test.ts
+++ b/tests/remove-canonical.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, rm, writeFile, lstat, symlink } from 'node:fs/promises';
+import { mkdir, rm, writeFile, lstat, symlink, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { removeCommand } from '../src/remove.ts';
@@ -46,6 +46,7 @@ describe('removeCommand canonical protection', () => {
     const canonicalPath = join(tempDir, '.agents/skills', skillName);
     const claudePath = join(tempDir, '.claude/skills', skillName);
     const continuePath = join(tempDir, '.continue/skills', skillName);
+    const lockPath = join(tempDir, 'skills-lock.json');
 
     // 1. Create canonical storage
     await mkdir(canonicalPath, { recursive: true });
@@ -54,6 +55,23 @@ describe('removeCommand canonical protection', () => {
     // 2. Install (symlink) to Claude and Continue
     await symlink(canonicalPath, claudePath, 'junction');
     await symlink(canonicalPath, continuePath, 'junction');
+    await writeFile(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            [skillName]: {
+              source: 'get-convex/agent-skills',
+              sourceType: 'github',
+              computedHash: 'test-hash',
+            },
+          },
+        },
+        null,
+        2
+      ) + '\n'
+    );
 
     // Verify setup
     expect(
@@ -81,6 +99,13 @@ describe('removeCommand canonical protection', () => {
     expect(
       (await lstat(continuePath)).isSymbolicLink() || (await lstat(continuePath)).isDirectory()
     ).toBe(true);
+
+    const lock = JSON.parse(await readFile(lockPath, 'utf-8'));
+    expect(lock.skills[skillName]).toEqual({
+      source: 'get-convex/agent-skills',
+      sourceType: 'github',
+      computedHash: 'test-hash',
+    });
   });
 
   it('should remove canonical storage if NO other agents are using it', async () => {


### PR DESCRIPTION
## Summary
- add a `--source` filter to `skills remove`
- filter installed skills by lockfile source metadata so `skills remove --source owner/repo --all` removes the right set and cleans up the matching lock entries
- document the new flag and cover the parser plus source-filtered removal flow in tests

## Test plan
- [x] `bun src/cli.ts remove --help`
- [x] ran `bun src/cli.ts remove --source get-convex/agent-skills --all -y` against a fixture project and verified only the matching skills and lock entries were removed
- [ ] `pnpm exec vitest run src/remove.test.ts` in this environment, the existing test helper shells out to `node src/cli.ts`, which fails before the assertions run


Made with [Cursor](https://cursor.com)