### PR TITLE
fix(git): skip LFS smudge during clone to avoid bandwidth bloat

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -23,7 +23,17 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const git = simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: '0',
+      // Skills are text files (HTML/MD/JSON) and never LFS-tracked. Registry
+      // repos frequently track unrelated large media (test fixtures, demos,
+      // docs videos) via LFS. Downloading those during clone adds tens or
+      // hundreds of MB of bandwidth for files the installer never reads, and
+      // is the main reason `skills add` times out against larger registries
+      // (e.g. heygen-com/hyperframes, see upstream report #300).
+      GIT_LFS_SKIP_SMUDGE: '1',
+    },
   });
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 


### PR DESCRIPTION
## Problem

`skills add <repo>` clones an entire registry just to copy skill files (text HTML/MD/JSON) into `~/.claude/skills/`. Many registries use git-LFS for unrelated large media — test fixtures, demo videos, docs previews — that the installer never reads. The default `git clone` smudges those LFS objects during checkout, turning a ~1MB skill install into a hundreds-of-MB download.

Reproducer from downstream report [heygen-com/hyperframes#300](https://github.com/heygen-com/hyperframes/issues/300):

```
$ time git clone --depth 1 https://github.com/heygen-com/hyperframes.git
real  > 60s on typical home/office connections
du -sh: ~554 MB
```

The `skills/` directory on that repo is 460 KB — so >99% of what was being downloaded was never going to be used, and the user hits #951's timeout before the clone finishes.

## Fix

Set `GIT_LFS_SKIP_SMUDGE=1` in the env passed to `simpleGit`. LFS objects are substituted with tiny (~130 byte) pointer files during checkout; the installer sees a clean directory tree it can enumerate and copy from.

## Empirical impact

Same reproducer, same network:

| | Before (default) | After (`GIT_LFS_SKIP_SMUDGE=1`) |
|---|---|---|
| Wall-clock clone | **>60s (timeout)** | **1.77s** |
| Checkout size | ~554 MB | **107 MB** |
| LFS file on disk | real 57MB MP4 | 130-byte pointer ✅ |

\> 30x speedup, > 5x size reduction, on the exact repo reported in #300.

## Relationship to #951

Complementary, not overlapping:

- **#951** (raise 60s timeout + env override): makes large clones at least *succeed* given enough time.
- **This PR**: makes large clones *fast* by not downloading bytes the installer ignores.
- hashmil's notes in #951 also offered a sparse-checkout follow-up (`--filter=blob:none` + `git sparse-checkout set skills/`). That's strictly better than this change for reducing bytes downloaded at the protocol level, but is a bigger refactor and depends on partial-clone support on the server. `GIT_LFS_SKIP_SMUDGE` is a one-line win that helps today.

All three changes — timeout bump, LFS skip, sparse-checkout — can land independently without conflict. Suggest landing them in that order.

## Safety

Skills themselves must remain plain text to be installable. If a registry ever decides to ship a skill that references an LFS-tracked asset (e.g. an example video), that's a deliberate design decision worth discussing — not something that should silently work via an implicit LFS fetch. Today, every skill in the ecosystem I've surveyed is text-only.

## Test plan

- [x] `time GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 https://github.com/heygen-com/hyperframes.git` → 1.77s, 107MB
- [x] Verified LFS files become pointer files (`cat ...output.mp4` shows the LFS v1 pointer header)
- [x] `prettier --check` passes on the modified file
- [ ] Installing a skill from an LFS-using registry works end-to-end — will confirm once branch is installable
- [x] `type-check` has pre-existing errors on `main` (noted in #951); this PR does not introduce new ones