### PR TITLE
fix(blob): authenticate raw.githubusercontent.com for private repos

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -373,15 +373,25 @@ export function findSkillMdPaths(tree: RepoTree, subpath?: string): string[] {
 /**
  * Fetch a single SKILL.md from raw.githubusercontent.com to get frontmatter.
  * Returns the raw content string, or null on failure.
+ *
+ * When a token is provided, sends it as `Authorization: Bearer <token>`.
+ * Required for private repos: raw.githubusercontent.com returns 404 to
+ * anonymous requests rather than 401.
  */
 async function fetchSkillMdContent(
   ownerRepo: string,
   branch: string,
-  skillMdPath: string
+  skillMdPath: string,
+  token?: string | null
 ): Promise<string | null> {
   try {
     const url = `https://raw.githubusercontent.com/${ownerRepo}/${branch}/${skillMdPath}`;
+    const headers: Record<string, string> = {};
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
     const response = await fetch(url, {
+      headers,
       signal: AbortSignal.timeout(FETCH_TIMEOUT),
     });
     if (!response.ok) return null;
@@ -481,12 +491,29 @@ export async function tryBlobInstall(
   }
 
   // 4. Fetch SKILL.md content from raw.githubusercontent.com in parallel
-  const mdFetches = await Promise.all(
+  let mdFetches = await Promise.all(
     skillMdPaths.map(async (mdPath) => {
       const content = await fetchSkillMdContent(ownerRepo, tree.branch, mdPath);
       return { mdPath, content };
     })
   );
+
+  // Authentication is lazy here for the same reason as fetchRepoTree: a private
+  // repo answers 404 to anonymous raw.githubusercontent.com requests, so only a
+  // miss is worth a token. The token is resolved once and the misses retried
+  // together, because `getToken` may shell out to `gh auth token` per call.
+  if (options.getToken && mdFetches.some((f) => f.content === null)) {
+    const token = options.getToken();
+    if (token) {
+      mdFetches = await Promise.all(
+        mdFetches.map(async (f) => {
+          if (f.content !== null) return f;
+          const content = await fetchSkillMdContent(ownerRepo, tree.branch, f.mdPath, token);
+          return { mdPath: f.mdPath, content };
+        })
+      );
+    }
+  }
 
   // Parse frontmatter to get skill names
   const parsedSkills: Array<{

--- a/tests/blob-auth.test.ts
+++ b/tests/blob-auth.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { tryBlobInstall } from '../src/blob.ts';
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+describe('tryBlobInstall — raw.githubusercontent.com authentication', () => {
+  let calls: FetchCall[];
+  let originalFetch: typeof globalThis.fetch;
+  let rawRequiresAuth: boolean;
+
+  const SKILL_MD = `---
+name: probe-skill
+description: a probe
+---
+body
+`;
+
+  const TREE_RESPONSE = {
+    sha: 'tree-sha-1',
+    tree: [{ path: 'SKILL.md', type: 'blob', sha: 'blob-sha-1' }],
+  };
+
+  const DOWNLOAD_RESPONSE = {
+    files: [{ path: 'SKILL.md', contents: SKILL_MD }],
+    hash: 'snapshot-hash-1',
+  };
+
+  function authHeaderOf(call: FetchCall): string | undefined {
+    return ((call.init?.headers ?? {}) as Record<string, string>).Authorization;
+  }
+
+  beforeEach(() => {
+    calls = [];
+    rawRequiresAuth = false;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      calls.push({ url, init });
+      if (url.includes('api.github.com/repos/')) {
+        return new Response(JSON.stringify(TREE_RESPONSE), { status: 200 });
+      }
+      if (url.includes('raw.githubusercontent.com/')) {
+        // A private repo answers 404 to anonymous requests, 200 once authorised.
+        const authorized = Boolean(
+          (init?.headers as Record<string, string> | undefined)?.Authorization
+        );
+        if (rawRequiresAuth && !authorized) {
+          return new Response('not found', { status: 404 });
+        }
+        return new Response(SKILL_MD, { status: 200 });
+      }
+      if (url.includes('/api/download/')) {
+        return new Response(JSON.stringify(DOWNLOAD_RESPONSE), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('retries a private-repo miss with a Bearer token', async () => {
+    rawRequiresAuth = true;
+    const getToken = vi.fn(() => 'ghp_testtoken');
+
+    const result = await tryBlobInstall('owner/repo', { getToken });
+    expect(result).not.toBeNull();
+
+    const rawCalls = calls.filter((c) => c.url.includes('raw.githubusercontent.com'));
+    expect(rawCalls).toHaveLength(2);
+    expect(authHeaderOf(rawCalls[0]!)).toBeUndefined();
+    expect(authHeaderOf(rawCalls[1]!)).toBe('Bearer ghp_testtoken');
+  });
+
+  it('never asks for a token when the unauthenticated fetch succeeds', async () => {
+    const getToken = vi.fn(() => 'ghp_testtoken');
+
+    const result = await tryBlobInstall('owner/repo', { getToken });
+    expect(result).not.toBeNull();
+
+    expect(getToken).not.toHaveBeenCalled();
+    const rawCalls = calls.filter((c) => c.url.includes('raw.githubusercontent.com'));
+    expect(rawCalls).toHaveLength(1);
+    expect(authHeaderOf(rawCalls[0]!)).toBeUndefined();
+  });
+
+  it('resolves the token once even when several skills miss', async () => {
+    rawRequiresAuth = true;
+    const getToken = vi.fn(() => 'ghp_testtoken');
+    TREE_RESPONSE.tree = [
+      { path: 'skills/one/SKILL.md', type: 'blob', sha: 'blob-sha-1' },
+      { path: 'skills/two/SKILL.md', type: 'blob', sha: 'blob-sha-2' },
+    ];
+
+    try {
+      const result = await tryBlobInstall('owner/repo', { getToken });
+      expect(result).not.toBeNull();
+      expect(getToken).toHaveBeenCalledTimes(1);
+    } finally {
+      TREE_RESPONSE.tree = [{ path: 'SKILL.md', type: 'blob', sha: 'blob-sha-1' }];
+    }
+  });
+
+  it('does not set Authorization when no getToken callback is supplied', async () => {
+    const result = await tryBlobInstall('owner/repo', {});
+    expect(result).not.toBeNull();
+
+    const rawCall = calls.find((c) => c.url.includes('raw.githubusercontent.com'));
+    expect(rawCall).toBeDefined();
+    expect(authHeaderOf(rawCall!)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`tryBlobInstall` is the fast-path skill installer that fetches snapshots from skills.sh instead of cloning. For private GitHub sources it always falls back to clone, even when blob install would work, because `fetchSkillMdContent` issues an unauthenticated `fetch` against `raw.githubusercontent.com`, which 404s for private repos:

```
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://raw.githubusercontent.com/<owner>/<private-repo>/HEAD/SKILL.md
404
$ curl -s -o /dev/null -w "%{http_code}\n" \
    -H "Authorization: Bearer $(gh auth token)" \
    https://raw.githubusercontent.com/<owner>/<private-repo>/HEAD/SKILL.md
200
```

Without auth, the parsedSkills array stays empty, `tryBlobInstall` returns null, and the caller falls through to clone. The slow path runs for every private install even when a token is available.

## Fix

`src/blob.ts:fetchSkillMdContent` accepts an optional token and forwards it as `Authorization: Bearer <token>` when present. The caller `tryBlobInstall` already has `options.token` (used by `fetchRepoTree` above), so the threading is one parameter and one call-site update.

Public repos are unaffected: when no token is provided the header is omitted and the fetch behaves exactly as before.

## Tests

`tests/blob-auth.test.ts` adds two unit tests asserting the Bearer header is set on `raw.githubusercontent.com` fetches when a token is provided and unset when it isn't.

## Relationship to other open PRs

Complementary to #908, which fixes the unrelated `cloneRepo` auth path for private GitHub URLs but does not touch the blob-install path. With both merged, private-repo installs use the fast blob path when they can and the gh-mediated clone fallback when they cannot. Either can land first; neither blocks the other.