### PR TITLE
feat: support --skills/--agents aliases and comma-separated lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ npx skills add ./my-local-skills
 | Option                    | Description                                                                                                                                        |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-g, --global`            | Install to user directory instead of project                                                                                                       |
-| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Available Agents](#available-agents)<!-- agent-names:end --> |
-| `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
+| `-a, --agent, --agents <agents...>` | <!-- agent-names:start -->Target specific agents (comma-separated or multiple flags). See [Available Agents](#available-agents)<!-- agent-names:end --> |
+| `-s, --skill, --skills <skills...>` | Install specific skills by name (comma-separated or multiple flags) (use `'*'` for all skills)                                                                                         |
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |

--- a/src/add.ts
+++ b/src/add.ts
@@ -1875,22 +1875,26 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.list = true;
     } else if (arg === '--all') {
       options.all = true;
-    } else if (arg === '-a' || arg === '--agent') {
+    } else if (arg === '-a' || arg === '--agent' || arg === '--agents') {
       options.agent = options.agent || [];
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.agent.push(nextArg);
+        nextArg.split(',').forEach((a) => {
+          if (a.trim()) options.agent!.push(a.trim());
+        });
         i++;
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
-    } else if (arg === '-s' || arg === '--skill') {
+    } else if (arg === '-s' || arg === '--skill' || arg === '--skills') {
       options.skill = options.skill || [];
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.skill.push(nextArg);
+        nextArg.split(',').forEach((s) => {
+          if (s.trim()) options.skill!.push(s.trim());
+        });
         i++;
         nextArg = args[i];
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,21 +132,21 @@ ${BOLD}Project:${RESET}
   experimental_sync    Sync skills from node_modules into agent directories
 
 ${BOLD}Add Options:${RESET}
-  -g, --global           Install skill globally (user-level) instead of project-level
-  -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
-  -s, --skill <skills>   Specify skill names to install (use '*' for all skills)
-  -l, --list             List available skills in the repository without installing
-  -y, --yes              Skip confirmation prompts
-  --copy                 Copy files instead of symlinking to agent directories
-  --all                  Shorthand for --skill '*' --agent '*' -y
-  --full-depth           Search all subdirectories even when a root SKILL.md exists
+  -g, --global             Install skill globally (user-level) instead of project-level
+  -a, --agent, --agents <agents> Specify agents to install to (comma-separated or multiple flags)
+  -s, --skill, --skills <skills> Specify skill names to install (comma-separated or multiple flags)
+  -l, --list               List available skills in the repository without installing
+  -y, --yes                Skip confirmation prompts
+  --copy                   Copy files instead of symlinking to agent directories
+  --all                    Shorthand for --skill '*' --agent '*' -y
+  --full-depth             Search all subdirectories even when a root SKILL.md exists
 
 ${BOLD}Remove Options:${RESET}
-  -g, --global           Remove from global scope
-  -a, --agent <agents>   Remove from specific agents (use '*' for all agents)
-  -s, --skill <skills>   Specify skills to remove (use '*' for all skills)
-  -y, --yes              Skip confirmation prompts
-  --all                  Shorthand for --skill '*' --agent '*' -y
+  -g, --global             Remove from global scope
+  -a, --agent, --agents <agents> Remove from specific agents (comma-separated or multiple flags)
+  -s, --skill, --skills <skills> Specify skills to remove (comma-separated or multiple flags)
+  -y, --yes                Skip confirmation prompts
+  --all                    Shorthand for --skill '*' --agent '*' -y
   
 ${BOLD}Experimental Sync Options:${RESET}
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -292,18 +292,33 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
       options.yes = true;
     } else if (arg === '--all') {
       options.all = true;
-    } else if (arg === '-a' || arg === '--agent') {
+    } else if (arg === '-a' || arg === '--agent' || arg === '--agents') {
       options.agent = options.agent || [];
       i++;
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.agent.push(nextArg);
+        nextArg.split(',').forEach((a) => {
+          if (a.trim()) options.agent!.push(a.trim());
+        });
+        i++;
+        nextArg = args[i];
+      }
+      i--; // Back up one since the loop will increment
+    } else if (arg === '-s' || arg === '--skill' || arg === '--skills') {
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        nextArg.split(',').forEach((s) => {
+          if (s.trim()) skills.push(s.trim());
+        });
         i++;
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
     } else if (arg && !arg.startsWith('-')) {
-      skills.push(arg);
+      arg.split(',').forEach((s) => {
+        if (s.trim()) skills.push(s.trim());
+      });
     }
   }
 


### PR DESCRIPTION
This PR enhances the CLI to be more user-friendly by:
1. Adding --skills and --agents as plural aliases for -s and -a.
2. Supporting comma-separated lists in these flags (e.g., --skills skill1,skill2).
3. Updating help text and README to reflect these changes.

This makes bulk installation/removal much cleaner and more intuitive.