### PR TITLE
feat: HostProvider plugin hook — let third parties register without forking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,10 @@ src/
 ├── plugin-manifest.ts # Plugin manifest discovery support
 ├── prompts/         # Interactive prompt helpers
 │   └── search-multiselect.ts
-├── providers/       # Remote skill providers (GitHub, HuggingFace, Mintlify)
-│   ├── index.ts
+├── providers/       # Remote skill providers (GitHub, HuggingFace, Mintlify).
+│   │                # Third-party packages can also register at runtime
+│   │                # via registerProvider — see README "Extending".
+│   ├── index.ts     # Public entry: registerProvider / findProvider / HostProvider
 │   ├── registry.ts
 │   ├── types.ts
 │   ├── huggingface.ts

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ npx skills add git@github.com:vercel-labs/agent-skills.git
 
 # Local path
 npx skills add ./my-local-skills
+
+# Third-party provider (see "Extending" below)
+npx skills add @my-org/my-skill --provider @my-org/skills-provider
+SKILLS_PROVIDERS=@my-org/skills-provider npx skills add @my-org/my-skill
 ```
 
 ### Options
@@ -47,6 +51,7 @@ npx skills add ./my-local-skills
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+| `-P, --provider <module>` | Load a third-party provider package (repeatable). Also via `SKILLS_PROVIDERS=a,b` env var. See [Extending](#extending)                             |
 
 ### Examples
 
@@ -435,6 +440,64 @@ Ensure you have write access to the target directory.
 # Install internal skills
 INSTALL_INTERNAL_SKILLS=1 npx skills add vercel-labs/agent-skills --list
 ```
