### PR TITLE
fix: warn instead of silently skipping malformed SKILL.md files (#1058)

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat } from 'fs/promises';
 import { join, basename, dirname, resolve, normalize, sep, relative } from 'path';
 import { parseFrontmatter } from './frontmatter.ts';
-import { sanitizeMetadata } from './sanitize.ts';
+import { sanitizeMetadata, stripTerminalEscapes } from './sanitize.ts';
 import type { Skill } from './types.ts';
 import { getPluginSkillPaths, getPluginGroupings } from './plugin-manifest.ts';
 import { readLocalLock } from './local-lock.ts';
@@ -68,42 +68,63 @@ async function hasSkillMd(dir: string): Promise<boolean> {
   }
 }
 
+function warnSkippedSkill(skillMdPath: string, reason: string): void {
+  console.warn(`⚠ Skipped ${sanitizeMetadata(skillMdPath)} — ${stripTerminalEscapes(reason)}`);
+}
+
 export async function parseSkillMd(
   skillMdPath: string,
   options?: { includeInternal?: boolean }
 ): Promise<Skill | null> {
+  let content: string;
   try {
-    const content = await readFile(skillMdPath, 'utf-8');
-    const { data } = parseFrontmatter(content);
-
-    if (!data.name || !data.description) {
-      return null;
-    }
-
-    // Ensure name and description are strings (YAML can parse numbers, booleans, etc.)
-    if (typeof data.name !== 'string' || typeof data.description !== 'string') {
-      return null;
-    }
-
-    // Skip internal skills unless:
-    // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
-    // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const metadata = isRecord(data.metadata) ? data.metadata : undefined;
-    const isInternal = metadata?.internal === true;
-    if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
-      return null;
-    }
-
-    return {
-      name: sanitizeMetadata(data.name),
-      description: sanitizeMetadata(data.description),
-      path: dirname(skillMdPath),
-      rawContent: content,
-      metadata,
-    };
-  } catch {
+    content = await readFile(skillMdPath, 'utf-8');
+  } catch (err) {
+    warnSkippedSkill(skillMdPath, `failed to read file: ${(err as Error).message}`);
     return null;
   }
