### PR TITLE
fix(add): make universal agent detection scope-aware

### DIFF
--- a/src/add-prompt.test.ts
+++ b/src/add-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { promptForAgents } from './add.js';
+import { promptForAgents, selectAgentsInteractive } from './add.js';
+import { agents } from './agents.js';
 import * as skillLock from './skill-lock.js';
 import * as searchMultiselectModule from './prompts/search-multiselect.js';
 
@@ -99,5 +100,33 @@ describe('promptForAgents', () => {
     await promptForAgents('Select agents', choices);
 
     expect(skillLock.saveSelectedAgents).not.toHaveBeenCalled();
+  });
+});
+
+describe('selectAgentsInteractive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses global universal grouping when selecting agents for global installs', async () => {
+    vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(['amp']);
+    vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue(['amp']);
+
+    await selectAgentsInteractive({ global: true });
+
+    expect(searchMultiselectModule.searchMultiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lockedSection: expect.objectContaining({
+          items: expect.not.arrayContaining([expect.objectContaining({ value: 'amp' })]),
+        }),
+        items: expect.arrayContaining([
+          expect.objectContaining({
+            value: 'amp',
+            hint: agents.amp.globalSkillsDir,
+          }),
+        ]),
+        initialSelected: ['amp'],
+      })
+    );
   });
 });

--- a/src/add.ts
+++ b/src/add.ts
@@ -29,6 +29,7 @@ import {
   installBlobSkillForAgent,
   isSkillInstalled,
   getCanonicalPath,
+  getAgentBaseDir,
   installWellKnownSkillForAgent,
   type InstallMode,
 } from './installer.ts';
