### PR TITLE
Add `skills outdated --json` read-only check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The `--json` flag emits a schema-versioned payload on stdout:
       "error": null
     }
   ],
-  "summary": { "checked": 13, "outdated": 1, "upToDate": 10, "skipped": 2, "errored": 0 }
+  "summary": { "checked": 1, "outdated": 1, "upToDate": 0, "errored": 0, "skipped": 0 }
 }
 ```
 
@@ -206,7 +206,9 @@ The `--json` flag emits a schema-versioned payload on stdout:
 
 - `true` — upstream folder hash differs from local; `npx skills update` will refresh
 - `false` — hashes match; skill is current
-- `null` — could not determine (local path, well-known skill, missing metadata, fetch error); `error` holds the reason
+- `null` — could not determine; `error` holds the reason. Two sub-cases, distinguished by `localHash`:
+  - `localHash` is non-null → counted as `errored` in `summary` (fetch failed, or upstream returned no hash)
+  - `localHash` is null → counted as `skipped` (local-path source, well-known skill, git URL, missing metadata, or project-scope — nothing to compare against)
 
 Project-scope skills always surface with `outdated: null` and `error: "Project-scope skills are refreshed on update"`, since project-scoped update is an unconditional re-clone.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ When installing interactively, you can choose:
 | `npx skills list`            | List installed skills (alias: `ls`)           |
 | `npx skills find [query]`    | Search for skills interactively or by keyword |
 | `npx skills remove [skills]` | Remove installed skills from agents           |
+| `npx skills outdated [skills]` | List skills with available updates (read-only) |
 | `npx skills update [skills]` | Update installed skills to latest versions    |
 | `npx skills init [name]`     | Create a new SKILL.md template                |
 
@@ -155,6 +156,69 @@ npx skills update -y
 | `-p, --project` | Only update project skills                                                |
 | `-y, --yes`     | Skip scope prompt (auto-detect: project if in a project dir, else global) |
 | `[skills...]`   | Update specific skills by name instead of all                             |
+
+### `skills outdated`
+
+Report which installed skills have updates available, without installing anything. Intended for CI checks, status dashboards, and tools that surface update reminders to users.
+
+```bash
+# Human-readable report across project + global scopes
+npx skills outdated
+
+# Machine-readable JSON (implies -y)
+npx skills outdated --json
+
+# Scope-specific
+npx skills outdated -g
+npx skills outdated -p
+
+# Filter by skill name
+npx skills outdated my-skill
+```
+
+The `--json` flag emits a schema-versioned payload on stdout:
+
+```json
+{
+  "schema": 1,
+  "checkedAt": "2026-04-17T18:00:00.000Z",
+  "scope": "global",
+  "skills": [
+    {
+      "name": "gmail",
+      "scope": "global",
+      "source": "sanjay3290/ai-skills",
+      "sourceUrl": "https://github.com/sanjay3290/ai-skills",
+      "sourceType": "github",
+      "ref": "main",
+      "skillPath": "skills/gmail/SKILL.md",
+      "localHash": "abc...",
+      "upstreamHash": "def...",
+      "outdated": true,
+      "error": null
+    }
+  ],
+  "summary": { "checked": 13, "outdated": 1, "upToDate": 10, "skipped": 2, "errored": 0 }
+}
+```
+
+`outdated` is a tri-state boolean:
+
+- `true` — upstream folder hash differs from local; `npx skills update` will refresh
+- `false` — hashes match; skill is current
+- `null` — could not determine (local path, well-known skill, missing metadata, fetch error); `error` holds the reason
+
+Project-scope skills always surface with `outdated: null` and `error: "Project-scope skills are refreshed on update"`, since project-scoped update is an unconditional re-clone.
+
+Exit code is `0` for any successful scan regardless of how many skills are outdated — callers should inspect `summary.outdated` in the JSON output rather than the exit code.
+
+| Option          | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `-g, --global`  | Only check global skills                                    |
+| `-p, --project` | Only check project skills                                   |
+| `-y, --yes`     | Skip scope prompt (auto-detect)                             |
+| `--json`        | Emit machine-readable JSON (implies `-y`)                   |
+| `[skills...]`   | Filter to specific skills by name                           |
 
 ### `skills init`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,25 +1,16 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'child_process';
-import { writeFileSync, readFileSync, existsSync, mkdirSync, readdirSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
 import { basename, join, dirname } from 'path';
-import { homedir } from 'os';
 import { fileURLToPath } from 'url';
-import * as p from '@clack/prompts';
 import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
 import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
-import { track } from './telemetry.ts';
-import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
-import { readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
-import {
-  buildUpdateInstallSource,
-  buildLocalUpdateSource,
-  formatSourceInput,
-} from './update-source.ts';
+import { runUpdate } from './updates.ts';
+import { runOutdated } from './outdated.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -87,6 +78,9 @@ function showBanner(): void {
   );
   console.log();
   console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills outdated${RESET}             ${DIM}List skills with available updates${RESET}`
