### PR TITLE
feat(telemetry): support configurable endpoint + opt-in private-source telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,9 +437,11 @@ Ensure you have write access to the target directory.
 
 | Variable                  | Description                                                                |
 | ------------------------- | -------------------------------------------------------------------------- |
-| `INSTALL_INTERNAL_SKILLS` | Set to `1` or `true` to show and install skills marked as `internal: true` |
-| `DISABLE_TELEMETRY`       | Set to disable anonymous usage telemetry                                   |
-| `DO_NOT_TRACK`            | Alternative way to disable telemetry                                       |
+| `INSTALL_INTERNAL_SKILLS`        | Set to `1` or `true` to show and install skills marked as `internal: true`                                          |
+| `DISABLE_TELEMETRY`              | Set to disable anonymous usage telemetry                                                                            |
+| `DO_NOT_TRACK`                   | Alternative way to disable telemetry                                                                                |
+| `SKILLS_TELEMETRY_URL`           | Override the telemetry endpoint (e.g. for self-hosted/internal install metrics)                                     |
+| `SKILLS_TELEMETRY_ALLOW_PRIVATE` | Set to `1` to allow install events from private/internal sources to be sent (only honored with a custom endpoint)   |
 
 ```bash
 # Install internal skills

--- a/src/add.ts
+++ b/src/add.ts
@@ -41,6 +41,7 @@ import {
 } from './agents.ts';
 import {
   track,
+  shouldSendInstallTelemetry,
   setVersion,
   fetchAuditData,
   type AuditResponse,
@@ -768,7 +769,7 @@ async function handleWellKnownSkills(
 
   // Privacy promise was started before installation — should be resolved by now
   const isPrivate = await wellKnownPrivacyPromise;
-  if (isPrivate !== true) {
+  if (shouldSendInstallTelemetry(isPrivate)) {
     track({
       event: 'install',
       source: sourceIdentifier,
@@ -1557,27 +1558,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const isSSH = parsed.url.startsWith('git@');
     const lockSource = isSSH ? parsed.url : normalizedSource;
 
-    // Only track if we have a valid remote source and it's not a private repo.
-    // repoPrivacyPromise was started early (right after parsing) so it has
-    // already been running in parallel with the entire install — no stall here.
+    // Only track if we have a valid remote source. repoPrivacyPromise was
+    // started early (right after parsing) so it has already been running in
+    // parallel with the entire install — no stall here. Privacy gating is
+    // centralized in shouldSendInstallTelemetry(); for non-owner/repo sources
+    // we don't have a privacy signal, so we treat them as unknown (null).
     if (normalizedSource) {
       const ownerRepo = parseOwnerRepo(normalizedSource);
-      if (ownerRepo) {
-        const isPrivate = await repoPrivacyPromise;
-        // Only send telemetry if repo is public (isPrivate === false)
-        // If we can't determine (null), err on the side of caution and skip telemetry
-        if (isPrivate === false) {
-          track({
-            event: 'install',
-            source: normalizedSource,
-            skills: selectedSkills.map((s) => s.name).join(','),
-            agents: targetAgents.join(','),
-            ...(installGlobally && { global: '1' }),
-            skillFiles: JSON.stringify(skillFiles),
-          });
-        }
-      } else {
-        // If we can't parse owner/repo, still send telemetry (for non-GitHub sources)
+      const isPrivate = ownerRepo ? await repoPrivacyPromise : null;
+      if (shouldSendInstallTelemetry(isPrivate)) {
         track({
           event: 'install',
           source: normalizedSource,

--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { shouldSendInstallTelemetry, track } from './telemetry.ts';
+
+const mockFetch = vi.fn((..._args: unknown[]) => Promise.resolve(new Response()));
+vi.stubGlobal('fetch', mockFetch);
+
+const TELEMETRY_ENV_VARS = [
+  'SKILLS_TELEMETRY_URL',
+  'npm_config_skills_telemetry_url',
+  'SKILLS_TELEMETRY_ALLOW_PRIVATE',
+  'DISABLE_TELEMETRY',
+  'DO_NOT_TRACK',
+];
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  for (const key of TELEMETRY_ENV_VARS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of TELEMETRY_ENV_VARS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+const payload = {
+  event: 'install' as const,
+  source: 'owner/repo',
+  skills: 'a',
+  agents: 'cursor',
+};
+
+describe('telemetry URL resolution', () => {
+  it('sends to default URL when no overrides are set', () => {
+    track(payload);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/add-skill\.vercel\.sh\/t\?/);
+  });
+
+  it('uses SKILLS_TELEMETRY_URL when set', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    track(payload);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/custom\.example\.com\/t\?/);
+  });
+
+  it('uses npm_config_skills_telemetry_url (from .npmrc) when set', () => {
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    track(payload);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/npmrc\.example\.com\/t\?/);
+  });
+
+  it('prefers SKILLS_TELEMETRY_URL over npm_config_skills_telemetry_url', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://envvar.example.com/t';
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    track(payload);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/envvar\.example\.com\/t\?/);
+  });
+});
+
+describe('telemetry opt-out', () => {
+  it('does not send when DISABLE_TELEMETRY is set', () => {
+    process.env.DISABLE_TELEMETRY = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not send when DO_NOT_TRACK is set', () => {
+    process.env.DO_NOT_TRACK = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('opt-out wins over a custom endpoint', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    process.env.DO_NOT_TRACK = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldSendInstallTelemetry', () => {
+  it('always sends for public sources (isPrivate === false)', () => {
+    expect(shouldSendInstallTelemetry(false)).toBe(true);
+  });
+
+  it('skips private sources by default (no custom endpoint)', () => {
+    expect(shouldSendInstallTelemetry(true)).toBe(false);
+  });
+
+  it('skips private sources with custom endpoint but no opt-in', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    expect(shouldSendInstallTelemetry(true)).toBe(false);
+  });
+
+  it('skips private sources with opt-in but no custom endpoint', () => {
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendInstallTelemetry(true)).toBe(false);
+  });
+
+  it('sends private sources when both custom endpoint AND opt-in are set', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendInstallTelemetry(true)).toBe(true);
+  });
+
+  it('treats an .npmrc-supplied endpoint (npm_config_skills_telemetry_url) as custom', () => {
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendInstallTelemetry(true)).toBe(true);
+  });
+
+  it('treats unknown privacy (null) the same as private', () => {
+    expect(shouldSendInstallTelemetry(null)).toBe(false);
+
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendInstallTelemetry(null)).toBe(true);
+  });
+
+  it('does not honor SKILLS_TELEMETRY_ALLOW_PRIVATE when endpoint equals the default', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendInstallTelemetry(true)).toBe(false);
+  });
+});

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,28 @@
-const TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
+const DEFAULT_TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
 const AUDIT_URL = 'https://add-skill.vercel.sh/audit';
+
+// npm/npx auto-inject `skills_telemetry_url` from .npmrc as
+// `npm_config_skills_telemetry_url` — supports centrally deployed config.
+function getTelemetryUrl(): string {
+  return (
+    process.env.SKILLS_TELEMETRY_URL ||
+    process.env.npm_config_skills_telemetry_url ||
+    DEFAULT_TELEMETRY_URL
+  );
+}
+
+function hasCustomTelemetryEndpoint(): boolean {
+  return getTelemetryUrl() !== DEFAULT_TELEMETRY_URL;
+}
+
+// Centralized gating for install telemetry across every install path.
+// Private/unknown sources never reach the default endpoint; they're only sent
+// when the operator has set a custom endpoint AND opted in explicitly via
+// SKILLS_TELEMETRY_ALLOW_PRIVATE=1. Opt-out vars are still enforced in track().
+export function shouldSendInstallTelemetry(isPrivate: boolean | null): boolean {
+  if (isPrivate === false) return true;
+  return hasCustomTelemetryEndpoint() && process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE === '1';
+}
 
 interface InstallTelemetryData {
   event: 'install';
@@ -151,7 +174,7 @@ export function track(data: TelemetryData): void {
 
     // Fire and forget during the workflow, but track the promise so
     // flushTelemetry() can await it before the process exits.
-    const p = fetch(`${TELEMETRY_URL}?${params.toString()}`)
+    const p = fetch(`${getTelemetryUrl()}?${params.toString()}`)
       .catch(() => {})
       .then(() => {});
     pendingTelemetry.push(p);


### PR DESCRIPTION
Closes #349. Picks up where #710 left off and folds in the follow-up [comment](https://github.com/vercel-labs/skills/pull/710#issuecomment-4365999254) on private-source telemetry.

## Summary

- Custom telemetry endpoint via `SKILLS_TELEMETRY_URL` env var or `skills_telemetry_url` in `.npmrc` (auto-injected by npm/npx as `npm_config_skills_telemetry_url`).
- New explicit opt-in `SKILLS_TELEMETRY_ALLOW_PRIVATE=1` so enterprise wrappers can collect install events for private/internal skill repos against their own endpoint — never against the default Vercel endpoint.
- Centralized `shouldSendInstallTelemetry(isPrivate)` so the GitHub install path and the well-known-provider install path apply the same policy.

## Resolution priority for the endpoint

1. `SKILLS_TELEMETRY_URL`
2. `npm_config_skills_telemetry_url` (i.e. `skills_telemetry_url` in `.npmrc`)
3. Built-in default (`https://add-skill.vercel.sh/t`)

