### PR TITLE
feat: auto-heal merge conflicts in skills-lock.json on update

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,11 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
-import { readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
+import {
+  readLocalLock,
+  resolveLocalLockConflicts,
+  type LocalSkillLockEntry,
+} from './local-lock.ts';
 import {
   buildUpdateInstallSource,
   buildLocalUpdateSource,
@@ -773,6 +777,19 @@ async function updateProjectSkills(
 async function runUpdate(args: string[] = []): Promise<void> {
   const options = parseUpdateOptions(args);
   const scope = await resolveUpdateScope(options);
+
+  // Yarn-install-style auto-heal: if skills-lock.json has merge conflict
+  // markers from a branch merge/rebase, resolve them by unioning entries from
+  // both sides and writing the cleaned lock back.
+  if (scope === 'project' || scope === 'both') {
+    try {
+      if (await resolveLocalLockConflicts()) {
+        console.log(`${TEXT}✓ Auto-resolved merge conflicts in skills-lock.json${RESET}`);
+      }
+    } catch {
+      // Non-fatal: fall through to normal update flow.
+    }
+  }
 
   if (options.skills) {
     console.log(`${TEXT}Updating ${options.skills.join(', ')}...${RESET}`);

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -4,6 +4,7 @@ import { createHash } from 'crypto';
 
 const LOCAL_LOCK_FILE = 'skills-lock.json';
 const CURRENT_VERSION = 1;
+const CONFLICT_START_MARKER = /^<{7}( |$)/m;
 
 /**
  * Represents a single skill entry in the local (project) lock file.
@@ -50,28 +51,133 @@ export function getLocalLockPath(cwd?: string): string {
 
 /**
  * Read the local skill lock file.
- * Returns an empty lock file structure if the file doesn't exist
- * or is corrupted (e.g., merge conflict markers).
+ *
+ * If the file contains git merge conflict markers (`<<<<<<<`, `=======`,
+ * `>>>>>>>`), each side is parsed independently and the `skills` maps are
+ * unioned — the "theirs" side wins on key collision. This mirrors the way
+ * `yarn install` heals `yarn.lock` conflicts, which is safe here because the
+ * lock format is intentionally timestamp-free and alphabetically sorted, so
+ * two branches adding different skills only ever conflict on JSON syntax.
+ *
+ * Returns an empty lock file structure if the file doesn't exist or cannot
+ * be parsed even after conflict resolution.
  */
 export async function readLocalLock(cwd?: string): Promise<LocalSkillLockFile> {
   const lockPath = getLocalLockPath(cwd);
 
+  let content: string;
   try {
-    const content = await readFile(lockPath, 'utf-8');
-    const parsed = JSON.parse(content) as LocalSkillLockFile;
-
-    if (typeof parsed.version !== 'number' || !parsed.skills) {
-      return createEmptyLocalLock();
-    }
-
-    if (parsed.version < CURRENT_VERSION) {
-      return createEmptyLocalLock();
-    }
-
-    return parsed;
+    content = await readFile(lockPath, 'utf-8');
   } catch {
     return createEmptyLocalLock();
   }
+
+  const parsed = parseLocalLockContent(content);
+  if (!parsed) return createEmptyLocalLock();
+  if (parsed.version < CURRENT_VERSION) return createEmptyLocalLock();
+  return parsed;
+}
+
+/**
+ * Parse lock file text, auto-resolving git merge conflict markers if present.
+ * Returns null if the content cannot be parsed into a valid lock structure.
+ */
+export function parseLocalLockContent(content: string): LocalSkillLockFile | null {
+  const tryParse = (text: string): LocalSkillLockFile | null => {
+    try {
+      const obj = JSON.parse(text) as LocalSkillLockFile;
+      if (typeof obj.version !== 'number' || !obj.skills) return null;
+      return obj;
+    } catch {
+      return null;
+    }
+  };
+
+  const direct = tryParse(content);
+  if (direct) return direct;
+
+  const sides = splitConflictSides(content);
+  if (!sides) return null;
+
+  const [ours, theirs] = sides;
+  const oursParsed = tryParse(ours);
+  const theirsParsed = tryParse(theirs);
+  if (!oursParsed) return theirsParsed;
+  if (!theirsParsed) return oursParsed;
+
+  // Union skills; on collision, "theirs" (incoming) wins. `skills update` will
+  // refresh whichever survives, so the tiebreaker mostly affects transient state.
+  return {
+    version: Math.max(oursParsed.version, theirsParsed.version),
+    skills: { ...oursParsed.skills, ...theirsParsed.skills },
+  };
+}
+
+/**
+ * If `content` contains git conflict markers, return [oursText, theirsText]
+ * with each side's JSON reconstructed. Returns null when no markers are found.
+ * Handles both default and diff3 styles (the latter inserts a `|||||||`
+ * ancestor block, which is ignored).
+ */
+function splitConflictSides(content: string): [string, string] | null {
+  if (!CONFLICT_START_MARKER.test(content)) return null;
+
+  const ours: string[] = [];
+  const theirs: string[] = [];
+  type State = 'common' | 'ours' | 'ancestor' | 'theirs';
+  let state: State = 'common';
+
+  for (const line of content.split('\n')) {
+    if (/^<{7}( |$)/.test(line)) {
+      state = 'ours';
+      continue;
+    }
+    if (/^\|{7}( |$)/.test(line)) {
+      state = 'ancestor';
+      continue;
+    }
+    if (/^={7}$/.test(line)) {
+      state = 'theirs';
+      continue;
+    }
+    if (/^>{7}( |$)/.test(line)) {
+      state = 'common';
+      continue;
+    }
+    if (state === 'common') {
+      ours.push(line);
+      theirs.push(line);
+    } else if (state === 'ours') {
+      ours.push(line);
+    } else if (state === 'theirs') {
+      theirs.push(line);
+    }
+  }
+
+  return [ours.join('\n'), theirs.join('\n')];
+}
+
+/**
+ * Detect and resolve merge conflicts in the local lock file on disk.
+ * If conflicts were present and successfully merged, writes the resolved
+ * lock back to disk and returns true. Otherwise returns false.
+ */
+export async function resolveLocalLockConflicts(cwd?: string): Promise<boolean> {
+  const lockPath = getLocalLockPath(cwd);
+  let content: string;
+  try {
+    content = await readFile(lockPath, 'utf-8');
+  } catch {
+    return false;
+  }
+
+  if (!CONFLICT_START_MARKER.test(content)) return false;
+
+  const parsed = parseLocalLockContent(content);
+  if (!parsed) return false;
+
+  await writeLocalLock(parsed, cwd);
+  return true;
 }
 
 /**

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -78,39 +78,44 @@ export async function readLocalLock(cwd?: string): Promise<LocalSkillLockFile> {
   return parsed;
 }
 
+function tryParseLockJson(text: string): LocalSkillLockFile | null {
+  try {
+    const obj = JSON.parse(text) as LocalSkillLockFile;
+    if (typeof obj.version !== 'number' || !obj.skills) return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+function mergeLocks(a: LocalSkillLockFile, b: LocalSkillLockFile): LocalSkillLockFile {
+  // Union skills; on collision, "theirs" (incoming / `b`) wins. `skills update`
+  // refreshes whichever entry survives, so the tiebreaker is transient.
+  return {
+    version: Math.max(a.version, b.version),
+    skills: { ...a.skills, ...b.skills },
+  };
+}
+
 /**
  * Parse lock file text, auto-resolving git merge conflict markers if present.
- * Returns null if the content cannot be parsed into a valid lock structure.
+ * Lenient: returns whatever can be recovered — both sides unioned when both
+ * parse, or a single side when only one parses. Returns null only when no
+ * valid lock can be reconstructed.
  */
 export function parseLocalLockContent(content: string): LocalSkillLockFile | null {
-  const tryParse = (text: string): LocalSkillLockFile | null => {
-    try {
-      const obj = JSON.parse(text) as LocalSkillLockFile;
-      if (typeof obj.version !== 'number' || !obj.skills) return null;
-      return obj;
-    } catch {
-      return null;
-    }
-  };
-
-  const direct = tryParse(content);
+  const direct = tryParseLockJson(content);
   if (direct) return direct;
 
   const sides = splitConflictSides(content);
   if (!sides) return null;
 
   const [ours, theirs] = sides;
-  const oursParsed = tryParse(ours);
-  const theirsParsed = tryParse(theirs);
+  const oursParsed = tryParseLockJson(ours);
+  const theirsParsed = tryParseLockJson(theirs);
   if (!oursParsed) return theirsParsed;
   if (!theirsParsed) return oursParsed;
-
-  // Union skills; on collision, "theirs" (incoming) wins. `skills update` will
-  // refresh whichever survives, so the tiebreaker mostly affects transient state.
-  return {
-    version: Math.max(oursParsed.version, theirsParsed.version),
-    skills: { ...oursParsed.skills, ...theirsParsed.skills },
-  };
+  return mergeLocks(oursParsed, theirsParsed);
 }
 
 /**
@@ -127,7 +132,9 @@ function splitConflictSides(content: string): [string, string] | null {
   type State = 'common' | 'ours' | 'ancestor' | 'theirs';
   let state: State = 'common';
 
-  for (const line of content.split('\n')) {
+  // Split on either LF or CRLF so marker lines still match their anchored
+  // regexes on Windows repos where git writes conflict markers with \r\n.
+  for (const line of content.split(/\r?\n/)) {
     if (/^<{7}( |$)/.test(line)) {
       state = 'ours';
       continue;
@@ -159,8 +166,14 @@ function splitConflictSides(content: string): [string, string] | null {
 
 /**
  * Detect and resolve merge conflicts in the local lock file on disk.
- * If conflicts were present and successfully merged, writes the resolved
- * lock back to disk and returns true. Otherwise returns false.
+ *
+ * Strict: only rewrites the file when BOTH sides of the conflict parse into
+ * valid lock structures and are unioned. If only one side parses (the other
+ * is truly corrupt), the conflicted file is left on disk so the user can see
+ * there's an issue rather than silently having one side's entries dropped.
+ * `readLocalLock` callers still get the partial recovery in memory.
+ *
+ * Returns true iff a union was produced and persisted.
  */
 export async function resolveLocalLockConflicts(cwd?: string): Promise<boolean> {
   const lockPath = getLocalLockPath(cwd);
@@ -171,12 +184,15 @@ export async function resolveLocalLockConflicts(cwd?: string): Promise<boolean> 
     return false;
   }
 
-  if (!CONFLICT_START_MARKER.test(content)) return false;
+  const sides = splitConflictSides(content);
+  if (!sides) return false;
 
-  const parsed = parseLocalLockContent(content);
-  if (!parsed) return false;
+  const [ours, theirs] = sides;
+  const oursParsed = tryParseLockJson(ours);
+  const theirsParsed = tryParseLockJson(theirs);
+  if (!oursParsed || !theirsParsed) return false;
 
-  await writeLocalLock(parsed, cwd);
+  await writeLocalLock(mergeLocks(oursParsed, theirsParsed), cwd);
   return true;
 }
 

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -9,6 +9,7 @@ import {
   removeSkillFromLocalLock,
   computeSkillFolderHash,
   getLocalLockPath,
+  resolveLocalLockConflicts,
 } from '../src/local-lock.ts';
 
 describe('local-lock', () => {
@@ -62,7 +63,7 @@ describe('local-lock', () => {
       }
     });
 
-    it('returns empty lock for corrupted JSON (merge conflict markers)', async () => {
+    it('auto-merges skills-lock.json with git conflict markers (union of both sides)', async () => {
       const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
       try {
         const conflicted = `{
@@ -78,7 +79,57 @@ describe('local-lock', () => {
         await writeFile(join(dir, 'skills-lock.json'), conflicted, 'utf-8');
 
         const lock = await readLocalLock(dir);
-        expect(lock).toEqual({ version: 1, skills: {} });
+        expect(lock.version).toBe(1);
+        expect(Object.keys(lock.skills).sort()).toEqual(['skill-a', 'skill-b']);
+        expect(lock.skills['skill-a']!.computedHash).toBe('aaa');
+        expect(lock.skills['skill-b']!.computedHash).toBe('bbb');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('auto-merges diff3-style conflict markers (ancestor block is ignored)', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const conflicted = `{
+  "version": 1,
+  "skills": {
+<<<<<<< HEAD
+    "skill-a": { "source": "org/a", "sourceType": "github", "computedHash": "aaa" }
+||||||| merged common ancestors
+    "skill-old": { "source": "org/old", "sourceType": "github", "computedHash": "ooo" }
+=======
+    "skill-b": { "source": "org/b", "sourceType": "github", "computedHash": "bbb" }
+>>>>>>> feature
+  }
+}`;
+        await writeFile(join(dir, 'skills-lock.json'), conflicted, 'utf-8');
+
+        const lock = await readLocalLock(dir);
+        expect(Object.keys(lock.skills).sort()).toEqual(['skill-a', 'skill-b']);
+        expect(lock.skills['skill-old']).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('on same-skill collision, theirs (incoming) wins', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const conflicted = `{
+  "version": 1,
+  "skills": {
+<<<<<<< HEAD
+    "shared": { "source": "org/x", "sourceType": "github", "computedHash": "ours" }
+=======
+    "shared": { "source": "org/x", "sourceType": "github", "computedHash": "theirs" }
+>>>>>>> feature
+  }
+}`;
+        await writeFile(join(dir, 'skills-lock.json'), conflicted, 'utf-8');
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['shared']!.computedHash).toBe('theirs');
       } finally {
         await rm(dir, { recursive: true, force: true });
       }
@@ -372,6 +423,59 @@ describe('local-lock', () => {
 
         const hash2 = await computeSkillFolderHash(skillDir);
         expect(hash1).toBe(hash2);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('resolveLocalLockConflicts', () => {
+    it('rewrites skills-lock.json without conflict markers and returns true', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const conflicted = `{
+  "version": 1,
+  "skills": {
+<<<<<<< HEAD
+    "skill-a": { "source": "org/a", "sourceType": "github", "computedHash": "aaa" }
+=======
+    "skill-b": { "source": "org/b", "sourceType": "github", "computedHash": "bbb" }
+>>>>>>> feature
+  }
+}`;
+        await writeFile(join(dir, 'skills-lock.json'), conflicted, 'utf-8');
+
+        const resolved = await resolveLocalLockConflicts(dir);
+        expect(resolved).toBe(true);
+
+        const raw = await readFile(join(dir, 'skills-lock.json'), 'utf-8');
+        expect(raw).not.toContain('<<<<<<<');
+        expect(raw).not.toContain('=======');
+        expect(raw).not.toContain('>>>>>>>');
+
+        const parsed = JSON.parse(raw);
+        expect(Object.keys(parsed.skills).sort()).toEqual(['skill-a', 'skill-b']);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns false when there are no conflict markers', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await writeFile(join(dir, 'skills-lock.json'), '{"version":1,"skills":{}}', 'utf-8');
+        const resolved = await resolveLocalLockConflicts(dir);
+        expect(resolved).toBe(false);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns false when the lock file does not exist', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const resolved = await resolveLocalLockConflicts(dir);
+        expect(resolved).toBe(false);
       } finally {
         await rm(dir, { recursive: true, force: true });
       }

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -113,6 +113,32 @@ describe('local-lock', () => {
       }
     });
 
+    it('auto-merges conflicts written with CRLF line endings', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const conflicted = [
+          '{',
+          '  "version": 1,',
+          '  "skills": {',
+          '<<<<<<< HEAD',
+          '    "skill-a": { "source": "org/a", "sourceType": "github", "computedHash": "aaa" }',
+          '=======',
+          '    "skill-b": { "source": "org/b", "sourceType": "github", "computedHash": "bbb" }',
+          '>>>>>>> feature',
+          '  }',
+          '}',
+        ].join('\r\n');
+        await writeFile(join(dir, 'skills-lock.json'), conflicted, 'utf-8');
+
+        const lock = await readLocalLock(dir);
+        expect(Object.keys(lock.skills).sort()).toEqual(['skill-a', 'skill-b']);
+        expect(lock.skills['skill-a']!.computedHash).toBe('aaa');
+        expect(lock.skills['skill-b']!.computedHash).toBe('bbb');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
     it('on same-skill collision, theirs (incoming) wins', async () => {
       const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
       try {
@@ -476,6 +502,31 @@ describe('local-lock', () => {
       try {
         const resolved = await resolveLocalLockConflicts(dir);
         expect(resolved).toBe(false);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('leaves the file untouched when only one side parses (no silent data loss)', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const conflicted = `{
+  "version": 1,
+  "skills": {
+<<<<<<< HEAD
+    "skill-a": { "source": "org/a", "sourceType": "github", "computedHash": "aaa" }
+=======
+    this side is truly corrupt and not JSON at all
+>>>>>>> feature
+  }
+}`;
+        await writeFile(join(dir, 'skills-lock.json'), conflicted, 'utf-8');
+
+        const resolved = await resolveLocalLockConflicts(dir);
+        expect(resolved).toBe(false);
+
+        const raw = await readFile(join(dir, 'skills-lock.json'), 'utf-8');
+        expect(raw).toBe(conflicted);
       } finally {
         await rm(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

- `skills update` now auto-resolves git merge conflict markers in `skills-lock.json` the way `yarn install` does for `yarn.lock`.
- When two branches each add skills (or edit the same hunk), the lockfile's conflict markers are parsed, both sides' `skills` maps are unioned (theirs/incoming wins on collision), and the cleaned lock is written back to disk.
- Conservative fallback preserved: truly corrupt content (neither side parses) still falls through to the existing empty-lock path.

## Why

`skills-lock.json` is designed to minimize merge conflicts — timestamp-free, alphabetically sorted (`src/local-lock.ts`). But conflicts still happen in practice: two branches editing the same hunk of the `skills` map, or both appending to the final entry without a trailing comma, produce `<<<<<<<` / `=======` / `>>>>>>>` markers.

Previously `readLocalLock` silently returned an empty lock on any parse failure. That's risky because the lockfile is the **authoritative record** of `source` / `sourceType` / `ref` — the installed `.agents/skills/<name>/` directories hold only skill contents, no sidecar metadata. Losing the lock means `skills install` from a clean checkout installs nothing, and `skills update` has no entries to refresh.

This PR adds a targeted recovery for the specific conflict-marker case while keeping the conservative empty-lock fallback for genuinely corrupt files.

## Implementation

- `splitConflictSides(content)` is a line-state machine that reconstructs `ours` and `theirs` text. Git guarantees markers start at column 0, so line-based parsing is robust. Diff3-style output (`|||||||` ancestor block) is also handled — the ancestor is ignored.
- `parseLocalLockContent(content)` tries `JSON.parse` first; only on failure does it attempt conflict splitting. If both sides parse, it unions the `skills` maps (theirs wins on collision). If only one side parses, that side is returned. If neither parses, it returns `null` and the caller falls back to an empty lock.
- `resolveLocalLockConflicts(cwd?)` is the write-back variant: it re-scans for markers, resolves, and persists via `writeLocalLock` only when a successful union was produced. Clean lockfiles are never touched.
- `runUpdate` in `src/cli.ts` calls `resolveLocalLockConflicts` at the top of the project-scope path and logs `✓ Auto-resolved merge conflicts in skills-lock.json` on success. After resolution, the subsequent update naturally re-fetches each skill, so the surviving entry matches upstream regardless of which side won the collision tiebreak.

## Test plan

Added 5 new tests in `tests/local-lock.test.ts` (25 total in the file, all passing):

- [x] `readLocalLock` unions both sides of a default-style conflict
- [x] `readLocalLock` handles diff3-style markers and discards the ancestor block
- [x] On same-skill key collision, incoming (theirs) side wins
- [x] `resolveLocalLockConflicts` rewrites the file without markers and returns `true`
- [x] `resolveLocalLockConflicts` returns `false` for clean files and for missing files
- [x] Full suite still passes: `pnpm vitest run` → 435/435

Manual reproduction:

```
# Create a lockfile with conflict markers
cat > skills-lock.json <<EOL
{
  "version": 1,
  "skills": {
<<<<<<< HEAD
    "skill-a": { "source": "org/a", "sourceType": "github", "computedHash": "aaa" }
=======
    "skill-b": { "source": "org/b", "sourceType": "github", "computedHash": "bbb" }
>>>>>>> feature
  }
}
EOL

# Run update
npx skills update
# → ✓ Auto-resolved merge conflicts in skills-lock.json
# → skills-lock.json now contains both skill-a and skill-b with no markers
```