+  );
+  console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills update${RESET}               ${DIM}Update installed skills${RESET}`
   );
   console.log();
@@ -119,12 +113,19 @@ ${BOLD}Manage Skills:${RESET}
   find [query]         Search for skills interactively
 
 ${BOLD}Updates:${RESET}
+  outdated [skills...] List skills with available updates (does not install)
   update [skills...]   Update skills to latest versions (alias: upgrade)
 
 ${BOLD}Update Options:${RESET}
-  -g, --global           Update global skills only
-  -p, --project          Update project skills only
+  -g, --global           Update/check global skills only
+  -p, --project          Update/check project skills only
   -y, --yes              Skip scope prompt (auto-detect: project if in a project, else global)
+
+${BOLD}Outdated Options:${RESET}
+  -g, --global           Check global skills only
+  -p, --project          Check project skills only
+  -y, --yes              Skip scope prompt
+  --json                 Emit machine-readable JSON (implies -y)
 
 ${BOLD}Project:${RESET}
   experimental_install Restore skills from skills-lock.json
@@ -175,6 +176,9 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills ls --json                      ${DIM}# JSON output${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}
+  ${DIM}$${RESET} skills outdated                     ${DIM}# report skills with updates${RESET}
+  ${DIM}$${RESET} skills outdated --json              ${DIM}# machine-readable report${RESET}
+  ${DIM}$${RESET} skills outdated my-skill -g         ${DIM}# check a single global skill${RESET}
   ${DIM}$${RESET} skills update
   ${DIM}$${RESET} skills update my-skill             ${DIM}# update a single skill${RESET}
   ${DIM}$${RESET} skills update -g                    ${DIM}# update global skills only${RESET}
@@ -282,558 +286,6 @@ Describe when this skill should be used.
 }
 
 // ============================================
-// Check and Update Commands
-// ============================================
-
-const AGENTS_DIR = '.agents';
-const LOCK_FILE = '.skill-lock.json';
-const CURRENT_LOCK_VERSION = 3; // Bumped from 2 to 3 for folder hash support
-
-interface SkillLockEntry {
-  source: string;
-  sourceType: string;
-  sourceUrl: string;
-  ref?: string;
-  skillPath?: string;
-  /** GitHub tree SHA for the entire skill folder (v3) */
-  skillFolderHash: string;
-  installedAt: string;
-  updatedAt: string;
-}
-
-interface SkillLockFile {
-  version: number;
-  skills: Record<string, SkillLockEntry>;
-}
-
-function getSkillLockPath(): string {
-  const xdgStateHome = process.env.XDG_STATE_HOME;
-  if (xdgStateHome) {
-    return join(xdgStateHome, 'skills', LOCK_FILE);
-  }
-  return join(homedir(), AGENTS_DIR, LOCK_FILE);
-}
-
-function readSkillLock(): SkillLockFile {
-  const lockPath = getSkillLockPath();
-  try {
-    const content = readFileSync(lockPath, 'utf-8');
-    const parsed = JSON.parse(content) as SkillLockFile;
-    if (typeof parsed.version !== 'number' || !parsed.skills) {
-      return { version: CURRENT_LOCK_VERSION, skills: {} };
-    }
-    // If old version, wipe and start fresh (backwards incompatible change)
-    // v3 adds skillFolderHash - we want fresh installs to populate it
-    if (parsed.version < CURRENT_LOCK_VERSION) {
-      return { version: CURRENT_LOCK_VERSION, skills: {} };
-    }
-    return parsed;
-  } catch {
-    return { version: CURRENT_LOCK_VERSION, skills: {} };
-  }
-}
-
-// ============================================
-// Scope Detection and Prompt
-// ============================================
-
-type UpdateScope = 'project' | 'global' | 'both';
-
-interface UpdateCheckOptions {
-  global?: boolean;
-  project?: boolean;
-  yes?: boolean;
-  /** Optional skill name(s) to filter on (positional args) */
-  skills?: string[];
-}
-
-function parseUpdateOptions(args: string[]): UpdateCheckOptions {
-  const options: UpdateCheckOptions = {};
-  const positional: string[] = [];
-  for (const arg of args) {
-    if (arg === '-g' || arg === '--global') {
-      options.global = true;
-    } else if (arg === '-p' || arg === '--project') {
-      options.project = true;
-    } else if (arg === '-y' || arg === '--yes') {
-      options.yes = true;
-    } else if (!arg.startsWith('-')) {
-      positional.push(arg);
-    }
-  }
-  if (positional.length > 0) {
-    options.skills = positional;
-  }
-  return options;
-}
-
-/**
- * Check whether the current working directory has project-level skills.
- * Returns true if either:
- * - skills-lock.json exists in cwd, OR
- * - .agents/skills/ contains at least one subdirectory with a SKILL.md
- */
-function hasProjectSkills(cwd?: string): boolean {
-  const dir = cwd || process.cwd();
-
-  // Check 1: skills-lock.json exists
-  const lockPath = join(dir, 'skills-lock.json');
-  if (existsSync(lockPath)) {
-    return true;
-  }
-
-  // Check 2: .agents/skills/ has at least one skill
-  const skillsDir = join(dir, '.agents', 'skills');
-  try {
-    const entries = readdirSync(skillsDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const skillMd = join(skillsDir, entry.name, 'SKILL.md');
-        if (existsSync(skillMd)) {
-          return true;
-        }
-      }
-    }
-  } catch {
-    // Directory doesn't exist
-  }
-
-  return false;
-}
-
-/**
- * Determine the update/check scope via interactive prompt or auto-detection.
- *
- * Interactive mode (default):
- *   Shows a prompt with Project / Global / Both options.
- *
- * Non-interactive mode (-y flag or non-TTY):
- *   If cwd has project-level skills → 'project'
- *   Otherwise → 'global'
- *
- * Explicit flags override everything:
- *   -g → 'global'
- *   -p → 'project'
- *   -g -p → 'both'
- */
-async function resolveUpdateScope(options: UpdateCheckOptions): Promise<UpdateScope> {
-  // When targeting specific skills, search both scopes to find them
-  if (options.skills && options.skills.length > 0) {
-    if (options.global) return 'global';
-    if (options.project) return 'project';
-    return 'both';
-  }
-
-  // Explicit flags take precedence
-  if (options.global && options.project) {
-    return 'both';
-  }
-  if (options.global) {
-    return 'global';
-  }
-  if (options.project) {
-    return 'project';
-  }
-
-  // Non-interactive auto-detection
-  if (options.yes || !process.stdin.isTTY) {
-    return hasProjectSkills() ? 'project' : 'global';
-  }
-
-  // Interactive prompt
-  const scope = await p.select({
-    message: 'Update scope',
-    options: [
-      {
-        value: 'project' as UpdateScope,
-        label: 'Project',
-        hint: 'Update skills in current directory',
-      },
-      {
-        value: 'global' as UpdateScope,
-        label: 'Global',
-        hint: 'Update skills in home directory',
-      },
-      {
-        value: 'both' as UpdateScope,
-        label: 'Both',
-        hint: 'Update all skills',
-      },
-    ],
-  });
-
-  if (p.isCancel(scope)) {
-    p.cancel('Cancelled');
-    process.exit(0);
-  }
-
-  return scope as UpdateScope;
-}
-
-/**
- * Check if a skill name matches any of the filter names (case-insensitive).
- * Returns true if no filter is set (match all).
- */
-function matchesSkillFilter(name: string, filter?: string[]): boolean {
-  if (!filter || filter.length === 0) return true;
-  const lower = name.toLowerCase();
-  return filter.some((f) => f.toLowerCase() === lower);
-}
-
-interface SkippedSkill {
-  name: string;
-  reason: string;
-  sourceUrl: string;
-  sourceType: string;
-  ref?: string;
-}
-
-/**
- * Determine why a skill cannot be checked for updates automatically.
- */
-function getSkipReason(entry: SkillLockEntry): string {
-  if (entry.sourceType === 'local') {
-    return 'Local path';
-  }
-  if (entry.sourceType === 'git') {
-    return 'Git URL';
-  }
-  if (entry.sourceType === 'well-known') {
-    return 'Well-known skill';
-  }
-  if (!entry.skillFolderHash) {
-    return 'Private or deleted repo';
-  }
-  if (!entry.skillPath) {
-    return 'No skill path recorded';
-  }
-  return 'No version tracking';
-}
-
-/**
- * For well-known skills, strip the .well-known/... path and /SKILL.md suffix
- * to produce the base URL the user originally used to install.
- * e.g., "https://mintlify.com/docs/.well-known/skills/mintlify/SKILL.md"
- *    -> "https://mintlify.com/docs"
- */
-function getInstallSource(skill: SkippedSkill): string {
-  let url = skill.sourceUrl;
-  if (skill.sourceType === 'well-known') {
-    // Strip everything from /.well-known/ onwards
-    const idx = url.indexOf('/.well-known/');
-    if (idx !== -1) {
-      url = url.slice(0, idx);
-    }
-  }
-  return formatSourceInput(url, skill.ref);
-}
-
-/**
- * Print a list of skills that cannot be checked automatically,
- * with the reason and a manual update command for each.
- * Skills from the same source are grouped together.
- */
-function printSkippedSkills(skipped: SkippedSkill[]): void {
-  if (skipped.length === 0) return;
-  console.log();
-  console.log(`${DIM}${skipped.length} skill(s) cannot be checked automatically:${RESET}`);
-
-  // Group by install source to dedupe skills from the same repo
-  const grouped = new Map<string, SkippedSkill[]>();
-  for (const skill of skipped) {
-    const source = getInstallSource(skill);
-    const existing = grouped.get(source) || [];
-    existing.push(skill);
-    grouped.set(source, existing);
-  }
-
-  for (const [source, skills] of grouped) {
-    if (skills.length === 1) {
-      const skill = skills[0]!;
-      console.log(`  ${TEXT}•${RESET} ${skill.name} ${DIM}(${skill.reason})${RESET}`);
-    } else {
-      const reason = skills[0]!.reason;
-      const names = skills.map((s) => s.name).join(', ');
-      console.log(`  ${TEXT}•${RESET} ${names} ${DIM}(${reason})${RESET}`);
-    }
-    console.log(`    ${DIM}To update: ${TEXT}npx skills add ${source} -g -y${RESET}`);
-  }
-}
-
-// ============================================
-// Project Skills Discovery
-// ============================================
-
-async function getProjectSkillsForUpdate(
-  skillFilter?: string[]
-): Promise<Array<{ name: string; source: string; entry: LocalSkillLockEntry }>> {
-  const localLock = await readLocalLock();
-  const skills: Array<{ name: string; source: string; entry: LocalSkillLockEntry }> = [];
-
-  for (const [name, entry] of Object.entries(localLock.skills)) {
-    if (!matchesSkillFilter(name, skillFilter)) continue;
-    // Skip node_modules and local path skills - they are managed by sync/manually
-    if (entry.sourceType === 'node_modules' || entry.sourceType === 'local') {
-      continue;
-    }
-    skills.push({ name, source: entry.source, entry });
-  }
-
-  return skills;
-}
-
-// ============================================
-// Update: Global Skills
-// ============================================
-
-async function updateGlobalSkills(
-  skillFilter?: string[]
-): Promise<{ successCount: number; failCount: number; checkedCount: number }> {
-  const lock = readSkillLock();
-  const skillNames = Object.keys(lock.skills);
-  let successCount = 0;
-  let failCount = 0;
-
-  if (skillNames.length === 0) {
-    if (!skillFilter) {
-      console.log(`${DIM}No global skills tracked in lock file.${RESET}`);
-      console.log(`${DIM}Install skills with${RESET} ${TEXT}npx skills add <package> -g${RESET}`);
-    }
-    return { successCount, failCount, checkedCount: 0 };
-  }
-
-  const token = getGitHubToken();
-  const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
-  const skipped: SkippedSkill[] = [];
-  const checkable: Array<{ name: string; entry: SkillLockEntry }> = [];
-
-  for (const skillName of skillNames) {
-    if (!matchesSkillFilter(skillName, skillFilter)) continue;
-
-    const entry = lock.skills[skillName];
-    if (!entry) continue;
-
-    if (!entry.skillFolderHash || !entry.skillPath) {
-      skipped.push({
-        name: skillName,
-        reason: getSkipReason(entry),
-        sourceUrl: entry.sourceUrl,
-        sourceType: entry.sourceType,
-        ref: entry.ref,
-      });
-      continue;
-    }
-
-    checkable.push({ name: skillName, entry });
-  }
-
-  for (let i = 0; i < checkable.length; i++) {
-    const { name: skillName, entry } = checkable[i]!;
-    process.stdout.write(
-      `\r${DIM}Checking global skill ${i + 1}/${checkable.length}: ${skillName}${RESET}\x1b[K`
-    );
-
-    try {
-      const latestHash = await fetchSkillFolderHash(
-        entry.source,
-        entry.skillPath!,
-        token,
-        entry.ref
-      );
-      if (latestHash && latestHash !== entry.skillFolderHash) {
-        updates.push({ name: skillName, source: entry.source, entry });
-      }
-    } catch {
-      // Skip skills that fail to check
-    }
-  }
-
-  if (checkable.length > 0) {
-    process.stdout.write('\r\x1b[K');
-  }
-
-  const checkedCount = checkable.length + skipped.length;
-
-  if (checkable.length === 0 && skipped.length === 0) {
-    if (!skillFilter) {
-      console.log(`${DIM}No global skills to check.${RESET}`);
-    }
-    return { successCount, failCount, checkedCount: 0 };
-  }
-
-  if (checkable.length === 0 && skipped.length > 0) {
-    printSkippedSkills(skipped);
-    return { successCount, failCount, checkedCount };
-  }
-
-  if (updates.length === 0) {
-    console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
-    return { successCount, failCount, checkedCount };
-  }
-
-  console.log(`${TEXT}Found ${updates.length} global update(s)${RESET}`);
-  console.log();
-
-  for (const update of updates) {
-    console.log(`${TEXT}Updating ${update.name}...${RESET}`);
-    const installUrl = buildUpdateInstallSource(update.entry);
-
-    const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
-    if (!existsSync(cliEntry)) {
-      failCount++;
-      console.log(
-        `  ${DIM}✗ Failed to update ${update.name}: CLI entrypoint not found at ${cliEntry}${RESET}`
-      );
-      continue;
-    }
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-      shell: process.platform === 'win32',
-    });
-
-    if (result.status === 0) {
-      successCount++;
-      console.log(`  ${TEXT}✓${RESET} Updated ${update.name}`);
-    } else {
-      failCount++;
-      console.log(`  ${DIM}✗ Failed to update ${update.name}${RESET}`);
-    }
-  }
-
-  printSkippedSkills(skipped);
-  return { successCount, failCount, checkedCount };
-}
-
-// ============================================
-// Update: Project Skills
-// ============================================
-
-async function updateProjectSkills(
-  skillFilter?: string[]
-): Promise<{ successCount: number; failCount: number; foundCount: number }> {
-  const projectSkills = await getProjectSkillsForUpdate(skillFilter);
-  let successCount = 0;
-  let failCount = 0;
-
-  if (projectSkills.length === 0) {
-    if (!skillFilter) {
-      console.log(`${DIM}No project skills to update.${RESET}`);
-      console.log(
-        `${DIM}Install project skills with${RESET} ${TEXT}npx skills add <package>${RESET}`
-      );
-    }
-    return { successCount, failCount, foundCount: 0 };
-  }
-
-  console.log(`${TEXT}Refreshing ${projectSkills.length} project skill(s)...${RESET}`);
-  console.log();
-
-  for (const skill of projectSkills) {
-    console.log(`${TEXT}Updating ${skill.name}...${RESET}`);
-    const installUrl = buildLocalUpdateSource(skill.entry);
-
-    const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
-    if (!existsSync(cliEntry)) {
-      failCount++;
-      console.log(
-        `  ${DIM}✗ Failed to update ${skill.name}: CLI entrypoint not found at ${cliEntry}${RESET}`
-      );
-      continue;
-    }
-
-    // Re-clone without -g to install at project scope
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-      shell: process.platform === 'win32',
-    });
-
-    if (result.status === 0) {
-      successCount++;
-      console.log(`  ${TEXT}✓${RESET} Updated ${skill.name}`);
-    } else {
-      failCount++;
-      console.log(`  ${DIM}✗ Failed to update ${skill.name}${RESET}`);
-    }
-  }
-
-  return { successCount, failCount, foundCount: projectSkills.length };
-}
-
-// ============================================
-// runUpdate
-// ============================================
-
-async function runUpdate(args: string[] = []): Promise<void> {
-  const options = parseUpdateOptions(args);
-  const scope = await resolveUpdateScope(options);
-
-  if (options.skills) {
-    console.log(`${TEXT}Updating ${options.skills.join(', ')}...${RESET}`);
-  } else {
-    console.log(`${TEXT}Checking for skill updates...${RESET}`);
-  }
-  console.log();
-
-  let totalSuccess = 0;
-  let totalFail = 0;
-  let totalFound = 0;
-
-  // ---- Global update ----
-  if (scope === 'global' || scope === 'both') {
-    if (scope === 'both' && !options.skills) {
-      console.log(`${BOLD}Global Skills${RESET}`);
-    }
-    const { successCount, failCount, checkedCount } = await updateGlobalSkills(options.skills);
-    totalSuccess += successCount;
-    totalFail += failCount;
-    totalFound += checkedCount;
-    if (scope === 'both' && !options.skills) {
-      console.log();
-    }
-  }
-
-  // ---- Project update ----
-  if (scope === 'project' || scope === 'both') {
-    if (scope === 'both' && !options.skills) {
-      console.log(`${BOLD}Project Skills${RESET}`);
-    }
-    const { successCount, failCount, foundCount } = await updateProjectSkills(options.skills);
-    totalSuccess += successCount;
-    totalFail += failCount;
-    totalFound += foundCount;
-  }
-
-  // If filtering by name and nothing was found anywhere, tell the user
-  if (options.skills && totalFound === 0) {
-    console.log(`${DIM}No installed skills found matching: ${options.skills.join(', ')}${RESET}`);
-  }
-
-  console.log();
-  if (totalSuccess > 0) {
-    console.log(`${TEXT}✓ Updated ${totalSuccess} skill(s)${RESET}`);
-  }
-  if (totalFail > 0) {
-    console.log(`${DIM}Failed to update ${totalFail} skill(s)${RESET}`);
-  }
-  if (totalSuccess === 0 && totalFail === 0) {
-    // No updates found/attempted - the sub-functions already printed their messages
-  }
-
-  // Track telemetry
-  track({
-    event: 'update',
-    scope,
-    skillCount: String(totalSuccess + totalFail),
-    successCount: String(totalSuccess),
-    failCount: String(totalFail),
-  });
-
-  console.log();
-}
-
-// ============================================
 // Main
 // ============================================
 
@@ -901,6 +353,9 @@ async function main(): Promise<void> {
     case 'update':
     case 'upgrade':
       await runUpdate(restArgs);
+      break;
+    case 'outdated':
+      await runOutdated(restArgs);
       break;
     case '--help':
     case '-h':

--- a/src/outdated.test.ts
+++ b/src/outdated.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseOutdatedOptions,
+  buildGlobalEntries,
+  summarize,
+  type OutdatedJsonSkill,
+} from './outdated.ts';
+import type { GlobalCheckResult, SkillLockEntry } from './updates.ts';
+
+// ----------------------------------------
+// Fixtures
+// ----------------------------------------
+
+function makeEntry(overrides: Partial<SkillLockEntry> = {}): SkillLockEntry {
+  return {
+    source: 'owner/repo',
+    sourceType: 'github',
+    sourceUrl: 'https://github.com/owner/repo',
+    ref: 'main',
+    skillPath: 'skills/demo/SKILL.md',
+    skillFolderHash: 'aaaaaaaaaaaaaaaa',
+    installedAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ----------------------------------------
+
+describe('parseOutdatedOptions', () => {
+  it('parses empty args', () => {
+    expect(parseOutdatedOptions([])).toEqual({});
+  });
+
+  it('parses -g / --global', () => {
+    expect(parseOutdatedOptions(['-g']).global).toBe(true);
+    expect(parseOutdatedOptions(['--global']).global).toBe(true);
+  });
+
+  it('parses -p / --project', () => {
+    expect(parseOutdatedOptions(['-p']).project).toBe(true);
+    expect(parseOutdatedOptions(['--project']).project).toBe(true);
+  });
+
+  it('parses -y / --yes', () => {
+    expect(parseOutdatedOptions(['-y']).yes).toBe(true);
+    expect(parseOutdatedOptions(['--yes']).yes).toBe(true);
+  });
+
+  it('parses --json', () => {
+    expect(parseOutdatedOptions(['--json']).json).toBe(true);
+  });
+
+  it('collects positional args as skill filter', () => {
+    expect(parseOutdatedOptions(['gmail', 'calendar']).skills).toEqual(['gmail', 'calendar']);
+  });
+
+  it('mixes flags and positionals', () => {
+    const opts = parseOutdatedOptions(['-g', '--json', 'gmail', '-y']);
+    expect(opts.global).toBe(true);
+    expect(opts.json).toBe(true);
+    expect(opts.yes).toBe(true);
+    expect(opts.skills).toEqual(['gmail']);
+  });
+
+  it('ignores unknown flags', () => {
+    const opts = parseOutdatedOptions(['--unknown', 'gmail']);
+    expect(opts).toEqual({ skills: ['gmail'] });
+  });
+});
+
+describe('buildGlobalEntries', () => {
+  it('emits outdated: true when upstream hash differs', () => {
+    const result: GlobalCheckResult = {
+      checked: [
+        {
+          name: 'gmail',
+          entry: makeEntry({ skillFolderHash: 'localhash' }),
+          upstreamHash: 'upstreamhash',
+          error: null,
+        },
+      ],
+      skipped: [],
+      checkedCount: 1,
+    };
+    const entries = buildGlobalEntries(result);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.outdated).toBe(true);
+    expect(entries[0]!.localHash).toBe('localhash');
+    expect(entries[0]!.upstreamHash).toBe('upstreamhash');
+    expect(entries[0]!.error).toBeNull();
+  });
+
+  it('emits outdated: false when hashes match', () => {
+    const result: GlobalCheckResult = {
+      checked: [
+        {
+          name: 'gmail',
+          entry: makeEntry({ skillFolderHash: 'samehash' }),
+          upstreamHash: 'samehash',
+          error: null,
+        },
+      ],
+      skipped: [],
+      checkedCount: 1,
+    };
+    const entries = buildGlobalEntries(result);
+    expect(entries[0]!.outdated).toBe(false);
+    expect(entries[0]!.error).toBeNull();
+  });
+
+  it('emits outdated: null with error when fetch threw', () => {
+    const result: GlobalCheckResult = {
+      checked: [
+        {
+          name: 'gmail',
+          entry: makeEntry(),
+          upstreamHash: null,
+          error: 'network: ENOTFOUND',
+        },
+      ],
+      skipped: [],
+      checkedCount: 1,
+    };
+    const entries = buildGlobalEntries(result);
+    expect(entries[0]!.outdated).toBeNull();
+    expect(entries[0]!.error).toBe('network: ENOTFOUND');
+    expect(entries[0]!.upstreamHash).toBeNull();
+  });
+
+  it('emits outdated: null when upstream returns no hash (private/deleted)', () => {
+    const result: GlobalCheckResult = {
+      checked: [
+        {
+          name: 'gmail',
+          entry: makeEntry(),
+          upstreamHash: null,
+          error: null,
+        },
+      ],
+      skipped: [],
+      checkedCount: 1,
+    };
+    const entries = buildGlobalEntries(result);
+    expect(entries[0]!.outdated).toBeNull();
+    expect(entries[0]!.error).toBe('No upstream hash available');
+  });
+
+  it('passes skipped skills through with reason as error', () => {
+    const result: GlobalCheckResult = {
+      checked: [],
+      skipped: [
+        {
+          name: 'my-local',
+          reason: 'Local path',
+          sourceUrl: '/Users/x/skill',
+          sourceType: 'local',
+        },
+      ],
+      checkedCount: 1,
+    };
+    const entries = buildGlobalEntries(result);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.outdated).toBeNull();
+    expect(entries[0]!.error).toBe('Local path');
+    expect(entries[0]!.sourceType).toBe('local');
+  });
+
+  it('handles a mixed result (outdated + current + errored + skipped)', () => {
+    const result: GlobalCheckResult = {
+      checked: [
+        {
+          name: 'a',
+          entry: makeEntry({ skillFolderHash: 'old' }),
+          upstreamHash: 'new',
+          error: null,
+        },
+        {
+          name: 'b',
+          entry: makeEntry({ skillFolderHash: 'same' }),
+          upstreamHash: 'same',
+          error: null,
+        },
+        {
+          name: 'c',
+          entry: makeEntry(),
+          upstreamHash: null,
+          error: 'rate limited',
+        },
+      ],
+      skipped: [
+        {
+          name: 'd',
+          reason: 'Well-known skill',
+          sourceUrl: 'https://example.com/.well-known/skills/d',
+          sourceType: 'well-known',
+        },
+      ],
+      checkedCount: 4,
+    };
+    const entries = buildGlobalEntries(result);
+    expect(entries.map((e) => e.name)).toEqual(['a', 'b', 'c', 'd']);
+    expect(entries[0]!.outdated).toBe(true);
+    expect(entries[1]!.outdated).toBe(false);
+    expect(entries[2]!.outdated).toBeNull();
+    expect(entries[2]!.error).toBe('rate limited');
+    expect(entries[3]!.outdated).toBeNull();
+    expect(entries[3]!.error).toBe('Well-known skill');
+  });
+});
+
+describe('summarize', () => {
+  it('counts each status bucket correctly', () => {
+    const skills: OutdatedJsonSkill[] = [
+      // outdated
+      {
+        name: 'a',
+        scope: 'global',
+        source: 'owner/a',
+        sourceUrl: '',
+        sourceType: 'github',
+        ref: null,
+        skillPath: null,
+        localHash: 'x',
+        upstreamHash: 'y',
+        outdated: true,
+        error: null,
+      },
+      // up to date
+      {
+        name: 'b',
+        scope: 'global',
+        source: 'owner/b',
+        sourceUrl: '',
+        sourceType: 'github',
+        ref: null,
+        skillPath: null,
+        localHash: 'x',
+        upstreamHash: 'x',
+        outdated: false,
+        error: null,
+      },
+      // errored (localHash present, but couldn't check)
+      {
+        name: 'c',
+        scope: 'global',
+        source: 'owner/c',
+        sourceUrl: '',
+        sourceType: 'github',
+        ref: null,
+        skillPath: null,
+        localHash: 'x',
+        upstreamHash: null,
+        outdated: null,
+        error: 'network',
+      },
+      // skipped (localHash null)
+      {
+        name: 'd',
+        scope: 'global',
+        source: '/local/d',
+        sourceUrl: '',
+        sourceType: 'local',
+        ref: null,
+        skillPath: null,
+        localHash: null,
+        upstreamHash: null,
+        outdated: null,
+        error: 'Local path',
+      },
+    ];
+    const summary = summarize(skills);
+    expect(summary).toEqual({
+      checked: 4,
+      outdated: 1,
+      upToDate: 1,
+      skipped: 1,
+      errored: 1,
+    });
+  });
+
+  it('handles an empty list', () => {
+    expect(summarize([])).toEqual({
+      checked: 0,
+      outdated: 0,
+      upToDate: 0,
+      skipped: 0,
+      errored: 0,
+    });
+  });
+});

--- a/src/outdated.test.ts
+++ b/src/outdated.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import {
-  parseOutdatedOptions,
   buildGlobalEntries,
+  parseOutdatedOptions,
+  runOutdated,
   summarize,
+  type OutdatedJson,
   type OutdatedJsonSkill,
 } from './outdated.ts';
 import type { GlobalCheckResult, SkillLockEntry } from './updates.ts';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // ----------------------------------------
 // Fixtures
@@ -288,4 +293,134 @@ describe('summarize', () => {
       errored: 0,
     });
   });
+});
+
+// ----------------------------------------
+// Integration: runOutdated end-to-end with stdout capture
+// ----------------------------------------
+
+describe('runOutdated --json integration', () => {
+  let prevHome: string | undefined;
+  let prevXdg: string | undefined;
+  let testRoot: string;
+  let logs: string[];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Redirect the lock-file lookup to a clean tempdir so we never
+    // touch the developer's real `~/.agents/.skill-lock.json`. The
+    // lockfile-path code reads `XDG_STATE_HOME` first, then `HOME`.
+    testRoot = mkdtempSync(join(tmpdir(), 'skills-outdated-test-'));
+    prevHome = process.env.HOME;
+    prevXdg = process.env.XDG_STATE_HOME;
+    process.env.HOME = testRoot;
+    process.env.XDG_STATE_HOME = join(testRoot, 'state');
+    // cwd stays the repo root so project-skill detection finds no
+    // project skills — cleaner test surface.
+    logs = [];
+    logSpy = vi.spyOn(console, 'log').mockImplementation((msg: unknown) => {
+      logs.push(typeof msg === 'string' ? msg : JSON.stringify(msg));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env.HOME = prevHome;
+    if (prevXdg === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = prevXdg;
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('emits a valid schema-1 JSON payload with --json', async () => {
+    await runOutdated(['--json', '-g']);
+
+    expect(logs.length).toBe(1);
+    const report: OutdatedJson = JSON.parse(logs[0]!);
+
+    expect(report.schema).toBe(1);
+    expect(typeof report.checkedAt).toBe('string');
+    expect(new Date(report.checkedAt).toString()).not.toBe('Invalid Date');
+    expect(report.scope).toBe('global');
+    expect(Array.isArray(report.skills)).toBe(true);
+    expect(report.summary).toMatchObject({
+      checked: expect.any(Number),
+      outdated: expect.any(Number),
+      upToDate: expect.any(Number),
+      skipped: expect.any(Number),
+      errored: expect.any(Number),
+    });
+    // Sum invariant: bucket counts must equal total.
+    const { outdated, upToDate, skipped, errored, checked } = report.summary;
+    expect(outdated + upToDate + skipped + errored).toBe(checked);
+  });
+
+  it('returns an empty report when there are no installed skills', async () => {
+    // Ensure the global lock file doesn't exist at all — summary.checked
+    // must be 0 and skills must be an empty array.
+    await runOutdated(['--json', '-g']);
+    const report: OutdatedJson = JSON.parse(logs[0]!);
+    expect(report.summary.checked).toBe(0);
+    expect(report.skills).toEqual([]);
+  });
+
+  it('--json implies -y (does not require a TTY for scope resolution)', async () => {
+    // If --json didn't imply -y, resolveUpdateScope would block on
+    // `p.select` for an interactive prompt. The test runs under vitest
+    // with no TTY, so hanging = failure. Timeout guard: 3s is plenty
+    // for the tempdir-backed empty-lockfile path.
+    await Promise.race([
+      runOutdated(['--json']),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('--json did not imply -y; runOutdated hung')), 3000)
+      ),
+    ]);
+    expect(logs.length).toBeGreaterThan(0);
+    // Just assert we got a parseable JSON report
+    const report = JSON.parse(logs[0]!) as OutdatedJson;
+    expect(report.schema).toBe(1);
+  });
+
+  it('supports project-level reporting with a local skills-lock.json', async () => {
+    // Write a project-level skills-lock.json in the test root and run
+    // outdated --json -p from that directory. Project skills always
+    // surface as `outdated: null` with the documented error message.
+    const lockPath = join(testRoot, 'skills-lock.json');
+    writeFileSync(
+      lockPath,
+      JSON.stringify({
+        version: 1,
+        skills: {
+          'my-skill': {
+            source: 'owner/repo',
+            ref: 'main',
+            sourceType: 'github',
+            computedHash: 'abc123',
+          },
+        },
+      })
+    );
+
+    const prevCwd = process.cwd();
+    process.chdir(testRoot);
+    try {
+      await runOutdated(['--json', '-p']);
+    } finally {
+      process.chdir(prevCwd);
+    }
+
+    const report: OutdatedJson = JSON.parse(logs[0]!);
+    expect(report.scope).toBe('project');
+    expect(report.skills).toHaveLength(1);
+    const [entry] = report.skills;
+    expect(entry.name).toBe('my-skill');
+    expect(entry.scope).toBe('project');
+    expect(entry.outdated).toBeNull();
+    expect(entry.error).toBe('Project-scope skills are refreshed on update');
+    expect(report.summary.skipped).toBe(1);
+  });
+
+  // Suppress unused-var warning on test helpers that future integration
+  // tests may need.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _helpers = { mkdirSync };
 });

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -78,11 +78,25 @@ export interface OutdatedJson {
   scope: UpdateScope;
   skills: OutdatedJsonSkill[];
   summary: {
+    /** Total number of skills in the report (sum of all buckets below). */
     checked: number;
+    /** Upstream hash differs from local. `outdated: true`, `error: null`. */
     outdated: number;
+    /** Upstream hash matches local. `outdated: false`, `error: null`. */
     upToDate: number;
-    skipped: number;
+    /**
+     * Skill has a local hash but we couldn't determine the upstream —
+     * either a transport/network failure or the remote returned no
+     * hash (private/deleted repo). `outdated: null`, `error` non-null.
+     */
     errored: number;
+    /**
+     * Skill has no local hash at all (local-path source, git URL,
+     * well-known skill, missing metadata, or project-scope skill
+     * which is always refreshed on update). `outdated: null`,
+     * `localHash: null`.
+     */
+    skipped: number;
   };
 }
 
@@ -179,7 +193,10 @@ async function buildProjectEntries(skillFilter?: string[]): Promise<OutdatedJson
   for (const skill of projectSkills) {
     // LocalSkillLockEntry intentionally doesn't carry sourceUrl — fall
     // back to `source` (owner/repo / npm / path). The UI can reconstruct
-    // a clickable URL from `sourceType` + `source` if needed.
+    // a clickable URL from `sourceType` + `source` if needed. We leave
+    // `localHash: null` so `summarize()` classifies project skills as
+    // `skipped` (no comparison possible) rather than `errored` (fetch
+    // failed) — matches the documented schema semantics.
     entries.push({
       name: skill.name,
       scope: 'project',
@@ -188,7 +205,7 @@ async function buildProjectEntries(skillFilter?: string[]): Promise<OutdatedJson
       sourceType: skill.entry.sourceType ?? 'unknown',
       ref: skill.entry.ref ?? null,
       skillPath: null,
-      localHash: skill.entry.computedHash ?? null,
+      localHash: null,
       upstreamHash: null,
       outdated: null,
       error: 'Project-scope skills are refreshed on update',

--- a/src/outdated.ts
+++ b/src/outdated.ts
@@ -1,0 +1,351 @@
+import {
+  checkGlobalSkillUpdates,
+  getProjectSkillsForUpdate,
+  resolveUpdateScope,
+  type GlobalCheckResult,
+  type SkippedSkill,
+  type UpdateCheckOptions,
+  type UpdateScope,
+} from './updates.ts';
+import { track } from './telemetry.ts';
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[38;5;102m';
+const TEXT = '\x1b[38;5;145m';
+
+// ============================================
+// Flag parsing
+// ============================================
+
+interface OutdatedOptions extends UpdateCheckOptions {
+  json?: boolean;
+}
+
+export function parseOutdatedOptions(args: string[]): OutdatedOptions {
+  const options: OutdatedOptions = {};
+  const positional: string[] = [];
+  for (const arg of args) {
+    if (arg === '-g' || arg === '--global') {
+      options.global = true;
+    } else if (arg === '-p' || arg === '--project') {
+      options.project = true;
+    } else if (arg === '-y' || arg === '--yes') {
+      options.yes = true;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (!arg.startsWith('-')) {
+      positional.push(arg);
+    }
+  }
+  if (positional.length > 0) {
+    options.skills = positional;
+  }
+  return options;
+}
+
+// ============================================
+// JSON output (stable contract, schema-versioned)
+// ============================================
+
+/**
+ * Per-skill outdated status. `outdated` is a tri-state:
+ *   - true  — upstream hash differs from local; update available
+ *   - false — upstream and local hashes match; skill is current
+ *   - null  — could not determine (local path, git URL, well-known, missing
+ *             metadata, fetch error); `error` explains why
+ */
+export interface OutdatedJsonSkill {
+  name: string;
+  scope: 'global' | 'project';
+  source: string;
+  sourceUrl: string;
+  sourceType: string;
+  ref: string | null;
+  skillPath: string | null;
+  localHash: string | null;
+  upstreamHash: string | null;
+  outdated: boolean | null;
+  error: string | null;
+}
+
+export interface OutdatedJson {
+  /** Bumped on breaking schema changes. Readers should check this field. */
+  schema: 1;
+  /** ISO 8601 timestamp when the scan started. */
+  checkedAt: string;
+  /** The scope this run covered (matches the resolved scope from -g/-p flags). */
+  scope: UpdateScope;
+  skills: OutdatedJsonSkill[];
+  summary: {
+    checked: number;
+    outdated: number;
+    upToDate: number;
+    skipped: number;
+    errored: number;
+  };
+}
+
+// ============================================
+// Building the JSON report
+// ============================================
+
+export function buildGlobalEntries(result: GlobalCheckResult): OutdatedJsonSkill[] {
+  const entries: OutdatedJsonSkill[] = [];
+
+  for (const c of result.checked) {
+    const { name, entry, upstreamHash, error } = c;
+    if (error !== null) {
+      entries.push({
+        name,
+        scope: 'global',
+        source: entry.source,
+        sourceUrl: entry.sourceUrl,
+        sourceType: entry.sourceType,
+        ref: entry.ref ?? null,
+        skillPath: entry.skillPath ?? null,
+        localHash: entry.skillFolderHash,
+        upstreamHash: null,
+        outdated: null,
+        error,
+      });
+      continue;
+    }
+
+    if (upstreamHash === null) {
+      // Fetch succeeded but the server returned no hash (private/deleted repo)
+      entries.push({
+        name,
+        scope: 'global',
+        source: entry.source,
+        sourceUrl: entry.sourceUrl,
+        sourceType: entry.sourceType,
+        ref: entry.ref ?? null,
+        skillPath: entry.skillPath ?? null,
+        localHash: entry.skillFolderHash,
+        upstreamHash: null,
+        outdated: null,
+        error: 'No upstream hash available',
+      });
+      continue;
+    }
+
+    entries.push({
+      name,
+      scope: 'global',
+      source: entry.source,
+      sourceUrl: entry.sourceUrl,
+      sourceType: entry.sourceType,
+      ref: entry.ref ?? null,
+      skillPath: entry.skillPath ?? null,
+      localHash: entry.skillFolderHash,
+      upstreamHash,
+      outdated: upstreamHash !== entry.skillFolderHash,
+      error: null,
+    });
+  }
+
+  for (const s of result.skipped) {
+    entries.push(buildSkippedEntry(s));
+  }
+
+  return entries;
+}
+
+function buildSkippedEntry(s: SkippedSkill): OutdatedJsonSkill {
+  return {
+    name: s.name,
+    scope: 'global',
+    source: s.sourceUrl,
+    sourceUrl: s.sourceUrl,
+    sourceType: s.sourceType,
+    ref: s.ref ?? null,
+    skillPath: null,
+    localHash: null,
+    upstreamHash: null,
+    outdated: null,
+    error: s.reason,
+  };
+}
+
+async function buildProjectEntries(skillFilter?: string[]): Promise<OutdatedJsonSkill[]> {
+  // Project-scope skills are always re-cloned on update; there is no
+  // authoritative hash-based check primitive for them. Report them with
+  // a structured reason so machine readers can surface "requires refresh"
+  // affordances without guessing at string messages.
+  const projectSkills = await getProjectSkillsForUpdate(skillFilter);
+  const entries: OutdatedJsonSkill[] = [];
+
+  for (const skill of projectSkills) {
+    // LocalSkillLockEntry intentionally doesn't carry sourceUrl — fall
+    // back to `source` (owner/repo / npm / path). The UI can reconstruct
+    // a clickable URL from `sourceType` + `source` if needed.
+    entries.push({
+      name: skill.name,
+      scope: 'project',
+      source: skill.source,
+      sourceUrl: skill.source,
+      sourceType: skill.entry.sourceType ?? 'unknown',
+      ref: skill.entry.ref ?? null,
+      skillPath: null,
+      localHash: skill.entry.computedHash ?? null,
+      upstreamHash: null,
+      outdated: null,
+      error: 'Project-scope skills are refreshed on update',
+    });
+  }
+
+  return entries;
+}
+
+export function summarize(skills: OutdatedJsonSkill[]): OutdatedJson['summary'] {
+  let outdated = 0;
+  let upToDate = 0;
+  let skipped = 0;
+  let errored = 0;
+  for (const s of skills) {
+    if (s.outdated === true) outdated++;
+    else if (s.outdated === false) upToDate++;
+    else if (s.localHash === null) skipped++;
+    else errored++;
+  }
+  return {
+    checked: skills.length,
+    outdated,
+    upToDate,
+    skipped,
+    errored,
+  };
+}
+
+// ============================================
+// Human-readable rendering
+// ============================================
+
+function printHuman(report: OutdatedJson): void {
+  const outdated = report.skills.filter((s) => s.outdated === true);
+  const upToDate = report.skills.filter((s) => s.outdated === false);
+  const notChecked = report.skills.filter((s) => s.outdated === null);
+
+  if (report.skills.length === 0) {
+    console.log(`${DIM}No installed skills found to check.${RESET}`);
+    return;
+  }
+
+  if (outdated.length > 0) {
+    console.log(`${TEXT}${BOLD}${outdated.length} skill(s) with updates available${RESET}`);
+    for (const s of outdated) {
+      const ref = s.ref ? `#${s.ref}` : '';
+      const localShort = s.localHash?.slice(0, 7) ?? '???';
+      const upstreamShort = s.upstreamHash?.slice(0, 7) ?? '???';
+      console.log(
+        `  ${TEXT}•${RESET} ${s.name} ${DIM}(${s.source}${ref} — ${localShort} → ${upstreamShort})${RESET}`
+      );
+    }
+    console.log();
+    console.log(`${DIM}Run ${TEXT}npx skills update${DIM} to apply.${RESET}`);
+  } else if (upToDate.length > 0) {
+    console.log(`${TEXT}✓ All checked skills are up to date (${upToDate.length})${RESET}`);
+  }
+
+  if (notChecked.length > 0) {
+    console.log();
+    console.log(`${DIM}${notChecked.length} skill(s) could not be checked:${RESET}`);
+    for (const s of notChecked) {
+      console.log(`  ${TEXT}•${RESET} ${s.name} ${DIM}(${s.error ?? 'unknown'})${RESET}`);
+    }
+  }
+}
+
+// ============================================
+// runOutdated entry
+// ============================================
+
+/**
+ * Check installed skills for available updates without installing anything.
+ *
+ * Flags:
+ *   -g / --global     Check only global skills
+ *   -p / --project    Check only project skills
+ *   -y / --yes        Skip interactive scope prompt
+ *   --json            Emit machine-readable JSON to stdout (implies -y)
+ *   [skill names...]  Filter to specific skills
+ *
+ * Exit codes:
+ *   0 on successful scan (even when outdated skills or errors exist)
+ *   Non-zero only on catastrophic failures (argument parse, etc.)
+ */
+export async function runOutdated(args: string[] = []): Promise<void> {
+  const options = parseOutdatedOptions(args);
+
+  // --json implies non-interactive
+  if (options.json) {
+    options.yes = true;
+  }
+
+  const scope = await resolveUpdateScope(options);
+  const checkedAt = new Date().toISOString();
+
+  const entries: OutdatedJsonSkill[] = [];
+
+  if (scope === 'global' || scope === 'both') {
+    const onProgress = options.json
+      ? undefined
+      : (i: number, total: number, name: string) => {
+          process.stdout.write(
+            `\r${DIM}Checking global skill ${i}/${total}: ${name}${RESET}\x1b[K`
+          );
+        };
+
+    const result = await checkGlobalSkillUpdates(options.skills, onProgress);
+    if (!options.json && result.checked.length > 0) {
+      process.stdout.write('\r\x1b[K');
+    }
+
+    entries.push(...buildGlobalEntries(result));
+  }
+
+  if (scope === 'project' || scope === 'both') {
+    entries.push(...(await buildProjectEntries(options.skills)));
+  }
+
+  if (options.skills && entries.length === 0) {
+    if (options.json) {
+      // Still emit a valid (empty) report so callers don't have to special-case.
+      const report: OutdatedJson = {
+        schema: 1,
+        checkedAt,
+        scope,
+        skills: [],
+        summary: { checked: 0, outdated: 0, upToDate: 0, skipped: 0, errored: 0 },
+      };
+      console.log(JSON.stringify(report));
+      return;
+    }
+    console.log(`${DIM}No installed skills found matching: ${options.skills.join(', ')}${RESET}`);
+    return;
+  }
+
+  const report: OutdatedJson = {
+    schema: 1,
+    checkedAt,
+    scope,
+    skills: entries,
+    summary: summarize(entries),
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(report));
+  } else {
+    printHuman(report);
+  }
+
+  track({
+    event: 'outdated',
+    scope,
+    skillCount: String(report.summary.checked),
+    outdatedCount: String(report.summary.outdated),
+    erroredCount: String(report.summary.errored),
+    json: options.json ? '1' : '0',
+  });
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -34,6 +34,16 @@ interface UpdateTelemetryData {
   failCount: string;
 }
 
