### PR TITLE
chore: add .husky/commit-msg placeholder for global agent-attribution hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# Husky commit-msg placeholder.
+#
+# This file's existence is what makes Husky source
+# ~/.config/husky/init.sh on every commit-msg invocation. Husky's
+# runner short-circuits with `exit 0` when the user-side hook is
+# missing, before it ever sources init.sh — so without this empty
+# placeholder the global agent-attribution-footer enforcement
+# (strip vendor `Generated with [<Agent>]` footers and add the
+# tool-neutral Fyodor footer) never runs in this repo.
+#
+# Body intentionally empty: all enforcement logic lives in
+# ~/.config/husky/init.sh which sources
+# ~/apps/dotfiles/lib/strip-agent-attribution.sh. Adding logic here
+# would duplicate it across every repo.
+#
+# Bypass: set BOSUN_PIPELINE=1 (init.sh respects it).


### PR DESCRIPTION
## Summary

Adds a tiny `.husky/commit-msg` placeholder file. The body is intentionally empty — all the work happens in `~/.config/husky/init.sh` (a per-developer file).

## Why

Husky's `_/h` runner short-circuits with `exit 0` whenever the user-side hook is missing, **before** it sources `~/.config/husky/init.sh`. So in repos that ship Husky but don't define their own `commit-msg` hook, anything global that lives in `init.sh` never runs.

I rely on `init.sh` to enforce a tool-neutral agent-attribution footer rule across every repo on my machine — strip auto-inserted vendor lines like `Generated with [Devin](...)` or `Co-Authored-By: Devin <bot@…>`, then append a canonical `_🤖 Written by an agent, not Fyodor. Ping me if this looks off._` footer. Without this placeholder, that enforcement quietly skips this repo.

## What the placeholder does

Nothing on its own. It exists purely so Husky's `[ ! -f "$s" ] && exit 0` check sees a file present and proceeds to source `~/.config/husky/init.sh`. The hook body itself is no-op `sh` — runs and exits 0.

## Effect on contributors who don't have `~/.config/husky/init.sh`

**Zero.** They run an empty hook on every commit, which exits 0 instantly. No new validation, no new failure mode.

## Test plan

- [x] Verified end-to-end: a `git commit -m "feat: x\n\nGenerated with [Devin](...)\nCo-authored-by: Devin <…>"` gets stripped + Fyodor footer appended in a Husky-managed sandbox repo with this placeholder + my `init.sh` installed.
- [x] Verified pass-through: a clean human commit (no agent attribution) is untouched.
- [x] Verified bypass: `BOSUN_PIPELINE=1 git commit ...` preserves attribution for pipeline-to-commit linkage.

---
_🤖 Written by an agent, not Fyodor. Ping me if this looks off._
