### PR TITLE
feat: add Moxby agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [50 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
 <!-- agent-list:end -->
 
 ## Install a Skill
@@ -258,6 +258,7 @@ Skills can be installed to any of these agents:
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
+| Moxby | `moxby` | `.moxby/skills/` | `~/.moxby/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
 | OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
@@ -367,6 +368,7 @@ The CLI searches for skills in these locations within a repository:
 - `.kode/skills/`
 - `.mcpjam/skills/`
 - `.vibe/skills/`
+- `.moxby/skills/`
 - `.mux/skills/`
 - `.openhands/skills/`
 - `.pi/skills/`

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "kode",
     "mcpjam",
     "mistral-vibe",
+    "moxby",
     "mux",
     "opencode",
     "openhands",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -347,6 +347,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(vibeHome);
     },
   },
+  moxby: {
+    name: 'moxby',
+    displayName: 'Moxby',
+    skillsDir: '.moxby/skills',
+    globalSkillsDir: join(home, '.moxby/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.moxby'));
+    },
+  },
   mux: {
     name: 'mux',
     displayName: 'Mux',

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export type AgentType =
   | 'kode'
   | 'mcpjam'
   | 'mistral-vibe'
+  | 'moxby'
   | 'mux'
   | 'neovate'
   | 'opencode'


### PR DESCRIPTION
## Summary
- Adds Moxby to the supported-agents list. Moxby is a Tauri-based desktop coding agent that wraps multiple CLIs (Claude Code, Codex, Gemini) inside a multi-panel workspace.
- Project path: `.moxby/skills/`
- Global path: `~/.moxby/skills/`
- Detection: `~/.moxby/` exists.

Skills installed via `npx skills add <pkg> -a moxby` will land where Moxby's runtime scanner already looks, so installs work out-of-the-box without any path translation on the consumer side.

## Files
- `src/types.ts` — adds `'moxby'` to the `AgentType` union (placed alphabetically between `'mistral-vibe'` and `'mux'`).
- `src/agents.ts` — adds the `moxby` agent config (placed alphabetically between `'mistral-vibe'` and `mux`).
- `README.md`, `package.json` — regenerated via `node --experimental-strip-types scripts/sync-agents.ts`.

## Testing
- `node --experimental-strip-types scripts/validate-agents.ts` — `All agents valid.`
- `pnpm test tests/openclaw-paths.test.ts tests/xdg-config-paths.test.ts tests/list-installed.test.ts` — 27 / 27 passing.
- `pnpm format` — no changes needed.

## Context
Moxby ships an in-app Skills modal (Installed / External / Marketplace tabs). The Marketplace tab calls `skills.sh/api/search` and shells out to `npx skills add` to install — so once this lands, `-a moxby` becomes the canonical way Moxby users pull skills from the ecosystem.

Project repo: https://github.com/openclaw (Moxby is built on top of OpenClaw, but uses its own user-data directory).