### PR TITLE
feat(trustless-work): add Trustless Work escrow skill

### DIFF
--- a/skills/trustless-work/SKILL.md
+++ b/skills/trustless-work/SKILL.md
@@ -1,0 +1,438 @@
+---
+name: trustless-work
+description: Integrate Trustless Work Escrow-as-a-Service (EaaS) on Stellar/Soroban. Use when the user asks to "set up escrow", "integrate escrow payments", "build a milestone payment flow", "add USDC escrow", "use Trustless Work", or "write a Trustless Work integration". Covers REST API, @trustless-work/escrow SDK, @trustless-work/blocks UI components, XDR signing patterns, escrow lifecycle, roles, and trustlines.
+metadata:
+  author: trustless-work
+  version: "1.2.0"
+---
+
+# Trustless Work
+
+> Source of truth: https://docs.trustlesswork.com/trustless-work/
+> Always consult this skill before writing or reviewing any Trustless Work integration.
+
+---
+
+## Scope of This Skill
+
+This skill is exclusively for **Trustless Work integration review and assistance**. When reviewing a codebase:
+
+- ✅ Flag issues related to Trustless Work: XDR signing patterns, role assignments, trustline setup, API usage, provider configuration, escrow lifecycle, etc.
+- ❌ Do **NOT** flag or suggest fixes for general programming logic errors, UI bugs, type issues, or code quality problems that are unrelated to Trustless Work.
+- ❌ Do **NOT** suggest refactors or improvements beyond what is necessary for a correct Trustless Work integration.
+
+If a code problem is not caused by how Trustless Work is being used, leave it out of the review.
+
+---
+
+## What Is Trustless Work?
+
+Trustless Work is **Escrow-as-a-Service (EaaS)** built on **Stellar's Soroban** smart contract platform. It enables non-custodial payment flows with milestones, approvals, and dispute resolution — without writing your own smart contracts.
+
+**Three integration paths:**
+- **API** — REST endpoints, usable from any backend or frontend
+- **SDK** (`@trustless-work/escrow`) — React/Next.js hooks that wrap the API
+- **Blocks** (`@trustless-work/blocks`) — Pre-built React UI components (forms, tables, dialogs)
+
+---
+
+## Escrow Types
+
+| Type | Milestones | Releases | Best For |
+|------|------------|----------|----------|
+| **Single-Release** | Multiple | One payout for all milestones | Simple jobs, deposits, one-off payments |
+| **Multi-Release** | Multiple | One payout per milestone | Grants, projects, milestone billing |
+
+Choose the type at deployment time. It cannot be changed after the escrow is created.
+
+---
+
+## Roles (9 total)
+
+Every escrow has a `roles` object. Each role is a **Stellar public address (G…)**. Signing authority follows the role — not the platform.
+
+| Role | Capabilities | Notes |
+|------|-------------|-------|
+| **Issuer** | Deploys the escrow | Indexed only — no fund control |
+| **Funder** | Deposits funds | Cannot move funds once deposited |
+| **Service Provider** | Updates milestone `status` text; can raise disputes | Cannot approve or release |
+| **Approver** | Sets `approved: true` on milestones; can raise disputes | Required for fund release |
+| **Release Signer** | Executes payout once all milestones approved | Two modes: Payout (platform sends) or Claim (receiver self-signs) |
+| **Receiver** | Receives released funds | In multi-release, each milestone can have its own receiver |
+| **Platform Address** | Updates metadata before funding; collects platform fees automatically | Can optionally serve as Dispute Resolver or Release Signer |
+| **Dispute Resolver** | Arbitrates conflicts; re-routes funds | Decisions are final and on-chain |
+| **Observer** | Read-only; no lifecycle involvement | Coming soon |
+
+**Principle of Least Privilege:** No single party controls the full fund flow alone.
+
+---
+
+## Escrow Lifecycle (6 Phases)
+
+```
+1. Initiation
+   └─ Platform/Issuer deploys contract with roles, milestones, token, fees
+   └─ Returns: unsigned XDR → sign as Issuer → submit
+
+2. Funding
+   └─ Funder deposits capital into the escrow contract
+   └─ Returns: unsigned XDR → sign as Funder → submit
+   └─ PREREQUISITE: Funder must have a trustline for the escrow asset
+
+3. Change Milestone Status
+   └─ Service Provider updates the milestone status text (free-form string)
+   └─ Example statuses: "In Progress", "Under Review", "Delivered"
+   └─ Returns: unsigned XDR → sign as Service Provider → submit
+
+4. Approval
+   └─ Approver sets approved: true on a milestone
+   └─ IRREVERSIBLE — no undo on-chain
+   └─ Returns: unsigned XDR → sign as Approver → submit
+   └─ Alternatively: Approver raises a dispute instead of approving
+
+5. Release
+   └─ Release Signer executes payout once all required milestones are approved
+   └─ Returns: unsigned XDR → sign as Release Signer → submit
+   └─ For multi-release: specify milestoneIndex
+
+6. Dispute Resolution (if needed)
+   └─ Dispute Resolver arbitrates
+   └─ Can re-route funds between Approver and Service Provider
+   └─ Returns: unsigned XDR → sign as Dispute Resolver → submit
+```
+
+---
+
+## Escrow Schema — Full Data Models
+
+> These schemas represent the stored escrow object returned by the API. Use them as the reference for all payloads and form field types.
+
+### Single-Release Escrow
+
+```typescript
+{
+  engagementId:  string;   // Your internal ID linking the escrow to your records
+  title:         string;
+  description:   string;
+  amount:        number;   // ✅ 1000   ❌ "1000" — ALWAYS a number
+  platformFee:   number;   // ✅ 2      ❌ "2"    — ALWAYS a number
+
+  roles: {
+    approver:        string;  // G… Stellar address
+    serviceProvider: string;  // G… Stellar address
+    platformAddress: string;  // G… Stellar address
+    releaseSigner:   string;  // G… Stellar address
+    disputeResolver: string;  // G… Stellar address
+    receiver:        string;  // G… Stellar address — only in Single-Release
+  };
+
+  milestones: Array<{
+    title:       string;
+    description: string;
+    status:      string;   // Free-form text set by Service Provider (default: "Pending")
+    approved:    boolean;  // Set to true by Approver. IRREVERSIBLE.
+    evidence?:   string;   // Optional — work documentation link
+  }>;
+
+  flags: {
+    disputed: boolean;
+    released: boolean;
+    resolved: boolean;
+  };
+
+  trustline: {
+    address: string;  // G… Stellar ISSUER address of the asset (e.g. USDC issuer)
+    symbol:  string;  // Asset ticker (e.g. "USDC", "EURC")
+  };
+}
+```
+
+### Multi-Release Escrow
+
+```typescript
+{
+  engagementId:  string;
+  title:         string;
+  description:   string;
+  // ⚠️ No top-level `amount` — amount is defined per-milestone
+  platformFee:   number;   // ✅ 2  ❌ "2"
+
+  roles: {
+    approver:        string;  // G… Stellar address
+    serviceProvider: string;  // G… Stellar address
+    platformAddress: string;  // G… Stellar address
+    releaseSigner:   string;  // G… Stellar address
+    disputeResolver: string;  // G… Stellar address
+    // ⚠️ No `receiver` here — each milestone defines its own receiver
+  };
+
+  milestones: Array<{
+    title:       string;
+    description: string;
+    status:      string;
+    amount:      number;  // ✅ 500  ❌ "500" — ALWAYS a number, per milestone
+    receiver:    string;  // G… Stellar address — defined per milestone (not in roles)
+    evidence?:   string;  // Optional
+    flags: {
+      disputed: boolean;
+      released: boolean;
+      resolved: boolean;
+      approved: boolean;  // Per-milestone in Multi-Release (vs top-level flags in Single)
+    };
+  }>;
+
+  trustline: {
+    address: string;  // G… Stellar ISSUER address of the asset
+    symbol:  string;  // "USDC", "EURC", etc.
+  };
+}
+```
+
+### Key Schema Differences: Single vs Multi-Release
+
+| Field | Single-Release | Multi-Release |
+|-------|---------------|---------------|
+| `amount` | Top-level, `number` | Per-milestone, `number` |
+| `receiver` | In `roles` object | Per-milestone in `milestones[]` |
+| `flags` | Single top-level object | Per-milestone `flags` object |
+| `approved` | In each milestone object | Inside per-milestone `flags` |
+
+### Type Rules — Critical for Forms and Payloads
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `amount` (deploy) | `number` | ✅ `1000` ❌ `"1000"` |
+| `amount` (fund-escrow) | `string` | ✅ `"1000"` ❌ `1000` — exception |
+| `platformFee` | `number` | ✅ `2` ❌ `"2"` |
+| Milestone `amount` (multi-release) | `number` | ✅ `500` ❌ `"500"` |
+| `milestoneIndex` | `string` | ✅ `"0"` ❌ `0` (operation params only) |
+| `distributions[].amount` | `number` | Amount per recipient in resolve-dispute |
+| All addresses | `string` | G… (wallets) or C… (contracts) |
+| `engagementId`, `title`, `description` | `string` | — |
+| `trustline.address` | `string` | Must be G… issuer address, NOT C… contract |
+| `trustline.symbol` | `string` | e.g. `"USDC"` |
+
+> 🔴 **Form validation rule:** `amount` in deploy and `platformFee` use `z.number()`. `milestoneIndex` uses `z.string()`. `amount` in fund-escrow uses `z.string()`. Use the table above as the reference — do not assume all amounts share the same type.
+
+---
+
+## Milestone Data Model
+
+```typescript
+// Single-Release milestone
+{
+  title:       string;
+  description: string;
+  status:      string;   // Free-form text, updated by Service Provider (default: "Pending")
+  approved:    boolean;  // Set to true by Approver. IRREVERSIBLE.
+  evidence?:   string;   // Optional — work documentation
+}
+
+// Multi-Release milestone (adds amount, receiver, flags)
+{
+  title:       string;
+  description: string;
+  status:      string;
+  amount:      number;   // Payout for this milestone — number, not string
+  receiver:    string;   // G… address — defined here, not in roles
+  evidence?:   string;
+  flags: {
+    disputed: boolean;
+    released: boolean;
+    resolved: boolean;
+    approved: boolean;
+  };
+}
+```
+
+**status** and **approved** are independent fields:
+- Service Provider updates `status` to communicate progress
+- Approver sets `approved: true` when satisfied (regardless of status text)
+- Once `approved: true`, there is **no unapprove**
+
+---
+
+## Trustlines (Stellar-Specific — Critical)
+
+On Stellar, every account must explicitly opt in to hold an asset by establishing a **trustline** before receiving or holding tokens (USDC, EURC, etc.).
+
+**ALL escrow participants must have a trustline for the escrow asset before any transaction can succeed.**
+
+Common trustline errors produce cryptic Soroban errors. Always check/establish trustlines early in your onboarding flow.
+
+> ⚠️ **The `/helper/set-trustline` endpoint no longer exists.**
+
+Each participant must add the trustline directly from their own wallet:
+
+```
+Setup flow:
+1. Open your Stellar wallet (e.g. Freighter, LOBSTR, xBull)
+2. Go to "Add Asset" or "Add Trustline"
+3. Search for the asset by name (e.g. USDC) or find it manually in the wallet
+4. Confirm the trustline addition in your wallet
+```
+
+> 🔴 **CRITICAL — `trustline` is an object, not a string:**
+> The `trustline` field in the escrow payload is an **object** with two fields:
+> ```json
+> "trustline": {
+>   "address": "G…",   // G… Stellar ISSUER address of the asset — NOT the C… contract address
+>   "symbol": "USDC"   // Asset ticker symbol
+> }
+> ```
+> **Do NOT** pass a plain string. **Do NOT** use the **C… Soroban contract address** in `trustline.address`. Using the C… address there is one of the most common mistakes and will cause escrow failures.
+
+---
+
+## THE XDR SIGNING PATTERN (Critical — Read This First)
+
+This is the most important concept in Trustless Work. **Every write operation follows this exact 3-step pattern:**
+
+```
+Step 1: Call API/SDK  →  receive { unsignedTransaction: "AAAA..." }
+Step 2: Sign XDR client-side with the CORRECT ROLE wallet
+Step 3: POST /helper/send-transaction { signedXdr }  (or useSendTransaction hook)
+```
+
+**Why?** Trustless Work never holds your private keys. The API constructs the transaction but you sign it — fully non-custodial.
+
+**Which wallet signs?** The wallet that holds the **role** required for that operation:
+
+| Operation | Must be signed by |
+|-----------|-------------------|
+| Deploy escrow | Issuer |
+| Fund escrow | Funder |
+| Change milestone status | Service Provider |
+| Approve milestone | Approver |
+| Release funds | Release Signer |
+| Raise dispute | Approver or Service Provider |
+| Resolve dispute | Dispute Resolver |
+| Set trustline | The account establishing the trustline (done from the wallet directly — no API endpoint) |
+
+**Common XDR mistakes:**
+- ❌ Calling a write endpoint and ignoring the returned `unsignedTransaction`
+- ❌ Signing with the wrong role wallet
+- ❌ Signing but never submitting (nothing happens on-chain)
+- ❌ Submitting on behalf of a user role from the server (never do this)
+
+---
+
+## Authentication
+
+- **Method:** HTTP header `x-api-key: <your-api-key>`
+- **Read operations:** No API key required
+- **Write operations:** API key required → 401 if missing or invalid
+- **Rate limit:** 50 requests / 60 seconds per client → 429 if exceeded
+
+**Getting an API key:**
+1. Connect Stellar wallet at https://dapp.trustlesswork.com
+2. Sign the authentication message (creates your profile)
+3. Go to Settings (click wallet address, bottom-left)
+4. Generate and copy your API key
+
+---
+
+## Environment Variables
+
+```bash
+# .env.local (Next.js — client-side SDK)
+NEXT_PUBLIC_API_KEY=your_trustless_work_api_key
+
+# .env (Node.js backend — server-side only)
+TW_API_KEY=your_trustless_work_api_key
+
+# Never commit these to git.
+# For Next.js: NEXT_PUBLIC_ prefix exposes the var to the browser bundle.
+# Consider proxying API calls through Route Handlers to avoid exposing the key.
+```
+
+---
+
+## API Environments
+
+| Environment | Base URL |
+|------------|----------|
+| **Development (Testnet)** | `https://dev.api.trustlesswork.com` |
+| **Production (Mainnet)** | `https://api.trustlesswork.com` |
+| **Swagger UI** | `https://dev.api.trustlesswork.com/docs` |
+
+Always start on testnet. Switch to mainnet for production.
+
+---
+
+## Error Handling
+
+| HTTP Status | Meaning | Action |
+|-------------|---------|--------|
+| 400 | Bad Request — malformed payload | Check required fields, types, and values |
+| 401 | Unauthorized — missing/invalid API key | Verify `x-api-key` header |
+| 429 | Rate limit exceeded | Implement exponential backoff |
+| 500 | Server error | Retry with backoff; report if persistent |
+
+**Retry pattern:**
+```javascript
+async function withRetry(fn, maxAttempts = 3) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err.status === 429 && i < maxAttempts - 1) {
+        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, i)));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+```
+
+---
+
+## Security Rules (Always Apply)
+
+1. **Never log or print API keys, private keys, or secrets**
+2. **Never sign on behalf of a user role from your server** — only sign platform-owned roles server-side
+3. **Never expose `TW_API_KEY` without `NEXT_PUBLIC_` prefix** in client bundles (prefer Route Handler proxy)
+4. **Validate all role addresses** before deploying escrows — wrong addresses cannot be changed
+5. **Add confirmation dialogs** before irreversible on-chain actions (approval, release, dispute)
+
+---
+
+## General Integration Checklist
+
+- [ ] All participants have trustlines for the escrow asset
+- [ ] API key configured in environment (not hardcoded)
+- [ ] XDR signing flow implemented: get → sign → submit
+- [ ] Correct role wallet signs each operation
+- [ ] Error handling for 400, 401, 429, 500
+- [ ] `engagementId` used to link escrows to internal records
+- [ ] Testnet integration tested end-to-end before mainnet
+- [ ] Confirmation dialogs on irreversible actions (approve, release)
+- [ ] Logging does not print secrets or private keys
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| 401 on write calls | Missing or invalid API key | Check `x-api-key` header / env var |
+| Transaction fails on submit | Wrong signer role | Re-check which role must sign the operation |
+| "No trustline" error | Participant missing trustline | Each participant must add the trustline from their own wallet (Add Asset). Use the G… issuer address — NOT the C… contract address |
+| "No QueryClient set" | Wrong provider order | `QueryClientProvider` must wrap `TrustlessWorkConfig` |
+| Hooks return nothing | Missing provider or Server Component | Ensure `TrustlessWorkConfig` is in a client component |
+| 429 Too Many Requests | Rate limit hit | Add exponential backoff; batch reads |
+| XDR signed but nothing happens | Forgot to submit | Call `sendTransaction` after signing |
+| Approval reverted | Trying to un-approve | Approvals are immutable — add UX confirmation first |
+
+---
+
+## Reference Files
+
+Deep-dive documentation for each integration path:
+
+- `references/api.md` — Complete REST API endpoint reference, auth, error codes, Node.js examples
+- `references/sdk.md` — @trustless-work/escrow React SDK: all hooks, provider setup, TypeScript types
+- `references/blocks.md` — @trustless-work/blocks UI components: provider order, wallet kit, context pattern
+- `references/checklist.md` — Pre-production integration checklist (per product)
+- `references/examples.md` — Full code examples: API (Node.js), SDK (React/Next.js), Blocks (Next.js layout)