+
+  let data: Record<string, unknown>;
+  try {
+    ({ data } = parseFrontmatter(content));
+  } catch (err) {
+    warnSkippedSkill(skillMdPath, `YAML parse error: ${(err as Error).message}`);
+    return null;
+  }
+
+  if (!data.name || !data.description) {
+    const missing: string[] = [];
+    if (!data.name) missing.push('name');
+    if (!data.description) missing.push('description');
+    warnSkippedSkill(skillMdPath, `missing required frontmatter field(s): ${missing.join(', ')}`);
+    return null;
+  }
+
+  // Ensure name and description are strings (YAML can parse numbers, booleans, etc.)
+  if (typeof data.name !== 'string' || typeof data.description !== 'string') {
+    warnSkippedSkill(
+      skillMdPath,
+      `frontmatter "name" and "description" must be strings (got ${typeof data.name} and ${typeof data.description})`
+    );
+    return null;
+  }
+
+  // Skip internal skills unless:
+  // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
+  // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
+  const metadata = isRecord(data.metadata) ? data.metadata : undefined;
+  const isInternal = metadata?.internal === true;
+  if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
+    return null;
+  }
+
+  return {
+    name: sanitizeMetadata(data.name),
+    description: sanitizeMetadata(data.description),
+    path: dirname(skillMdPath),
+    rawContent: content,
+    metadata,
+  };
 }
 
 async function findSkillDirs(dir: string, depth = 0, maxDepth = 5): Promise<string[]> {
@@ -156,6 +177,7 @@ export async function discoverSkills(
 ): Promise<Skill[]> {
   const skills: Skill[] = [];
   const seenNames = new Set<string>();
+  const parsedSkillPaths = new Set<string>();
   const localLock = await readLocalLock(basePath);
   const lockedSkillNames = new Set(Object.keys(localLock.skills).map(normalizeSkillName));
 
@@ -195,11 +217,18 @@ export async function discoverSkills(
     return lockedSkillNames.has(skillName) || lockedSkillNames.has(directoryName);
   };
 
+  const parseSkillAt = async (skillDir: string): Promise<Skill | null> => {
+    const skillMdPath = resolve(skillDir, 'SKILL.md');
+    if (parsedSkillPaths.has(skillMdPath)) return null;
+    parsedSkillPaths.add(skillMdPath);
+    return parseSkillMd(skillMdPath, options);
+  };
+
   // If pointing directly at a skill, add it (and return early unless fullDepth is set).
   // If the root SKILL.md is an installed project skill tracked by skills-lock.json,
   // ignore it and continue scanning in case the repo also contains source skills.
   if (await hasSkillMd(searchPath)) {
-    let skill = await parseSkillMd(join(searchPath, 'SKILL.md'), options);
+    let skill = await parseSkillAt(searchPath);
     if (skill) {
       if (!isInstalledProjectSkill(skill)) {
         skill = enhanceSkill(skill);
@@ -236,7 +265,7 @@ export async function discoverSkills(
 
   const tryAddSkillAt = async (skillDir: string): Promise<boolean> => {
     if (!(await hasSkillMd(skillDir))) return false;
-    let skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+    let skill = await parseSkillAt(skillDir);
     if (!skill || seenNames.has(skill.name)) return true;
     if (isInstalledProjectSkill(skill)) return true;
     skill = enhanceSkill(skill);
@@ -284,7 +313,7 @@ export async function discoverSkills(
     const allSkillDirs = await findSkillDirs(searchPath);
 
     for (const skillDir of allSkillDirs) {
-      let skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+      let skill = await parseSkillAt(skillDir);
       if (skill && !seenNames.has(skill.name) && !isInstalledProjectSkill(skill)) {
         skill = enhanceSkill(skill);
         skills.push(skill);

--- a/tests/skill-matching.test.ts
+++ b/tests/skill-matching.test.ts
@@ -5,11 +5,11 @@
  * must be quoted on the command line (e.g., --skill "Convex Best Practices").
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { filterSkills, parseSkillMd } from '../src/skills.ts';
+import { discoverSkills, filterSkills, parseSkillMd } from '../src/skills.ts';
 import type { Skill } from '../src/types.ts';
 
 // Mock skill factory
@@ -97,14 +97,17 @@ describe('filterSkills', () => {
 
 describe('parseSkillMd with non-string frontmatter values', () => {
   let testDir: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     testDir = join(tmpdir(), `skills-nonstring-test-${Date.now()}`);
     mkdirSync(testDir, { recursive: true });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     rmSync(testDir, { recursive: true, force: true });
+    warnSpy.mockRestore();
   });
 
   it('rejects skill with numeric name', async () => {
@@ -121,6 +124,7 @@ description: A skill with numeric name
     );
     const result = await parseSkillMd(skillPath);
     expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('must be strings'));
   });
 
   it('rejects skill with boolean name', async () => {
@@ -137,6 +141,7 @@ description: A skill with boolean name
     );
     const result = await parseSkillMd(skillPath);
     expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('must be strings'));
   });
 
   it('rejects skill with array name', async () => {
@@ -155,6 +160,7 @@ description: A skill with array name
     );
     const result = await parseSkillMd(skillPath);
     expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('must be strings'));
   });
 
   it('rejects skill with numeric description', async () => {
@@ -171,6 +177,7 @@ description: 456
     );
     const result = await parseSkillMd(skillPath);
     expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('must be strings'));
   });
 
   it('accepts skill with valid string name and description', async () => {
@@ -188,6 +195,142 @@ description: A valid skill
     const result = await parseSkillMd(skillPath);
     expect(result).not.toBeNull();
     expect(result!.name).toBe('valid-skill');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseSkillMd warnings on parse failures', () => {
+  let testDir: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-warn-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    warnSpy.mockRestore();
+  });
+
+  it('warns when YAML frontmatter fails to parse (issue #1058)', async () => {
+    // Reproduces the exact case from issue #1058: a description containing
+    // ": " is parsed by the yaml package as a nested compact mapping.
+    const skillPath = join(testDir, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+name: my-skill
+description: Configure the harness: Hooks, MCP Servers, Skills
+---
+
+# My Skill
+`
+    );
+    const result = await parseSkillMd(skillPath);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(skillPath));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('YAML parse error'));
+  });
+
+  it('warns once when discovery skips a malformed skill', async () => {
+    const skillDir = join(testDir, 'skills', 'broken-skill');
+    const skillPath = join(skillDir, 'SKILL.md');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      skillPath,
+      `---
+name: broken-skill
+description: Configure the harness: Hooks, MCP Servers, Skills
+---
+`
+    );
+
+    const result = await discoverSkills(testDir);
+
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(skillPath));
+  });
+
+  it('strips terminal escapes from malformed-skill warnings', async () => {
+    const skillDir = join(testDir, 'skills', 'bad-\x1b[31mred');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: broken-skill
+description: Configure the harness: Hooks
+---
+`
+    );
+
+    await discoverSkills(testDir);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).not.toContain('\x1b');
+  });
+
+  it('warns when name is missing', async () => {
+    const skillPath = join(testDir, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+description: A skill with no name
+---
+
+# No Name
+`
+    );
+    const result = await parseSkillMd(skillPath);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('missing required'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('name'));
+  });
+
+  it('warns when description is missing', async () => {
+    const skillPath = join(testDir, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+name: nameless
+---
+
+# No Description
+`
+    );
+    const result = await parseSkillMd(skillPath);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('missing required'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('description'));
+  });
+
+  it('warns when SKILL.md cannot be read', async () => {
+    const skillPath = join(testDir, 'does-not-exist', 'SKILL.md');
+    const result = await parseSkillMd(skillPath);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('failed to read file'));
+  });
+
+  it('does not warn for internal skills filtered by default', async () => {
+    const skillPath = join(testDir, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+name: internal-skill
+description: An internal skill
+metadata:
+  internal: true
+---
+
+# Internal Skill
+`
+    );
+    const result = await parseSkillMd(skillPath);
+    expect(result).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #1058.

## What

When `parseSkillMd` encounters a `SKILL.md` it can't parse, the skill is currently dropped from the result set with no warning. \"Found N skills\" silently understates the count and skill authors have no way to know what broke or why.

This change makes `parseSkillMd` write a warning to `stderr` whenever it returns `null` due to a parse failure, while preserving the existing return behavior.

## Why

I hit this while building a skill of my own — a `description` field containing `: ` (colon + space) is valid-looking YAML but the `yaml` package rejects it as a compact nested mapping:

```
Error: Nested mappings are not allowed in compact mappings at line 2, column 14
```

Without a warning, the skill just doesn't appear in `--list` and there's nothing to diagnose against. The fix on the author's side (a block scalar) is one character, but discovering you need it is the hard part.

## What it looks like now

```
⚠ Skipped /path/to/SKILL.md — YAML parse error: Nested mappings are not allowed in compact mappings at line 2, column 14:

description: Configure the harness: Hooks, MCP Servers, Skills
             ^
```

Verified end-to-end against the exact reproduction from the issue.

## Coverage

Each silent-failure path now warns:
- File can't be read (`ENOENT`, perms, …)
- Frontmatter YAML parse error
- Required field missing (`name` or `description`)
- Required field present but non-string (number, boolean, array, …)

Internal-skill filtering (`metadata.internal: true`) still returns `null` without warning, since that's intentional filtering rather than a parse failure.

Function still returns `null` in every error case — no behavior change beyond the new warnings.

## Tests

- Updated all 5 existing `parseSkillMd` tests to assert the appropriate warning is logged
- Added 5 new tests covering: YAML parse error (the exact issue repro), missing `name`, missing `description`, file read failure, and the internal-skill no-warn path

All 20 tests in `tests/skill-matching.test.ts` pass. `pnpm format:check` passes.