### PR TITLE
Add Hermes Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [49 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [50 more](#supported-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -251,6 +251,7 @@ Skills can be installed to any of these agents:
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Hermes Agent | `hermes-agent` | `.hermes/skills/` | `~/.hermes/skills/` |
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
@@ -360,6 +361,7 @@ The CLI searches for skills in these locations within a repository:
 - `.factory/skills/`
 - `.forge/skills/`
 - `.goose/skills/`
+- `.hermes/skills/`
 - `.junie/skills/`
 - `.iflow/skills/`
 - `.kilocode/skills/`

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gemini-cli",
     "github-copilot",
     "goose",
+    "hermes-agent",
     "junie",
     "iflow-cli",
     "kilo",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -266,6 +266,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(configHome, 'goose'));
     },
   },
+  'hermes-agent': {
+    name: 'hermes-agent',
+    displayName: 'Hermes Agent',
+    skillsDir: '.hermes/skills',
+    globalSkillsDir: join(home, '.hermes/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.hermes'));
+    },
+  },
   junie: {
     name: 'junie',
     displayName: 'Junie',

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type AgentType =
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'
+  | 'hermes-agent'
   | 'iflow-cli'
   | 'junie'
   | 'kilo'


### PR DESCRIPTION
## Summary
- add Hermes Agent to supported agents
- configure project/global skill paths from #688
- update generated README agent metadata and package keywords

Closes #688

## Testing
- node scripts/validate-agents.ts
- pnpm test tests/xdg-config-paths.test.ts tests/openclaw-paths.test.ts tests/list-installed.test.ts
- pnpm test tests/list-installed.test.ts src/list.test.ts
- pnpm build
- pnpm test tests/dist.test.ts

Note: pnpm type-check currently fails on existing unrelated typing errors in src/git.ts, src/providers/wellknown.ts, and src/skills.ts.