### PR TITLE
fix: skip license generation when no package.json in cwd

### DIFF
--- a/scripts/generate-licenses.ts
+++ b/scripts/generate-licenses.ts
@@ -41,6 +41,13 @@ function getLicenseText(pkgPath: string): string {
 function main() {
   console.log('Generating ThirdPartyNoticeText.txt...');
 
+  // Skip license generation if cwd has no package.json (e.g. when npx runs from /Users/foo with no project)
+  if (!existsSync(join(process.cwd(), 'package.json'))) {
+    console.log('No package.json in cwd — skipping license generation (npx run from non-project dir)');
+    writeFileSync('ThirdPartyNoticeText.txt', '/* No licenses generated — skipped */\n');
+    return;
+  }
+
   // Get license info from license-checker
   const output = execSync('npx license-checker --json', { encoding: 'utf-8' });
   const allLicenses: Record<string, LicenseInfo> = JSON.parse(output);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -748,7 +748,8 @@ async function updateProjectSkills(
     }
 
     // Re-clone without -g to install at project scope
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-y'], {
+    // Pass --skill to scope the install to just the requested skill (not the whole source repo)
+    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '--skill', skill.name, '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
       shell: process.platform === 'win32',


### PR DESCRIPTION
## Fixes two bugs in skills CLI

### Bug 1 (fixes #983): ENOENT error when `npx skills` runs outside a project directory

**Problem:** Running `npx skills` from a directory without `package.json` (e.g. `cd ~ && npx skills find "react"`) crashes with:
```
npm error code ENOENT
npm error syscall open
npm error path /Users/user/package.json
```

**Root cause:** `prepare` / `prepublishOnly` lifecycle scripts run `node scripts/generate-licenses.ts`, which calls `npx license-checker`. When npm runs lifecycle scripts from a directory without `package.json`, tools that depend on it fail.

**Fix:** In `scripts/generate-licenses.ts`, detect whether `package.json` exists in `process.cwd()` before running `npx license-checker`. If absent, write a placeholder and exit early.

---

### Bug 2 (fixes #982): `skills update -p <name>` installs ALL skills from source repo

**Problem:** `skills update deep-review -p --yes` (project scope) installs every skill in the source repo instead of just `deep-review`.

**Root cause:** `buildLocalUpdateSource()` returns only the bare source URL (no path qualification), so `skills add Ben2pc/g-claude-code-plugins -y` installs all skills from that repo. The global path works correctly because it uses path-qualified URLs.

**Fix:** In `updateProjectSkills()`, pass `--skill <name>` to the internal `add` call so only the target skill gets updated.

---

### Testing
```bash
# Bug 1
cd /tmp  # no package.json
npx skills find "react"  # was: ENOENT; now: works

# Bug 2
mkdir /tmp/repro && cd /tmp/repro
npx skills add Ben2pc/g-claude-code-plugins --skill deep-review --yes
npx skills update deep-review -p --yes
ls .claude/skills/  # was: 7 skills; now: only deep-review
```