+interface OutdatedTelemetryData {
+  event: 'outdated';
+  scope?: string;
+  skillCount: string;
+  outdatedCount: string;
+  erroredCount: string;
+  /** '1' when --json was used, '0' otherwise */
+  json?: string;
+}
+
 interface FindTelemetryData {
   event: 'find';
   query: string;
@@ -52,6 +62,7 @@ type TelemetryData =
   | InstallTelemetryData
   | RemoveTelemetryData
   | UpdateTelemetryData
+  | OutdatedTelemetryData
   | FindTelemetryData
   | SyncTelemetryData;
 

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -1,0 +1,608 @@
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { fileURLToPath } from 'url';
+import * as p from '@clack/prompts';
+import { track } from './telemetry.ts';
+import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
+import {
+  buildUpdateInstallSource,
+  buildLocalUpdateSource,
+  formatSourceInput,
+} from './update-source.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[38;5;102m';
+const TEXT = '\x1b[38;5;145m';
+
+const AGENTS_DIR = '.agents';
+const LOCK_FILE = '.skill-lock.json';
+const CURRENT_LOCK_VERSION = 3;
+
+// ============================================
+// Lock file types and reader
+// ============================================
+
+export interface SkillLockEntry {
+  source: string;
+  sourceType: string;
+  sourceUrl: string;
+  ref?: string;
+  skillPath?: string;
+  /** GitHub tree SHA for the entire skill folder (v3) */
+  skillFolderHash: string;
+  installedAt: string;
+  updatedAt: string;
+}
+
+export interface SkillLockFile {
+  version: number;
+  skills: Record<string, SkillLockEntry>;
+}
+
+export function getSkillLockPath(): string {
+  const xdgStateHome = process.env.XDG_STATE_HOME;
+  if (xdgStateHome) {
+    return join(xdgStateHome, 'skills', LOCK_FILE);
+  }
+  return join(homedir(), AGENTS_DIR, LOCK_FILE);
+}
+
+export function readSkillLock(): SkillLockFile {
+  const lockPath = getSkillLockPath();
+  try {
+    const content = readFileSync(lockPath, 'utf-8');
+    const parsed = JSON.parse(content) as SkillLockFile;
+    if (typeof parsed.version !== 'number' || !parsed.skills) {
+      return { version: CURRENT_LOCK_VERSION, skills: {} };
+    }
+    // If old version, wipe and start fresh (backwards incompatible change)
+    if (parsed.version < CURRENT_LOCK_VERSION) {
+      return { version: CURRENT_LOCK_VERSION, skills: {} };
+    }
+    return parsed;
+  } catch {
+    return { version: CURRENT_LOCK_VERSION, skills: {} };
+  }
+}
+
+// ============================================
+// Scope resolution
+// ============================================
+
+export type UpdateScope = 'project' | 'global' | 'both';
+
+export interface UpdateCheckOptions {
+  global?: boolean;
+  project?: boolean;
+  yes?: boolean;
+  /** Optional skill name(s) to filter on (positional args) */
+  skills?: string[];
+}
+
+export function parseUpdateOptions(args: string[]): UpdateCheckOptions {
+  const options: UpdateCheckOptions = {};
+  const positional: string[] = [];
+  for (const arg of args) {
+    if (arg === '-g' || arg === '--global') {
+      options.global = true;
+    } else if (arg === '-p' || arg === '--project') {
+      options.project = true;
+    } else if (arg === '-y' || arg === '--yes') {
+      options.yes = true;
+    } else if (!arg.startsWith('-')) {
+      positional.push(arg);
+    }
+  }
+  if (positional.length > 0) {
+    options.skills = positional;
+  }
+  return options;
+}
+
+/**
+ * Check whether the current working directory has project-level skills.
+ */
+export function hasProjectSkills(cwd?: string): boolean {
+  const dir = cwd || process.cwd();
+
+  const lockPath = join(dir, 'skills-lock.json');
+  if (existsSync(lockPath)) {
+    return true;
+  }
+
+  const skillsDir = join(dir, '.agents', 'skills');
+  try {
+    const entries = readdirSync(skillsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const skillMd = join(skillsDir, entry.name, 'SKILL.md');
+        if (existsSync(skillMd)) {
+          return true;
+        }
+      }
+    }
+  } catch {
+    // Directory doesn't exist
+  }
+
+  return false;
+}
+
+/**
+ * Determine the update/check scope via interactive prompt or auto-detection.
+ */
+export async function resolveUpdateScope(options: UpdateCheckOptions): Promise<UpdateScope> {
+  // When targeting specific skills, search both scopes to find them
+  if (options.skills && options.skills.length > 0) {
+    if (options.global) return 'global';
+    if (options.project) return 'project';
+    return 'both';
+  }
+
+  if (options.global && options.project) {
+    return 'both';
+  }
+  if (options.global) {
+    return 'global';
+  }
+  if (options.project) {
+    return 'project';
+  }
+
+  if (options.yes || !process.stdin.isTTY) {
+    return hasProjectSkills() ? 'project' : 'global';
+  }
+
+  const scope = await p.select({
+    message: 'Update scope',
+    options: [
+      {
+        value: 'project' as UpdateScope,
+        label: 'Project',
+        hint: 'Update skills in current directory',
+      },
+      {
+        value: 'global' as UpdateScope,
+        label: 'Global',
+        hint: 'Update skills in home directory',
+      },
+      {
+        value: 'both' as UpdateScope,
+        label: 'Both',
+        hint: 'Update all skills',
+      },
+    ],
+  });
+
+  if (p.isCancel(scope)) {
+    p.cancel('Cancelled');
+    process.exit(0);
+  }
+
+  return scope as UpdateScope;
+}
+
+// ============================================
+// Skill filter
+// ============================================
+
+export function matchesSkillFilter(name: string, filter?: string[]): boolean {
+  if (!filter || filter.length === 0) return true;
+  const lower = name.toLowerCase();
+  return filter.some((f) => f.toLowerCase() === lower);
+}
+
+// ============================================
+// Skipped skills (unchecked) reporting
+// ============================================
+
+export interface SkippedSkill {
+  name: string;
+  reason: string;
+  sourceUrl: string;
+  sourceType: string;
+  ref?: string;
+}
+
+/**
+ * Determine why a skill cannot be checked for updates automatically.
+ */
+export function getSkipReason(entry: SkillLockEntry): string {
+  if (entry.sourceType === 'local') {
+    return 'Local path';
+  }
+  if (entry.sourceType === 'git') {
+    return 'Git URL';
+  }
+  if (entry.sourceType === 'well-known') {
+    return 'Well-known skill';
+  }
+  if (!entry.skillFolderHash) {
+    return 'Private or deleted repo';
+  }
+  if (!entry.skillPath) {
+    return 'No skill path recorded';
+  }
+  return 'No version tracking';
+}
+
+/**
+ * For well-known skills, strip the .well-known/... path and /SKILL.md suffix
+ * to produce the base URL the user originally used to install.
+ */
+function getInstallSource(skill: SkippedSkill): string {
+  let url = skill.sourceUrl;
+  if (skill.sourceType === 'well-known') {
+    const idx = url.indexOf('/.well-known/');
+    if (idx !== -1) {
+      url = url.slice(0, idx);
+    }
+  }
+  return formatSourceInput(url, skill.ref);
+}
+
+/**
+ * Print a list of skills that cannot be checked automatically,
+ * with the reason and a manual update command for each.
+ */
+function printSkippedSkills(skipped: SkippedSkill[]): void {
+  if (skipped.length === 0) return;
+  console.log();
+  console.log(`${DIM}${skipped.length} skill(s) cannot be checked automatically:${RESET}`);
+
+  const grouped = new Map<string, SkippedSkill[]>();
+  for (const skill of skipped) {
+    const source = getInstallSource(skill);
+    const existing = grouped.get(source) || [];
+    existing.push(skill);
+    grouped.set(source, existing);
+  }
+
+  for (const [source, skills] of grouped) {
+    if (skills.length === 1) {
+      const skill = skills[0]!;
+      console.log(`  ${TEXT}•${RESET} ${skill.name} ${DIM}(${skill.reason})${RESET}`);
+    } else {
+      const reason = skills[0]!.reason;
+      const names = skills.map((s) => s.name).join(', ');
+      console.log(`  ${TEXT}•${RESET} ${names} ${DIM}(${reason})${RESET}`);
+    }
+    console.log(`    ${DIM}To update: ${TEXT}npx skills add ${source} -g -y${RESET}`);
+  }
+}
+
+// ============================================
+// Check (no install): the authoritative primitive
+// ============================================
+
+/**
+ * Result of a per-skill fetch attempt. `upstreamHash === null` combined
+ * with `error !== null` means the fetch threw; `upstreamHash === null`
+ * combined with `error === null` means the server returned no hash
+ * (private/deleted repo, rate limit). `upstreamHash !== null` is a
+ * definitive upstream answer — compare against `entry.skillFolderHash`
+ * to derive the `outdated` boolean.
+ */
+export interface GlobalCheckedEntry {
+  name: string;
+  entry: SkillLockEntry;
+  upstreamHash: string | null;
+  error: string | null;
+}
+
+export interface GlobalCheckResult {
+  /** Skills that we attempted to fetch upstream hashes for. */
+  checked: GlobalCheckedEntry[];
+  /** Skills that couldn't be checked at all (local path, well-known, missing metadata). */
+  skipped: SkippedSkill[];
+  /** checked.length + skipped.length */
+  checkedCount: number;
+}
+
+export interface CheckProgress {
+  (index: number, total: number, name: string): void;
+}
+
+/**
+ * Partition installed global skills and fetch upstream hashes.
+ * Does NOT install anything. Used by both `runUpdate` (for the install
+ * phase) and `runOutdated` (for the check-only report).
+ */
+export async function checkGlobalSkillUpdates(
+  skillFilter?: string[],
+  onProgress?: CheckProgress
+): Promise<GlobalCheckResult> {
+  const lock = readSkillLock();
+  const skillNames = Object.keys(lock.skills);
+
+  const skipped: SkippedSkill[] = [];
+  const checkable: Array<{ name: string; entry: SkillLockEntry }> = [];
+
+  for (const skillName of skillNames) {
+    if (!matchesSkillFilter(skillName, skillFilter)) continue;
+
+    const entry = lock.skills[skillName];
+    if (!entry) continue;
+
+    if (!entry.skillFolderHash || !entry.skillPath) {
+      skipped.push({
+        name: skillName,
+        reason: getSkipReason(entry),
+        sourceUrl: entry.sourceUrl,
+        sourceType: entry.sourceType,
+        ref: entry.ref,
+      });
+      continue;
+    }
+
+    checkable.push({ name: skillName, entry });
+  }
+
+  const token = getGitHubToken();
+  const checked: GlobalCheckedEntry[] = [];
+
+  for (let i = 0; i < checkable.length; i++) {
+    const { name: skillName, entry } = checkable[i]!;
+    if (onProgress) onProgress(i + 1, checkable.length, skillName);
+
+    try {
+      const latestHash = await fetchSkillFolderHash(
+        entry.source,
+        entry.skillPath!,
+        token,
+        entry.ref
+      );
+      checked.push({
+        name: skillName,
+        entry,
+        upstreamHash: latestHash ?? null,
+        error: null,
+      });
+    } catch (err) {
+      checked.push({
+        name: skillName,
+        entry,
+        upstreamHash: null,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    checked,
+    skipped,
+    checkedCount: checkable.length + skipped.length,
+  };
+}
+
+/** Derived view: which entries have a definitive upstream hash that differs from local. */
+export function selectOutdated(result: GlobalCheckResult): GlobalCheckedEntry[] {
+  return result.checked.filter(
+    (c) => c.upstreamHash !== null && c.upstreamHash !== c.entry.skillFolderHash
+  );
+}
+
+// ============================================
+// Project Skills Discovery (for update + outdated)
+// ============================================
+
+export async function getProjectSkillsForUpdate(
+  skillFilter?: string[]
+): Promise<Array<{ name: string; source: string; entry: LocalSkillLockEntry }>> {
+  const localLock = await readLocalLock();
+  const skills: Array<{ name: string; source: string; entry: LocalSkillLockEntry }> = [];
+
+  for (const [name, entry] of Object.entries(localLock.skills)) {
+    if (!matchesSkillFilter(name, skillFilter)) continue;
+    // Skip node_modules and local path skills - they are managed by sync/manually
+    if (entry.sourceType === 'node_modules' || entry.sourceType === 'local') {
+      continue;
+    }
+    skills.push({ name, source: entry.source, entry });
+  }
+
+  return skills;
+}
+
+// ============================================
+// Update: Global Skills
+// ============================================
+
+async function updateGlobalSkills(
+  skillFilter?: string[]
+): Promise<{ successCount: number; failCount: number; checkedCount: number }> {
+  let successCount = 0;
+  let failCount = 0;
+
+  const result = await checkGlobalSkillUpdates(skillFilter, (i, total, name) => {
+    process.stdout.write(`\r${DIM}Checking global skill ${i}/${total}: ${name}${RESET}\x1b[K`);
+  });
+
+  if (result.checked.length > 0) {
+    process.stdout.write('\r\x1b[K');
+  }
+
+  const outdated = selectOutdated(result);
+  const erroredCount = result.checked.filter((c) => c.error !== null).length;
+
+  if (result.checked.length === 0 && result.skipped.length === 0) {
+    if (!skillFilter) {
+      const lock = readSkillLock();
+      if (Object.keys(lock.skills).length === 0) {
+        console.log(`${DIM}No global skills tracked in lock file.${RESET}`);
+        console.log(`${DIM}Install skills with${RESET} ${TEXT}npx skills add <package> -g${RESET}`);
+      } else {
+        console.log(`${DIM}No global skills to check.${RESET}`);
+      }
+    }
+    return { successCount, failCount, checkedCount: 0 };
+  }
+
+  if (result.checked.length === 0 && result.skipped.length > 0) {
+    printSkippedSkills(result.skipped);
+    return { successCount, failCount, checkedCount: result.checkedCount };
+  }
+
+  if (outdated.length === 0 && erroredCount === 0) {
+    console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    return { successCount, failCount, checkedCount: result.checkedCount };
+  }
+
+  console.log(`${TEXT}Found ${outdated.length} global update(s)${RESET}`);
+  console.log();
+
+  for (const update of outdated) {
+    console.log(`${TEXT}Updating ${update.name}...${RESET}`);
+    const installUrl = buildUpdateInstallSource(update.entry);
+
+    const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
+    if (!existsSync(cliEntry)) {
+      failCount++;
+      console.log(
+        `  ${DIM}✗ Failed to update ${update.name}: CLI entrypoint not found at ${cliEntry}${RESET}`
+      );
+      continue;
+    }
+    const spawnResult = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      shell: process.platform === 'win32',
+    });
+
+    if (spawnResult.status === 0) {
+      successCount++;
+      console.log(`  ${TEXT}✓${RESET} Updated ${update.name}`);
+    } else {
+      failCount++;
+      console.log(`  ${DIM}✗ Failed to update ${update.name}${RESET}`);
+    }
+  }
+
+  printSkippedSkills(result.skipped);
+  return { successCount, failCount, checkedCount: result.checkedCount };
+}
+
+// ============================================
+// Update: Project Skills
+// ============================================
+
+async function updateProjectSkills(
+  skillFilter?: string[]
+): Promise<{ successCount: number; failCount: number; foundCount: number }> {
+  const projectSkills = await getProjectSkillsForUpdate(skillFilter);
+  let successCount = 0;
+  let failCount = 0;
+
+  if (projectSkills.length === 0) {
+    if (!skillFilter) {
+      console.log(`${DIM}No project skills to update.${RESET}`);
+      console.log(
+        `${DIM}Install project skills with${RESET} ${TEXT}npx skills add <package>${RESET}`
+      );
+    }
+    return { successCount, failCount, foundCount: 0 };
+  }
+
+  console.log(`${TEXT}Refreshing ${projectSkills.length} project skill(s)...${RESET}`);
+  console.log();
+
+  for (const skill of projectSkills) {
+    console.log(`${TEXT}Updating ${skill.name}...${RESET}`);
+    const installUrl = buildLocalUpdateSource(skill.entry);
+
+    const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
+    if (!existsSync(cliEntry)) {
+      failCount++;
+      console.log(
+        `  ${DIM}✗ Failed to update ${skill.name}: CLI entrypoint not found at ${cliEntry}${RESET}`
+      );
+      continue;
+    }
+
+    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-y'], {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      shell: process.platform === 'win32',
+    });
+
+    if (result.status === 0) {
+      successCount++;
+      console.log(`  ${TEXT}✓${RESET} Updated ${skill.name}`);
+    } else {
+      failCount++;
+      console.log(`  ${DIM}✗ Failed to update ${skill.name}${RESET}`);
+    }
+  }
+
+  return { successCount, failCount, foundCount: projectSkills.length };
+}
+
+// ============================================
+// runUpdate entry
+// ============================================
+
+export async function runUpdate(args: string[] = []): Promise<void> {
+  const options = parseUpdateOptions(args);
+  const scope = await resolveUpdateScope(options);
+
+  if (options.skills) {
+    console.log(`${TEXT}Updating ${options.skills.join(', ')}...${RESET}`);
+  } else {
+    console.log(`${TEXT}Checking for skill updates...${RESET}`);
+  }
+  console.log();
+
+  let totalSuccess = 0;
+  let totalFail = 0;
+  let totalFound = 0;
+
+  if (scope === 'global' || scope === 'both') {
+    if (scope === 'both' && !options.skills) {
+      console.log(`${BOLD}Global Skills${RESET}`);
+    }
+    const { successCount, failCount, checkedCount } = await updateGlobalSkills(options.skills);
+    totalSuccess += successCount;
+    totalFail += failCount;
+    totalFound += checkedCount;
+    if (scope === 'both' && !options.skills) {
+      console.log();
+    }
+  }
+
+  if (scope === 'project' || scope === 'both') {
+    if (scope === 'both' && !options.skills) {
+      console.log(`${BOLD}Project Skills${RESET}`);
+    }
+    const { successCount, failCount, foundCount } = await updateProjectSkills(options.skills);
+    totalSuccess += successCount;
+    totalFail += failCount;
+    totalFound += foundCount;
+  }
+
+  if (options.skills && totalFound === 0) {
+    console.log(`${DIM}No installed skills found matching: ${options.skills.join(', ')}${RESET}`);
+  }
+
+  console.log();
+  if (totalSuccess > 0) {
+    console.log(`${TEXT}✓ Updated ${totalSuccess} skill(s)${RESET}`);
+  }
+  if (totalFail > 0) {
+    console.log(`${DIM}Failed to update ${totalFail} skill(s)${RESET}`);
+  }
+
+  track({
+    event: 'update',
+    scope,
+    skillCount: String(totalSuccess + totalFail),
+    successCount: String(totalSuccess),
+    failCount: String(totalFail),
+  });
+  console.log();
+}

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -429,7 +429,7 @@ async function updateGlobalSkills(
   }
 
   const outdated = selectOutdated(result);