`DISABLE_TELEMETRY` / `DO_NOT_TRACK` continue to suppress everything.

## Gating policy

| `isPrivate` | Default endpoint | Custom endpoint | Custom endpoint + `ALLOW_PRIVATE=1` |
|---|---|---|---|
| `false` (public)  | send | send | send |
| `true` (private)  | skip | skip | **send** |
| `null` (unknown)  | skip | skip | **send** |

Notes:
- Public-source telemetry to the default endpoint is unchanged.
- Private/unknown sources are *never* sent to the default endpoint, even with `ALLOW_PRIVATE=1` set — the opt-in is only honored against a custom endpoint.
- The previous well-known path was permissive on `null` (sent unless known private); it now matches the GitHub path's stricter behavior. This is a minor tightening for the error case where `isSourcePrivate` throws.

## Changes

- `src/telemetry.ts` — replace hardcoded `TELEMETRY_URL` with `getTelemetryUrl()` resolver, add `hasCustomTelemetryEndpoint()`, export `shouldSendInstallTelemetry(isPrivate)`.
- `src/add.ts` — both install paths (well-known, GitHub) now call `shouldSendInstallTelemetry(isPrivate)` instead of inline `isPrivate` checks.
- `src/telemetry.test.ts` — 15 new tests covering URL resolution priority, opt-out vars, and every cell of the gating matrix above (including the `.npmrc`-supplied endpoint case and the unknown-privacy case).
- `README.md` — document `SKILLS_TELEMETRY_URL` and `SKILLS_TELEMETRY_ALLOW_PRIVATE`.

## Test plan

- [x] Default endpoint unchanged when no overrides set.
- [x] `SKILLS_TELEMETRY_URL` overrides default.
- [x] `npm_config_skills_telemetry_url` (from `.npmrc`) overrides default.
- [x] `SKILLS_TELEMETRY_URL` wins over `npm_config_skills_telemetry_url`.
- [x] `DISABLE_TELEMETRY` / `DO_NOT_TRACK` still suppress everything, including against a custom endpoint.
- [x] `shouldSendInstallTelemetry`: public always sends; private/unknown skip unless custom endpoint **and** `ALLOW_PRIVATE=1`.
- [x] `ALLOW_PRIVATE=1` is ignored when the resolved URL equals the default.
- [x] Full test suite: no new failures vs. clean upstream baseline.