### PR TITLE
fix(git): disable LFS filter during clone to survive missing git-lfs

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -26,14 +26,29 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     env: {
       ...process.env,
       GIT_TERMINAL_PROMPT: '0',
-      // Skills are text files (HTML/MD/JSON) and never LFS-tracked. Registry
-      // repos frequently track unrelated large media (test fixtures, demos,
-      // docs videos) via LFS. Downloading those during clone adds tens or
-      // hundreds of MB of bandwidth for files the installer never reads, and
-      // is the main reason `skills add` times out against larger registries
-      // (e.g. heygen-com/hyperframes, see upstream report #300).
+      // When git-lfs IS installed, tell it not to download LFS content
+      // during checkout. See #952 for context and empirical impact.
       GIT_LFS_SKIP_SMUDGE: '1',
     },
+    // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect —
+    // git sees `filter=lfs` in .gitattributes, tries to run
+    // `git-lfs filter-process`, and aborts the checkout with:
+    //   git-lfs filter-process: git-lfs: command not found
+    //   fatal: the remote end hung up unexpectedly
+    //   warning: Clone succeeded, but checkout failed.
+    // Overriding filter.lfs.* at the command level disables the filter
+    // entirely for this clone, so checkout succeeds regardless of whether
+    // git-lfs is installed. LFS-tracked files are left as ~130-byte
+    // pointer files, which the skills installer doesn't read anyway
+    // (skills are plain text — HTML/MD/JSON — never LFS-tracked).
+    //
+    // Reported downstream: heygen-com/hyperframes#407.
+    config: [
+      'filter.lfs.required=false',
+      'filter.lfs.smudge=',
+      'filter.lfs.clean=',
+      'filter.lfs.process=',
+    ],
   });
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 


### PR DESCRIPTION
## Problem

#952 (landed in v1.5.1) set `GIT_LFS_SKIP_SMUDGE=1` when cloning, which solved the bandwidth-bloat problem for users who **have** `git-lfs` installed. But that env var is read **by `git-lfs` itself** — so if the user doesn't have `git-lfs` installed at all, it does nothing.

Instead, git sees the `filter=lfs` attribute in the registry's `.gitattributes`, tries to spawn `git-lfs filter-process`, fails to find the binary, and aborts the checkout mid-clone:

```
$ npx skills add heygen-com/hyperframes
Failed to clone https://github.com/heygen-com/hyperframes.git: Cloning into
  '/var/folders/.../skills-XXXXXX'...

git-lfs filter-process: git-lfs: command not found
fatal: the remote end hung up unexpectedly
warning: Clone succeeded, but checkout failed.
```

Reported downstream: [heygen-com/hyperframes#407](https://github.com/heygen-com/hyperframes/issues/407), with [additional confirmation](https://github.com/heygen-com/hyperframes/issues/407#issuecomment-4295225328) that `GIT_LFS_SKIP_SMUDGE=1` alone doesn't fix it when `git-lfs` is missing.

## Fix

Pass `filter.lfs.*` config overrides to the clone via simpleGit's `config: string[]` option. This disables the LFS smudge/clean/process filters **at the git-command level**, so git never tries to invoke the missing `git-lfs` binary in the first place. LFS-tracked files are left as ~130-byte pointer files, which the skills installer ignores anyway (skills are plain text — HTML/MD/JSON — never LFS-tracked).

`GIT_LFS_SKIP_SMUDGE=1` is kept as defense-in-depth for the git-lfs-installed case; the new overrides handle the git-lfs-missing case.

The two mechanisms solve orthogonal failure modes:

|                         | `git-lfs` installed                 | `git-lfs` missing                    |
|-------------------------|-------------------------------------|--------------------------------------|
| #952 env var alone      | ✅ Skips download (pointer files)   | ❌ Checkout aborts with "not found"  |
| This PR (filter.lfs.*)  | ✅ Skips filter (pointer files)     | ✅ Skips filter (pointer files)      |

## Empirical verification

Simulated "git-lfs not installed" by constraining `$PATH` to a directory containing only `git` and `ssh` symlinks. Both runs clone the same LFS-using repo (`heygen-com/hyperframes`, ~240 MB of LFS assets).

**Before this PR** (current `main` / v1.5.1 behavior — reproduces #407 exactly):

```
$ PATH=/tmp/git-only GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 git@github.com:heygen-com/hyperframes.git /tmp/hf-unfix
Cloning into '/tmp/hf-unfix'...
git-lfs filter-process: 1: git-lfs: not found
fatal: the remote end hung up unexpectedly
warning: Clone succeeded, but checkout failed.
```

**After this PR** (same constrained PATH, no `git-lfs` reachable):

```
$ time PATH=/tmp/git-only git \
    -c filter.lfs.required=false \
    -c filter.lfs.smudge= \
    -c filter.lfs.clean= \
    -c filter.lfs.process= \
    clone --depth 1 git@github.com:heygen-com/hyperframes.git /tmp/hf-fix
Cloning into '/tmp/hf-fix'...
real    0m0.93s

$ du -sh /tmp/hf-fix
25M     /tmp/hf-fix

$ ls /tmp/hf-fix/skills/ | wc -l
5    # skills dir intact, installer has what it needs

$ head -c 60 /tmp/hf-fix/packages/producer/tests/chat/output/output.mp4
version https://git-lfs.github.com/spec/v1
oid sha256:d002c0
    # LFS file is a pointer, as expected — installer doesn't read these
```

Clone succeeds, 25 MB on disk (vs ~554 MB unfixed, ~107 MB with #952 alone when git-lfs is installed), `skills/` directory is populated, LFS files left as pointers.

## Safety / compatibility

- Does not change behavior when `git-lfs` is installed — the new env var makes LFS skip downloads, and the new config overrides make git skip the filter. Both produce pointer files.
- `filter.lfs.required=false` opt-out is standard. Git documents this pattern for handling LFS-tracked repos without LFS: https://git-scm.com/docs/gitattributes (see "Filter attribute").
- The existing `GIT_LFS_SKIP_SMUDGE=1` stays as belt-and-suspenders — no regression for #952's stated win.
- No change to authentication, timeout, or error-handling paths.

## Relationship to prior work

- #951 — timeout bump (orthogonal, still useful)
- #952 — `GIT_LFS_SKIP_SMUDGE=1` (this PR complements it; does not replace)
- Sparse-checkout (`--filter=blob:none` + `sparse-checkout set skills/`) — strictly better at the protocol level but a much bigger refactor; this is a ~20-line win for today

## Test plan

- [x] Reproduced #407 before the fix (see Empirical verification above) — confirmed exact error message
- [x] Verified fix resolves the bug against the same reproducer — clone succeeds in <1s
- [x] Verified LFS files are pointer files post-clone (installer-safe — installer ignores binary content)
- [x] `npm run format:check` passes on the modified file
- [x] Verified full test suite has the same pass/fail count as `main` — no new failures introduced (type-check and some tests have pre-existing failures on `main`, not touched by this PR)