@@ -187,7 +188,10 @@ function formatList(items: string[], maxShow: number = 5): string {
  * Splits agents into universal and non-universal (symlinked) groups.
  * Returns display names for each group.
  */
-function splitAgentsByType(agentTypes: AgentType[]): {
+function splitAgentsByType(
+  agentTypes: AgentType[],
+  options: { global?: boolean } = {}
+): {
   universal: string[];
   symlinked: string[];
 } {
@@ -195,7 +199,7 @@ function splitAgentsByType(agentTypes: AgentType[]): {
   const symlinked: string[] = [];
 
   for (const a of agentTypes) {
-    if (isUniversalAgent(a)) {
+    if (isUniversalAgent(a, options)) {
       universal.push(agents[a].displayName);
     } else {
       symlinked.push(agents[a].displayName);
@@ -208,9 +212,13 @@ function splitAgentsByType(agentTypes: AgentType[]): {
 /**
  * Builds summary lines showing universal vs symlinked agents
  */
-function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallMode): string[] {
+function buildAgentSummaryLines(
+  targetAgents: AgentType[],
+  installMode: InstallMode,
+  options: { global?: boolean } = {}
+): string[] {
   const lines: string[] = [];
-  const { universal, symlinked } = splitAgentsByType(targetAgents);
+  const { universal, symlinked } = splitAgentsByType(targetAgents, options);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -232,8 +240,11 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
  * Ensures universal agents are always included in the target agents list.
  * Used when -y flag is passed or when auto-selecting agents.
  */
-function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
-  const universalAgents = getUniversalAgents();
+function ensureUniversalAgents(
+  targetAgents: AgentType[],
+  options: { global?: boolean } = {}
+): AgentType[] {
+  const universalAgents = getUniversalAgents(options);
   const result = [...targetAgents];
 
   for (const ua of universalAgents) {
@@ -253,12 +264,13 @@ function buildResultLines(
     agent: string;
     symlinkFailed?: boolean;
   }>,
-  targetAgents: AgentType[]
+  targetAgents: AgentType[],
+  options: { global?: boolean } = {}
 ): string[] {
   const lines: string[] = [];
 
   // Split target agents by type
-  const { universal, symlinked: symlinkAgents } = splitAgentsByType(targetAgents);
+  const { universal } = splitAgentsByType(targetAgents, options);
 
   // For symlink results, also track which ones actually succeeded vs failed
   const successfulSymlinks = results
@@ -355,14 +367,18 @@ export async function promptForAgents(
  * Interactive agent selection using fuzzy search.
  * Shows universal agents as locked (always selected), and other agents as selectable.
  */
-async function selectAgentsInteractive(options: {
+export async function selectAgentsInteractive(options: {
   global?: boolean;
 }): Promise<AgentType[] | symbol> {
   // Filter out agents that don't support global installation when --global is used
   const supportsGlobalFilter = (a: AgentType) => !options.global || agents[a].globalSkillsDir;
 
-  const universalAgents = getUniversalAgents().filter(supportsGlobalFilter);
-  const otherAgents = getNonUniversalAgents().filter(supportsGlobalFilter);
+  const universalAgents = getUniversalAgents({ global: options.global }).filter(
+    supportsGlobalFilter
+  );
+  const otherAgents = getNonUniversalAgents({ global: options.global }).filter(
+    supportsGlobalFilter
+  );
 
   // Universal agents shown as locked section
   const universalSection = {
@@ -533,6 +549,33 @@ async function handleWellKnownSkills(
     selectedSkills = selected as WellKnownSkill[];
   }
 
+  let installGlobally = options.global ?? false;
+
+  if (options.global === undefined && !options.yes) {
+    const scope = await p.select({
+      message: 'Installation scope',
+      options: [
+        {
+          value: false,
+          label: 'Project',
+          hint: 'Install in current directory (committed with your project)',
+        },
+        {
+          value: true,
+          label: 'Global',
+          hint: 'Install in home directory (available across all projects)',
+        },
+      ],
+    });
+
+    if (p.isCancel(scope)) {
+      p.cancel('Installation cancelled');
+      process.exit(0);
+    }
+
+    installGlobally = scope as boolean;
+  }
+
   // Detect agents
   let targetAgents: AgentType[];
   const validAgents = Object.keys(agents);
@@ -584,7 +627,7 @@ async function handleWellKnownSkills(
       }
     } else if (installedAgents.length === 1 || options.yes) {
       // Auto-select detected agents + ensure universal agents are included
-      targetAgents = ensureUniversalAgents(installedAgents);
+      targetAgents = ensureUniversalAgents(installedAgents, { global: installGlobally });
       if (installedAgents.length === 1) {
         const firstAgent = installedAgents[0]!;
         p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
@@ -594,7 +637,7 @@ async function handleWellKnownSkills(
         );
       }
     } else {
-      const selected = await selectAgentsInteractive({ global: options.global });
+      const selected = await selectAgentsInteractive({ global: installGlobally });
 
       if (p.isCancel(selected)) {
         p.cancel('Installation cancelled');
@@ -605,42 +648,14 @@ async function handleWellKnownSkills(
     }
   }
 
-  let installGlobally = options.global ?? false;
-
-  // Check if any selected agents support global installation
-  const supportsGlobal = targetAgents.some((a) => agents[a].globalSkillsDir !== undefined);
-
-  if (options.global === undefined && !options.yes && supportsGlobal) {
-    const scope = await p.select({
-      message: 'Installation scope',
-      options: [
-        {
-          value: false,
-          label: 'Project',
-          hint: 'Install in current directory (committed with your project)',
-        },
-        {
-          value: true,
-          label: 'Global',
-          hint: 'Install in home directory (available across all projects)',
-        },
-      ],
-    });
-
-    if (p.isCancel(scope)) {
-      p.cancel('Installation cancelled');
-      process.exit(0);
-    }
-
-    installGlobally = scope as boolean;
-  }
+  const cwd = process.cwd();
 
   // Determine install mode (symlink vs copy)
   let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
   // Only prompt for install mode when there are multiple unique target directories.
-  // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-  const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+  // When all selected agents share the same target directory, symlink vs copy is meaningless.
+  const uniqueDirs = new Set(targetAgents.map((a) => getAgentBaseDir(a, installGlobally, cwd)));
 
   if (!options.copy && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
@@ -665,8 +680,6 @@ async function handleWellKnownSkills(
     // Single target directory — default to copy (no symlink needed)
     installMode = 'copy';
   }
-
-  const cwd = process.cwd();
 
   // Build installation summary
   const summaryLines: string[] = [];
@@ -696,7 +709,9 @@ async function handleWellKnownSkills(
     const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
     const shortCanonical = shortenPath(canonicalPath, cwd);
     summaryLines.push(`${pc.cyan(shortCanonical)}`);
-    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+    summaryLines.push(
+      ...buildAgentSummaryLines(targetAgents, installMode, { global: installGlobally })
+    );
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
     }
@@ -857,7 +872,9 @@ async function handleWellKnownSkills(
         } else {
           resultLines.push(`${pc.green('✓')} ${skillName}`);
         }
-        resultLines.push(...buildResultLines(skillResults, targetAgents));
+        resultLines.push(
+          ...buildResultLines(skillResults, targetAgents, { global: installGlobally })
+        );
       }
     }
 
@@ -1226,6 +1243,34 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         )
       : Promise.resolve(null);
 
+    let installGlobally = options.global ?? false;
+
+    if (options.global === undefined && !options.yes) {
+      const scope = await p.select({
+        message: 'Installation scope',
+        options: [
+          {
+            value: false,
+            label: 'Project',
+            hint: 'Install in current directory (committed with your project)',
+          },
+          {
+            value: true,
+            label: 'Global',
+            hint: 'Install in home directory (available across all projects)',
+          },
+        ],
+      });
+
+      if (p.isCancel(scope)) {
+        p.cancel('Installation cancelled');
+        await cleanup(tempDir);
+        process.exit(0);
+      }
+
+      installGlobally = scope as boolean;
+    }
+
     let targetAgents: AgentType[];
     const validAgents = Object.keys(agents);
 
@@ -1278,7 +1323,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
       } else if (installedAgents.length === 1 || options.yes) {
         // Auto-select detected agents + ensure universal agents are included
-        targetAgents = ensureUniversalAgents(installedAgents);
+        targetAgents = ensureUniversalAgents(installedAgents, { global: installGlobally });
         if (installedAgents.length === 1) {
           const firstAgent = installedAgents[0]!;
           p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
@@ -1288,7 +1333,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           );
         }
       } else {
-        const selected = await selectAgentsInteractive({ global: options.global });
+        const selected = await selectAgentsInteractive({ global: installGlobally });
 
         if (p.isCancel(selected)) {
           p.cancel('Installation cancelled');
@@ -1300,43 +1345,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    let installGlobally = options.global ?? false;
-
-    // Check if any selected agents support global installation
-    const supportsGlobal = targetAgents.some((a) => agents[a].globalSkillsDir !== undefined);
-
-    if (options.global === undefined && !options.yes && supportsGlobal) {
-      const scope = await p.select({
-        message: 'Installation scope',
-        options: [
-          {
-            value: false,
-            label: 'Project',
-            hint: 'Install in current directory (committed with your project)',
-          },
-          {
-            value: true,
-            label: 'Global',
-            hint: 'Install in home directory (available across all projects)',
-          },
-        ],
-      });
-
-      if (p.isCancel(scope)) {
-        p.cancel('Installation cancelled');
-        await cleanup(tempDir);
-        process.exit(0);
-      }
-
-      installGlobally = scope as boolean;
-    }
+    const cwd = process.cwd();
 
     // Determine install mode (symlink vs copy)
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
     // Only prompt for install mode when there are multiple unique target directories.
-    // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-    const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+    // When all selected agents share the same target directory, symlink vs copy is meaningless.
+    const uniqueDirs = new Set(targetAgents.map((a) => getAgentBaseDir(a, installGlobally, cwd)));
 
     if (!options.copy && !options.yes && uniqueDirs.size > 1) {
       const modeChoice = await p.select({
@@ -1362,8 +1378,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Single target directory — default to copy (no symlink needed)
       installMode = 'copy';
     }
-
-    const cwd = process.cwd();
 
     // Build installation summary
     const summaryLines: string[] = [];
@@ -1409,7 +1423,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally });
         const shortCanonical = shortenPath(canonicalPath, cwd);
         summaryLines.push(`${pc.cyan(shortCanonical)}`);
-        summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+        summaryLines.push(
+          ...buildAgentSummaryLines(targetAgents, installMode, { global: installGlobally })
+        );
 
         const skillOverwrites = overwriteStatus.get(skill.name);
         const overwriteAgents = targetAgents
@@ -1717,7 +1733,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             } else {
               resultLines.push(`${pc.green('✓')} ${entry.skill}`);
             }
-            resultLines.push(...buildResultLines(skillResults, targetAgents));
+            resultLines.push(
+              ...buildResultLines(skillResults, targetAgents, { global: installGlobally })
+            );
           }
         }
       };

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,8 +1,9 @@
 import { homedir } from 'os';
-import { join } from 'path';
+import { join, normalize, resolve } from 'path';
 import { existsSync } from 'fs';
 import { xdgConfig } from 'xdg-basedir';
 import type { AgentConfig, AgentType } from './types.ts';
+import { UNIVERSAL_SKILLS_DIR } from './constants.ts';
 
 const home = homedir();
 // Use xdg-basedir (not env-paths) to match OpenCode/Amp/Goose behavior on all platforms.
@@ -10,6 +11,12 @@ const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
+
+const globalUniversalSkillsDir = join(home, UNIVERSAL_SKILLS_DIR);
+
+function isSamePath(a: string, b: string): boolean {
+  return normalize(resolve(a)) === normalize(resolve(b));
+}
 
 export function getOpenClawGlobalSkillsDir(
   homeDir = home,
@@ -535,31 +542,42 @@ export function getAgentConfig(type: AgentType): AgentConfig {
 }
 
 /**
- * Returns agents that use the universal .agents/skills directory.
+ * Returns agents that use the universal .agents/skills directory for a scope.
  * These agents share a common skill location and don't need symlinks.
  * Agents with showInUniversalList: false are excluded.
  */
-export function getUniversalAgents(): AgentType[] {
+export function getUniversalAgents(options: { global?: boolean } = {}): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
-    .filter(
-      ([_, config]) => config.skillsDir === '.agents/skills' && config.showInUniversalList !== false
-    )
+    .filter(([type, config]) => {
+      return isUniversalAgent(type, options) && config.showInUniversalList !== false;
+    })
     .map(([type]) => type);
 }
 
 /**
- * Returns agents that use agent-specific skill directories (not universal).
+ * Returns agents that use agent-specific skill directories for a scope (not universal).
  * These agents need symlinks from the canonical .agents/skills location.
  */
-export function getNonUniversalAgents(): AgentType[] {
+export function getNonUniversalAgents(options: { global?: boolean } = {}): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
-    .filter(([_, config]) => config.skillsDir !== '.agents/skills')
+    .filter(([type, config]) => {
+      return !isUniversalAgent(type, options) && config.showInUniversalList !== false;
+    })
     .map(([type]) => type);
 }
 
 /**
- * Check if an agent uses the universal .agents/skills directory.
+ * Check if an agent uses the universal .agents/skills directory for a scope.
  */
-export function isUniversalAgent(type: AgentType): boolean {
-  return agents[type].skillsDir === '.agents/skills';
+export function isUniversalAgent(type: AgentType, options: { global?: boolean } = {}): boolean {
+  const agent = agents[type];
+
+  if (options.global) {
+    return (
+      agent.globalSkillsDir !== undefined &&
+      isSamePath(agent.globalSkillsDir, globalUniversalSkillsDir)
+    );
+  }
+
+  return agent.skillsDir === UNIVERSAL_SKILLS_DIR;
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -92,7 +92,7 @@ export function getCanonicalSkillsDir(global: boolean, cwd?: string): string {
  * redundant symlinks and double-listing of skills.
  */
 export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: string): string {
-  if (isUniversalAgent(agentType)) {
+  if (isUniversalAgent(agentType, { global })) {
     return getCanonicalSkillsDir(global, cwd);
   }
 
@@ -292,10 +292,9 @@ export async function installSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     await copyDirectory(skill.path, canonicalDir);
 
-    // For universal agents with global install, the skill is already in the canonical
-    // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
-    // (e.g. ~/.copilot/skills) to avoid duplicates.
-    if (isGlobal && isUniversalAgent(agentType)) {
+    // For agents whose target directory is already canonical for this scope,
+    // avoid creating a symlink from the skill directory to itself.
+    if (isUniversalAgent(agentType, { global: isGlobal })) {
       return {
         success: true,
         path: canonicalDir,
@@ -532,8 +531,9 @@ export async function installRemoteSkillForAgent(
     const skillMdPath = join(canonicalDir, 'SKILL.md');
     await writeFile(skillMdPath, skill.content, 'utf-8');
 
-    // For universal agents with global install, skip creating agent-specific symlink
-    if (isGlobal && isUniversalAgent(agentType)) {
+    // For agents whose target directory is already canonical for this scope,
+    // avoid creating a symlink from the skill directory to itself.
+    if (isUniversalAgent(agentType, { global: isGlobal })) {
       return {
         success: true,
         path: canonicalDir,
@@ -670,8 +670,9 @@ export async function installWellKnownSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     await writeSkillFiles(canonicalDir);
 
-    // For universal agents with global install, skip creating agent-specific symlink
-    if (isGlobal && isUniversalAgent(agentType)) {
+    // For agents whose target directory is already canonical for this scope,
+    // avoid creating a symlink from the skill directory to itself.
+    if (isUniversalAgent(agentType, { global: isGlobal })) {
       return {
         success: true,
         path: canonicalDir,
@@ -785,7 +786,7 @@ export async function installBlobSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     await writeSkillFiles(canonicalDir);
 
-    if (isGlobal && isUniversalAgent(agentType)) {
+    if (isUniversalAgent(agentType, { global: isGlobal })) {
       return {
         success: true,
         path: canonicalDir,

--- a/tests/agent-universal.test.ts
+++ b/tests/agent-universal.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  agents,
+  getNonUniversalAgents,
+  getUniversalAgents,
+  isUniversalAgent,
+} from '../src/agents.ts';
+import { getAgentBaseDir } from '../src/installer.ts';
+
+describe('scope-aware universal agent classification', () => {
+  it('keeps project-level universal agents separate from global universal agents', () => {
+    expect(isUniversalAgent('amp')).toBe(true);
+    expect(isUniversalAgent('antigravity')).toBe(true);
+
+    expect(isUniversalAgent('amp', { global: true })).toBe(false);
+    expect(isUniversalAgent('antigravity', { global: true })).toBe(false);
+    expect(isUniversalAgent('cline', { global: true })).toBe(true);
+  });
+
+  it('uses agent-specific global directories for agents that only share project .agents/skills', () => {
+    const projectDir = join(homedir(), 'example-project');
+
+    expect(getAgentBaseDir('amp', false, projectDir)).toBe(join(projectDir, '.agents', 'skills'));
+    expect(getAgentBaseDir('amp', true, projectDir)).toBe(agents.amp.globalSkillsDir);
+    expect(getAgentBaseDir('antigravity', true, projectDir)).toBe(
+      agents.antigravity.globalSkillsDir
+    );
+  });
+
+  it('builds universal agent lists for the selected install scope', () => {
+    expect(getUniversalAgents()).toContain('amp');
+    expect(getUniversalAgents({ global: true })).not.toContain('amp');
+    expect(getUniversalAgents({ global: true })).not.toContain('antigravity');
+    expect(getUniversalAgents({ global: true })).toContain('cline');
+
+    expect(getNonUniversalAgents({ global: true })).toContain('amp');
+    expect(getNonUniversalAgents({ global: true })).toContain('antigravity');
+    expect(getNonUniversalAgents({ global: true })).not.toContain('universal');
+  });
+});


### PR DESCRIPTION
## Problem

Global installs currently classify agents as "universal" using their project-level `skillsDir`. That works for project installs, where `.agents/skills` is the shared canonical location, but it is wrong for agents whose documented global directory differs.

For example, Amp and Antigravity both use `.agents/skills` at the project level, but their global skill directories are agent-specific. A global symlink install can therefore report them under `~/.agents/skills` as universal instead of linking into the global directory those agents actually read.

Fixes #1060.

## Root cause

The universal-agent helpers only checked `skillsDir === ".agents/skills"`. The add/install flow reused that same project-scope classification for global installs, so it decided which agents were universal before it knew which scope-specific directory should be used.

The install-mode prompt had the same scope leak: it compared project `skillsDir` values even for global installs, so it could decide symlink vs copy was meaningless when the selected agents actually had different global target directories.

## Fix

This changes the add flow so scope is chosen before the interactive agent picker needs to decide which agents are universal. With that information available up front, the locked "Universal" group in the picker can reflect the actual install scope instead of always using project-level `.agents/skills` behavior.

The universality check is now scope-aware. For project installs, agents that use `.agents/skills` are still treated as universal, preserving the existing project behavior. For global installs, an agent is only treated as universal when its `globalSkillsDir` resolves to the canonical global `.agents/skills` directory. Agents like Amp and Antigravity still share the project-level universal directory, but they are no longer grouped as globally universal because their documented global directories are agent-specific.

That same scoped definition is used by the installer when resolving an agent's target directory and deciding whether to skip creating a symlink. As a result, global installs now link or copy into the agent's documented global directory unless that global directory really is the shared canonical location. The symlink/copy prompt also compares the scoped target directories instead of comparing project `skillsDir` values, so it only suppresses the install-method choice when the selected agents truly share the same destination for the selected scope.

## Tests

- `pnpm test tests/agent-universal.test.ts tests/installer-symlink.test.ts src/add.test.ts src/add-prompt.test.ts`
- `pnpm format`
- `pnpm format:check`
- `git diff --check`

Notes: `pnpm type-check` still fails on the same pre-existing unrelated errors in `src/git.ts`, `src/providers/wellknown.ts`, and `src/skills.ts`; this change does not add new type-check failures.
