### PR TITLE
fix: support update checking for non-GitHub git sources

### DIFF
--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -202,6 +202,41 @@ export async function fetchSkillFolderHash(
 }
 
 /**
+ * Fetch the skill folder hash for a non-GitHub git source (Bitbucket, GitLab,
+ * Azure DevOps, self-hosted, etc.) by performing a shallow clone and computing
+ * a SHA-256 hash of the skill folder contents.
+ *
+ * Uses the same hashing algorithm as the install path in add.ts so stored and
+ * fetched hashes are directly comparable.
+ *
+ * @param sourceUrl - Git clone URL (e.g., "git@bitbucket.org:owner/repo.git")
+ * @param skillPath - Path to skill folder or SKILL.md within the repo
+ * @param ref - Optional branch/tag ref
+ * @returns SHA-256 hash of the skill folder contents, or null on failure
+ */
+export async function fetchGitSkillFolderHash(
+  sourceUrl: string,
+  skillPath: string,
+  ref?: string
+): Promise<string | null> {
+  const { cloneRepo, cleanupTempDir } = await import('./git.ts');
+  const { computeSkillFolderHash } = await import('./local-lock.ts');
+
+  let tempDir: string | null = null;
+  try {
+    tempDir = await cloneRepo(sourceUrl, ref);
+    const skillDir = join(tempDir, dirname(skillPath));
+    return await computeSkillFolderHash(skillDir);
+  } catch {
+    return null;
+  } finally {
+    if (tempDir) {
+      await cleanupTempDir(tempDir).catch(() => {});
+    }
+  }
+}
+
+/**
  * Add or update a skill entry in the lock file.
  */
 export async function addSkillToLock(

--- a/src/update.ts
+++ b/src/update.ts
@@ -8,6 +8,7 @@ import pc from 'picocolors';
 import {
   readSkillLock,
   fetchSkillFolderHash,
+  fetchGitSkillFolderHash,
   getGitHubToken,
   type SkillLockEntry,
 } from './skill-lock.ts';
@@ -172,9 +173,6 @@ export function getSkipReason(entry: SkillLockEntry): string {
   if (entry.sourceType === 'local') {
     return 'Local path';
   }
-  if (entry.sourceType === 'git') {
-    return 'Git URL';
-  }
   if (entry.sourceType === 'well-known') {
     return 'Well-known skill';
   }
@@ -312,6 +310,17 @@ export async function updateGlobalSkills(
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
+    if (entry.sourceType === 'local' || entry.sourceType === 'well-known') {
+      skipped.push({
+        name: skillName,
+        reason: getSkipReason(entry),
+        sourceUrl: entry.sourceUrl,
+        sourceType: entry.sourceType,
+        ref: entry.ref,
+      });
+      continue;
+    }
+
     if (!entry.skillFolderHash || !entry.skillPath) {
       skipped.push({
         name: skillName,
@@ -340,32 +349,45 @@ export async function updateGlobalSkills(
     process.stdout.write(`\r${DIM}Checking skills from source: ${source}${RESET}\x1b[K\n`);
 
     try {
-      const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);
+      if (firstEntry.sourceType === 'github') {
+        const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);
 
-      if (tree) {
-        const discoveredPaths = findSkillMdPaths(tree);
+        if (tree) {
+          const discoveredPaths = findSkillMdPaths(tree);
 
-        const allLockedForSource = Object.entries(lock.skills)
-          .filter(([_, entry]) => entry.source === source)
-          .map(([name, _]) => name);
+          const allLockedForSource = Object.entries(lock.skills)
+            .filter(([_, entry]) => entry.source === source)
+            .map(([name, _]) => name);
 
-        const deletedSkills = await checkAndPromptForDeletions(
-          source,
-          allLockedForSource,
-          lock.skills,
-          true,
-          options,
-          discoveredPaths
-        );
+          const deletedSkills = await checkAndPromptForDeletions(
+            source,
+            allLockedForSource,
+            lock.skills,
+            true,
+            options,
+            discoveredPaths
+          );
 
+          for (const { name: skillName, entry } of itemsForSource) {
+            const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
+            if (latestHash && latestHash !== entry.skillFolderHash) {
+              updates.push({ name: skillName, source, entry });
+            }
+          }
+        } else {
+          console.log(`  ${DIM}✗ Failed to fetch tree for ${source}${RESET}`);
+        }
+      } else {
         for (const { name: skillName, entry } of itemsForSource) {
-          const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
+          const latestHash = await fetchGitSkillFolderHash(
+            entry.sourceUrl,
+            entry.skillPath!,
+            entry.ref
+          );
           if (latestHash && latestHash !== entry.skillFolderHash) {
             updates.push({ name: skillName, source, entry });
           }
         }
-      } else {
-        console.log(`  ${DIM}✗ Failed to fetch tree for ${source}${RESET}`);
       }
     } catch (error) {
       console.log(`  ${DIM}✗ Error checking skills from ${source}${RESET}`);


### PR DESCRIPTION
Skills installed from non-GitHub git sources (Bitbucket, GitLab, etc.) always report as up to date because `fetchSkillFolderHash` exclusively calls the GitHub Trees API, which returns `null` for non-GitHub URLs — causing the update check to silently pass. This adds `fetchGitSkillFolderHash` for `git` and `gitlab` source types using a shallow clone and SHA-256 hash of the skill folder contents — the same mechanism already used at install time, and more precise than commit SHA tracking since it only flags updates when the skill folder itself changes, not on every commit to the repo. Fixes #386.
