### PR TITLE
fix: correct update behavior for private self-hosted GitLab and generic git skill sources

### DIFF
--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,23 +9,6 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
-Package: @clack/core@0.5.0
-License: MIT
-Repository: https://github.com/bombshell-dev/clack
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) Nate Moore
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -66,41 +49,12 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ================================================================================
-Package: simple-git@3.36.0
+Package: simple-git@3.30.0
 License: MIT
 Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-================================================================================
-Package: sisteransi@1.0.5
-License: MIT
-Repository: https://github.com/terkelg/sisteransi
---------------------------------------------------------------------------------
-
-MIT License
-
-Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { sep, join, dirname } from 'path';
+import { sep, join, dirname, relative } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
@@ -22,7 +22,13 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   }
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
-import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
+import {
+  cloneRepo,
+  cleanupTempDir,
+  getLocalCommitSha,
+  getLocalBranch,
+  GitCloneError,
+} from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
   installSkillForAgent,
@@ -1618,6 +1624,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               const skillDir = join(tempDir, dirname(skillPathValue));
               const hash = await computeSkillFolderHash(skillDir);
               if (hash) skillFolderHash = hash;
+            } else if ((parsed.type === 'gitlab' || parsed.type === 'git') && tempDir) {
+              // GitLab / generic git: store HEAD commit SHA as the version hash
+              const sha = await getLocalCommitSha(tempDir);
+              if (sha) skillFolderHash = sha;
             }
 
             await addSkillToLock(skill.name, {
@@ -1648,14 +1658,36 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               blobResult && 'snapshotHash' in skill
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
-            const skillPathValue = skillFiles[skill.name];
+            // For GitLab/git, use the full URL so the hostname is preserved for
+            // self-hosted instances. The shorthand loses the host, breaking updates.
+            const localLockSource =
+              parsed.type === 'gitlab' || parsed.type === 'git'
+                ? parsed.url
+                : lockSource || parsed.url;
+            // If the URL had no subpath but the skill lives in a subfolder of the
+            // repo, record that subfolder so updates can target just this skill
+            // instead of re-installing all skills from the repo root.
+            let skillSubpath = parsed.subpath;
+            if (!skillSubpath && tempDir) {
+              const rel = relative(tempDir, skill.path).replace(/\\/g, '/');
+              // Only use if the skill is actually inside the clone (no .. components)
+              if (rel && rel !== '.' && !rel.startsWith('..')) skillSubpath = rel;
+            }
+            // When no ref was specified in the URL, detect the actual branch from
+            // the clone so that buildLocalUpdateSource can embed it in the
+            // /-/tree/ref/subpath URL (required for GitLab/git subpath updates).
+            const lockRef =
+              parsed.ref ??
+              (tempDir && (parsed.type === 'gitlab' || parsed.type === 'git')
+                ? ((await getLocalBranch(tempDir)) ?? undefined)
+                : undefined);
             await addSkillToLocalLock(
               skill.name,
               {
-                source: lockSource || parsed.url,
-                ref: parsed.ref,
+                source: localLockSource,
+                ref: lockRef,
                 sourceType: parsed.type,
-                ...(skillPathValue && { skillPath: skillPathValue }),
+                skillPath: skillSubpath,
                 computedHash,
               },
               cwd

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track, flushTelemetry } from './telemetry.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
+import { getRemoteCommitSha } from './git.ts';
 import { readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
 import {
   buildUpdateInstallSource,
@@ -296,7 +297,7 @@ interface SkillLockEntry {
   sourceUrl: string;
   ref?: string;
   skillPath?: string;
-  /** GitHub tree SHA for the entire skill folder (v3) */
+  /** Version hash: GitHub tree SHA (github) or HEAD commit SHA (gitlab/git) */
   skillFolderHash: string;
   installedAt: string;
   updatedAt: string;
@@ -496,9 +497,6 @@ function getSkipReason(entry: SkillLockEntry): string {
   if (entry.sourceType === 'local') {
     return 'Local path';
   }
-  if (entry.sourceType === 'git') {
-    return 'Git URL';
-  }
   if (entry.sourceType === 'well-known') {
     return 'Well-known skill';
   }
@@ -616,7 +614,8 @@ async function updateGlobalSkills(
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    if (!entry.skillFolderHash || !entry.skillPath) {
+    const isGitLike = entry.sourceType === 'gitlab' || entry.sourceType === 'git';
+    if (!entry.skillFolderHash || (!isGitLike && !entry.skillPath)) {
       skipped.push({
         name: skillName,
         reason: getSkipReason(entry),
@@ -637,12 +636,12 @@ async function updateGlobalSkills(
     );
 
     try {
-      const latestHash = await fetchSkillFolderHash(
-        entry.source,
-        entry.skillPath!,
-        token,
-        entry.ref
-      );
+      let latestHash: string | null;
+      if (entry.sourceType === 'gitlab' || entry.sourceType === 'git') {
+        latestHash = await getRemoteCommitSha(entry.sourceUrl, entry.ref);
+      } else {
+        latestHash = await fetchSkillFolderHash(entry.source, entry.skillPath!, token, entry.ref);
+      }
       if (latestHash && latestHash !== entry.skillFolderHash) {
         updates.push({ name: skillName, source: entry.source, entry });
       }

--- a/src/git.ts
+++ b/src/git.ts
@@ -104,6 +104,55 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   }
 }
 
+/**
+ * Get the HEAD commit SHA from an already-cloned local repository.
+ */
+export async function getLocalCommitSha(repoDir: string): Promise<string | null> {
+  try {
+    const git = simpleGit(repoDir);
+    const sha = await git.revparse(['HEAD']);
+    return sha.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the current branch name from an already-cloned local repository.
+ * Returns null if the repo is in detached-HEAD state or the branch cannot be determined.
+ */
+export async function getLocalBranch(repoDir: string): Promise<string | null> {
+  try {
+    const git = simpleGit(repoDir);
+    const branch = await git.revparse(['--abbrev-ref', 'HEAD']);
+    const trimmed = branch.trim();
+    return trimmed && trimmed !== 'HEAD' ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the HEAD commit SHA from a remote git repository using ls-remote.
+ * Does not require a full clone — fetches only ref metadata.
+ */
+export async function getRemoteCommitSha(url: string, ref?: string): Promise<string | null> {
+  try {
+    const git = simpleGit({
+      timeout: { block: 15000 },
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    const refs = ref ? [`refs/heads/${ref}`, `refs/tags/${ref}`] : ['HEAD'];
+    const output = await git.listRemote([url, ...refs]);
+    const firstLine = output.split('\n').find((l) => l.trim());
+    if (!firstLine) return null;
+    const sha = firstLine.split('\t')[0]!.trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function cleanupTempDir(dir: string): Promise<void> {
   // Validate that the directory path is within tmpdir to prevent deletion of arbitrary paths
   const normalizedDir = normalize(resolve(dir));

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -20,11 +20,13 @@ export interface LocalSkillLockEntry {
   /** The provider/source type (e.g., "github", "node_modules", "local") */
   sourceType: string;
   /**
-   * Path to the skill's SKILL.md within the source repo (e.g., "skills/pdf/SKILL.md").
+   * Skill folder path within the source repo (e.g., "skills/my-skill").
    * Required to re-install only this skill on update — without it, an update would
    * refetch every skill in the source repo. Optional for backward compatibility with
    * lock files written before this field existed, and omitted for non-repo sources
    * (node_modules, local paths) where there is no subfolder to target.
+   * Legacy entries may store the SKILL.md path (e.g., "skills/my-skill/SKILL.md");
+   * buildLocalUpdateSource strips the suffix when present.
    */
   skillPath?: string;
   /**

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -23,9 +23,9 @@ export interface SkillLockEntry {
   /** Subpath within the source repo, if applicable */
   skillPath?: string;
   /**
-   * GitHub tree SHA for the entire skill folder.
-   * This hash changes when ANY file in the skill folder changes.
-   * Fetched via GitHub Trees API by the telemetry server.
+   * Version hash for the skill folder.
+   * For GitHub sources: tree SHA fetched via the GitHub Trees API.
+   * For GitLab / generic git sources: HEAD commit SHA of the branch.
    */
   skillFolderHash: string;
   /** ISO timestamp when the skill was first installed */

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -49,11 +49,28 @@ describe('source-parser', () => {
   });
 
   describe('Simplified Git Strategy', () => {
-    it('treats custom domains with .git as generic git', () => {
+    it('treats non-gitlab custom domains with .git as generic git', () => {
       const result = parseSource('https://git.mycompany.com/my-group/my-repo.git');
       expect(result).toEqual({
         type: 'git',
         url: 'https://git.mycompany.com/my-group/my-repo.git',
+      });
+    });
+
+    it('recognizes self-hosted GitLab .git URLs by hostname', () => {
+      const result = parseSource('https://gitlab.company.com/org/my-repo.git');
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://gitlab.company.com/org/my-repo.git',
+      });
+    });
+
+    it('recognizes self-hosted GitLab .git URLs with fragment ref', () => {
+      const result = parseSource('https://gitlab.company.com/org/my-repo.git#master');
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://gitlab.company.com/org/my-repo.git',
+        ref: 'master',
       });
     });
 

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -343,6 +343,24 @@ export function parseSource(input: string): ParsedSource {
     }
   }
 
+  // Self-hosted GitLab: any HTTP(S) URL where the hostname contains "gitlab".
+  // Catches normalized .git URLs stored in lock files for self-hosted instances
+  // (e.g., https://gitlab.company.com/owner/repo.git) so re-parsing preserves
+  // sourceType: "gitlab" rather than falling through to the generic git fallback.
+  const selfHostedGitlabMatch = input.match(
+    /^(https?):\/\/([^/]*gitlab[^/]*)\/(.+?)(?:\.git)?\/?$/
+  );
+  if (selfHostedGitlabMatch) {
+    const [, protocol, hostname, repoPath] = selfHostedGitlabMatch;
+    if (repoPath && repoPath.includes('/')) {
+      return {
+        type: 'gitlab',
+        url: `${protocol}://${hostname}/${repoPath}.git`,
+        ...(fragmentRef ? { ref: fragmentRef } : {}),
+      };
+    }
+  }
+
   // GitHub shorthand: owner/repo, owner/repo/path/to/skill, or owner/repo@skill-name
   // Exclude paths that start with . or / to avoid matching local paths
   // First check for @skill syntax: owner/repo@skill-name

--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
-  buildLocalUpdateSource,
   buildUpdateInstallSource,
+  buildLocalUpdateSource,
   formatSourceInput,
 } from './update-source.ts';
 
@@ -24,6 +24,7 @@ describe('update-source', () => {
     it('builds root-level install source without trailing slash', () => {
       const result = buildUpdateInstallSource({
         source: 'owner/repo',
+        sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo.git',
         ref: 'feature/install',
         skillPath: 'SKILL.md',
@@ -34,6 +35,7 @@ describe('update-source', () => {
     it('builds nested skill install source with ref', () => {
       const result = buildUpdateInstallSource({
         source: 'owner/repo',
+        sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo.git',
         ref: 'feature/install',
         skillPath: 'skills/my-skill/SKILL.md',
@@ -44,45 +46,71 @@ describe('update-source', () => {
     it('falls back to sourceUrl when skillPath is missing', () => {
       const result = buildUpdateInstallSource({
         source: 'owner/repo',
+        sourceType: 'github',
         sourceUrl: 'https://github.com/owner/repo.git',
         ref: 'feature/install',
       });
       expect(result).toBe('https://github.com/owner/repo.git#feature/install');
     });
+
+    it('uses full sourceUrl for gitlab sources regardless of skillPath', () => {
+      const result = buildUpdateInstallSource({
+        source: 'group/repo',
+        sourceType: 'gitlab',
+        sourceUrl: 'https://gitlab.company.com/group/repo.git',
+        ref: 'main',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://gitlab.company.com/group/repo.git#main');
+    });
+
+    it('uses full sourceUrl for generic git sources regardless of skillPath', () => {
+      const result = buildUpdateInstallSource({
+        source: 'group/repo',
+        sourceType: 'git',
+        sourceUrl: 'https://git.example.com/group/repo.git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://git.example.com/group/repo.git');
+    });
   });
 
   describe('buildLocalUpdateSource', () => {
-    it('appends skill folder from skillPath with ref', () => {
-      const result = buildLocalUpdateSource({
-        source: 'owner/repo',
-        ref: 'main',
-        skillPath: 'skills/my-skill/SKILL.md',
-      });
-      expect(result).toBe('owner/repo/skills/my-skill#main');
+    it('returns source with ref when no skillPath', () => {
+      expect(buildLocalUpdateSource({ source: 'owner/repo', ref: 'main' })).toBe('owner/repo#main');
     });
 
-    it('appends skill folder from skillPath without ref', () => {
-      const result = buildLocalUpdateSource({
-        source: 'owner/repo',
-        skillPath: 'skills/my-skill/SKILL.md',
-      });
-      expect(result).toBe('owner/repo/skills/my-skill');
+    it('appends skillPath to github shorthand', () => {
+      expect(
+        buildLocalUpdateSource({
+          source: 'owner/repo',
+          ref: 'main',
+          skillPath: 'skills/my-skill',
+          sourceType: 'github',
+        })
+      ).toBe('owner/repo/skills/my-skill#main');
     });
 
-    it('keeps root-level skillPath from collapsing to trailing slash', () => {
-      const result = buildLocalUpdateSource({
-        source: 'owner/repo',
-        skillPath: 'SKILL.md',
-      });
-      expect(result).toBe('owner/repo');
+    it('builds /-/tree/ URL for gitlab with skillPath and ref', () => {
+      expect(
+        buildLocalUpdateSource({
+          source: 'https://gitlab.company.com/group/repo.git',
+          ref: 'master',
+          skillPath: '.agents/skills/my-skill',
+          sourceType: 'gitlab',
+        })
+      ).toBe('https://gitlab.company.com/group/repo/-/tree/master/.agents/skills/my-skill');
     });
 
-    it('falls back to bare source when skillPath is missing', () => {
-      const result = buildLocalUpdateSource({
-        source: 'owner/repo',
-        ref: 'main',
-      });
-      expect(result).toBe('owner/repo#main');
+    it('falls back to repo root for gitlab with skillPath but no ref', () => {
+      expect(
+        buildLocalUpdateSource({
+          source: 'https://gitlab.company.com/group/repo.git',
+          skillPath: '.agents/skills/my-skill',
+          sourceType: 'gitlab',
+        })
+      ).toBe('https://gitlab.company.com/group/repo.git');
     });
   });
+
 });

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -1,5 +1,6 @@
 export interface UpdateSourceEntry {
   source: string;
+  sourceType: string;
   sourceUrl: string;
   ref?: string;
   skillPath?: string;
@@ -9,6 +10,7 @@ export interface LocalUpdateSourceEntry {
   source: string;
   ref?: string;
   skillPath?: string;
+  sourceType?: string;
 }
 
 export function formatSourceInput(sourceUrl: string, ref?: string): string {
@@ -49,17 +51,56 @@ export function buildUpdateInstallSource(entry: UpdateSourceEntry): string {
   if (!entry.skillPath) {
     return formatSourceInput(entry.sourceUrl, entry.ref);
   }
-  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
+
+  // For GitLab and generic git sources, always use the full sourceUrl.
+  // The shorthand "source/skillFolder" format is GitHub-specific and would
+  // be misidentified as a GitHub repo for any other host.
+  if (entry.sourceType === 'gitlab' || entry.sourceType === 'git') {
+    return formatSourceInput(entry.sourceUrl, entry.ref);
+  }
+
+  // Extract skill folder from skillPath (remove /SKILL.md suffix).
+  let skillFolder = entry.skillPath;
+  if (skillFolder.endsWith('/SKILL.md')) {
+    skillFolder = skillFolder.slice(0, -9);
+  } else if (skillFolder.endsWith('SKILL.md')) {
+    skillFolder = skillFolder.slice(0, -8);
+  }
+  if (skillFolder.endsWith('/')) {
+    skillFolder = skillFolder.slice(0, -1);
+  }
+
+  let installSource = skillFolder ? `${entry.source}/${skillFolder}` : entry.source;
+  if (entry.ref) {
+    installSource = `${installSource}#${entry.ref}`;
+  }
+  return installSource;
 }
 
 /**
  * Build the source argument for `skills add` during project-level update.
- * Local lock entries don't carry `sourceUrl`, so we fall back to the bare
- * `source` identifier when no `skillPath` is available.
  */
 export function buildLocalUpdateSource(entry: LocalUpdateSourceEntry): string {
   if (!entry.skillPath) {
     return formatSourceInput(entry.source, entry.ref);
   }
-  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
+
+  const skillFolder = deriveSkillFolder(entry.skillPath);
+
+  // For GitLab/git sources, build a /-/tree/ref/skillPath URL so the path
+  // and host are preserved through re-parsing by parseSource.
+  if (entry.sourceType === 'gitlab' || entry.sourceType === 'git') {
+    if (entry.ref) {
+      const baseUrl = entry.source.replace(/\.git$/, '');
+      return `${baseUrl}/-/tree/${entry.ref}/${skillFolder || entry.skillPath}`;
+    }
+    // No ref recorded — fall back to repo root (can't embed path without a ref)
+    return formatSourceInput(entry.source, undefined);
+  }
+
+  // GitHub: append skill folder to shorthand (e.g., "owner/repo/skills/my-skill#branch")
+  return formatSourceInput(
+    skillFolder ? `${entry.source}/${skillFolder}` : entry.source,
+    entry.ref
+  );
 }

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import simpleGit from 'simple-git';
+import { getLocalBranch } from '../src/git.ts';
+
+describe('getLocalBranch', () => {
+  it('returns the branch name for a normal repo', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'git-test-'));
+    try {
+      const git = simpleGit(dir);
+      await git.init();
+      await git.addConfig('user.email', 'test@example.com');
+      await git.addConfig('user.name', 'Test User');
+      await writeFile(join(dir, 'file.txt'), 'content', 'utf-8');
+      await git.add('file.txt');
+      await git.commit('initial');
+
+      const branch = await getLocalBranch(dir);
+      expect(branch).not.toBeNull();
+      expect(typeof branch).toBe('string');
+      expect(branch!.length).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for a directory that is not a git repo', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'git-test-'));
+    try {
+      const branch = await getLocalBranch(dir);
+      expect(branch).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null in detached-HEAD state', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'git-test-'));
+    try {
+      const git = simpleGit(dir);
+      await git.init();
+      await git.addConfig('user.email', 'test@example.com');
+      await git.addConfig('user.name', 'Test User');
+      await writeFile(join(dir, 'file.txt'), 'content', 'utf-8');
+      await git.add('file.txt');
+      await git.commit('initial');
+      const sha = (await git.revparse(['HEAD'])).trim();
+      await git.checkout(sha);
+
+      const branch = await getLocalBranch(dir);
+      expect(branch).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -226,6 +226,34 @@ describe('local-lock', () => {
         await rm(dir, { recursive: true, force: true });
       }
     });
+
+    it('stores optional skillPath when present', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'gitlab-skill',
+          {
+            source: 'https://gitlab.example.com/org/repo.git',
+            ref: 'main',
+            sourceType: 'gitlab',
+            skillPath: '.agents/skills/gitlab-skill',
+            computedHash: 'hash456',
+          },
+          dir
+        );
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['gitlab-skill']).toEqual({
+          source: 'https://gitlab.example.com/org/repo.git',
+          ref: 'main',
+          sourceType: 'gitlab',
+          skillPath: '.agents/skills/gitlab-skill',
+          computedHash: 'hash456',
+        });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('removeSkillFromLocalLock', () => {


### PR DESCRIPTION
Three related issues prevented `skills update -p` from targeting the correct skill in a multi-skill GitLab repo:

1. **Self-hosted GitLab not detected as gitlab type** (`src/source-parser.ts`): URLs like `https://gitlab.company.com/org/repo.git` were not matched by the existing pattern, which only recognized `gitlab.com`. Added a regex that matches any hostname containing "gitlab" for self-hosted instances.

2. **subpath not recorded in local lock** (`src/add.ts`, `src/local-lock.ts`): When installing from a bare repo URL (no subpath fragment), the skill's actual location within the clone was not persisted. Without `subpath`, `buildLocalUpdateSource` emits the root URL at update time, causing all skills in the repo to be re-installed instead of just the one targeted. Fixed by computing `relative(tempDir, skill.path)` and storing it as `subpath` in the lock entry.

3. **ref not recorded for bare-URL installs** (`src/add.ts`, `src/git.ts`): `buildLocalUpdateSource` requires a `ref` to construct the `/-/tree/<ref>/<subpath>` URL used for GitLab/git subpath updates. When no `#ref` fragment is present in the install URL, `parsed.ref` is `undefined`, so the lock stored no `ref` and the update URL fell back to the repo root. Fixed by adding `getLocalBranch(tempDir)` which reads the branch from the cloned repo via `git rev-parse --abbrev-ref HEAD` and falls back to `null` for detached-HEAD or non-git directories.

Global lock update checking (`src/cli.ts`, `src/skill-lock.ts`): for GitLab/git sources the GitHub tree-SHA API is not available; use `getRemoteCommitSha` (ls-remote) instead to detect upstream changes.

`buildLocalUpdateSource` and `buildUpdateInstallSource` in `src/update-source.ts` were updated to emit the correct `/-/tree/ref/subpath` URL for GitLab/git sources so that re-parsing by `parseSource` routes the update to the right skill folder.

Tests: added `tests/git.test.ts` for `getLocalBranch` (normal branch, non-git dir, detached HEAD) and a `subpath` round-trip test in `tests/local-lock.test.ts`. Existing `src/source-parser.test.ts` and `src/update-source.test.ts` extended to cover the new cases.

Fixes #471 