### PR TITLE
Add --tag filter for `skills add`

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -389,6 +389,32 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse --tag with a single value', () => {
+    const result = parseAddOptions(['source', '--tag', 'python']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.tag).toEqual(['python']);
+  });
+
+  it('should parse -t short flag', () => {
+    const result = parseAddOptions(['source', '-t', 'security']);
+    expect(result.options.tag).toEqual(['security']);
+  });
+
+  it('should parse repeated --tag flags and multi-value form', () => {
+    const repeated = parseAddOptions(['source', '--tag', 'python', '--tag', 'security']);
+    expect(repeated.options.tag).toEqual(['python', 'security']);
+
+    const multi = parseAddOptions(['source', '--tag', 'python', 'security']);
+    expect(multi.options.tag).toEqual(['python', 'security']);
+  });
+
+  it('should parse --tag alongside --skill and -g', () => {
+    const result = parseAddOptions(['source', '--skill', 'foo', '--tag', 'python', '-g']);
+    expect(result.options.skill).toEqual(['foo']);
+    expect(result.options.tag).toEqual(['python']);
+    expect(result.options.global).toBe(true);
+  });
 });
 
 describe('openclaw source blocking', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -22,7 +22,7 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
-import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
+import { discoverSkills, getSkillDisplayName, filterSkills, filterSkillsByTag } from './skills.ts';
 import {
   installSkillForAgent,
   installBlobSkillForAgent,
@@ -419,6 +419,7 @@ export interface AddOptions {
   agent?: string[];
   yes?: boolean;
   skill?: string[];
+  tag?: string[];
   list?: boolean;
   all?: boolean;
   fullDepth?: boolean;
@@ -1061,6 +1062,25 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       spinner.stop(`Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
     }
 
+    const hasSkillFilter =
+      !!(options.skill && options.skill.length > 0) && !options.skill!.includes('*');
+    const hasTagFilter = !!(options.tag && options.tag.length > 0);
+
+    // Pre-compute filtered set so --list and the install path see the same skills.
+    let preFiltered: Skill[];
+    if (options.skill?.includes('*') || (!hasSkillFilter && !hasTagFilter)) {
+      preFiltered = skills;
+    } else {
+      const byName = hasSkillFilter ? filterSkills(skills, options.skill!) : [];
+      const byTag = hasTagFilter ? filterSkillsByTag(skills, options.tag!) : [];
+      const seen = new Set<string>();
+      preFiltered = [...byName, ...byTag].filter((s) => {
+        if (seen.has(s.path)) return false;
+        seen.add(s.path);
+        return true;
+      });
+    }
+
     if (options.list) {
       console.log();
       p.log.step(pc.bold('Available Skills'));
@@ -1069,7 +1089,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const groupedSkills: Record<string, Skill[]> = {};
       const ungroupedSkills: Skill[] = [];
 
-      for (const skill of skills) {
+      for (const skill of preFiltered) {
         if (skill.pluginName) {
           const group = skill.pluginName;
           if (!groupedSkills[group]) groupedSkills[group] = [];
@@ -1106,7 +1126,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       console.log();
-      p.outro('Use --skill <name> to install specific skills');
+      p.outro('Use --skill <name> or --tag <tag> to filter skills');
       await cleanup(tempDir);
       process.exit(0);
     }
@@ -1117,14 +1137,21 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // --skill '*' selects all skills
       selectedSkills = skills;
       p.log.info(`Installing all ${skills.length} skills`);
-    } else if (options.skill && options.skill.length > 0) {
-      selectedSkills = filterSkills(skills, options.skill);
+    } else if (hasSkillFilter || hasTagFilter) {
+      selectedSkills = preFiltered;
 
       if (selectedSkills.length === 0) {
-        p.log.error(`No matching skills found for: ${options.skill.join(', ')}`);
+        const criteria = [
+          hasSkillFilter ? `name: ${options.skill!.join(', ')}` : null,
+          hasTagFilter ? `tag: ${options.tag!.join(', ')}` : null,
+        ]
+          .filter(Boolean)
+          .join('; ');
+        p.log.error(`No matching skills found for ${criteria}`);
         p.log.info('Available skills:');
         for (const s of skills) {
-          p.log.message(`  - ${getSkillDisplayName(s)}`);
+          const tagStr = s.tags && s.tags.length > 0 ? pc.dim(` [${s.tags.join(', ')}]`) : '';
+          p.log.message(`  - ${getSkillDisplayName(s)}${tagStr}`);
         }
         await cleanup(tempDir);
         process.exit(1);
@@ -1891,6 +1918,16 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       let nextArg = args[i];
       while (i < args.length && nextArg && !nextArg.startsWith('-')) {
         options.skill.push(nextArg);
+        i++;
+        nextArg = args[i];
+      }
+      i--; // Back up one since the loop will increment
+    } else if (arg === '-t' || arg === '--tag') {
+      options.tag = options.tag || [];
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        options.tag.push(nextArg);
         i++;
         nextArg = args[i];
       }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -15,6 +15,27 @@ export function shouldInstallInternalSkills(): boolean {
   return envValue === '1' || envValue === 'true';
 }
 
+/**
+ * Normalize a frontmatter `tags` value into a lowercased string array.
+ * Accepts YAML array form (`tags: [a, b]`) or comma-separated string form
+ * (`tags: a, b`). Non-string items and empty values are dropped. Returns
+ * undefined if no usable tags are present (keeps Skill.tags truly optional).
+ */
+function parseTags(raw: unknown): string[] | undefined {
+  const collect = (xs: unknown[]): string[] =>
+    xs
+      .filter((t): t is string => typeof t === 'string' && t.trim().length > 0)
+      .map((t) => t.trim().toLowerCase());
+
+  let tags: string[] = [];
+  if (Array.isArray(raw)) {
+    tags = collect(raw);
+  } else if (typeof raw === 'string') {
+    tags = collect(raw.split(','));
+  }
+  return tags.length > 0 ? tags : undefined;
+}
+
 async function hasSkillMd(dir: string): Promise<boolean> {
   try {
     const skillPath = join(dir, 'SKILL.md');
@@ -55,6 +76,7 @@ export async function parseSkillMd(
       description: data.description,
       path: dirname(skillMdPath),
       rawContent: content,
+      tags: parseTags(data.metadata?.tags),
       metadata: data.metadata,
     };
   } catch {
@@ -241,4 +263,14 @@ export function filterSkills(skills: Skill[], inputNames: string[]): Skill[] {
 
     return normalizedInputs.some((input) => input === name || input === displayName);
   });
+}
+
+/**
+ * Filter skills by frontmatter `tags` field (case-insensitive, OR semantics).
+ * A skill matches if any of its tags equals any of the requested tags.
+ * Skills without a `tags` field never match.
+ */
+export function filterSkillsByTag(skills: Skill[], inputTags: string[]): Skill[] {
+  const wanted = new Set(inputTags.map((t) => t.toLowerCase()));
+  return skills.filter((skill) => skill.tags?.some((t) => wanted.has(t.toLowerCase())) ?? false);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export interface Skill {
   rawContent?: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  /** Tags from SKILL.md frontmatter (lowercased) for --tag filtering */
+  tags?: string[];
   metadata?: Record<string, unknown>;
 }
 

--- a/tests/skill-matching.test.ts
+++ b/tests/skill-matching.test.ts
@@ -9,12 +9,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { filterSkills, parseSkillMd } from '../src/skills.ts';
+import { filterSkills, filterSkillsByTag, parseSkillMd } from '../src/skills.ts';
 import type { Skill } from '../src/types.ts';
 
 // Mock skill factory
-function makeSkill(name: string, path: string = '/tmp/skill'): Skill {
-  return { name, description: 'desc', path };
+function makeSkill(name: string, path: string = '/tmp/skill', tags?: string[]): Skill {
+  return { name, description: 'desc', path, tags };
 }
 
 const skills: Skill[] = [
@@ -92,6 +92,90 @@ describe('filterSkills', () => {
       const result = filterSkills(skills, []);
       expect(result.length).toBe(0);
     });
+  });
+});
+
+describe('filterSkillsByTag', () => {
+  const tagged: Skill[] = [
+    makeSkill('py-lint', '/tmp/a', ['python', 'linting']),
+    makeSkill('py-fmt', '/tmp/b', ['python', 'formatting']),
+    makeSkill('sec-scan', '/tmp/c', ['security']),
+    makeSkill('untagged', '/tmp/d'),
+    makeSkill('mixed-case', '/tmp/e', ['Python']),
+  ];
+
+  it('matches skills with any of the given tags (OR semantics)', () => {
+    const result = filterSkillsByTag(tagged, ['python']);
+    const names = result.map((s) => s.name).sort();
+    expect(names).toEqual(['mixed-case', 'py-fmt', 'py-lint']);
+  });
+
+  it('matches case-insensitively against stored tags', () => {
+    const result = filterSkillsByTag(tagged, ['PYTHON']);
+    expect(result.map((s) => s.name).sort()).toEqual(['mixed-case', 'py-fmt', 'py-lint']);
+  });
+
+  it('unions matches from multiple tags', () => {
+    const result = filterSkillsByTag(tagged, ['linting', 'security']);
+    expect(result.map((s) => s.name).sort()).toEqual(['py-lint', 'sec-scan']);
+  });
+
+  it('excludes skills with no tags field', () => {
+    const result = filterSkillsByTag(tagged, ['python']);
+    expect(result.find((s) => s.name === 'untagged')).toBeUndefined();
+  });
+
+  it('returns empty array for unknown tag', () => {
+    expect(filterSkillsByTag(tagged, ['rust'])).toEqual([]);
+  });
+});
+
+describe('parseSkillMd metadata.tags frontmatter', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-tags-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  async function writeSkill(frontmatter: string): Promise<Skill | null> {
+    const skillPath = join(testDir, 'SKILL.md');
+    writeFileSync(skillPath, `---\nname: test-skill\ndescription: desc\n${frontmatter}---\n`);
+    return parseSkillMd(skillPath);
+  }
+
+  it('parses metadata.tags YAML array and lowercases them', async () => {
+    const skill = await writeSkill('metadata:\n  tags:\n    - Python\n    - Security\n');
+    expect(skill?.tags).toEqual(['python', 'security']);
+  });
+
+  it('parses metadata.tags comma-separated string', async () => {
+    const skill = await writeSkill('metadata:\n  tags: python, security\n');
+    expect(skill?.tags).toEqual(['python', 'security']);
+  });
+
+  it('omits tags field when metadata.tags is absent', async () => {
+    const skill = await writeSkill('metadata:\n  internal: false\n');
+    expect(skill?.tags).toBeUndefined();
+  });
+
+  it('omits tags field when metadata block itself is absent', async () => {
+    const skill = await writeSkill('');
+    expect(skill?.tags).toBeUndefined();
+  });
+
+  it('ignores top-level tags (must live under metadata)', async () => {
+    const skill = await writeSkill('tags: [python]\n');
+    expect(skill?.tags).toBeUndefined();
+  });
+
+  it('drops non-string and empty entries', async () => {
+    const skill = await writeSkill('metadata:\n  tags:\n    - python\n    - ""\n    - 42\n');
+    expect(skill?.tags).toEqual(['python']);
   });
 });
 


### PR DESCRIPTION
Lets you install only the skills from a repo whose metadata.tags contain one of the given tags, useful for curated multi-skill repos where you don't want everything. Repeatable (-t/--tag), OR semantics across values, and unions cleanly with --skill. Skills without a tags field are unaffected.

Closes #956