+
+## Extending
+
+`skills` accepts third-party `HostProvider` plug-ins, letting a package claim
+a URL scheme before the built-in GitHub / GitLab / well-known matchers run.
+This lets private registries (enterprise, internal, paid) integrate without
+forking the CLI. See [`src/providers/types.ts`](src/providers/types.ts) for
+the full interface.
+
+A minimal provider:
+
+```ts
+// my-provider/index.ts
+import { registerProvider } from 'skills';
+
+registerProvider({
+  id: 'my-registry',
+  displayName: 'My Registry',
+  match(url) {
+    return { matches: /^@my-org\//.test(url) };
+  },
+  async fetchSkill(url) {
+    const res = await fetch(`https://my-registry/skills/${url.slice(1)}`);
+    if (!res.ok) return null;
+    return {
+      name: url,
+      description: '',
+      content: await res.text(),
+      installName: url.split('/')[1]!,
+      sourceUrl: url,
+    };
+  },
+  toRawUrl(url) {
+    return url;
+  },
+  getSourceIdentifier(url) {
+    return url;
+  },
+});
+```
+
+Consumers install it and pass `--provider <module>` (or set
+`SKILLS_PROVIDERS=<module>`) when invoking any `skills` command:
+
+```bash
+npm install --save-dev my-provider
+npx skills --provider my-provider add @my-org/my-skill
+# or
+SKILLS_PROVIDERS=my-provider npx skills add @my-org/my-skill
+```
+
+Both flags are repeatable (`--provider a --provider b`) and the env var is
+comma-separated. Import failures are reported on stderr but do not abort
+the CLI — the built-in matchers still work.
+
+For a complete, production-style provider implementation see
+[`src/providers/wellknown.ts`](src/providers/wellknown.ts) (the RFC 8615
+`/.well-known/agent-skills/index.json` provider).
 
 ## Telemetry
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "skills": "./bin/cli.mjs",
     "add-skill": "./bin/cli.mjs"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
   "files": [
     "dist",
     "bin",

--- a/src/add.ts
+++ b/src/add.ts
@@ -45,7 +45,7 @@ import {
   type AuditResponse,
   type PartnerAudit,
 } from './telemetry.ts';
-import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
+import { findProvider, wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
   fetchSkillFolderHash,
@@ -431,6 +431,80 @@ export interface AddOptions {
  * Discovers skills from /.well-known/agent-skills/index.json (preferred)
  * or /.well-known/skills/index.json (legacy fallback).
  */
+/**
+ * Install via an external HostProvider (see `registerProvider()`).
+ * This is the fast path used by third-party providers such as private
+ * registries. It bypasses the GitHub blob / git clone / well-known
+ * fallback chain in favor of a single `provider.fetchSkill()` call,
+ * then hands off to the standard `installRemoteSkillForAgent()` installer.
+ */
+async function handleProviderInstall(
+  parsed: import('./types.ts').ParsedSource,
+  options: AddOptions,
+  spinner: ReturnType<typeof p.spinner>
+): Promise<void> {
+  const provider = findProvider(parsed.url);
+  if (!provider) {
+    spinner.stop(pc.red('provider not found'));
+    p.outro(pc.red(`No provider registered that matches: ${parsed.url}`));
+    process.exit(1);
+  }
+  spinner.start(`Fetching via ${provider.displayName}…`);
+  const remote = await provider.fetchSkill(parsed.url);
+  if (!remote) {
+    // Provider should have already printed a user-visible reason
+    // (auth / policy / cancel / 404).
+    spinner.stop(pc.red('fetch failed'));
+    process.exit(1);
+  }
+  spinner.stop(`fetched ${pc.cyan(remote.installName)}`);
+
+  // Shape the provider's RemoteSkill into the installer's local one
+  // (adds providerId + sourceIdentifier for telemetry / lockfile).
+  const skill: import('./types.ts').RemoteSkill = {
+    name: remote.name,
+    description: remote.description,
+    content: remote.content,
+    installName: remote.installName,
+    sourceUrl: remote.sourceUrl,
+    providerId: provider.id,
+    sourceIdentifier: parsed.sourceIdentifier ?? provider.getSourceIdentifier(parsed.url),
+    metadata: remote.metadata,
+  };
+
+  // Agent selection: use --agent if given, else detect installed agents,
+  // else default to claude-code. Keep this minimal; richer interactive
+  // selection lives in the well-known and blob flows.
+  const requested = (options.agent ?? []).filter(Boolean) as AgentType[];
+  const detected = requested.length > 0 ? requested : await detectInstalledAgents();
+  const targets: AgentType[] = detected.length > 0 ? detected : ['claude-code'];
+
+  const { installRemoteSkillForAgent } = await import('./installer.ts');
+  for (const agent of targets) {
+    const res = await installRemoteSkillForAgent(skill, agent, {
+      global: options.global ?? false,
+      mode: options.copy ? 'copy' : 'symlink',
+    });
+    if (res.success) {
+      p.log.success(`installed ${pc.cyan(skill.installName)} → ${pc.dim(res.path)} (${agent})`);
+    } else {
+      p.log.error(`install failed for ${agent}: ${res.error ?? 'unknown'}`);
+    }
+  }
+
+  // Telemetry (fire-and-forget).
+  try {
+    track({
+      event: 'skill_install',
+      source: skill.sourceIdentifier,
+      sourceType: 'provider',
+      provider: provider.id,
+    });
+  } catch {
+    /* telemetry best-effort */
+  }
+}
+
 async function handleWellKnownSkills(
   source: string,
   url: string,
@@ -965,6 +1039,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Handle well-known skills from arbitrary URLs
     if (parsed.type === 'well-known') {
       await handleWellKnownSkills(source, parsed.url, options, spinner);
+      return;
+    }
+
+    // Handle external HostProvider (private registries, etc.).
+    if (parsed.type === 'provider' && parsed.providerId) {
+      await handleProviderInstall(parsed, options, spinner);
       return;
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -837,8 +837,41 @@ async function runUpdate(args: string[] = []): Promise<void> {
 // Main
 // ============================================
 
+/**
+ * Dynamically import external provider modules so they can call
+ * `registerProvider()` at import time. Providers are specified via
+ * repeatable `--provider <module>` flags and/or the `SKILLS_PROVIDERS`
+ * env var (comma-separated). Failures are warned, not fatal — the rest
+ * of the CLI still works (GitHub, well-known, etc.).
+ *
+ * Returns argv stripped of the consumed flags.
+ */
+async function loadExternalProviders(argv: string[]): Promise<string[]> {
+  const out: string[] = [];
+  const modules: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if ((argv[i] === '--provider' || argv[i] === '-P') && argv[i + 1]) {
+      modules.push(argv[++i]!);
+    } else {
+      out.push(argv[i]!);
+    }
+  }
+  const envMods = (process.env.SKILLS_PROVIDERS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  for (const mod of [...envMods, ...modules]) {
+    try {
+      await import(mod);
+    } catch (err) {
+      process.stderr.write(`[skills] failed to load provider ${mod}: ${(err as Error).message}\n`);
+    }
+  }
+  return out;
+}
+
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
+  const args = await loadExternalProviders(process.argv.slice(2));
 
   if (args.length === 0) {
     showBanner();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,23 @@
+// Public library entry for the `skills` package.
+//
+// This lets third-party providers (e.g. private registries) register
+// themselves against upstream's `ProviderRegistry` without forking. Users
+// load the provider module via `--provider <module>` on the CLI, the
+// `SKILLS_PROVIDERS=mod-a,mod-b` env var, or by importing `skills` directly
+// from their own Node program.
+//
+// Example third-party usage:
+//   // my-provider/index.ts
+//   import { registerProvider } from 'skills';
+//   registerProvider({
+//     id: 'my-registry',
+//     displayName: 'My Registry',
+//     match(url) { … },
+//     async fetchSkill(url) { … },
+//     toRawUrl(url) { return url },
+//     getSourceIdentifier(url) { … },
+//   });
+//
+// Then:
+//   $ skills --provider my-provider add @my-org/my-skill
+export * from './providers/index.ts';

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, resolve } from 'path';
+import { findProvider } from './providers/index.ts';
 import type { ParsedSource } from './types.ts';
 
 /**
@@ -226,6 +227,21 @@ export function parseSource(input: string): ParsedSource {
       type: 'local',
       url: resolvedPath, // Store resolved path in url for consistency
       localPath: resolvedPath,
+    };
+  }
+
+  // Third-party provider hook: consult registered HostProviders *before*
+  // any of the built-in GitHub/GitLab/well-known matchers. This lets
+  // external packages claim identifiers like `@owner/name` or
+  // `my-registry://…` without forking the CLI.
+  const providerMatch = findProvider(input);
+  if (providerMatch) {
+    const match = providerMatch.match(input);
+    return {
+      type: 'provider',
+      url: input,
+      providerId: providerMatch.id,
+      ...(match.sourceIdentifier ? { sourceIdentifier: match.sourceIdentifier } : {}),
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,13 +68,17 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known';
+  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known' | 'provider';
   url: string;
   subpath?: string;
   localPath?: string;
   ref?: string;
   /** Skill name extracted from @skill syntax (e.g., owner/repo@skill-name) */
   skillFilter?: string;
+  /** For type=provider: the registered HostProvider id that matched. */
+  providerId?: string;
+  /** For type=provider: provider-reported source identifier (for telemetry). */
+  sourceIdentifier?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Exposes the already-present `ProviderRegistry` (in `src/providers/registry.ts`) as a first-class extension point so private registries, enterprise setups, and other third-party hosts can plug in **without forking the CLI**.

The plumbing already exists internally — `registerProvider()`, `findProvider()`, `getProviders()` — but three small gaps keep it inaccessible from outside:

1. No `exports` field in `package.json`, so consumers can't `import { registerProvider } from 'skills'`.
2. `parseSource()` goes straight to the built-in GitHub/GitLab/well-known matchers and never consults the registry, so a provider that registers itself at runtime never gets a chance to claim a URL.
3. The CLI binary has no load-order hook where a provider package could register itself before command dispatch.

This PR closes all three gaps **without changing behavior for any existing source format**.

## Changes

- **`package.json`** — adds `exports` pointing at `dist/index.{mjs,d.mts}`.
- **`src/index.ts`** (new) — library entry re-exporting `src/providers/index.ts` (types + `registerProvider` + `findProvider` + `getProviders`).
- **`src/cli.ts`** — `loadExternalProviders(argv)` runs before command dispatch. Accepts repeatable `--provider <module>` (short `-P`) and the `SKILLS_PROVIDERS` env var (comma-separated), dynamic-imports each. Import failures are warned on stderr and do not abort the CLI.
- **`src/types.ts`** — extends `ParsedSource.type` with a `provider` variant and adds `providerId` / `sourceIdentifier` fields.
- **`src/source-parser.ts`** — at the top of `parseSource()`, right after the local-path short-circuit, consults `findProvider(input)`. If a registered provider matches, returns the `provider` variant. All existing matchers (GitHub shorthand, GitLab, well-known, raw git) remain unchanged and run afterwards as before.
- **`src/add.ts`** — `handleProviderInstall()` fast path mirroring `handleWellKnownSkills()`: calls `provider.fetchSkill(url)`, shapes the result into the installer's `RemoteSkill`, hands off to `installRemoteSkillForAgent()` for each detected/selected agent, and records a `sourceType: 'provider'` telemetry event.

Total: **6 files, ~160 lines added**.

## Third-party usage

```ts
// my-provider/index.ts
import { registerProvider } from 'skills';

registerProvider({
  id: 'my-registry',
  displayName: 'My Registry',
  match(url) { /* decide if URL is ours */ },
  async fetchSkill(url) { /* return RemoteSkill */ },
  toRawUrl(url) { return url; },
  getSourceIdentifier(url) { /* for telemetry */ },
});
```

```sh
$ skills --provider my-provider add @my-org/my-skill
$ SKILLS_PROVIDERS=my-provider skills add @my-org/my-skill
```

## Motivation

Today anyone pointing `skills` at a private registry has to hard-fork the CLI — even though the registry pattern already exists internally. This turns the existing internal seam into a supported public one.

Concrete example: I'm building a self-hosted enterprise skills registry (auth, approval workflow, scanners) and the only thing forcing me to maintain a fork is the lack of these three hooks. With this PR, all the enterprise-specific code moves into a sibling npm package (`@hiddenlayer/skills-provider` in our case) that depends on `skills` as a regular dependency.

## Test plan

Existing test suite is the test plan — the invariant is "no behavior change for existing sources." Verified locally with upstream toolchain:

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm build` (obuild, 13 files, 375kB)
- [x] `pnpm format:check`
- [x] `pnpm test` — **26 files, 402 tests, all passing**
- [x] `pnpm type-check`

Manual smoke-test with a toy provider: `skills add @demo/skill` dispatches to the provider, `skills add vercel-labs/agent-skills` still goes through the GitHub blob path unchanged, `skills add https://example.com` still tries the well-known endpoint.

## Notes for reviewers

- The `--provider` flag is consumed before the command dispatcher sees argv, so it composes with every subcommand (add, find, list, etc.). Currently only `add` has a provider-aware path; richer integration (provider-driven `find` search, `update` via provider) would be follow-up PRs.
- The provider variant in `ParsedSource` is intentionally narrow — just the minimum for dispatch. If you'd rather keep `ParsedSource` closed and carry the provider id on the side, happy to refactor.
- If you want this patch split further (e.g. ship `exports` + `src/index.ts` as one PR first, then the `--provider` plumbing as a second), say the word and I'll split.
