### PR TITLE
Add Skills宝 as a Chinese install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [41 more](#av
 npx skills add vercel-labs/agent-skills
 ```
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ### Source Formats
 
 ```bash


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This matches the install-oriented workflow and gives Chinese users a faster entry point to the catalog.