### PR TITLE
fix(installer): discover symlinked skill directories

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -67,6 +67,20 @@ function isPathSafe(basePath: string, targetPath: string): boolean {
   return normalizedTarget.startsWith(normalizedBase + sep) || normalizedTarget === normalizedBase;
 }
 
+// Dirent.isDirectory() is false for symlinks; follow and verify the target is a directory.
+async function isDirEntryOrSymlinkToDir(
+  entry: { isDirectory(): boolean; isSymbolicLink(): boolean },
+  entryPath: string
+): Promise<boolean> {
+  if (entry.isDirectory()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return (await stat(entryPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 export function getCanonicalSkillsDir(global: boolean, cwd?: string): string {
   const baseDir = global ? homedir() : cwd || process.cwd();
   return join(baseDir, AGENTS_DIR, SKILLS_SUBDIR);
@@ -910,11 +924,9 @@ export async function listInstalledSkills(
       const entries = await readdir(scope.path, { withFileTypes: true });
 
       for (const entry of entries) {
-        if (!entry.isDirectory()) {
-          continue;
-        }
-
         const skillDir = join(scope.path, entry.name);
+        if (!(await isDirEntryOrSymlinkToDir(entry, skillDir))) continue;
+
         const skillMdPath = join(skillDir, 'SKILL.md');
 
         // Check if SKILL.md exists
@@ -999,9 +1011,8 @@ export async function listInstalledSkills(
             try {
               const agentEntries = await readdir(agentBase, { withFileTypes: true });
               for (const agentEntry of agentEntries) {
-                if (!agentEntry.isDirectory()) continue;
-
                 const candidateDir = join(agentBase, agentEntry.name);
+                if (!(await isDirEntryOrSymlinkToDir(agentEntry, candidateDir))) continue;
                 if (!isPathSafe(agentBase, candidateDir)) continue;
 
                 try {

--- a/tests/list-installed.test.ts
+++ b/tests/list-installed.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, writeFile, rm } from 'fs/promises';
+import { mkdir, writeFile, rm, symlink } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { listInstalledSkills } from '../src/installer.ts';
@@ -159,6 +159,51 @@ ${skillData.description}
     expect(skills[0]!.agents).not.toContain('kimi-cli');
 
     vi.restoreAllMocks();
+  });
+
+  // Directory symlinks pointing at a real skill dir should be discovered.
+  it('should find skill when the skill directory is a symlink', async () => {
+    const realSkillDir = join(testDir, 'shared', 'linked-skill');
+    await mkdir(realSkillDir, { recursive: true });
+    await writeFile(
+      join(realSkillDir, 'SKILL.md'),
+      `---
+name: linked-skill
+description: Skill reached through a directory symlink
+---
+
+# linked-skill
+`
+    );
+
+    const agentSkillsDir = join(testDir, '.agents', 'skills');
+    await mkdir(agentSkillsDir, { recursive: true });
+    await symlink(realSkillDir, join(agentSkillsDir, 'linked-skill'), 'dir');
+
+    const skills = await listInstalledSkills({ global: false, cwd: testDir });
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.name).toBe('linked-skill');
+  });
+
+  it('should ignore dangling symlinks without a reachable SKILL.md', async () => {
+    const agentSkillsDir = join(testDir, '.agents', 'skills');
+    await mkdir(agentSkillsDir, { recursive: true });
+    await symlink(join(testDir, 'does-not-exist'), join(agentSkillsDir, 'broken'), 'dir');
+
+    const skills = await listInstalledSkills({ global: false, cwd: testDir });
+    expect(skills).toEqual([]);
+  });
+
+  it('should ignore symlinks that point to a regular file', async () => {
+    const filePath = join(testDir, 'not-a-skill.md');
+    await writeFile(filePath, '# not a skill');
+
+    const agentSkillsDir = join(testDir, '.agents', 'skills');
+    await mkdir(agentSkillsDir, { recursive: true });
+    await symlink(filePath, join(agentSkillsDir, 'file-link'));
+
+    const skills = await listInstalledSkills({ global: false, cwd: testDir });
+    expect(skills).toEqual([]);
   });
 
   // Issue #225 part 2: Skills in agent-specific directories should be found


### PR DESCRIPTION
## Problem

`skills list` misses skill directories that are symlinks. `Dirent.isDirectory()` returns `false` for symlinks, even when they resolve to a directory containing `SKILL.md`.

Repos that expose skills to agents via symlink hit this:

```
skills-src/my-skill/SKILL.md
.claude/skills/my-skill -> ../../skills-src/my-skill
```

`npx skills list` reports "No project skills found".

## Fix

Both `readdir` loops in `listInstalledSkills` now accept symlinks and `stat()` them to confirm the target is a directory — symlinks to files and dangling symlinks are rejected. The check lives in a new helper `isDirEntryOrSymlinkToDir` since it's needed in two places.

Tests cover the three cases: directory (found), file (ignored), dangling (ignored).

Related to #105.