### PR TITLE
Issue 915 fixed with changes made to include one more flag for skill …

### DIFF
--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,6 +9,23 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
+Package: @clack/core@0.5.0
+License: MIT
+Repository: https://github.com/bombshell-dev/clack
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -49,12 +66,41 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ================================================================================
-Package: simple-git@3.30.0
+Package: simple-git@3.36.0
 License: MIT
 Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+Package: sisteransi@1.0.5
+License: MIT
+Repository: https://github.com/terkelg/sisteransi
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/add.ts
+++ b/src/add.ts
@@ -1632,12 +1632,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               blobResult && 'snapshotHash' in skill
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
+            const skillPathValue = skillFiles[skill.name];
             await addSkillToLocalLock(
               skill.name,
               {
                 source: lockSource || parsed.url,
                 ref: parsed.ref,
                 sourceType: parsed.type,
+                ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
               },
               cwd

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -730,10 +730,22 @@ async function updateProjectSkills(
     return { successCount, failCount, foundCount: 0 };
   }
 
-  console.log(`${TEXT}Refreshing ${projectSkills.length} project skill(s)...${RESET}`);
+  // Legacy lock entries (written before skillPath was tracked) can't be updated
+  // in place — without skillPath, a reinstall would fetch every skill in the
+  // source repo. Skip them and tell the user how to refresh the lock entry.
+  const updatable = projectSkills.filter((s) => s.entry.skillPath);
+  const legacy = projectSkills.filter((s) => !s.entry.skillPath);
+
+  if (updatable.length === 0) {
+    console.log(`${DIM}No project skills can be updated in place.${RESET}`);
+    printLegacyProjectSkills(legacy);
+    return { successCount, failCount, foundCount: projectSkills.length };
+  }
+
+  console.log(`${TEXT}Refreshing ${updatable.length} project skill(s)...${RESET}`);
   console.log();
 
-  for (const skill of projectSkills) {
+  for (const skill of updatable) {
     const safeName = sanitizeMetadata(skill.name);
     console.log(`${TEXT}Updating ${safeName}...${RESET}`);
     const installUrl = buildLocalUpdateSource(skill.entry);
@@ -763,7 +775,28 @@ async function updateProjectSkills(
     }
   }
 
+  printLegacyProjectSkills(legacy);
   return { successCount, failCount, foundCount: projectSkills.length };
+}
+
+/**
+ * Print a hint for each legacy project skill entry that predates skillPath
+ * tracking. Lists the manual reinstall command so the user can refresh the
+ * lock entry and future updates stay scoped to a single skill.
+ */
+function printLegacyProjectSkills(
+  legacy: Array<{ name: string; source: string; entry: LocalSkillLockEntry }>
+): void {
+  if (legacy.length === 0) return;
+  console.log();
+  console.log(
+    `${DIM}${legacy.length} project skill(s) cannot be updated automatically (installed before skillPath tracking):${RESET}`
+  );
+  for (const skill of legacy) {
+    const reinstall = formatSourceInput(skill.entry.source, skill.entry.ref);
+    console.log(`  ${TEXT}•${RESET} ${sanitizeMetadata(skill.name)}`);
+    console.log(`    ${DIM}To refresh: ${TEXT}npx skills add ${reinstall} -y${RESET}`);
+  }
 }
 
 // ============================================

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -20,6 +20,14 @@ export interface LocalSkillLockEntry {
   /** The provider/source type (e.g., "github", "node_modules", "local") */
   sourceType: string;
   /**
+   * Path to the skill's SKILL.md within the source repo (e.g., "skills/pdf/SKILL.md").
+   * Required to re-install only this skill on update — without it, an update would
+   * refetch every skill in the source repo. Optional for backward compatibility with
+   * lock files written before this field existed, and omitted for non-repo sources
+   * (node_modules, local paths) where there is no subfolder to target.
+   */
+  skillPath?: string;
+  /**
    * SHA-256 hash computed from all files in the skill folder.
    * Unlike the global lock which uses GitHub tree SHA, the local lock
    * computes the hash from actual file contents on disk.

--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildUpdateInstallSource, formatSourceInput } from './update-source.ts';
+import {
+  buildLocalUpdateSource,
+  buildUpdateInstallSource,
+  formatSourceInput,
+} from './update-source.ts';
 
 describe('update-source', () => {
   describe('formatSourceInput', () => {
@@ -44,6 +48,41 @@ describe('update-source', () => {
         ref: 'feature/install',
       });
       expect(result).toBe('https://github.com/owner/repo.git#feature/install');
+    });
+  });
+
+  describe('buildLocalUpdateSource', () => {
+    it('appends skill folder from skillPath with ref', () => {
+      const result = buildLocalUpdateSource({
+        source: 'owner/repo',
+        ref: 'main',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('owner/repo/skills/my-skill#main');
+    });
+
+    it('appends skill folder from skillPath without ref', () => {
+      const result = buildLocalUpdateSource({
+        source: 'owner/repo',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('owner/repo/skills/my-skill');
+    });
+
+    it('keeps root-level skillPath from collapsing to trailing slash', () => {
+      const result = buildLocalUpdateSource({
+        source: 'owner/repo',
+        skillPath: 'SKILL.md',
+      });
+      expect(result).toBe('owner/repo');
+    });
+
+    it('falls back to bare source when skillPath is missing', () => {
+      const result = buildLocalUpdateSource({
+        source: 'owner/repo',
+        ref: 'main',
+      });
+      expect(result).toBe('owner/repo#main');
     });
   });
 });

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -8,6 +8,7 @@ export interface UpdateSourceEntry {
 export interface LocalUpdateSourceEntry {
   source: string;
   ref?: string;
+  skillPath?: string;
 }
 
 export function formatSourceInput(sourceUrl: string, ref?: string): string {
@@ -18,6 +19,29 @@ export function formatSourceInput(sourceUrl: string, ref?: string): string {
 }
 
 /**
+ * Derive the skill's folder path from a SKILL.md-terminated skillPath.
+ * Returns '' when the skill lives at the repo root.
+ */
+function deriveSkillFolder(skillPath: string): string {
+  let folder = skillPath;
+  if (folder.endsWith('/SKILL.md')) {
+    folder = folder.slice(0, -9);
+  } else if (folder.endsWith('SKILL.md')) {
+    folder = folder.slice(0, -8);
+  }
+  if (folder.endsWith('/')) {
+    folder = folder.slice(0, -1);
+  }
+  return folder;
+}
+
+function appendFolderAndRef(source: string, skillPath: string, ref?: string): string {
+  const folder = deriveSkillFolder(skillPath);
+  const withFolder = folder ? `${source}/${folder}` : source;
+  return ref ? `${withFolder}#${ref}` : withFolder;
+}
+
+/**
  * Build the source argument for `skills add` during update.
  * Uses shorthand form for path-targeted updates to avoid branch/path ambiguity.
  */
@@ -25,30 +49,17 @@ export function buildUpdateInstallSource(entry: UpdateSourceEntry): string {
   if (!entry.skillPath) {
     return formatSourceInput(entry.sourceUrl, entry.ref);
   }
-
-  // Extract skill folder from skillPath (remove /SKILL.md suffix).
-  let skillFolder = entry.skillPath;
-  if (skillFolder.endsWith('/SKILL.md')) {
-    skillFolder = skillFolder.slice(0, -9);
-  } else if (skillFolder.endsWith('SKILL.md')) {
-    skillFolder = skillFolder.slice(0, -8);
-  }
-  if (skillFolder.endsWith('/')) {
-    skillFolder = skillFolder.slice(0, -1);
-  }
-
-  let installSource = skillFolder ? `${entry.source}/${skillFolder}` : entry.source;
-  if (entry.ref) {
-    installSource = `${installSource}#${entry.ref}`;
-  }
-  return installSource;
+  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
 }
 
 /**
  * Build the source argument for `skills add` during project-level update.
- * Local lock entries only have `source` and `ref` (no skillPath or sourceUrl),
- * so we use the source directly (e.g., "vercel-labs/agent-skills").
+ * Local lock entries don't carry `sourceUrl`, so we fall back to the bare
+ * `source` identifier when no `skillPath` is available.
  */
 export function buildLocalUpdateSource(entry: LocalUpdateSourceEntry): string {
-  return formatSourceInput(entry.source, entry.ref);
+  if (!entry.skillPath) {
+    return formatSourceInput(entry.source, entry.ref);
+  }
+  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
 }


### PR DESCRIPTION
## What does this fix?

Right now, if you install one skill from a repo that has many skills and later run npx skills update <skill>, it downloads all the skills from that repo instead of just the one you asked about. That's the bug in issue #915.

## Why was it happening? 

 When you install a skill to a project, the skills-lock.json file saves where it came from, but not which folder inside the repo the skill lived in. So when the update runs, it only knows the repo name, and it just re-adds the whole thing. 

The global lock file doesn't have this problem because it already tracks the folder path. Only the project (local) flow was missing it. 

## Changes Made                                                                                                                                                                                                    
 
  1. Added a new optional field skillPath to the project lock entry. This stores the folder, like skills/pdf/SKILL.md.                                                                                               
  2. Made "add" save this field whenever you install a project skill from a git repo.
  3. Made "update" use that field to build a proper install URL so only that one skill gets refreshed.                                                                               
  4. Pulled the folder-slicing logic into a small helper so the global and local update paths share the same code.                                                                                                   

## Tests 

  Added four new tests in update-source.test.ts covering the cases I care about:                                                                                                                                     
  - skillPath with a ref
  - skillPath without a ref                                                                                                                                                                                          
  - skill at the repo root (no folder to append)
  - no skillPath at all (the legacy fallback)                                                                                                                                                                        

All 70 existing + new tests pass.

## Verification Steps 

Installed one skill (pdf) from anthropics/skills (which has 17 skills total), ran npx skills update pdf, and confirmed only pdf got touched.

## Files changed   

  - src/local-lock.ts — added skillPath? to the entry type 
  - src/add.ts — save skillPath on project install
  - src/update-source.ts — shared folder helper, buildLocalUpdateSource uses skillPath 
  - src/cli.ts — split updatable vs legacy entries, print hint for legacy 
  - src/update-source.test.ts — new tests 

                                                                                                                                                   
  Fixes #915.                                                                                                                                                                                                        