-  const erroredCount = result.checked.filter((c) => c.error !== null).length;
+  const errored = result.checked.filter((c) => c.error !== null);
 
   if (result.checked.length === 0 && result.skipped.length === 0) {
     if (!skillFilter) {
@@ -449,8 +449,20 @@ async function updateGlobalSkills(
     return { successCount, failCount, checkedCount: result.checkedCount };
   }
 
-  if (outdated.length === 0 && erroredCount === 0) {
+  if (outdated.length === 0 && errored.length === 0) {
     console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    return { successCount, failCount, checkedCount: result.checkedCount };
+  }
+
+  if (errored.length > 0) {
+    console.log(`${DIM}${errored.length} skill(s) could not be checked (network or auth):${RESET}`);
+    for (const e of errored) {
+      console.log(`  ${DIM}•${RESET} ${e.name}: ${e.error}`);
+    }
+    console.log();
+  }
+
+  if (outdated.length === 0) {
     return { successCount, failCount, checkedCount: result.checkedCount };
   }
 


### PR DESCRIPTION
## Summary

Adds a new subcommand that reports which installed skills have updates available **without installing anything**. The `update` command keeps its current behaviour; `outdated` is the read-only sibling.

Motivated by downstream tools that need to answer *"which of my skills are out of date?"* programmatically — for example, a desktop update notifier that surfaces a badge on the user's Skills panel. Without a check-only command, callers are forced to either parse the live update output (brittle) or reimplement the hash comparison themselves (drift risk). `outdated --json` makes the check primitive a first-class, schema-versioned contract.

## New surface

```bash
skills outdated                     # human-readable report
skills outdated --json              # machine-readable JSON (implies -y)
skills outdated -g / -p             # scope flags — same semantics as `update`
skills outdated my-skill            # filter by name
```

### JSON contract (schema 1)

```json
{
  "schema": 1,
  "checkedAt": "2026-04-17T18:00:00.000Z",
  "scope": "global",
  "skills": [
    {
      "name": "gmail",
      "scope": "global",
      "source": "sanjay3290/ai-skills",
      "sourceUrl": "https://github.com/sanjay3290/ai-skills",
      "sourceType": "github",
      "ref": "main",
      "skillPath": "skills/gmail/SKILL.md",
      "localHash": "abc...",
      "upstreamHash": "def...",
      "outdated": true,
      "error": null
    }
  ],
  "summary": { "checked": 13, "outdated": 1, "upToDate": 10, "skipped": 2, "errored": 0 }
}
```

- `outdated` is tri-state — `true` / `false` / `null`. `null` means "could not determine" and `error` explains why (Local path, Well-known skill, Private/deleted repo, No skill path recorded, No upstream hash available, or a network error message).
- Exit code is `0` for any successful scan regardless of outdated count. Callers read `summary.outdated` instead.
- Project-scope skills always surface as `outdated: null` with `error: "Project-scope skills are refreshed on update"` because the existing project-level `update` is an unconditional re-clone — there's no hash-based primitive to report against.

## Refactor

`update` is currently the only verb whose implementation lives inline in `cli.ts`; every other verb (`add`, `list`, `remove`, `sync`, `find`, `install`) has its own module. This PR moves the update/check machinery into a new `src/updates.ts` to match, then `cli.ts` becomes a pure dispatcher. Net effect on `cli.ts`: −560 lines.

The new `checkGlobalSkillUpdates(skillFilter, onProgress)` helper in `updates.ts` is the one authoritative implementation of the "Checking for skill updates" loop. Both `runUpdate` (install phase) and `runOutdated` (report only) consume it — same `fetchSkillFolderHash` call, same skip-reason classification, same progress callback shape. No duplicated check logic.

## Behaviour preservation

- `skills update`, `skills check`, `skills upgrade` continue to call `runUpdate` with identical semantics. All existing skip-reason messages, scope resolution (interactive prompt, `-y` auto-detect, explicit flags), and telemetry shape are preserved.
- `src/update-source.test.ts` still passes unchanged — the source-URL helpers weren't touched.

## Tests

New `src/outdated.test.ts` — 16 tests covering:

- `parseOutdatedOptions` — every flag + combinations + unknown flags ignored
- `buildGlobalEntries` — all four result shapes (outdated, up-to-date, fetch-errored, no-hash-returned) and skipped-skill passthrough
- `summarize` — counter correctness across the mixed-state fixture

All 16 green locally. `src/update-source.test.ts` and `src/outdated.test.ts` together: **21/21 pass**.

Pre-existing type-check and test failures in `src/git.ts`, `src/providers/wellknown.ts`, `src/skills.ts`, `src/add.test.ts`, `src/list.test.ts` are not touched by this PR.

## Test plan

- [x] `pnpm run type-check` clean on new/changed files
- [x] `pnpm vitest run src/outdated.test.ts` → 16/16 pass
- [x] `pnpm vitest run src/update-source.test.ts` → 5/5 pass (sanity check existing behaviour)
- [x] `pnpm run format` clean via lint-staged pre-commit
- [ ] Manual smoke: `skills outdated --json -g` against a real skill-lock.json with a known-outdated skill (reviewer-verifiable)

## Schema stability

`schema: 1` is bumped only on breaking shape changes. Adding new fields to existing objects is non-breaking. Readers are expected to check `schema` and fail gracefully on unknowns — noted in the README.

## Follow-ups (not in this PR)

- Project-scope skills could gain a real hash-based check primitive (would need a lock entry with `computedHash` present for the reinstalled skill) — deferred, doesn't block this PR.
- `skills update --json` for parity — straightforward follow-up using the same schema shape.