--- a/skills/trustless-work/references/api.md
+++ b/skills/trustless-work/references/api.md
@@ -1,0 +1,341 @@
+# Trustless Work — API Reference
+
+> Read SKILL.md first for core concepts (roles, lifecycle, XDR pattern).
+> Ref: https://docs.trustlesswork.com/trustless-work/api-reference
+
+---
+
+## Base URLs
+
+| Environment | URL |
+|------------|-----|
+| Development (Testnet) | `https://dev.api.trustlesswork.com` |
+| Production (Mainnet) | `https://api.trustlesswork.com` |
+| Swagger UI | `https://dev.api.trustlesswork.com/docs` |
+
+---
+
+## Authentication
+
+All write requests require the `x-api-key` header:
+
+```http
+POST /deployer/single-release HTTP/1.1
+Host: dev.api.trustlesswork.com
+Content-Type: application/json
+x-api-key: your_api_key_here
+```
+
+Read-only endpoints (GET) work without the header.
+
+---
+
+## Endpoint Reference
+
+### Deployer
+
+| Method | Path | Signer Role | Returns |
+|--------|------|-------------|---------|
+| POST | `/deployer/single-release` | Issuer | `{ unsignedTransaction }` |
+| POST | `/deployer/multi-release` | Issuer | `{ unsignedTransaction }` |
+
+**Deploy payload (single-release):**
+```json
+{
+  "signer": "GISSUER_ADDRESS",
+  "engagementId": "invoice-2024-001",
+  "title": "Website Redesign",
+  "description": "Complete redesign of marketing site",
+  "amount": 1000,
+  "roles": {
+    "approver": "GAPPROVER_ADDRESS",
+    "serviceProvider": "GSERVICE_PROVIDER_ADDRESS",
+    "releaseSigner": "GRELEASE_SIGNER_ADDRESS",
+    "disputeResolver": "GDISPUTE_RESOLVER_ADDRESS",
+    "receiver": "GRECEIVER_ADDRESS",
+    "platformAddress": "GPLATFORM_ADDRESS"
+  },
+  "platformFee": 2,
+  "trustline": {
+    "address": "GUSDC_ISSUER_STELLAR_ADDRESS",
+    "symbol": "USDC"
+  },
+  "milestones": [
+    {
+      "title": "Design Mockups",
+      "description": "Deliver Figma mockups for all pages"
+    },
+    {
+      "title": "Development",
+      "description": "Implement designs in React"
+    }
+  ]
+}
+```
+
+> ⚠️ **Type rules for this payload:**
+> - `amount` and `platformFee` are **numbers** (`1000`, `2`) — not strings
+> - `trustline.address` is the **G… Stellar issuer address** of the asset — NOT the C… Soroban contract address
+> - All role addresses are G… Stellar public keys
+
+**Deploy payload (multi-release):** No top-level `amount`. Each milestone has its own `amount` (number) and `receiver` (G… address). No `receiver` in `roles`.
+```json
+{
+  "signer": "GISSUER_ADDRESS",
+  "engagementId": "invoice-2024-001",
+  "title": "Website Redesign",
+  "description": "Complete redesign of marketing site",
+  "roles": {
+    "approver": "GAPPROVER_ADDRESS",
+    "serviceProvider": "GSERVICE_PROVIDER_ADDRESS",
+    "releaseSigner": "GRELEASE_SIGNER_ADDRESS",
+    "disputeResolver": "GDISPUTE_RESOLVER_ADDRESS",
+    "platformAddress": "GPLATFORM_ADDRESS"
+  },
+  "platformFee": 2,
+  "trustline": {
+    "address": "GUSDC_ISSUER_STELLAR_ADDRESS",
+    "symbol": "USDC"
+  },
+  "milestones": [
+    { "title": "Phase 1", "description": "...", "amount": 400, "receiver": "GRECEIVER_ADDRESS" },
+    { "title": "Phase 2", "description": "...", "amount": 600, "receiver": "GRECEIVER_ADDRESS" }
+  ]
+}
+```
+
+---
+
+### Escrow Operations
+
+All paths use `{type}` = `single-release` or `multi-release`.
+
+| Method | Path | Signer Role | Returns |
+|--------|------|-------------|---------|
+| POST | `/escrow/{type}/fund-escrow` | Funder | `{ unsignedTransaction }` |
+| POST | `/escrow/{type}/change-milestone-status` | Service Provider | `{ unsignedTransaction }` |
+| POST | `/escrow/{type}/approve-milestone` | Approver | `{ unsignedTransaction }` |
+| POST | `/escrow/{type}/release-funds` | Release Signer | `{ unsignedTransaction }` |
+| POST | `/escrow/{type}/dispute-escrow` | Approver or Service Provider | `{ unsignedTransaction }` |
+| POST | `/escrow/{type}/resolve-dispute` | Dispute Resolver | `{ unsignedTransaction }` |
+| GET  | `/escrow/{type}/get-escrow` | — | Escrow object |
+| POST | `/escrow/{type}/update-escrow` | Platform Address | `{ unsignedTransaction }` |
+
+**Fund escrow (single-release and multi-release):**
+```json
+{
+  "contractId": "CXXXXX...",
+  "signer": "GFUNDER_ADDRESS",
+  "amount": "1000"
+}
+```
+
+**Change milestone status (single-release and multi-release):**
+```json
+{
+  "contractId": "CXXXXX...",
+  "serviceProvider": "GSERVICE_PROVIDER_ADDRESS",
+  "milestoneIndex": "0",
+  "newStatus": "Under Review",
+  "newEvidence": "https://link-to-evidence.com"
+}
+```
+
+**Approve milestone (single-release and multi-release):**
+```json
+{
+  "contractId": "CXXXXX...",
+  "approver": "GAPPROVER_ADDRESS",
+  "milestoneIndex": "0"
+}
+```
+
+**Release funds (single-release):**
+```json
+{ "contractId": "CXXXXX...", "releaseSigner": "GRELEASE_SIGNER_ADDRESS" }
+```
+
+**Release funds (multi-release):**
+```json
+{ "contractId": "CXXXXX...", "releaseSigner": "GRELEASE_SIGNER_ADDRESS", "milestoneIndex": "0" }
+```
+
+**Dispute escrow (single-release):**
+```json
+{ "contractId": "CXXXXX...", "signer": "GAPPROVER_OR_SP_ADDRESS" }
+```
+
+**Dispute milestone (multi-release):**
+```json
+{ "contractId": "CXXXXX...", "signer": "GAPPROVER_OR_SP_ADDRESS", "milestoneIndex": "0" }
+```
+
+**Resolve dispute (single-release):**
+```json
+{
+  "contractId": "CXXXXX...",
+  "disputeResolver": "GDISPUTE_RESOLVER_ADDRESS",
+  "distributions": [
+    { "address": "GAPPROVER_ADDRESS", "amount": 300 },
+    { "address": "GRECEIVER_ADDRESS", "amount": 700 }
+  ]
+}
+```
+
+**Resolve dispute (multi-release):**
+```json
+{
+  "contractId": "CXXXXX...",
+  "disputeResolver": "GDISPUTE_RESOLVER_ADDRESS",
+  "milestoneIndex": "0",
+  "distributions": [
+    { "address": "GAPPROVER_ADDRESS", "amount": 300 },
+    { "address": "GRECEIVER_ADDRESS", "amount": 700 }
+  ]
+}
+```
+
+**Get escrow:**
+```
+GET /escrow/single-release/get-escrow?contractId=CXXXXX...
+```
+
+---
+
+### Helpers
+
+| Method | Path | Description | Returns |
+|--------|------|-------------|---------|
+| POST | `/helper/send-transaction` | Submit signed XDR to Stellar | Transaction result |
+| GET  | `/helper/get-escrows-by-signer` | Query escrows by signer | Escrow list |
+| GET  | `/helper/get-escrows-by-role` | Query escrows by role | Escrow list |
+| GET  | `/helper/get-escrow-by-contract-ids` | Query by contract IDs | Escrow list |
+| GET  | `/helper/get-multiple-escrow-balance` | Batch balance query | Balances |
+
+> ⚠️ **Trustlines:** The `/helper/set-trustline` endpoint no longer exists. Each participant must find the asset in their own wallet (e.g. Freighter → Add Asset / Add Trustline) and add it manually.
+
+**Send transaction (final step of every write flow):**
+```json
+{ "signedXdr": "AAAAAgAAAAB..." }
+```
+
+---
+
+### Indexer
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/indexer/update-from-tx-hash` | Sync indexer state from a transaction hash |
+
+---
+
+## Complete Write Flow (Node.js / fetch)
+
+```javascript
+const BASE_URL = process.env.NODE_ENV === 'production'
+  ? 'https://api.trustlesswork.com'
+  : 'https://dev.api.trustlesswork.com';
+
+const HEADERS = {
+  'Content-Type': 'application/json',
+  'x-api-key': process.env.TW_API_KEY,
+};
+
+// Step 1: Get unsigned XDR
+async function deployEscrow(payload) {
+  const res = await fetch(`${BASE_URL}/deployer/single-release`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`Deploy failed: ${res.status} ${await res.text()}`);
+  return res.json(); // { unsignedTransaction: "AAAA..." }
+}
+
+// Step 3: Submit
+async function sendTransaction(signedXdr) {
+  const res = await fetch(`${BASE_URL}/helper/send-transaction`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify({ signedXdr }),
+  });
+  if (!res.ok) throw new Error(`Submit failed: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+```
+
+---
+
+## Error Codes
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 400 | Malformed payload | Check required fields, numeric amounts, trustline object, valid G… addresses |
+| 401 | Bad API key | Verify `x-api-key` header; regenerate key if needed |
+| 429 | Rate limit (50 req/60s) | Implement exponential backoff |
+| 500 | Server error | Retry 2-3x with backoff |
+
+---
+
+## Common Mistakes (API)
+
+### ❌ 1. Ignoring the unsigned XDR
+```javascript
+// WRONG — escrow is never created on-chain
+await fetch('/deployer/single-release', { method: 'POST', body: ... });
+// Nothing happens without signing and submitting the returned XDR
+```
+
+### ❌ 2. Signing with the wrong wallet
+Every operation has a required signer role. Signing `approve-milestone` with the Service Provider wallet will produce an on-chain auth error.
+
+### ❌ 3. Amounts as strings instead of numbers
+```json
+// WRONG — will cause a 400 error
+{ "amount": "1000", "platformFee": "2" }
+
+// CORRECT
+{ "amount": 1000, "platformFee": 2 }
+```
+Same rule applies to milestone `amount` in multi-release payloads. Note: `fund-escrow`'s `amount` is a **string** (exception to the rule).
+
+### ❌ 4. Missing `trustline` object or using wrong address type
+```json
+// WRONG — trustline missing entirely
+{ "amount": 1000, "roles": {...} }
+
+// WRONG — trustline as plain string
+{ "trustline": "GXXX..." }
+
+// WRONG — using C… Soroban contract address in trustline.address
+{ "trustline": { "address": "CXXX...", "symbol": "USDC" } }
+
+// CORRECT — G… Stellar issuer address in trustline.address
+{ "trustline": { "address": "GXXX...", "symbol": "USDC" } }
+```
+`trustline.address` must be the G… Stellar issuer address — not the C… Soroban contract address.
+
+### ❌ 5. Missing required role addresses
+Single-release: all six roles (approver, serviceProvider, releaseSigner, disputeResolver, receiver, platformAddress) must be valid G… Stellar addresses.
+Multi-release: same but **no `receiver` in roles** — receiver is defined per-milestone inside `milestones[]`.
+
+### ❌ 6. Calling write endpoints without API key
+```javascript
+// WRONG — will return 401
+const headers = { 'Content-Type': 'application/json' };
+```
+
+### ❌ 7. Using production URL on testnet wallets
+Testnet accounts only exist on testnet. Using `api.trustlesswork.com` (mainnet) with testnet accounts will fail.
+
+### ❌ 8. Not guiding participants to add trustlines before transacting
+If any participant hasn't added the trustline for the escrow asset, the transaction will fail. The `/helper/set-trustline` endpoint no longer exists — each participant must add the trustline directly from their wallet using the G… issuer address.
+
+---
+
+## Security Best Practices
+
+- **Server-side only:** Keep `TW_API_KEY` in server env vars, never in client bundles
+- **Proxy pattern:** Use Next.js Route Handlers to proxy API calls (hides API key from browser)
+- **Validate addresses:** Verify all role addresses are valid Stellar public keys (G…, 56 chars) before calling deploy
+- **Log without secrets:** Never log the `x-api-key` header value or any private key material

--- a/skills/trustless-work/references/blocks.md
+++ b/skills/trustless-work/references/blocks.md
@@ -1,0 +1,342 @@
+# Trustless Work — Blocks Reference (@trustless-work/blocks)
+
+> Read SKILL.md first for core concepts. Read references/sdk.md for SDK setup.
+> Ref: https://docs.trustlesswork.com/trustless-work/escrow-blocks-sdk/getting-started
+
+---
+
+## What Are Blocks?
+
+`@trustless-work/blocks` is a **production-ready React component library** with pre-built UI for the full escrow lifecycle: forms, tables, dialogs, wallet connect, and operation buttons. Target: go from zero to MVP in under an hour.
+
+---
+
+## Installation
+
+### Option A: npm (manual setup)
+
+```bash
+npm install @trustless-work/blocks
+```
+
+### Option B: CLI (recommended for Next.js — auto-wires providers)
+
+```bash
+npx trustless-work init
+```
+
+The CLI:
+1. Installs shadcn/ui (interactive prompts)
+2. Installs all peer dependencies
+3. Creates `.twblocks.json` config
+4. Optionally wires providers into `app/layout.tsx`
+
+### Add specific blocks
+
+```bash
+npx trustless-work add wallet-kit
+npx trustless-work escrows   # installs escrow blocks under /escrows directory
+```
+
+---
+
+## Required Peer Dependencies
+
+```bash
+npm install \
+  @tanstack/react-query \
+  @tanstack/react-query-devtools \
+  @tanstack/react-table \
+  @trustless-work/escrow \
+  @creit.tech/stellar-wallets-kit \
+  @hookform/resolvers \
+  react-hook-form \
+  zod \
+  axios
+```
+
+---
+
+## Provider Setup (Critical — Order Matters)
+
+**Required nesting order:** `QueryClientProvider` → `TrustlessWorkConfig` → `WalletProvider`
+
+Wrong order causes runtime errors. This is the most common mistake.
+
+```typescript
+// app/layout.tsx  (or src/App.tsx for React SPA)
+"use client";
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { TrustlessWorkConfig, development, mainNet } from '@trustless-work/escrow';
+import { WalletProvider } from '@/providers/WalletProvider'; // your wallet context
+
+// Create queryClient OUTSIDE the component to avoid recreating on each render
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000, // 1 minute
+      retry: 2,
+    },
+  },
+});
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const isMainnet = process.env.NEXT_PUBLIC_USE_MAINNET === 'true';
+
+  return (
+    <html lang="en">
+      <body>
+        {/* 1. QueryClientProvider — OUTERMOST */}
+        <QueryClientProvider client={queryClient}>
+
+          {/* 2. TrustlessWorkConfig — handles API key + base URL */}
+          <TrustlessWorkConfig
+            baseURL={isMainnet ? mainNet : development}
+            apiKey={process.env.NEXT_PUBLIC_API_KEY ?? ''}
+          >
+
+            {/* 3. WalletProvider — your Stellar Wallets Kit context */}
+            <WalletProvider>
+              {children}
+            </WalletProvider>
+
+          </TrustlessWorkConfig>
+
+          {/* DevTools: only in development */}
+          {process.env.NODE_ENV === 'development' && (
+            <ReactQueryDevtools initialIsOpen={false} />
+          )}
+
+        </QueryClientProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+---
+
+## Stellar Wallets Kit Setup
+
+```typescript
+// providers/WalletProvider.tsx
+"use client";
+
+import { createContext, useContext, useState } from 'react';
+import {
+  StellarWalletsKit,
+  WalletNetwork,
+  FREIGHTER_ID,
+  FreighterModule,
+  AlbedoModule,
+  xBullModule,
+} from '@creit.tech/stellar-wallets-kit';
+
+const kit = new StellarWalletsKit({
+  network: process.env.NEXT_PUBLIC_USE_MAINNET === 'true'
+    ? WalletNetwork.PUBLIC
+    : WalletNetwork.TESTNET,
+  selectedWalletId: FREIGHTER_ID,
+  modules: [
+    new FreighterModule(),
+    new AlbedoModule(),
+    new xBullModule(),
+  ],
+});
+
+export function WalletProvider({ children }: { children: React.ReactNode }) {
+  const [address, setAddress] = useState<string | null>(null);
+
+  const connect = async () => {
+    await kit.openModal({
+      onWalletSelected: async (option) => {
+        kit.setWallet(option.id);
+        const { address } = await kit.getAddress();
+        setAddress(address);
+      },
+    });
+  };
+
+  return (
+    <WalletContext.Provider value={{ kit, address, connect, disconnect: () => setAddress(null) }}>
+      {children}
+    </WalletContext.Provider>
+  );
+}
+```
+
+---
+
+## Environment Variables
+
+```bash
+# .env.local
+NEXT_PUBLIC_API_KEY=your_trustless_work_api_key
+NEXT_PUBLIC_USE_MAINNET=false   # true for production
+```
+
+---
+
+## Available UI Components
+
+| Component | Description |
+|-----------|-------------|
+| `WalletButton` | Connect/disconnect wallet UI |
+| `EscrowsByRole` | List escrows filtered by role |
+| `EscrowsBySigner` | List escrows for a given signer address |
+| `InitializeEscrowForm` | Form for creating new escrows |
+| `ApproveMilestone` | Dialog for approving milestones |
+| `ChangeMilestoneStatus` | Form for updating milestone status |
+| `ReleaseEscrow` | UI for releasing funds |
+| `UpdateEscrow` | Form for editing escrow metadata |
+| `DisputeEscrow` | UI for raising a dispute |
+| `ResolveDispute` | UI for resolving disputes |
+
+Explore all at: https://blocks.trustlesswork.com
+
+---
+
+## Context Pattern: `setSelectedEscrow`
+
+The Blocks library uses a shared context. When a user selects an escrow, call `setSelectedEscrow(escrow)` — all operation hooks and components then read `contractId` and `roles` from this context automatically:
+
+```typescript
+import { useEscrowContext } from '@trustless-work/blocks';
+
+function EscrowList({ escrows }) {
+  const { setSelectedEscrow } = useEscrowContext();
+
+  return escrows.map(escrow => (
+    <div
+      key={escrow.contractId}
+      onClick={() => setSelectedEscrow(escrow)}  // sets global context
+    >
+      {escrow.title}
+    </div>
+  ));
+}
+
+// Elsewhere — ApproveMilestone reads selectedEscrow from context automatically
+function ApprovePanel() {
+  const { approveMilestone } = useApproveMilestone();
+  // contractId is read from the shared EscrowContext — no prop drilling needed
+}
+```
+
+---
+
+## Signing Pattern with Blocks
+
+```typescript
+"use client";
+import { useInitializeEscrow, useSendTransaction } from '@trustless-work/escrow/hooks';
+import { useWallet } from '@/providers/WalletProvider';
+import { WalletNetwork } from '@creit.tech/stellar-wallets-kit';
+
+export function CreateEscrowBlock() {
+  const { deployEscrow } = useInitializeEscrow();
+  const { sendTransaction } = useSendTransaction();
+  const { kit, address } = useWallet();
+
+  const handleSubmit = async (formData: FormData) => {
+    // 1. Build unsigned transaction
+    const { unsignedTransaction } = await deployEscrow(
+      buildPayload(formData),
+      'single-release'
+    );
+
+    // 2. Sign with issuer wallet client-side
+    const { signedTxXdr } = await kit.signTransaction(unsignedTransaction, {
+      networkPassphrase: WalletNetwork.TESTNET,
+      address: address!,
+    });
+
+    // 3. Submit
+    await sendTransaction({ signedXdr: signedTxXdr });
+  };
+
+  return <form onSubmit={handleSubmit}>...</form>;
+}
+```
+
+---
+
+## Common Mistakes (Blocks)
+
+### ❌ 1. Wrong provider order
+```typescript
+// WRONG — causes "No QueryClient set" or context errors
+<TrustlessWorkConfig>
+  <QueryClientProvider>  {/* must be OUTSIDE TrustlessWorkConfig */}
+    ...
+  </QueryClientProvider>
+</TrustlessWorkConfig>
+```
+
+### ❌ 2. Creating QueryClient inside the component
+```typescript
+// WRONG — new QueryClient on every render, loses cache
+function Layout() {
+  const queryClient = new QueryClient(); // ← inside component
+
+// CORRECT — create outside component (module scope)
+const queryClient = new QueryClient();
+function Layout() { ... }
+```
+
+### ❌ 3. Missing "use client" on layout with providers (Next.js)
+Providers that use React Context (`QueryClientProvider`, `TrustlessWorkConfig`, `WalletProvider`) must be in client components. Create a dedicated `Providers.tsx` file with `"use client"`.
+
+### ❌ 4. Wrong WalletNetwork for environment
+```typescript
+// WRONG — testnet passphrase on mainnet (signing will fail)
+const kit = new StellarWalletsKit({ network: WalletNetwork.TESTNET });
+
+// CORRECT — match network to environment
+const network = isMainnet ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET;
+```
+
+### ❌ 5. Not calling setSelectedEscrow before operations
+All operation components (Approve, Release, etc.) read from the shared escrow context. If `setSelectedEscrow` was never called, they operate on `null` and fail silently.
+
+### ❌ 6. Approving without confirmation
+```typescript
+// WRONG — approval is irreversible, no confirmation
+const handleApprove = () => approveMilestone(payload);
+
+// CORRECT — always confirm irreversible actions
+const handleApprove = async () => {
+  if (!confirm('Approve milestone? This cannot be undone.')) return;
+  await approveMilestone(payload);
+};
+```
+
+### ❌ 7. Forgetting trustlines in the onboarding flow
+When a new user connects their wallet, check and establish trustlines before they can participate in any escrow. Use `POST /helper/set-trustline` and sign/submit the returned XDR.
+
+---
+
+## `.twblocks.json` Configuration
+
+Created by `npx trustless-work init`:
+
+```json
+{
+  "version": "1.0.0",
+  "network": "testnet",
+  "apiKey": "NEXT_PUBLIC_API_KEY",
+  "components": []
+}
+```
+
+---
+
+## Key URLs
+
+| Resource | URL |
+|----------|-----|
+| Blocks showcase | https://blocks.trustlesswork.com |
+| GitHub (blocks) | https://github.com/Trustless-Work/react-library-trustless-work-blocks |
+| Docs | https://docs.trustlesswork.com/trustless-work/escrow-blocks-sdk/getting-started |

--- a/skills/trustless-work/references/checklist.md
+++ b/skills/trustless-work/references/checklist.md
@@ -1,0 +1,90 @@
+# Trustless Work — Integration Checklist
+
+Use this checklist before going to production. Each item maps to a verifiable signal in your codebase.
+
+---
+
+## Core (All Products)
+
+- [ ] **Trustlines established** — Every participant wallet has added the trustline for the escrow asset (USDC/EURC) directly from their own wallet. The `/helper/set-trustline` endpoint no longer exists — users must find the asset in their wallet and add it manually. Verified before any escrow transaction.
+- [ ] **Correct `trustline` object in deploy payload** — `trustline` is an object `{ address: "G…", symbol: "USDC" }`. The `address` must be the **G… Stellar issuer address** of the asset, NOT the C… Soroban contract address.
+- [ ] **API key stored in env var** — `NEXT_PUBLIC_API_KEY` or `TW_API_KEY`, never hardcoded in source.
+- [ ] **API key not in server-rendered output** — Either use `NEXT_PUBLIC_` only on client components, or proxy via Route Handlers.
+- [ ] **XDR sign → submit pattern implemented** — Every write call: receive `unsignedTransaction` → `kit.signTransaction()` → `sendTransaction({ signedXdr })`.
+- [ ] **Correct role signs each operation** — See SKILL.md role-to-operation table.
+- [ ] **Error handling** — 400, 401, 429, 500 all handled with user feedback.
+- [ ] **Rate limit backoff** — Exponential backoff for 429 responses.
+- [ ] **`engagementId` used** — Links escrows to your internal records.
+- [ ] **No secrets in logs** — API keys, private keys, and XDR never logged.
+- [ ] **Testnet tested** — Full lifecycle tested on testnet before mainnet.
+- [ ] **Environment toggle** — Base URL configurable between dev/prod via env var.
+- [ ] **Confirmation dialogs** — On approve-milestone, release-funds, and resolve-dispute.
+
+---
+
+## API (REST)
+
+- [ ] `x-api-key` header on all write requests
+- [ ] `amount` (deploy) and `platformFee` sent as **numbers** (`1000`, not `"1000"`)
+- [ ] `amount` in `fund-escrow` sent as **string** (`"1000"`, not `1000`) — exception to the rule
+- [ ] Milestone `amount` (multi-release) sent as **number**
+- [ ] `milestoneIndex` sent as **string** (e.g., `"0"` not `0`)
+- [ ] `distributions` array used in resolve-dispute (not `approverFunds`/`receiverFunds`)
+- [ ] All role addresses are valid G… Stellar public keys (56 chars)
+- [ ] `trustline` object included in deploy payload: `{ address: "G…", symbol: "USDC" }` — `address` must be the G… Stellar **issuer** address, NOT the C… contract address
+- [ ] Single-release: `receiver` is in `roles`; Multi-release: `receiver` is per-milestone (NOT in `roles`)
+- [ ] `POST /helper/send-transaction` called after every write operation
+- [ ] `GET` endpoints used for reads (no API key needed)
+- [ ] `engagementId` provided in deploy payloads
+
+---
+
+## SDK (@trustless-work/escrow)
+
+- [ ] `@trustless-work/escrow` in `dependencies`
+- [ ] `@tanstack/react-query` in `dependencies`
+- [ ] `@creit.tech/stellar-wallets-kit` in `dependencies`
+- [ ] `TrustlessWorkConfig` is a client component (`"use client"` in Next.js)
+- [ ] Provider order correct: `QueryClientProvider` → `TrustlessWorkConfig` → `WalletProvider`
+- [ ] `NEXT_PUBLIC_API_KEY` in `.env.local` (Next.js) or `VITE_API_KEY` (Vite)
+- [ ] `useSendTransaction` called after every write hook + signing
+- [ ] `useInitializeEscrow` → `deployEscrow(payload, type)` — type matches your escrow type
+- [ ] Single vs multi-release payloads used correctly (multi needs `milestoneIndex`)
+- [ ] Write hooks only called inside `TrustlessWorkConfig` tree
+
+---
+
+## Blocks (@trustless-work/blocks)
+
+- [ ] `@trustless-work/blocks` in `dependencies`
+- [ ] All peer deps installed (react-query, react-query-table, escrow, wallets-kit, react-hook-form, zod)
+- [ ] `QueryClient` instantiated **outside** the component (module scope)
+- [ ] Provider nesting: `QueryClientProvider` → `TrustlessWorkConfig` → `WalletProvider`
+- [ ] Provider file has `"use client"` (Next.js App Router)
+- [ ] `StellarWalletsKit` network matches environment (`WalletNetwork.TESTNET` / `WalletNetwork.PUBLIC`)
+- [ ] `setSelectedEscrow(escrow)` called before any operation component is used
+- [ ] Confirmation dialog before `approveMilestone`
+- [ ] Trustline guidance exists in onboarding — users are instructed to add the trustline from their wallet using the G… issuer address (not C… contract address)
+- [ ] `ReactQueryDevtools` added (dev only) for debugging
+
+---
+
+## Security
+
+- [ ] API keys only in `.env*` files (in `.gitignore`)
+- [ ] No private keys in source code or env vars client-side
+- [ ] No secrets in git history
+- [ ] `NEXT_PUBLIC_API_KEY` reviewed — acceptable to expose? (Consider Route Handler proxy)
+- [ ] Stellar addresses validated before escrow deployment
+
+---
+
+## Pre-Production Checklist
+
+- [ ] End-to-end escrow lifecycle tested on **testnet**: deploy → fund → change status → approve → release
+- [ ] Dispute resolution tested
+- [ ] All error scenarios tested (missing trustline, wrong signer, rate limit)
+- [ ] Switch base URL to `https://api.trustlesswork.com` for mainnet
+- [ ] Switch `WalletNetwork.TESTNET` → `WalletNetwork.PUBLIC` for mainnet
+- [ ] Real USDC/EURC token address used (not testnet placeholder)
+- [ ] Rate limit monitoring in place for high-volume use cases

--- a/skills/trustless-work/references/examples.md
+++ b/skills/trustless-work/references/examples.md
@@ -1,0 +1,428 @@
+# Trustless Work — Code Examples
+
+Full working examples for each integration path.
+Read SKILL.md for XDR signing concepts before using these.
+
+---
+
+## Example 1 — REST API (Node.js)
+
+Full escrow lifecycle: deploy → fund → change status → approve → release.
+
+> **Note:** Server-side signing shown here is only valid for **platform-owned roles**.
+> Never sign on behalf of user roles (Approver, Service Provider) from the server.
+
+```javascript
+import { Keypair, Transaction, Networks } from '@stellar/stellar-sdk';
+
+const BASE_URL = process.env.NODE_ENV === 'production'
+  ? 'https://api.trustlesswork.com'
+  : 'https://dev.api.trustlesswork.com';
+
+const HEADERS = {
+  'Content-Type': 'application/json',
+  'x-api-key': process.env.TW_API_KEY,
+};
+
+// ── Utilities ─────────────────────────────────────────────────────────────
+
+async function callApi(path, body) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`API ${path} failed (${res.status}): ${await res.text()}`);
+  return res.json();
+}
+
+function signXdr(unsignedTransaction, secretKey) {
+  const network = process.env.NODE_ENV === 'production' ? Networks.PUBLIC : Networks.TESTNET;
+  const keypair = Keypair.fromSecret(secretKey);
+  const tx = new Transaction(unsignedTransaction, network);
+  tx.sign(keypair);
+  return tx.toEnvelope().toXDR('base64');
+}
+
+async function sendTransaction(signedXdr) {
+  const res = await fetch(`${BASE_URL}/helper/send-transaction`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify({ signedXdr }),
+  });
+  if (!res.ok) throw new Error(`send-transaction failed (${res.status})`);
+  return res.json();
+}
+
+async function withRetry(fn, maxAttempts = 3) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err.message.includes('429') && i < maxAttempts - 1) {
+        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, i)));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+// ── Step 1: Deploy Escrow ─────────────────────────────────────────────────
+
+async function deployEscrow() {
+  const { unsignedTransaction } = await withRetry(() =>
+    callApi('/deployer/single-release', {
+      signer: process.env.PLATFORM_ADDRESS,
+      engagementId: `order-${Date.now()}`,
+      title: 'Website Redesign Project',
+      description: 'Full redesign of marketing website',
+      amount: 1000,                             // ✅ number, not string
+      roles: {
+        approver: process.env.APPROVER_ADDRESS,
+        serviceProvider: process.env.SERVICE_PROVIDER_ADDRESS,
+        releaseSigner: process.env.PLATFORM_ADDRESS,
+        disputeResolver: process.env.PLATFORM_ADDRESS,
+        receiver: process.env.SERVICE_PROVIDER_ADDRESS,  // only in single-release
+        platformAddress: process.env.PLATFORM_ADDRESS,
+      },
+      platformFee: 2,                           // ✅ number, not string
+      trustline: {
+        address: process.env.USDC_ISSUER_ADDRESS,  // G… Stellar issuer address
+        symbol: 'USDC',
+      },
+      milestones: [
+        { title: 'Design Phase', description: 'Deliver Figma mockups' },
+        { title: 'Dev Phase', description: 'Implement in React' },
+      ],
+    })
+  );
+
+  const signedXdr = signXdr(unsignedTransaction, process.env.PLATFORM_SECRET_KEY);
+  const result = await sendTransaction(signedXdr);
+  return result; // contains contractId
+}
+
+// ── Step 2: Fund Escrow ───────────────────────────────────────────────────
+
+async function fundEscrow(contractId) {
+  const { unsignedTransaction } = await callApi('/escrow/single-release/fund-escrow', {
+    contractId,
+    signer: process.env.FUNDER_ADDRESS,
+    amount: '1000',   // string in fund-escrow (unlike deploy where amount is number)
+  });
+  const signedXdr = signXdr(unsignedTransaction, process.env.FUNDER_SECRET_KEY);
+  return sendTransaction(signedXdr);
+}
+
+// ── Step 3: Change Milestone Status ──────────────────────────────────────
+
+async function changeMilestoneStatus(contractId, milestoneIndex, newStatus, newEvidence) {
+  const { unsignedTransaction } = await callApi(
+    '/escrow/single-release/change-milestone-status',
+    {
+      contractId,
+      serviceProvider: process.env.SERVICE_PROVIDER_ADDRESS,  // `serviceProvider`, not `signer`
+      milestoneIndex,   // string e.g. '0'
+      newStatus,
+      newEvidence,
+    }
+  );
+  const signedXdr = signXdr(unsignedTransaction, process.env.SERVICE_PROVIDER_SECRET);
+  return sendTransaction(signedXdr);
+}
+
+// ── Step 4: Approve Milestone (IRREVERSIBLE) ──────────────────────────────
+
+async function approveMilestone(contractId, milestoneIndex) {
+  const { unsignedTransaction } = await callApi(
+    '/escrow/single-release/approve-milestone',
+    {
+      contractId,
+      approver: process.env.APPROVER_ADDRESS,  // `approver`, not `signer`
+      milestoneIndex,   // string e.g. '0'
+    }
+  );
+  const signedXdr = signXdr(unsignedTransaction, process.env.APPROVER_SECRET);
+  return sendTransaction(signedXdr);
+}
+
+// ── Step 5: Release Funds ─────────────────────────────────────────────────
+
+async function releaseFunds(contractId) {
+  const { unsignedTransaction } = await callApi('/escrow/single-release/release-funds', {
+    contractId,
+    releaseSigner: process.env.PLATFORM_ADDRESS,  // `releaseSigner`, not `signer`
+  });
+  const signedXdr = signXdr(unsignedTransaction, process.env.PLATFORM_SECRET_KEY);
+  return sendTransaction(signedXdr);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { contractId } = await deployEscrow();
+  await fundEscrow(contractId);
+  await changeMilestoneStatus(contractId, '0', 'Under Review', 'https://evidence.com');
+  await approveMilestone(contractId, '0');
+  await approveMilestone(contractId, '1');
+  await releaseFunds(contractId);
+  console.log('Escrow lifecycle complete! Contract:', contractId);
+}
+
+main().catch(console.error);
+```
+
+---
+
+## Example 2 — SDK (React / Next.js App Router)
+
+Provider setup + create escrow + approve milestone + read escrows.
+
+```tsx
+// ── 1. Providers (components/Providers.tsx) ───────────────────────────────
+"use client"; // ← REQUIRED
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TrustlessWorkConfig, development, mainNet } from "@trustless-work/escrow";
+import { StellarWalletsKit, WalletNetwork, FREIGHTER_ID, FreighterModule } from "@creit.tech/stellar-wallets-kit";
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+// Create OUTSIDE component — never inside
+const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 60_000 } } });
+const isMainnet = process.env.NEXT_PUBLIC_USE_MAINNET === "true";
+
+const kit = new StellarWalletsKit({
+  network: isMainnet ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
+  selectedWalletId: FREIGHTER_ID,
+  modules: [new FreighterModule()],
+});
+
+// Wallet context
+const WalletContext = createContext<{ kit: typeof kit; address: string | null; connect: () => Promise<void> } | null>(null);
+
+function WalletProvider({ children }: { children: ReactNode }) {
+  const [address, setAddress] = useState<string | null>(null);
+  const connect = async () => {
+    await kit.openModal({ onWalletSelected: async (opt) => {
+      kit.setWallet(opt.id);
+      const { address } = await kit.getAddress();
+      setAddress(address);
+    }});
+  };
+  return <WalletContext.Provider value={{ kit, address, connect }}>{children}</WalletContext.Provider>;
+}
+
+export const useWallet = () => {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be inside WalletProvider");
+  return ctx;
+};
+
+// ORDER IS CRITICAL: QueryClientProvider → TrustlessWorkConfig → WalletProvider
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TrustlessWorkConfig baseURL={isMainnet ? mainNet : development} apiKey={process.env.NEXT_PUBLIC_API_KEY ?? ""}>
+        <WalletProvider>{children}</WalletProvider>
+      </TrustlessWorkConfig>
+    </QueryClientProvider>
+  );
+}
+
+// ── 2. Create Escrow Component ─────────────────────────────────────────────
+"use client";
+import { useInitializeEscrow, useSendTransaction } from "@trustless-work/escrow/hooks";
+
+export function CreateEscrowForm() {
+  const { deployEscrow } = useInitializeEscrow();
+  const { sendTransaction } = useSendTransaction();
+  const { kit, address } = useWallet();
+
+  const handleCreate = async () => {
+    if (!address) return;
+
+    // Step 1: Get unsigned XDR
+    const { unsignedTransaction } = await deployEscrow({
+      signer: address,
+      engagementId: `order-${Date.now()}`,
+      title: "Website Redesign",
+      description: "Full redesign",
+      amount: 1000,                             // ✅ number, not string
+      roles: {
+        approver: process.env.NEXT_PUBLIC_APPROVER_ADDRESS ?? "",
+        serviceProvider: address,
+        releaseSigner: process.env.NEXT_PUBLIC_PLATFORM_ADDRESS ?? "",
+        disputeResolver: process.env.NEXT_PUBLIC_PLATFORM_ADDRESS ?? "",
+        receiver: address,                      // only for single-release
+        platformAddress: process.env.NEXT_PUBLIC_PLATFORM_ADDRESS ?? "",
+      },
+      platformFee: 2,                           // ✅ number, not string
+      trustline: {
+        address: process.env.NEXT_PUBLIC_USDC_ISSUER_ADDRESS ?? "",  // G… issuer
+        symbol: "USDC",
+      },
+      milestones: [
+        { title: "Mockups", description: "Figma mockups" },
+        { title: "Dev", description: "React implementation" },
+      ],
+    }, "single-release");
+
+    // Step 2: Sign with Issuer wallet
+    const { signedTxXdr } = await kit.signTransaction(unsignedTransaction, {
+      networkPassphrase: isMainnet ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
+      address,
+    });
+
+    // Step 3: Submit
+    await sendTransaction({ signedXdr: signedTxXdr });
+  };
+
+  return <button onClick={handleCreate}>Create Escrow</button>;
+}
+
+// ── 3. Approve Milestone (Approver role only) ──────────────────────────────
+"use client";
+import { useApproveMilestone, useSendTransaction } from "@trustless-work/escrow/hooks";
+
+export function ApproveMilestoneButton({ contractId, milestoneIndex }: { contractId: string; milestoneIndex: string }) {
+  const { approveMilestone } = useApproveMilestone();
+  const { sendTransaction } = useSendTransaction();
+  const { kit, address } = useWallet();
+
+  const handleApprove = async () => {
+    // ALWAYS confirm — approval is irreversible on-chain
+    if (!confirm("Approve this milestone? This cannot be undone.")) return;
+
+    const { unsignedTransaction } = await approveMilestone({
+      contractId,
+      approver: address!,      // field is `approver`, not `signer`
+      milestoneIndex,           // string e.g. '0'
+    });
+
+    const { signedTxXdr } = await kit.signTransaction(unsignedTransaction, {
+      networkPassphrase: isMainnet ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
+      address: address!,
+    });
+
+    await sendTransaction({ signedXdr: signedTxXdr });
+  };
+
+  return <button onClick={handleApprove}>Approve Milestone {Number(milestoneIndex) + 1}</button>;
+}
+
+// ── 4. Read Escrows (no API key needed) ───────────────────────────────────
+"use client";
+import { useGetEscrowsFromIndexerBySigner } from "@trustless-work/escrow/hooks";
+import { useEffect, useState } from "react";
+
+export function EscrowList() {
+  const { getEscrowsBySigner } = useGetEscrowsFromIndexerBySigner();
+  const { address } = useWallet();
+  const [escrows, setEscrows] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (address) getEscrowsBySigner({ signer: address }).then(setEscrows);
+  }, [address]);
+
+  return (
+    <ul>
+      {escrows.map((e) => (
+        <li key={e.contractId}>{e.title} — {e.contractId}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+---
+
+## Example 3 — Blocks (Next.js App Router full layout)
+
+Correct provider setup with all three providers in the right order.
+
+```tsx
+// ── app/layout.tsx (Server Component — no "use client") ───────────────────
+import { type ReactNode } from "react";
+import { Providers } from "@/components/Providers";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body><Providers>{children}</Providers></body>
+    </html>
+  );
+}
+
+// ── components/Providers.tsx ───────────────────────────────────────────────
+"use client"; // ← REQUIRED — all providers use React Context
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { TrustlessWorkConfig, development, mainNet } from "@trustless-work/escrow";
+import { WalletProvider } from "@/providers/WalletProvider";
+
+// OUTSIDE component — avoid recreation on every render
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: 60_000, retry: 2, refetchOnWindowFocus: false } },
+});
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const isMainnet = process.env.NEXT_PUBLIC_USE_MAINNET === "true";
+  return (
+    // ── PROVIDER ORDER IS CRITICAL ─────────────────────────────────────
+    // 1. QueryClientProvider   (outermost)
+    // 2. TrustlessWorkConfig   (middle)
+    // 3. WalletProvider        (inner)
+    // ──────────────────────────────────────────────────────────────────
+    <QueryClientProvider client={queryClient}>
+      <TrustlessWorkConfig
+        baseURL={isMainnet ? mainNet : development}
+        apiKey={process.env.NEXT_PUBLIC_API_KEY ?? ""}
+      >
+        <WalletProvider>{children}</WalletProvider>
+      </TrustlessWorkConfig>
+      {process.env.NODE_ENV === "development" && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  );
+}
+
+// ── providers/WalletProvider.tsx ──────────────────────────────────────────
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+import { StellarWalletsKit, WalletNetwork, FREIGHTER_ID, FreighterModule, AlbedoModule, xBullModule } from "@creit.tech/stellar-wallets-kit";
+
+const isMainnet = process.env.NEXT_PUBLIC_USE_MAINNET === "true";
+
+// Create kit at module scope
+const kit = new StellarWalletsKit({
+  network: isMainnet ? WalletNetwork.PUBLIC : WalletNetwork.TESTNET,
+  selectedWalletId: FREIGHTER_ID,
+  modules: [new FreighterModule(), new AlbedoModule(), new xBullModule()],
+});
+
+const WalletContext = createContext<{ kit: typeof kit; address: string | null; isConnected: boolean; connect: () => Promise<void>; disconnect: () => void } | null>(null);
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [address, setAddress] = useState<string | null>(null);
+  const connect = async () => {
+    await kit.openModal({ onWalletSelected: async (opt) => {
+      kit.setWallet(opt.id);
+      const { address } = await kit.getAddress();
+      setAddress(address);
+    }});
+  };
+  return (
+    <WalletContext.Provider value={{ kit, address, isConnected: !!address, connect, disconnect: () => setAddress(null) }}>
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export const useWallet = () => {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be inside WalletProvider");
+  return ctx;
+};
+```

--- a/skills/trustless-work/references/sdk.md
+++ b/skills/trustless-work/references/sdk.md
@@ -1,0 +1,448 @@
+# Trustless Work — SDK Reference (@trustless-work/escrow)
+
+> Read SKILL.md first for core concepts (roles, lifecycle, XDR pattern).
+> Ref: https://docs.trustlesswork.com/trustless-work/escrow-react-sdk/getting-started
+
+---
+
+## Installation
+
+```bash
+npm install @trustless-work/escrow
+# Also required:
+npm install @tanstack/react-query @creit.tech/stellar-wallets-kit
+```
+
+---
+
+## Package Exports
+
+```typescript
+// Provider
+import { TrustlessWorkConfig, development, mainNet } from '@trustless-work/escrow';
+
+// Hooks (write)
+import {
+  useInitializeEscrow,
+  useFundEscrow,
+  useApproveMilestone,
+  useChangeMilestoneStatus,
+  useReleaseFunds,
+  useStartDispute,
+  useResolveDispute,
+  useUpdateEscrow,
+  useWithdrawRemainingFunds,
+  useSendTransaction,
+} from '@trustless-work/escrow/hooks';
+
+// Hooks (read — no API key required)
+import {
+  useGetEscrowsFromIndexerBySigner,
+  useGetEscrowsFromIndexerByRole,
+  useGetEscrowFromIndexerByContractIds,
+  useGetMultipleEscrowBalances,
+} from '@trustless-work/escrow/hooks';
+
+// Types
+import {
+  InitializeSingleReleaseEscrowPayload,
+  InitializeMultiReleaseEscrowPayload,
+  FundEscrowPayload,
+  ApproveMilestonePayload,
+  ChangeMilestoneStatusPayload,
+  SingleReleaseReleaseFundsPayload,
+  MultiReleaseReleaseFundsPayload,
+  SingleReleaseResolveDisputePayload,
+  MultiReleaseResolveDisputePayload,
+  UpdateSingleReleaseEscrowPayload,
+  UpdateMultiReleaseEscrowPayload,
+} from '@trustless-work/escrow/types';
+```
+
+---
+
+## Provider Setup (Required)
+
+### Next.js App Router
+
+```typescript
+// providers/TrustlessWorkProvider.tsx
+"use client";  // ← REQUIRED — TrustlessWorkConfig uses React Context
+import { TrustlessWorkConfig, development, mainNet } from '@trustless-work/escrow';
+
+export function TrustlessWorkProvider({ children }: { children: React.ReactNode }) {
+  const isMainnet = process.env.NEXT_PUBLIC_USE_MAINNET === 'true';
+  return (
+    <TrustlessWorkConfig
+      baseURL={isMainnet ? mainNet : development}
+      apiKey={process.env.NEXT_PUBLIC_API_KEY ?? ''}
+    >
+      {children}
+    </TrustlessWorkConfig>
+  );
+}
+```
+
+```typescript
+// app/layout.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TrustlessWorkProvider } from '@/providers/TrustlessWorkProvider';
+import { WalletProvider } from '@/providers/WalletProvider'; // your wallet context
+
+const queryClient = new QueryClient();
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        {/* PROVIDER ORDER IS CRITICAL — never change this nesting */}
+        <QueryClientProvider client={queryClient}>
+          <TrustlessWorkProvider>
+            <WalletProvider>
+              {children}
+            </WalletProvider>
+          </TrustlessWorkProvider>
+        </QueryClientProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### React SPA (Vite / CRA)
+
+```typescript
+// src/main.tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TrustlessWorkConfig, development } from '@trustless-work/escrow';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <QueryClientProvider client={queryClient}>
+    <TrustlessWorkConfig baseURL={development} apiKey={import.meta.env.VITE_API_KEY}>
+      <WalletProvider>
+        <App />
+      </WalletProvider>
+    </TrustlessWorkConfig>
+  </QueryClientProvider>
+);
+```
+
+**Provider order rule:** `QueryClientProvider` → `TrustlessWorkConfig` → `WalletProvider`
+
+---
+
+## Environment Variables
+
+```bash
+# .env.local (Next.js)
+NEXT_PUBLIC_API_KEY=your_trustless_work_api_key
+NEXT_PUBLIC_USE_MAINNET=false   # set to true for production
+
+# .env (Vite)
+VITE_API_KEY=your_trustless_work_api_key
+```
+
+---
+
+## All Write Hooks
+
+Every write hook returns `{ unsignedTransaction }`. You **must** sign and submit.
+
+### `useInitializeEscrow` — Deploy an escrow
+
+```typescript
+const { deployEscrow } = useInitializeEscrow();
+
+// ── Single-Release ──────────────────────────────────────────────────────────
+const result = await deployEscrow(
+  {
+    signer: issuerAddress,
+    engagementId: 'order-123',
+    title: 'Website Project',
+    description: 'Full redesign',
+    amount: 1000,                // ✅ number  ❌ "1000"
+    roles: {
+      approver: approverAddress,
+      serviceProvider: spAddress,
+      releaseSigner: releaseSignerAddress,
+      disputeResolver: drAddress,
+      receiver: receiverAddress,      // only in single-release roles
+      platformAddress: platformAddress,
+    },
+    platformFee: 2,              // ✅ number  ❌ "2"
+    trustline: {
+      address: USDC_ISSUER_ADDRESS,   // G… Stellar issuer address — NOT the C… contract
+      symbol: 'USDC',
+    },
+    milestones: [
+      { title: 'Mockups', description: 'Deliver Figma files' },
+      { title: 'Dev', description: 'Implement in React' },
+    ],
+  } satisfies InitializeSingleReleaseEscrowPayload,
+  'single-release'
+);
+// result.unsignedTransaction → sign → submit
+
+// ── Multi-Release ────────────────────────────────────────────────────────────
+// No top-level `amount`. Each milestone has its own `amount` (number) and `receiver`.
+// No `receiver` in roles.
+const result = await deployEscrow(
+  {
+    signer: issuerAddress,
+    engagementId: 'order-123',
+    title: 'Website Project',
+    description: 'Full redesign',
+    // ⚠️ No `amount` here for multi-release
+    roles: {
+      approver: approverAddress,
+      serviceProvider: spAddress,
+      releaseSigner: releaseSignerAddress,
+      disputeResolver: drAddress,
+      platformAddress: platformAddress,
+      // ⚠️ No `receiver` in roles for multi-release
+    },
+    platformFee: 2,
+    trustline: {
+      address: USDC_ISSUER_ADDRESS,   // G… Stellar issuer address
+      symbol: 'USDC',
+    },
+    milestones: [
+      { title: 'Phase 1', description: 'Design', amount: 400, receiver: receiverAddress },
+      { title: 'Phase 2', description: 'Dev',    amount: 600, receiver: receiverAddress },
+    ],
+  } satisfies InitializeMultiReleaseEscrowPayload,
+  'multi-release'
+);
+// result.unsignedTransaction → sign → submit
+```
+
+### `useFundEscrow` — Fund an escrow
+
+```typescript
+const { fundEscrow } = useFundEscrow();
+
+const result = await fundEscrow({
+  contractId: 'CXXXXX...',
+  signer: funderAddress,   // must be the Funder role address
+  amount: '1000',          // string in fund-escrow (unlike deploy where amount is number)
+} satisfies FundEscrowPayload);
+```
+
+### `useChangeMilestoneStatus` — Update milestone status text
+
+```typescript
+const { changeMilestoneStatus } = useChangeMilestoneStatus();
+
+const result = await changeMilestoneStatus({
+  contractId: 'CXXXXX...',
+  serviceProvider: serviceProviderAddress,  // field is `serviceProvider`, not `signer`
+  milestoneIndex: '0',                      // string, not number
+  newStatus: 'Under Review',
+  newEvidence: 'https://link-to-evidence.com',
+} satisfies ChangeMilestoneStatusPayload);
+```
+
+### `useApproveMilestone` — Approve a milestone (irreversible)
+
+```typescript
+const { approveMilestone } = useApproveMilestone();
+
+// ALWAYS show a confirmation dialog first — approval cannot be undone
+const confirmed = confirm('Approve this milestone? This action cannot be reversed.');
+if (!confirmed) return;
+
+const result = await approveMilestone({
+  contractId: 'CXXXXX...',
+  approver: approverAddress,   // field is `approver`, not `signer`
+  milestoneIndex: '0',         // string, not number
+} satisfies ApproveMilestonePayload);
+```
+
+### `useReleaseFunds` — Release funds
+
+```typescript
+const { releaseFunds } = useReleaseFunds();
+
+// Single-release
+const result = await releaseFunds({
+  contractId: 'CXXXXX...',
+  releaseSigner: releaseSignerAddress,  // field is `releaseSigner`, not `signer`
+} satisfies SingleReleaseReleaseFundsPayload);
+
+// Multi-release (adds milestoneIndex)
+const result = await releaseFunds({
+  contractId: 'CXXXXX...',
+  releaseSigner: releaseSignerAddress,
+  milestoneIndex: '0',                  // string, not number
+} satisfies MultiReleaseReleaseFundsPayload);
+```
+
+### `useStartDispute` — Raise a dispute
+
+```typescript
+const { startDispute } = useStartDispute();
+
+// Single-release
+const result = await startDispute({ contractId: 'CXXXXX...', signer: approverOrSpAddress });
+
+// Multi-release (adds milestoneIndex)
+const result = await startDispute({ contractId: 'CXXXXX...', signer: approverOrSpAddress, milestoneIndex: '0' });
+```
+
+### `useResolveDispute` — Resolve a dispute
+
+```typescript
+const { resolveDispute } = useResolveDispute();
+
+// Single-release
+const result = await resolveDispute({
+  contractId: 'CXXXXX...',
+  disputeResolver: disputeResolverAddress,
+  distributions: [
+    { address: approverAddress, amount: 300 },
+    { address: receiverAddress, amount: 700 },
+  ],
+} satisfies SingleReleaseResolveDisputePayload);
+
+// Multi-release (adds milestoneIndex)
+const result = await resolveDispute({
+  contractId: 'CXXXXX...',
+  disputeResolver: disputeResolverAddress,
+  milestoneIndex: '0',
+  distributions: [
+    { address: approverAddress, amount: 300 },
+    { address: receiverAddress, amount: 700 },
+  ],
+} satisfies MultiReleaseResolveDisputePayload);
+```
+
+### `useUpdateEscrow` — Update escrow metadata
+
+```typescript
+const { updateEscrow } = useUpdateEscrow();
+// Only works before funding. Signed by Platform Address.
+const result = await updateEscrow({ contractId, signer: platformAddress, ...changes });
+```
+
+### `useSendTransaction` — Submit signed XDR (final step)
+
+```typescript
+const { sendTransaction } = useSendTransaction();
+const result = await sendTransaction({ signedXdr: signedTxXdr });
+```
+
+---
+
+## Complete XDR Sign + Submit Pattern
+
+```typescript
+"use client";
+import { useInitializeEscrow, useSendTransaction } from '@trustless-work/escrow/hooks';
+import { StellarWalletsKit, WalletNetwork } from '@creit.tech/stellar-wallets-kit';
+
+// Assuming `kit` comes from your WalletProvider context
+function CreateEscrowButton({ kit, issuerAddress }) {
+  const { deployEscrow } = useInitializeEscrow();
+  const { sendTransaction } = useSendTransaction();
+
+  const handleCreate = async () => {
+    try {
+      // 1. Get unsigned XDR from Trustless Work API
+      const { unsignedTransaction } = await deployEscrow(payload, 'single-release');
+
+      // 2. Sign client-side with the ISSUER wallet
+      const { signedTxXdr } = await kit.signTransaction(unsignedTransaction, {
+        networkPassphrase: WalletNetwork.TESTNET,  // or WalletNetwork.PUBLIC for mainnet
+        address: issuerAddress,
+      });
+
+      // 3. Submit to Stellar network
+      await sendTransaction({ signedXdr: signedTxXdr });
+
+      console.log('Escrow created on-chain!');
+    } catch (error) {
+      console.error('Failed:', error);
+    }
+  };
+
+  return <button onClick={handleCreate}>Create Escrow</button>;
+}
+```
+
+---
+
+## Read Hooks (No API Key Required)
+
+```typescript
+// Get escrows by signer address
+const { getEscrowsBySigner } = useGetEscrowsFromIndexerBySigner();
+const escrows = await getEscrowsBySigner({ signer: 'GXXX...' });
+
+// Get escrows by role
+const { getEscrowsByRole } = useGetEscrowsFromIndexerByRole();
+const escrows = await getEscrowsByRole({ role: 'approver', address: 'GXXX...' });
+
+// Get escrows by contract IDs
+const { getEscrowByContractIds } = useGetEscrowFromIndexerByContractIds();
+const escrows = await getEscrowByContractIds({ contractIds: ['CXXX...', 'CYYY...'] });
+
+// Get balances for multiple escrows
+const { getMultipleEscrowBalances } = useGetMultipleEscrowBalances();
+```
+
+---
+
+## Common Mistakes (SDK)
+
+### ❌ 1. Missing "use client" on the provider (Next.js)
+```typescript
+// WRONG — will cause "createContext called on the server" error
+export function TrustlessWorkProvider(...) { ... }
+
+// CORRECT — first line of the file must be:
+"use client";
+export function TrustlessWorkProvider(...) { ... }
+```
+
+### ❌ 2. Wrong provider order
+```typescript
+// WRONG — TanStack Query won't be available inside TrustlessWorkConfig
+<TrustlessWorkConfig>
+  <QueryClientProvider>  {/* Too late */}
+    <App />
+  </QueryClientProvider>
+</TrustlessWorkConfig>
+
+// CORRECT
+<QueryClientProvider>
+  <TrustlessWorkConfig>
+    <App />
+  </TrustlessWorkConfig>
+</QueryClientProvider>
+```
+
+### ❌ 3. Forgetting to call `sendTransaction` after signing
+```typescript
+// WRONG — escrow is never created on-chain
+const { unsignedTransaction } = await deployEscrow(payload, 'single-release');
+const { signedTxXdr } = await kit.signTransaction(unsignedTransaction, opts);
+// MISSING: await sendTransaction({ signedXdr: signedTxXdr })
+```
+
+### ❌ 4. Single vs Multi-Release payload confusion
+```typescript
+// Multi-release needs milestoneIndex (string) on release and resolve
+const result = await releaseFunds({
+  contractId,
+  releaseSigner,           // `releaseSigner`, not `signer`
+  milestoneIndex: '0',     // string, REQUIRED for multi-release, omitted for single-release
+});
+```
+
+### ❌ 5. engagementId omitted
+```typescript
+// Always include to link the escrow to your system's records
+{ engagementId: `order-${order.id}`, ... }
+```


### PR DESCRIPTION
## Summary

This PR adds the `trustless-work` skill to the open agent skills ecosystem.

The skill enables any agent to integrate **Trustless Work Escrow-as-a-Service (EaaS)** built on Stellar/Soroban — covering the three integration paths:

- **REST API** — direct endpoint calls from any backend or frontend
- **SDK** (`@trustless-work/escrow`) — React/Next.js hooks wrapping the API
- **UI Blocks** (`@trustless-work/blocks`) — pre-built React components (forms, tables, dialogs)

## What's included

- `skills/trustless-work/SKILL.md` — core skill: XDR signing pattern, escrow lifecycle (6 phases), roles (9 total), escrow schemas, trustlines, auth, error handling, security rules
- `skills/trustless-work/references/api.md` — complete REST API endpoint reference with Node.js examples
- `skills/trustless-work/references/sdk.md` — all React hooks, provider setup, TypeScript types
- `skills/trustless-work/references/blocks.md` — UI component setup, provider order, wallet kit integration
- `skills/trustless-work/references/checklist.md` — pre-production integration checklist
- `skills/trustless-work/references/examples.md` — full end-to-end code examples for each integration path

References are kept in separate files for context efficiency — only loaded when the agent needs deep-dive detail on a specific integration path.

## Install

```bash
npx skills add vercel-labs/skills --skill trustless-work
```