### PR TITLE
feat: agent-interactive mode for prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@clack/prompts": "^0.11.0",
+    "@clack/prompts": "npm:@posva/clack-prompts@^1.2.2",
     "@types/bun": "latest",
     "@types/node": "^22.10.0",
     "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 2.8.3
     devDependencies:
       '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
+        specifier: npm:@posva/clack-prompts@^1.2.2
+        version: '@posva/clack-prompts@1.2.2'
       '@types/bun':
         specifier: latest
         version: 1.3.6
@@ -71,12 +71,6 @@ packages:
   '@babel/types@8.0.0-beta.4':
     resolution: {integrity: sha512-xjk2xqYp25ePzAs0I08hN2lrbUDDQFfCjwq6MIEa8HwHa0WK8NfNtdvtXod8Ku2CbE1iui7qwWojGvjQiyrQeA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@clack/core@0.5.0':
-    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
-
-  '@clack/prompts@0.11.0':
-    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -267,6 +261,12 @@ packages:
 
   '@oxc-project/types@0.110.0':
     resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
+
+  '@posva/clack-core@1.2.1':
+    resolution: {integrity: sha512-+qV0OTeTsiuns+7J0IUW5wdt26ahdUaiNphvndQGGK7XoWkAlAexHamZNj0ZyMKbkAQfWSwon9phbSuHNmhoWg==}
+
+  '@posva/clack-prompts@1.2.2':
+    resolution: {integrity: sha512-szxQoBTuDvhQxT6QIdnng3OHcUeAL+IVmKlttOkZR2gykokSaaEgvP97l2An+er+646F9Irv/bHbO3xHcLin0Q==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.1':
     resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
@@ -656,6 +656,15 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -876,6 +885,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -1043,17 +1055,6 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-beta.4
       '@babel/helper-validator-identifier': 8.0.0-beta.4
 
-  '@clack/core@0.5.0':
-    dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@0.11.0':
-    dependencies:
-      '@clack/core': 0.5.0
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -1178,6 +1179,19 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.110.0': {}
+
+  '@posva/clack-core@1.2.1':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+      std-env: 4.1.0
+
+  '@posva/clack-prompts@1.2.2':
+    dependencies:
+      '@posva/clack-core': 1.2.1
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@rolldown/binding-android-arm64@1.0.0-rc.1':
     optional: true
@@ -1489,6 +1503,16 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -1741,6 +1765,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   string-argv@0.3.2: {}
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -283,6 +283,7 @@ function buildResultLines(
  * Accepts options with required labels (matching our usage pattern).
  */
 function multiselect<Value>(opts: {
+  id?: string;
   message: string;
   options: Array<{ value: Value; label: string; hint?: string }>;
   initialValues?: Value[];
@@ -332,6 +333,7 @@ export async function promptForAgents(
   }
 
   const selected = await searchMultiselect({
+    id: 'agents-select',
     message,
     items: choices,
     initialSelected: initialValues,
@@ -394,6 +396,7 @@ async function selectAgentsInteractive(options: {
     : [];
 
   const selected = await searchMultiselect({
+    id: 'agents-select',
     message: 'Which agents do you want to install to?',
     items: otherChoices,
     initialSelected,
@@ -512,13 +515,17 @@ async function handleWellKnownSkills(
     p.log.info(`Installing all ${skills.length} skills`);
   } else {
     // Prompt user to select skills
+    // Use installName as value (lightweight string) so the agent-mode session
+    // file doesn't balloon with the full skill object (rawContent, metadata, …).
+    const skillByName = new Map(skills.map((s) => [s.installName, s]));
     const skillChoices = skills.map((s) => ({
-      value: s,
+      value: s.installName,
       label: s.installName,
       hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
     }));
 
     const selected = await multiselect({
+      id: 'select-skills',
       message: 'Select skills to install',
       options: skillChoices,
       required: true,
@@ -529,7 +536,7 @@ async function handleWellKnownSkills(
       process.exit(0);
     }
 
-    selectedSkills = selected as WellKnownSkill[];
+    selectedSkills = (selected as string[]).map((name) => skillByName.get(name)!);
   }
 
   // Detect agents
@@ -611,6 +618,7 @@ async function handleWellKnownSkills(
 
   if (options.global === undefined && !options.yes && supportsGlobal) {
     const scope = await p.select({
+      id: 'install-scope',
       message: 'Installation scope',
       options: [
         {
@@ -643,6 +651,7 @@ async function handleWellKnownSkills(
 
   if (!options.copy && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
+      id: 'install-mode',
       message: 'Installation method',
       options: [
         {
@@ -714,7 +723,10 @@ async function handleWellKnownSkills(
   p.note(summaryLines.join('\n'), 'Installation Summary');
 
   if (!options.yes) {
-    const confirmed = await p.confirm({ message: 'Proceed with installation?' });
+    const confirmed = await p.confirm({
+      id: 'confirm-install',
+      message: 'Proceed with installation?',
+    });
 
     if (p.isCancel(confirmed) || !confirmed) {
       p.cancel('Installation cancelled');
@@ -724,7 +736,7 @@ async function handleWellKnownSkills(
 
   spinner.start('Installing skills...');
 
-  const results: {
+  type InstallResult = {
     skill: string;
     agent: string;
     success: boolean;
@@ -733,21 +745,25 @@ async function handleWellKnownSkills(
     mode: InstallMode;
     symlinkFailed?: boolean;
     error?: string;
-  }[] = [];
+  };
 
-  for (const skill of selectedSkills) {
-    for (const agent of targetAgents) {
-      const result = await installWellKnownSkillForAgent(skill, agent, {
-        global: installGlobally,
-        mode: installMode,
-      });
-      results.push({
-        skill: skill.installName,
-        agent: agents[agent].displayName,
-        ...result,
-      });
+  const results = await p.once('install-results', async () => {
+    const acc: InstallResult[] = [];
+    for (const skill of selectedSkills) {
+      for (const agent of targetAgents) {
+        const result = await installWellKnownSkillForAgent(skill, agent, {
+          global: installGlobally,
+          mode: installMode,
+        });
+        acc.push({
+          skill: skill.installName,
+          agent: agents[agent].displayName,
+          ...result,
+        });
+      }
     }
-  }
+    return acc;
+  });
 
   spinner.stop('Installation complete');
 
@@ -779,51 +795,54 @@ async function handleWellKnownSkills(
     });
   }
 
-  // Add to skill lock file for update tracking (only for global installs)
-  if (successful.length > 0 && installGlobally) {
-    const successfulSkillNames = new Set(successful.map((r) => r.skill));
-    for (const skill of selectedSkills) {
-      if (successfulSkillNames.has(skill.installName)) {
-        try {
-          await addSkillToLock(skill.installName, {
-            source: sourceIdentifier,
-            sourceType: 'well-known',
-            sourceUrl: skill.sourceUrl,
-            skillFolderHash: '', // Well-known skills don't have a folder hash
-          });
-        } catch {
-          // Don't fail installation if lock file update fails
-        }
-      }
-    }
-  }
-
-  // Add to local lock file for project-scoped installs
-  if (successful.length > 0 && !installGlobally) {
-    const successfulSkillNames = new Set(successful.map((r) => r.skill));
-    for (const skill of selectedSkills) {
-      if (successfulSkillNames.has(skill.installName)) {
-        try {
-          const matchingResult = successful.find((r) => r.skill === skill.installName);
-          const installDir = matchingResult?.canonicalPath || matchingResult?.path;
-          if (installDir) {
-            const computedHash = await computeSkillFolderHash(installDir);
-            await addSkillToLocalLock(
-              skill.installName,
-              {
-                source: sourceIdentifier,
-                sourceType: 'well-known',
-                computedHash,
-              },
-              cwd
-            );
+  await p.once('install-lockfile', async () => {
+    // Add to skill lock file for update tracking (only for global installs)
+    if (successful.length > 0 && installGlobally) {
+      const successfulSkillNames = new Set(successful.map((r) => r.skill));
+      for (const skill of selectedSkills) {
+        if (successfulSkillNames.has(skill.installName)) {
+          try {
+            await addSkillToLock(skill.installName, {
+              source: sourceIdentifier,
+              sourceType: 'well-known',
+              sourceUrl: skill.sourceUrl,
+              skillFolderHash: '', // Well-known skills don't have a folder hash
+            });
+          } catch {
+            // Don't fail installation if lock file update fails
           }
-        } catch {
-          // Don't fail installation if lock file update fails
         }
       }
     }
-  }
+
+    // Add to local lock file for project-scoped installs
+    if (successful.length > 0 && !installGlobally) {
+      const successfulSkillNames = new Set(successful.map((r) => r.skill));
+      for (const skill of selectedSkills) {
+        if (successfulSkillNames.has(skill.installName)) {
+          try {
+            const matchingResult = successful.find((r) => r.skill === skill.installName);
+            const installDir = matchingResult?.canonicalPath || matchingResult?.path;
+            if (installDir) {
+              const computedHash = await computeSkillFolderHash(installDir);
+              await addSkillToLocalLock(
+                skill.installName,
+                {
+                  source: sourceIdentifier,
+                  sourceType: 'well-known',
+                  computedHash,
+                },
+                cwd
+              );
+            }
+          } catch {
+            // Don't fail installation if lock file update fails
+          }
+        }
+      }
+    }
+    return true;
+  });
 
   if (successful.length > 0) {
     const bySkill = new Map<string, typeof results>();
@@ -928,7 +947,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   console.log();
   p.intro(pc.bgCyan(pc.black(' skills ')));
 
-  if (!process.stdin.isTTY) {
+  if (!process.stdin.isTTY && !p.isAgent()) {
     showInstallTip();
   }
 
@@ -1027,7 +1046,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       } else {
         // Blob failed — fall back to git clone
         spinner.start('Cloning repository...');
-        tempDir = await cloneRepo(parsed.url, parsed.ref);
+        tempDir = await p.once('clone', () => cloneRepo(parsed.url, parsed.ref));
         spinner.stop('Repository cloned');
 
         spinner.start('Discovering skills...');
@@ -1156,7 +1175,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Check if any skills have plugin grouping
       const hasGroups = sortedSkills.some((s) => s.pluginName);
 
-      let selected: Skill[] | symbol;
+      // Use a short string key as the option value so the agent-mode session
+      // file doesn't serialize full Skill objects (rawContent, metadata, …).
+      const skillKey = (s: Skill): string =>
+        s.pluginName ? `${s.pluginName}/${getSkillDisplayName(s)}` : getSkillDisplayName(s);
+      const skillByKey = new Map(sortedSkills.map((s) => [skillKey(s), s]));
+
+      let selected: string[] | symbol;
 
       if (hasGroups) {
         // Build grouped options for groupMultiselect
@@ -1166,30 +1191,32 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
             .join(' ');
 
-        const grouped: Record<string, p.Option<Skill>[]> = {};
+        const grouped: Record<string, p.Option<string>[]> = {};
         for (const s of sortedSkills) {
           const groupName = s.pluginName ? kebabToTitle(s.pluginName) : 'Other';
           if (!grouped[groupName]) grouped[groupName] = [];
           grouped[groupName]!.push({
-            value: s,
+            value: skillKey(s),
             label: getSkillDisplayName(s),
             hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
           });
         }
 
         selected = await p.groupMultiselect({
+          id: 'select-skills',
           message: `Select skills to install ${pc.dim('(space to toggle)')}`,
           options: grouped,
           required: true,
         });
       } else {
         const skillChoices = sortedSkills.map((s) => ({
-          value: s,
+          value: skillKey(s),
           label: getSkillDisplayName(s),
           hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
         }));
 
         selected = await multiselect({
+          id: 'select-skills',
           message: 'Select skills to install',
           options: skillChoices,
           required: true,
@@ -1202,7 +1229,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         process.exit(0);
       }
 
-      selectedSkills = selected as Skill[];
+      selectedSkills = (selected as string[]).map((key) => skillByKey.get(key)!);
     }
 
     // Kick off security audit fetch early (non-blocking) so it runs
@@ -1296,6 +1323,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     if (options.global === undefined && !options.yes && supportsGlobal) {
       const scope = await p.select({
+        id: 'install-scope',
         message: 'Installation scope',
         options: [
           {
@@ -1329,6 +1357,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     if (!options.copy && !options.yes && uniqueDirs.size > 1) {
       const modeChoice = await p.select({
+        id: 'install-mode',
         message: 'Installation method',
         options: [
           {
@@ -1458,7 +1487,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     if (!options.yes) {
-      const confirmed = await p.confirm({ message: 'Proceed with installation?' });
+      const confirmed = await p.confirm({
+        id: 'confirm-install',
+        message: 'Proceed with installation?',
+      });
 
       if (p.isCancel(confirmed) || !confirmed) {
         p.cancel('Installation cancelled');
@@ -1469,7 +1501,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     spinner.start('Installing skills...');
 
-    const results: {
+    type InstallResult = {
       skill: string;
       agent: string;
       success: boolean;
@@ -1479,34 +1511,38 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       symlinkFailed?: boolean;
       error?: string;
       pluginName?: string;
-    }[] = [];
+    };
 
-    for (const skill of selectedSkills) {
-      for (const agent of targetAgents) {
-        let result;
-        if (blobResult && 'files' in skill) {
-          // Blob-based install: write files from snapshot
-          const blobSkill = skill as BlobSkill;
-          result = await installBlobSkillForAgent(
-            { installName: blobSkill.name, files: blobSkill.files },
-            agent,
-            { global: installGlobally, mode: installMode }
-          );
-        } else {
-          // Disk-based install: copy from cloned/local directory
-          result = await installSkillForAgent(skill, agent, {
-            global: installGlobally,
-            mode: installMode,
+    const results = await p.once('install-results', async () => {
+      const acc: InstallResult[] = [];
+      for (const skill of selectedSkills) {
+        for (const agent of targetAgents) {
+          let result;
+          if (blobResult && 'files' in skill) {
+            // Blob-based install: write files from snapshot
+            const blobSkill = skill as BlobSkill;
+            result = await installBlobSkillForAgent(
+              { installName: blobSkill.name, files: blobSkill.files },
+              agent,
+              { global: installGlobally, mode: installMode }
+            );
+          } else {
+            // Disk-based install: copy from cloned/local directory
+            result = await installSkillForAgent(skill, agent, {
+              global: installGlobally,
+              mode: installMode,
+            });
+          }
+          acc.push({
+            skill: getSkillDisplayName(skill),
+            agent: agents[agent].displayName,
+            pluginName: skill.pluginName,
+            ...result,
           });
         }
-        results.push({
-          skill: getSkillDisplayName(skill),
-          agent: agents[agent].displayName,
-          pluginName: skill.pluginName,
-          ...result,
-        });
       }
-    }
+      return acc;
+    });
 
     spinner.stop('Installation complete');
 
@@ -1578,76 +1614,79 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Add to skill lock file for update tracking (only for global installs)
-    if (successful.length > 0 && installGlobally && normalizedSource) {
-      const successfulSkillNames = new Set(successful.map((r) => r.skill));
-      for (const skill of selectedSkills) {
-        const skillDisplayName = getSkillDisplayName(skill);
-        if (successfulSkillNames.has(skillDisplayName)) {
-          try {
-            let skillFolderHash = '';
-            const skillPathValue = skillFiles[skill.name];
+    await p.once('install-lockfile', async () => {
+      // Add to skill lock file for update tracking (only for global installs)
+      if (successful.length > 0 && installGlobally && normalizedSource) {
+        const successfulSkillNames = new Set(successful.map((r) => r.skill));
+        for (const skill of selectedSkills) {
+          const skillDisplayName = getSkillDisplayName(skill);
+          if (successfulSkillNames.has(skillDisplayName)) {
+            try {
+              let skillFolderHash = '';
+              const skillPathValue = skillFiles[skill.name];
 
-            if (blobResult && skillPathValue) {
-              // Blob path: extract hash from the tree we already fetched (no extra API call)
-              const hash = getSkillFolderHashFromTree(blobResult.tree, skillPathValue);
-              if (hash) skillFolderHash = hash;
-            } else if (parsed.type === 'github' && skillPathValue) {
-              // Clone path: fetch folder hash from GitHub Trees API
-              const token = getGitHubToken();
-              const hash = await fetchSkillFolderHash(
-                normalizedSource,
-                skillPathValue,
-                token,
-                parsed.ref
-              );
-              if (hash) skillFolderHash = hash;
-            }
+              if (blobResult && skillPathValue) {
+                // Blob path: extract hash from the tree we already fetched (no extra API call)
+                const hash = getSkillFolderHashFromTree(blobResult.tree, skillPathValue);
+                if (hash) skillFolderHash = hash;
+              } else if (parsed.type === 'github' && skillPathValue) {
+                // Clone path: fetch folder hash from GitHub Trees API
+                const token = getGitHubToken();
+                const hash = await fetchSkillFolderHash(
+                  normalizedSource,
+                  skillPathValue,
+                  token,
+                  parsed.ref
+                );
+                if (hash) skillFolderHash = hash;
+              }
 
-            await addSkillToLock(skill.name, {
-              source: lockSource || normalizedSource,
-              sourceType: parsed.type,
-              sourceUrl: parsed.url,
-              ref: parsed.ref,
-              skillPath: skillPathValue,
-              skillFolderHash,
-              pluginName: skill.pluginName,
-            });
-          } catch {
-            // Don't fail installation if lock file update fails
-          }
-        }
-      }
-    }
-
-    // Add to local lock file for project-scoped installs
-    if (successful.length > 0 && !installGlobally) {
-      const successfulSkillNames = new Set(successful.map((r) => r.skill));
-      for (const skill of selectedSkills) {
-        const skillDisplayName = getSkillDisplayName(skill);
-        if (successfulSkillNames.has(skillDisplayName)) {
-          try {
-            // For blob skills, use the snapshot hash; for disk skills, compute from files
-            const computedHash =
-              blobResult && 'snapshotHash' in skill
-                ? (skill as BlobSkill).snapshotHash
-                : await computeSkillFolderHash(skill.path);
-            await addSkillToLocalLock(
-              skill.name,
-              {
-                source: lockSource || parsed.url,
-                ref: parsed.ref,
+              await addSkillToLock(skill.name, {
+                source: lockSource || normalizedSource,
                 sourceType: parsed.type,
-                computedHash,
-              },
-              cwd
-            );
-          } catch {
-            // Don't fail installation if lock file update fails
+                sourceUrl: parsed.url,
+                ref: parsed.ref,
+                skillPath: skillPathValue,
+                skillFolderHash,
+                pluginName: skill.pluginName,
+              });
+            } catch {
+              // Don't fail installation if lock file update fails
+            }
           }
         }
       }
-    }
+
+      // Add to local lock file for project-scoped installs
+      if (successful.length > 0 && !installGlobally) {
+        const successfulSkillNames = new Set(successful.map((r) => r.skill));
+        for (const skill of selectedSkills) {
+          const skillDisplayName = getSkillDisplayName(skill);
+          if (successfulSkillNames.has(skillDisplayName)) {
+            try {
+              // For blob skills, use the snapshot hash; for disk skills, compute from files
+              const computedHash =
+                blobResult && 'snapshotHash' in skill
+                  ? (skill as BlobSkill).snapshotHash
+                  : await computeSkillFolderHash(skill.path);
+              await addSkillToLocalLock(
+                skill.name,
+                {
+                  source: lockSource || parsed.url,
+                  ref: parsed.ref,
+                  sourceType: parsed.type,
+                  computedHash,
+                },
+                cwd
+              );
+            } catch {
+              // Don't fail installation if lock file update fails
+            }
+          }
+        }
+      }
+      return true;
+    });
 
     if (successful.length > 0) {
       const bySkill = new Map<string, typeof results>();
@@ -1793,7 +1832,7 @@ async function promptForFindSkills(
   targetAgents?: AgentType[]
 ): Promise<void> {
   // Skip if already dismissed or not in interactive mode
-  if (!process.stdin.isTTY) return;
+  if (!process.stdin.isTTY && !p.isAgent()) return;
   if (options?.yes) return;
 
   try {
@@ -1813,6 +1852,7 @@ async function promptForFindSkills(
     console.log();
     p.log.message(pc.dim("One-time prompt - you won't be asked again if you dismiss."));
     const install = await p.confirm({
+      id: 'install-find-skills',
       message: `Install the ${pc.cyan('find-skills')} skill? It helps your agent discover and suggest skills.`,
     });
 
@@ -1837,12 +1877,14 @@ async function promptForFindSkills(
       p.log.step('Installing find-skills skill...');
 
       try {
-        // Call runAdd directly
-        await runAdd(['vercel-labs/skills'], {
-          skill: ['find-skills'],
-          global: true,
-          yes: true,
-          agent: findSkillsAgents,
+        await p.once('install-find-skills-run', async () => {
+          await runAdd(['vercel-labs/skills'], {
+            skill: ['find-skills'],
+            global: true,
+            yes: true,
+            agent: findSkillsAgents,
+          });
+          return true;
         });
       } catch {
         p.log.warn('Failed to install find-skills. You can try again with:');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -437,12 +437,13 @@ async function resolveUpdateScope(options: UpdateCheckOptions): Promise<UpdateSc
   }
 
   // Non-interactive auto-detection
-  if (options.yes || !process.stdin.isTTY) {
+  if (options.yes || (!process.stdin.isTTY && !p.isAgent())) {
     return hasProjectSkills() ? 'project' : 'global';
   }
 
   // Interactive prompt
   const scope = await p.select({
+    id: 'update-scope',
     message: 'Update scope',
     options: [
       {

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -1,6 +1,7 @@
 import * as readline from 'readline';
 import { Writable } from 'stream';
 import pc from 'picocolors';
+import * as p from '@clack/prompts';
 
 // Silent writable stream to prevent readline from echoing input
 const silentOutput = new Writable({
@@ -21,6 +22,8 @@ export interface LockedSection<T> {
 }
 
 export interface SearchMultiselectOptions<T> {
+  /** Stable id used in agent mode (delegates to clack's multiselect). */
+  id?: string;
   message: string;
   items: SearchItem<T>[];
   maxVisible?: number;
@@ -59,6 +62,31 @@ export async function searchMultiselect<T>(
     required = false,
     lockedSection,
   } = options;
+
+  // Agent mode: the raw-readline loop below never gets keypresses, so hand off
+  // to clack's multiselect (which speaks the JSON + session-file protocol).
+  // Locked items are always included; we only ask about the non-locked ones.
+  if (p.isAgent()) {
+    const lockedValues = lockedSection ? lockedSection.items.map((i) => i.value) : [];
+    const askItems = items.filter((i) => !lockedValues.includes(i.value));
+    const initialValues = initialSelected.filter((v) => !lockedValues.includes(v));
+
+    if (askItems.length === 0) return lockedValues;
+
+    const result = await p.multiselect({
+      id: options.id,
+      message,
+      options: askItems.map((i) => ({
+        value: i.value,
+        label: i.label,
+        hint: i.hint,
+      })) as p.Option<T>[],
+      initialValues,
+      required: required && lockedValues.length === 0,
+    });
+    if (p.isCancel(result)) return result;
+    return [...lockedValues, ...(result as T[])];
+  }
 
   return new Promise((resolve) => {
     const rl = readline.createInterface({

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -98,6 +98,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }));
 
     const selected = await p.multiselect({
+      id: 'select-skills-remove',
       message: `Select skills to remove ${pc.dim('(space to toggle)')}`,
       options: choices,
       required: true,
@@ -130,6 +131,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     console.log();
 
     const confirmed = await p.confirm({
+      id: 'confirm-remove',
       message: `Are you sure you want to uninstall ${selectedSkills.length} skill(s)?`,
     });
 
@@ -141,95 +143,99 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
   spinner.start('Removing skills...');
 
-  const results: {
+  type RemoveResult = {
     skill: string;
     success: boolean;
     source?: string;
     sourceType?: string;
     error?: string;
-  }[] = [];
+  };
 
-  for (const skillName of selectedSkills) {
-    try {
-      const canonicalPath = getCanonicalPath(skillName, { global: isGlobal, cwd });
+  const results = await p.once('remove-results', async () => {
+    const acc: RemoveResult[] = [];
+    for (const skillName of selectedSkills) {
+      try {
+        const canonicalPath = getCanonicalPath(skillName, { global: isGlobal, cwd });
 
-      for (const agentKey of targetAgents) {
-        const agent = agents[agentKey];
-        const skillPath = getInstallPath(skillName, agentKey, { global: isGlobal, cwd });
+        for (const agentKey of targetAgents) {
+          const agent = agents[agentKey];
+          const skillPath = getInstallPath(skillName, agentKey, { global: isGlobal, cwd });
 
-        // Determine potential paths to cleanup. For universal agents, getInstallPath
-        // now returns the canonical path, so we also need to check their 'native'
-        // directory to clean up any legacy symlinks.
-        const pathsToCleanup = new Set([skillPath]);
-        const sanitizedName = sanitizeName(skillName);
-        if (isGlobal && agent.globalSkillsDir) {
-          pathsToCleanup.add(join(agent.globalSkillsDir, sanitizedName));
-        } else {
-          pathsToCleanup.add(join(cwd, agent.skillsDir, sanitizedName));
-        }
-
-        for (const pathToCleanup of pathsToCleanup) {
-          // Skip if this is the canonical path - we'll handle that after checking all agents
-          if (pathToCleanup === canonicalPath) {
-            continue;
+          // Determine potential paths to cleanup. For universal agents, getInstallPath
+          // now returns the canonical path, so we also need to check their 'native'
+          // directory to clean up any legacy symlinks.
+          const pathsToCleanup = new Set([skillPath]);
+          const sanitizedName = sanitizeName(skillName);
+          if (isGlobal && agent.globalSkillsDir) {
+            pathsToCleanup.add(join(agent.globalSkillsDir, sanitizedName));
+          } else {
+            pathsToCleanup.add(join(cwd, agent.skillsDir, sanitizedName));
           }
 
-          try {
-            const stats = await lstat(pathToCleanup).catch(() => null);
-            if (stats) {
-              await rm(pathToCleanup, { recursive: true, force: true });
+          for (const pathToCleanup of pathsToCleanup) {
+            // Skip if this is the canonical path - we'll handle that after checking all agents
+            if (pathToCleanup === canonicalPath) {
+              continue;
             }
-          } catch (err) {
-            p.log.warn(
-              `Could not remove skill from ${agent.displayName}: ${
-                err instanceof Error ? err.message : String(err)
-              }`
-            );
+
+            try {
+              const stats = await lstat(pathToCleanup).catch(() => null);
+              if (stats) {
+                await rm(pathToCleanup, { recursive: true, force: true });
+              }
+            } catch (err) {
+              p.log.warn(
+                `Could not remove skill from ${agent.displayName}: ${
+                  err instanceof Error ? err.message : String(err)
+                }`
+              );
+            }
           }
         }
-      }
 
-      // Only remove the canonical path if no other installed agents are using it.
-      // This prevents breaking other agents when uninstalling from a specific agent (#287).
-      const installedAgents = await detectInstalledAgents();
-      const remainingAgents = installedAgents.filter((a) => !targetAgents.includes(a));
+        // Only remove the canonical path if no other installed agents are using it.
+        // This prevents breaking other agents when uninstalling from a specific agent (#287).
+        const installedAgents = await detectInstalledAgents();
+        const remainingAgents = installedAgents.filter((a) => !targetAgents.includes(a));
 
-      let isStillUsed = false;
-      for (const agentKey of remainingAgents) {
-        const path = getInstallPath(skillName, agentKey, { global: isGlobal, cwd });
-        const exists = await lstat(path).catch(() => null);
-        if (exists) {
-          isStillUsed = true;
-          break;
+        let isStillUsed = false;
+        for (const agentKey of remainingAgents) {
+          const path = getInstallPath(skillName, agentKey, { global: isGlobal, cwd });
+          const exists = await lstat(path).catch(() => null);
+          if (exists) {
+            isStillUsed = true;
+            break;
+          }
         }
+
+        if (!isStillUsed) {
+          await rm(canonicalPath, { recursive: true, force: true });
+        }
+
+        const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
+        const effectiveSource = lockEntry?.source || 'local';
+        const effectiveSourceType = lockEntry?.sourceType || 'local';
+
+        if (isGlobal) {
+          await removeSkillFromLock(skillName);
+        }
+
+        acc.push({
+          skill: skillName,
+          success: true,
+          source: effectiveSource,
+          sourceType: effectiveSourceType,
+        });
+      } catch (err) {
+        acc.push({
+          skill: skillName,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
-
-      if (!isStillUsed) {
-        await rm(canonicalPath, { recursive: true, force: true });
-      }
-
-      const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
-      const effectiveSource = lockEntry?.source || 'local';
-      const effectiveSourceType = lockEntry?.sourceType || 'local';
-
-      if (isGlobal) {
-        await removeSkillFromLock(skillName);
-      }
-
-      results.push({
-        skill: skillName,
-        success: true,
-        source: effectiveSource,
-        sourceType: effectiveSourceType,
-      });
-    } catch (err) {
-      results.push({
-        skill: skillName,
-        success: false,
-        error: err instanceof Error ? err.message : String(err),
-      });
     }
-  }
+    return acc;
+  });
 
   spinner.stop('Removal process complete');
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -232,6 +232,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         }));
 
         const selected = await searchMultiselect({
+          id: 'agents-select',
           message: 'Which agents do you want to install to?',
           items: otherChoices,
           initialSelected: [],
@@ -269,6 +270,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
       }));
 
       const selected = await searchMultiselect({
+        id: 'agents-select',
         message: 'Which agents do you want to install to?',
         items: otherChoices,
         initialSelected: installedAgents.filter((a) => !universalAgents.includes(a)),
@@ -303,7 +305,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   p.note(summaryLines.join('\n'), 'Sync Summary');
 
   if (!options.yes) {
-    const confirmed = await p.confirm({ message: 'Proceed with sync?' });
+    const confirmed = await p.confirm({ id: 'confirm-sync', message: 'Proceed with sync?' });
 
     if (p.isCancel(confirmed) || !confirmed) {
       p.cancel('Sync cancelled');
@@ -314,7 +316,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   // 5. Install skills (always project-scoped, always symlink)
   spinner.start('Syncing skills...');
 
-  const results: Array<{
+  type SyncResult = {
     skill: string;
     packageName: string;
     agent: string;
@@ -322,26 +324,30 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     path: string;
     canonicalPath?: string;
     error?: string;
-  }> = [];
+  };
 
-  for (const skill of toInstall) {
-    for (const agent of targetAgents) {
-      const result = await installSkillForAgent(skill, agent, {
-        global: false,
-        cwd,
-        mode: 'symlink',
-      });
-      results.push({
-        skill: skill.name,
-        packageName: skill.packageName,
-        agent: agents[agent].displayName,
-        success: result.success,
-        path: result.path,
-        canonicalPath: result.canonicalPath,
-        error: result.error,
-      });
+  const results = await p.once('sync-results', async () => {
+    const acc: SyncResult[] = [];
+    for (const skill of toInstall) {
+      for (const agent of targetAgents) {
+        const result = await installSkillForAgent(skill, agent, {
+          global: false,
+          cwd,
+          mode: 'symlink',
+        });
+        acc.push({
+          skill: skill.name,
+          packageName: skill.packageName,
+          agent: agents[agent].displayName,
+          success: result.success,
+          path: result.path,
+          canonicalPath: result.canonicalPath,
+          error: result.error,
+        });
+      }
     }
-  }
+    return acc;
+  });
 
   spinner.stop('Sync complete');
 
@@ -350,24 +356,27 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   const failed = results.filter((r) => !r.success);
   const successfulSkillNames = new Set(successful.map((r) => r.skill));
 
-  for (const skill of toInstall) {
-    if (successfulSkillNames.has(skill.name)) {
-      try {
-        const computedHash = await computeSkillFolderHash(skill.path);
-        await addSkillToLocalLock(
-          skill.name,
-          {
-            source: skill.packageName,
-            sourceType: 'node_modules',
-            computedHash,
-          },
-          cwd
-        );
-      } catch {
-        // Don't fail sync if lock file update fails
+  await p.once('sync-lockfile', async () => {
+    for (const skill of toInstall) {
+      if (successfulSkillNames.has(skill.name)) {
+        try {
+          const computedHash = await computeSkillFolderHash(skill.path);
+          await addSkillToLocalLock(
+            skill.name,
+            {
+              source: skill.packageName,
+              sourceType: 'node_modules',
+              computedHash,
+            },
+            cwd
+          );
+        } catch {
+          // Don't fail sync if lock file update fails
+        }
       }
     }
-  }
+    return true;
+  });
 
   // 7. Display results
   console.log();


### PR DESCRIPTION
Experiment: let agents drive interactive CLI prompts that can't be fully invoked through flags: agent picks the choices. **Draft because this is currently for demo purposes**

Upstream prompts fork: https://github.com/posva/clack/tree/feat/agent-mode

Tested locally (must be run after building skills) with:

```
Install globally skills that are useful for raw HTML dev and deploying to Vercel. Ignore any other skill. Directly use `./bin/cli.mjs add vercel-labs/agent-skills`, don't read local files, don't use `--help`
```

The `don't read local files` / `don't use --help` hints are there because Claude tends to sidestep the interactive flow when it can and files are local.