### PR TITLE
feat: add skills link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ When installing interactively, you can choose:
 
 | Command                      | Description                                   |
 | ---------------------------- | --------------------------------------------- |
+| `npx skills link [skills]`   | Link installed global skills to agents        |
 | `npx skills list`            | List installed skills (alias: `ls`)           |
 | `npx skills find [query]`    | Search for skills interactively or by keyword |
 | `npx skills remove [skills]` | Remove installed skills from agents           |
@@ -204,6 +205,31 @@ npx skills rm my-skill
 | `-s, --skill`  | Specify skills to remove (use `'*'` for all)     |
 | `-y, --yes`    | Skip confirmation prompts                        |
 | `--all`        | Shorthand for `--skill '*' --agent '*' -y`       |
+
+### `skills link`
+
+Link already-installed global skills to one or more agents.
+
+```bash
+# Interactively search and select from installed global skills
+npx skills link
+
+# Link one global skill to a specific agent
+npx skills link pr-review -a claude-code
+
+# Link multiple global skills
+npx skills link pr-review sql-safety -a claude-code -a cursor
+
+# Link all installed global skills without confirmation
+npx skills link --all -a claude-code -y
+```
+
+| Option         | Description                             |
+| -------------- | --------------------------------------- |
+| `-a, --agent`  | Link to specific agents                 |
+| `-s, --skill`  | Specify installed global skills to link |
+| `-y, --yes`    | Skip confirmation prompts               |
+| `--all`        | Link all installed global skills        |
 
 ## What are Agent Skills?
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import * as p from '@clack/prompts';
 import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
 import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
+import { runLink, parseLinkOptions } from './link.ts';
 import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
