### PR TITLE
fix(git): raise clone timeout and allow override for large repos

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -3,7 +3,13 @@ import { join, normalize, resolve, sep } from 'path';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 
-const CLONE_TIMEOUT_MS = 60000; // 60 seconds
+const DEFAULT_CLONE_TIMEOUT_MS = 300_000; // 5 minutes
+const CLONE_TIMEOUT_MS = (() => {
+  const raw = process.env.SKILLS_CLONE_TIMEOUT_MS;
+  if (!raw) return DEFAULT_CLONE_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CLONE_TIMEOUT_MS;
+})();
 
 export class GitCloneError extends Error {
   readonly url: string;
@@ -43,11 +49,14 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       errorMessage.includes('Repository not found');
 
     if (isTimeout) {
+      const seconds = Math.round(CLONE_TIMEOUT_MS / 1000);
       throw new GitCloneError(
-        `Clone timed out after 60s. This often happens with private repos that require authentication.\n` +
-          `  Ensure you have access and your SSH keys or credentials are configured:\n` +
-          `  - For SSH: ssh-add -l (to check loaded keys)\n` +
-          `  - For HTTPS: gh auth status (if using GitHub CLI)`,
+        `Clone timed out after ${seconds}s. Common causes:\n` +
+          `  - Large repository: raise the timeout with SKILLS_CLONE_TIMEOUT_MS=600000 (10m)\n` +
+          `  - Slow network: retry, or clone manually and pass the local path to 'skills add'\n` +
+          `  - Private repo without credentials: ensure auth is configured\n` +
+          `      - For SSH: ssh-add -l (to check loaded keys)\n` +
+          `      - For HTTPS: gh auth status (if using GitHub CLI)`,
         url,
         true,
         false


### PR DESCRIPTION
## Problem

`skills add <repo>` fails on larger registries because the clone is bound by a hard-coded 60s timeout, and the resulting error message attributes the failure to authentication:

```
■  Failed to clone repository
│  Clone timed out after 60s. This often happens with private repos that require authentication.
│    Ensure you have access and your SSH keys or credentials are configured:
│    - For SSH: ssh-add -l (to check loaded keys)
│    - For HTTPS: gh auth status (if using GitHub CLI)
```

Reproducer: `npx skills add heygen-com/hyperframes` — a public repo with a working tree of ~554 MB. A shallow clone takes well over 60s on typical home/office connections, so the install reliably fails even though auth is fine.

Reported downstream at heygen-com/hyperframes#300.

## Change

`src/git.ts`:

- Raise the default clone timeout from 60s to 300s (5 min).
- Allow users to override it with the `SKILLS_CLONE_TIMEOUT_MS` env var (same naming style as `SKILLS_DOWNLOAD_URL` / `SKILLS_API_URL` already used in the codebase). Non-numeric / non-positive values fall back to the default.
- Reword the timeout error to list the actual common causes (large repo, slow network, private-repo auth) rather than implying auth is the only possibility. Included the env-var hint directly in the message.

## Before / after

Before:
```
Clone timed out after 60s. This often happens with private repos that require authentication.
  Ensure you have access and your SSH keys or credentials are configured:
  - For SSH: ssh-add -l (to check loaded keys)
  - For HTTPS: gh auth status (if using GitHub CLI)
```

After:
```
Clone timed out after 300s. Common causes:
  - Large repository: raise the timeout with SKILLS_CLONE_TIMEOUT_MS=600000 (10m)
  - Slow network: retry, or clone manually and pass the local path to 'skills add'
  - Private repo without credentials: ensure auth is configured
      - For SSH: ssh-add -l (to check loaded keys)
      - For HTTPS: gh auth status (if using GitHub CLI)
```

## Notes

- No existing tests assert on the old timeout string, so nothing needed updating there.
- `pnpm type-check` still fails with the same pre-existing errors as on `main` (in `src/providers/wellknown.ts`, `src/skills.ts`, and the `simpleGit(...)` call in `src/git.ts`). This PR does not introduce any new type errors.
- Happy to follow up with a `--filter=blob:none` / sparse-checkout pass so large registries don't need to pull their entire working tree just to install skills — wanted to keep this PR minimal.