@@ -81,6 +82,9 @@ function showBanner(): void {
     `  ${DIM}$${RESET} ${TEXT}npx skills remove${RESET}               ${DIM}Remove installed skills${RESET}`
   );
   console.log(
+    `  ${DIM}$${RESET} ${TEXT}npx skills link${RESET}                 ${DIM}Link global skills to an agent${RESET}`
+  );
+  console.log(
     `  ${DIM}$${RESET} ${TEXT}npx skills list${RESET}                 ${DIM}List installed skills${RESET}`
   );
   console.log(
@@ -116,6 +120,7 @@ ${BOLD}Manage Skills:${RESET}
                        e.g. vercel-labs/agent-skills
                             https://github.com/vercel-labs/agent-skills
   remove [skills]      Remove installed skills
+  link [skills]        Link installed global skills to agents
   list, ls             List installed skills
   find [query]         Search for skills interactively
 
@@ -148,6 +153,12 @@ ${BOLD}Remove Options:${RESET}
   -s, --skill <skills>   Specify skills to remove (use '*' for all skills)
   -y, --yes              Skip confirmation prompts
   --all                  Shorthand for --skill '*' --agent '*' -y
+
+${BOLD}Link Options:${RESET}
+  -a, --agent <agents>   Specify agents to link to
+  -s, --skill <skills>   Specify installed global skills to link
+  -y, --yes              Skip confirmation prompts
+  --all                  Link all installed global skills
   
 ${BOLD}Experimental Sync Options:${RESET}
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
@@ -170,6 +181,8 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills remove                        ${DIM}# interactive remove${RESET}
   ${DIM}$${RESET} skills remove web-design             ${DIM}# remove by name${RESET}
   ${DIM}$${RESET} skills rm --global frontend-design
+  ${DIM}$${RESET} skills link                          ${DIM}# interactively link global skills${RESET}
+  ${DIM}$${RESET} skills link pr-review -a claude-code ${DIM}# link one global skill${RESET}
   ${DIM}$${RESET} skills list                          ${DIM}# list project skills${RESET}
   ${DIM}$${RESET} skills ls -g                         ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
@@ -930,6 +943,12 @@ async function main(): Promise<void> {
       const { skills, options: removeOptions } = parseRemoveOptions(restArgs);
       await removeCommand(skills, removeOptions);
       break;
+    case 'link': {
+      showLogo();
+      const { skills, options: linkOptions } = parseLinkOptions(restArgs);
+      await runLink(skills, linkOptions);
+      break;
+    }
     case 'experimental_sync': {
       showLogo();
       const { options: syncOptions } = parseSyncOptions(restArgs);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -213,7 +213,7 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
     // Use the real (symlink-resolved) parent directory for computing the relative path.
     // This ensures the symlink target is correct even when the link's parent dir is a symlink.
     const realLinkDir = await resolveParentSymlinks(linkDir);
-    const relativePath = relative(realLinkDir, target);
+    const relativePath = relative(realLinkDir, realTargetWithParents);
     const symlinkType = platform() === 'win32' ? 'junction' : undefined;
 
     await symlink(relativePath, linkPath, symlinkType);
@@ -255,6 +255,8 @@ export async function installSkillForAgent(
   const agentDir = join(agentBase, skillName);
 
   const installMode = options.mode ?? 'symlink';
+  const sourceDir = resolve(skill.path);
+  const canonicalSource = resolve(canonicalDir);
 
   // Validate paths
   if (!isPathSafe(canonicalBase, canonicalDir)) {
@@ -278,6 +280,13 @@ export async function installSkillForAgent(
   try {
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
+      if (sourceDir === resolve(agentDir)) {
+        return {
+          success: true,
+          path: agentDir,
+          mode: 'copy',
+        };
+      }
       await cleanAndCreateDirectory(agentDir);
       await copyDirectory(skill.path, agentDir);
 
@@ -289,8 +298,10 @@ export async function installSkillForAgent(
     }
 
     // Symlink mode: copy to canonical location and symlink to agent location
-    await cleanAndCreateDirectory(canonicalDir);
-    await copyDirectory(skill.path, canonicalDir);
+    if (sourceDir !== canonicalSource) {
+      await cleanAndCreateDirectory(canonicalDir);
+      await copyDirectory(skill.path, canonicalDir);
+    }
 
     // For universal agents with global install, the skill is already in the canonical
     // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir

--- a/src/link.test.ts
+++ b/src/link.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseLinkOptions } from './link.ts';
+import { runCli } from './test-utils.ts';
+
+describe('link command', () => {
+  let testDir: string;
+  let homeDir: string;
+  let env: Record<string, string>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'skills-link-test-'));
+    homeDir = join(testDir, 'home');
+    mkdirSync(homeDir, { recursive: true });
+    env = {
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      LOCALAPPDATA: join(homeDir, 'AppData', 'Local'),
+      APPDATA: join(homeDir, 'AppData', 'Roaming'),
+    };
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  function createGlobalSkill(name: string, description?: string) {
+    const skillDir = join(homeDir, '.agents', 'skills', name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: ${name}
+description: ${description || `A test skill called ${name}`}
+---
+
+# ${name}
+
+This is a test skill.
+`
+    );
+  }
+
+  describe('parseLinkOptions', () => {
+    it('should parse positional skill names', () => {
+      const { skills, options } = parseLinkOptions(['skill-one', 'skill-two']);
+      expect(skills).toEqual(['skill-one', 'skill-two']);
+      expect(options).toEqual({});
+    });
+
+    it('should parse skill and agent flags', () => {
+      const { skills, options } = parseLinkOptions([
+        '--skill',
+        'skill-one',
+        '--agent',
+        'claude-code',
+        'cursor',
+        '-y',
+      ]);
+      expect(skills).toEqual(['skill-one']);
+      expect(options.skill).toEqual(['skill-one']);
+      expect(options.agent).toEqual(['claude-code', 'cursor']);
+      expect(options.yes).toBe(true);
+    });
+
+    it('should parse --all flag', () => {
+      const { skills, options } = parseLinkOptions(['--all', '-a', 'claude-code']);
+      expect(skills).toEqual([]);
+      expect(options.all).toBe(true);
+      expect(options.agent).toEqual(['claude-code']);
+    });
+  });
+
+  describe('CLI integration', () => {
+    it('should show message when no global skills found', () => {
+      const result = runCli(['link', '--all', '-a', 'claude-code', '-y'], testDir, env);
+      expect(result.stdout).toContain('No global skills found');
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should show error for invalid agent name', () => {
+      createGlobalSkill('test-skill');
+
+      const result = runCli(['link', 'test-skill', '--agent', 'invalid-agent', '-y'], testDir, env);
+
+      expect(result.stdout).toContain('Invalid agents');
+      expect(result.stdout).toContain('invalid-agent');
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('should link a specific global skill to an agent-specific global directory', () => {
+      createGlobalSkill('test-skill');
+
+      const result = runCli(['link', 'test-skill', '-a', 'claude-code', '-y'], testDir, env);
+
+      expect(result.stdout).toContain('Successfully linked');
+      expect(result.stdout).toContain('test-skill');
+      expect(result.exitCode).toBe(0);
+
+      const linkedSkillPath = join(homeDir, '.claude', 'skills', 'test-skill', 'SKILL.md');
+      expect(existsSync(linkedSkillPath)).toBe(true);
+      expect(readFileSync(linkedSkillPath, 'utf-8')).toContain('name: test-skill');
+    });
+
+    it('should link all global skills with --all', () => {
+      createGlobalSkill('skill-one');
+      createGlobalSkill('skill-two');
+
+      const result = runCli(['link', '--all', '-a', 'claude-code', '-y'], testDir, env);
+
+      expect(result.stdout).toContain('Successfully linked');
+      expect(result.stdout).toContain('2 skill');
+      expect(result.exitCode).toBe(0);
+
+      expect(existsSync(join(homeDir, '.claude', 'skills', 'skill-one', 'SKILL.md'))).toBe(true);
+      expect(existsSync(join(homeDir, '.claude', 'skills', 'skill-two', 'SKILL.md'))).toBe(true);
+    });
+
+    it('should match skill names case-insensitively', () => {
+      createGlobalSkill('test-skill');
+
+      const result = runCli(['link', 'TEST-SKILL', '-a', 'claude-code', '-y'], testDir, env);
+
+      expect(result.stdout).toContain('Successfully linked');
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(homeDir, '.claude', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+    });
+
+    it('should warn about unmatched skills while linking matched skills', () => {
+      createGlobalSkill('skill-one');
+
+      const result = runCli(
+        ['link', 'skill-one', 'missing-skill', '-a', 'claude-code', '-y'],
+        testDir,
+        env
+      );
+
+      expect(result.stdout).toContain('Global skills not found');
+      expect(result.stdout).toContain('missing-skill');
+      expect(result.stdout).toContain('Successfully linked 1 link(s) for 1 skill(s)');
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(homeDir, '.claude', 'skills', 'skill-one', 'SKILL.md'))).toBe(true);
+    });
+
+    it('should report successful link count separately from skill count', () => {
+      createGlobalSkill('test-skill');
+
+      const result = runCli(
+        ['link', 'test-skill', '-a', 'claude-code', 'continue', '-y'],
+        testDir,
+        env
+      );
+
+      expect(result.stdout).toContain('Successfully linked 2 link(s) for 1 skill(s)');
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(homeDir, '.claude', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+      expect(existsSync(join(homeDir, '.continue', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+    });
+  });
+});

--- a/src/link.ts
+++ b/src/link.ts
@@ -1,0 +1,287 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { agents, detectInstalledAgents } from './agents.ts';
+import {
+  installSkillForAgent,
+  listInstalledSkills,
+  type InstalledSkill,
+  type InstallMode,
+} from './installer.ts';
+import { searchMultiselect } from './prompts/search-multiselect.ts';
+import { track } from './telemetry.ts';
+import type { AgentType, Skill } from './types.ts';
+
+export interface LinkOptions {
+  agent?: string[];
+  yes?: boolean;
+  skill?: string[];
+  all?: boolean;
+  global?: boolean;
+}
+
+const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
+
+export function parseLinkOptions(args: string[]): { skills: string[]; options: LinkOptions } {
+  const options: LinkOptions = {};
+  const skills: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === undefined) {
+      continue;
+    }
+
+    if (arg === '-y' || arg === '--yes') {
+      options.yes = true;
+    } else if (arg === '--all') {
+      options.all = true;
+    } else if (arg === '-g' || arg === '--global') {
+      options.global = true;
+    } else if (arg === '-a' || arg === '--agent') {
+      options.agent = options.agent || [];
+      while (i + 1 < args.length && !args[i + 1]!.startsWith('-')) {
+        options.agent.push(args[++i]!);
+      }
+    } else if (arg === '-s' || arg === '--skill') {
+      options.skill = options.skill || [];
+      while (i + 1 < args.length && !args[i + 1]!.startsWith('-')) {
+        const skill = args[++i]!;
+        options.skill.push(skill);
+        skills.push(skill);
+      }
+    } else if (!arg.startsWith('-')) {
+      skills.push(arg);
+    }
+  }
+
+  return { skills, options };
+}
+
+async function promptForSkills(
+  installedSkills: InstalledSkill[]
+): Promise<InstalledSkill[] | symbol> {
+  const selectedNames = await searchMultiselect({
+    message: 'Which global skills do you want to link?',
+    items: installedSkills.map((skill) => ({
+      value: skill.name,
+      label: skill.name,
+      hint:
+        skill.agents.length > 0 ? `linked to ${skill.agents.length} agent(s)` : 'not linked yet',
+    })),
+    required: true,
+  });
+
+  if (isCancelled(selectedNames)) {
+    return selectedNames;
+  }
+
+  const selectedSet = new Set(selectedNames);
+  return installedSkills.filter((skill) => selectedSet.has(skill.name));
+}
+
+async function promptForAgents(): Promise<AgentType[] | symbol> {
+  const installedAgents = await detectInstalledAgents();
+  const selectableAgents = (Object.keys(agents) as AgentType[])
+    .filter((agentType) => agents[agentType].globalSkillsDir !== undefined)
+    .sort((a, b) => agents[a].displayName.localeCompare(agents[b].displayName));
+
+  const initialSelected = installedAgents.filter(
+    (agentType) => agents[agentType].globalSkillsDir !== undefined
+  );
+
+  const selected = await searchMultiselect({
+    message: 'Which agents do you want to link skills to?',
+    items: selectableAgents.map((agentType) => ({
+      value: agentType,
+      label: agents[agentType].displayName,
+      hint: agents[agentType].globalSkillsDir,
+    })),
+    initialSelected,
+    required: true,
+  });
+
+  if (isCancelled(selected)) {
+    return selected;
+  }
+
+  return selected as AgentType[];
+}
+
+function toSourceSkill(installedSkill: InstalledSkill): Skill {
+  return {
+    name: installedSkill.name,
+    description: installedSkill.description,
+    path: installedSkill.path,
+  };
+}
+
+export async function runLink(inputSkills: string[], options: LinkOptions = {}): Promise<void> {
+  const cwd = process.cwd();
+  const spinner = p.spinner();
+
+  spinner.start('Scanning installed global skills...');
+  const installedSkills = await listInstalledSkills({ global: true, cwd });
+  spinner.stop(`Found ${installedSkills.length} global skill(s)`);
+
+  if (installedSkills.length === 0) {
+    p.outro(pc.yellow('No global skills found to link.'));
+    return;
+  }
+
+  if (options.agent && options.agent.length > 0) {
+    const validAgents = (Object.keys(agents) as AgentType[]).filter(
+      (agentType) => agents[agentType].globalSkillsDir !== undefined
+    );
+    const invalidAgents = options.agent.filter(
+      (agent) => !validAgents.includes(agent as AgentType)
+    );
+
+    if (invalidAgents.length > 0) {
+      p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
+      p.log.info(`Valid agents: ${validAgents.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
+  let selectedSkills: InstalledSkill[];
+  let missingSkillNames: string[] = [];
+  if (options.all) {
+    selectedSkills = installedSkills;
+  } else if (inputSkills.length > 0) {
+    const requested = new Set(inputSkills.map((skill) => skill.toLowerCase()));
+    selectedSkills = installedSkills.filter((skill) => requested.has(skill.name.toLowerCase()));
+    const matchedNames = new Set(selectedSkills.map((skill) => skill.name.toLowerCase()));
+    missingSkillNames = inputSkills.filter((skill) => !matchedNames.has(skill.toLowerCase()));
+
+    if (selectedSkills.length === 0) {
+      p.log.error(`No matching global skills found for: ${inputSkills.join(', ')}`);
+      return;
+    }
+
+    if (missingSkillNames.length > 0) {
+      p.log.warn(`Global skills not found: ${missingSkillNames.join(', ')}`);
+    }
+  } else if (options.yes) {
+    selectedSkills = installedSkills;
+  } else {
+    const selected = await promptForSkills(installedSkills);
+    if (isCancelled(selected)) {
+      p.cancel('Link cancelled');
+      process.exit(0);
+    }
+    selectedSkills = selected;
+  }
+
+  let targetAgents: AgentType[];
+  if (options.agent && options.agent.length > 0) {
+    targetAgents = options.agent as AgentType[];
+  } else if (options.yes) {
+    const detectedAgents = await detectInstalledAgents();
+    const globalCapableDetected = detectedAgents.filter(
+      (agentType) => agents[agentType].globalSkillsDir !== undefined
+    );
+    targetAgents =
+      globalCapableDetected.length > 0
+        ? globalCapableDetected
+        : (Object.keys(agents) as AgentType[]).filter(
+            (agentType) => agents[agentType].globalSkillsDir !== undefined
+          );
+  } else {
+    const selected = await promptForAgents();
+    if (isCancelled(selected)) {
+      p.cancel('Link cancelled');
+      process.exit(0);
+    }
+    targetAgents = selected;
+  }
+
+  if (!options.yes) {
+    console.log();
+    p.log.info('Global skills to link:');
+    for (const skill of selectedSkills) {
+      p.log.message(`  ${pc.cyan('•')} ${skill.name}`);
+    }
+    console.log();
+    p.log.info(
+      `Target agents: ${targetAgents.map((agent) => agents[agent].displayName).join(', ')}`
+    );
+
+    const confirmed = await p.confirm({
+      message: `Proceed with linking ${selectedSkills.length} skill(s)?`,
+    });
+
+    if (p.isCancel(confirmed) || !confirmed) {
+      p.cancel('Link cancelled');
+      process.exit(0);
+    }
+  }
+
+  spinner.start('Linking global skills...');
+
+  const results: Array<{
+    skill: string;
+    agent: string;
+    success: boolean;
+    path: string;
+    mode: InstallMode;
+    error?: string;
+  }> = [];
+
+  for (const installedSkill of selectedSkills) {
+    const sourceSkill = toSourceSkill(installedSkill);
+    for (const agentType of targetAgents) {
+      const result = await installSkillForAgent(sourceSkill, agentType, {
+        global: true,
+        cwd,
+        mode: 'symlink',
+      });
+      results.push({
+        skill: installedSkill.name,
+        agent: agents[agentType].displayName,
+        success: result.success,
+        path: result.path,
+        mode: result.mode,
+        error: result.error,
+      });
+    }
+  }
+
+  spinner.stop('Linking complete');
+
+  const failed = results.filter((result) => !result.success);
+  const successfulLinkCount = results.filter((result) => result.success).length;
+  const succeededSkillNames = new Set(
+    results.filter((result) => result.success).map((result) => result.skill)
+  );
+
+  console.log();
+  const successfulLinks = results.filter((result) => result.success);
+  for (const success of successfulLinks) {
+    p.log.message(`  ${pc.green('✓')} ${success.skill} → ${success.agent}`);
+  }
+
+  if (failed.length > 0) {
+    for (const failure of failed) {
+      p.log.error(`${failure.skill} → ${failure.agent}: ${failure.error ?? 'Unknown error'}`);
+    }
+  }
+
+  if (succeededSkillNames.size > 0) {
+    p.outro(
+      pc.green(
+        `Successfully linked ${successfulLinkCount} link(s) for ${succeededSkillNames.size} skill(s).`
+      )
+    );
+  } else {
+    p.outro(pc.red('Failed to link any skills.'));
+  }
+
+  track({
+    event: 'link',
+    scope: 'global',
+    skillCount: String(selectedSkills.length),
+    agents: targetAgents.join(','),
+    successCount: String(succeededSkillNames.size),
+    failCount: String(failed.length),
+  });
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -48,12 +48,22 @@ interface SyncTelemetryData {
   agents: string;
 }
 
+interface LinkTelemetryData {
+  event: 'link';
+  scope: 'global';
+  skillCount: string;
+  agents: string;
+  successCount: string;
+  failCount: string;
+}
+
 type TelemetryData =
   | InstallTelemetryData
   | RemoveTelemetryData
   | UpdateTelemetryData
   | FindTelemetryData
-  | SyncTelemetryData;
+  | SyncTelemetryData
+  | LinkTelemetryData;
 
 let cliVersion: string | null = null;
 


### PR DESCRIPTION
  ## Summary

  Adds a new `skills link` command for linking already-installed global skills to one or more agent-specific skill directories.

  This addresses the workflow discussed in #1002: users may already have skills installed globally under the canonical skills directory, but still need a way
  to apply/link those existing skills to additional agents without re-running `skills add`.

  ## What changed

  - Adds `skills link [skills]`
  - Supports interactive skill and agent selection
  - Supports non-interactive usage with `--all`, `--skill`, `--agent`, and `--yes`
  - Links global skills to agent-specific global skill directories using the existing installer path
  - Warns when some requested skills are not found while still linking matched skills
  - Reports successful link count separately from skill count
  - Adds CLI tests for parsing, invalid agents, case-insensitive matching, partial misses, and multi-agent linking

  ## Notes

  The command is named `link` because the implementation reuses existing global skill installs and links them into agent-specific skill directories. This is
  close to the `apply` concept discussed in #1002; if maintainers prefer `apply` as the command name, I’m happy to rename it or add `apply` as an alias.