### PR TITLE
Warn when SKILL.md frontmatter is invalid

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { sep, join, dirname } from 'path';
+import { sep, join, dirname, relative } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
@@ -68,6 +68,11 @@ import {
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
   setVersion(version);
+}
+
+function warnInvalidSkill(skillPath: string, message: string, basePath?: string | null): void {
+  const displayPath = basePath ? relative(basePath, skillPath) || skillPath : skillPath;
+  p.log.warn(`Skipped ${pc.cyan(displayPath)} - ${message}`);
 }
 
 // ─── Security Advisory ───
@@ -1010,6 +1015,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       skills = await discoverSkills(parsed.localPath!, parsed.subpath, {
         includeInternal,
         fullDepth: options.fullDepth,
+        onInvalid: ({ path, message }) => warnInvalidSkill(path, message, parsed.localPath!),
       });
     } else if (parsed.type === 'github' && !options.fullDepth) {
       // Try blob-based fast install for GitHub sources
@@ -1026,6 +1032,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           ref: parsed.ref,
           token,
           includeInternal,
+          onInvalid: ({ path, message }) => warnInvalidSkill(path, message),
         });
         if (!blobResult) {
           spinner.stop(pc.dim('Falling back to clone...'));
@@ -1045,6 +1052,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         skills = await discoverSkills(tempDir, parsed.subpath, {
           includeInternal,
           fullDepth: options.fullDepth,
+          onInvalid: ({ path, message }) => warnInvalidSkill(path, message, tempDir),
         });
       }
     } else {
@@ -1057,6 +1065,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       skills = await discoverSkills(tempDir, parsed.subpath, {
         includeInternal,
         fullDepth: options.fullDepth,
+        onInvalid: ({ path, message }) => warnInvalidSkill(path, message, tempDir),
       });
     }
 

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -314,6 +314,7 @@ export async function tryBlobInstall(
     ref?: string;
     token?: string | null;
     includeInternal?: boolean;
+    onInvalid?: (details: { path: string; message: string }) => void;
   } = {}
 ): Promise<BlobInstallResult | null> {
   // 1. Fetch the full repo tree
@@ -357,13 +358,39 @@ export async function tryBlobInstall(
     slug: string;
     metadata?: Record<string, unknown>;
   }> = [];
+  let fetchedSkillMdCount = 0;
 
   for (const { mdPath, content } of mdFetches) {
     if (!content) continue;
+    fetchedSkillMdCount += 1;
 
-    const { data } = parseFrontmatter(content);
-    if (!data.name || !data.description) continue;
-    if (typeof data.name !== 'string' || typeof data.description !== 'string') continue;
+    let data: Record<string, unknown>;
+    try {
+      ({ data } = parseFrontmatter(content));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      options.onInvalid?.({
+        path: mdPath,
+        message: `YAML parse error: ${message}`,
+      });
+      continue;
+    }
+
+    if (!data.name || !data.description) {
+      options.onInvalid?.({
+        path: mdPath,
+        message: 'Missing frontmatter `name` or `description`.',
+      });
+      continue;
+    }
+
+    if (typeof data.name !== 'string' || typeof data.description !== 'string') {
+      options.onInvalid?.({
+        path: mdPath,
+        message: 'Frontmatter `name` and `description` must both be strings.',
+      });
+      continue;
+    }
 
     // Skip internal skills unless explicitly requested
     const isInternal = (data.metadata as Record<string, unknown>)?.internal === true;
@@ -382,7 +409,9 @@ export async function tryBlobInstall(
     });
   }
 
-  if (parsedSkills.length === 0) return null;
+  if (parsedSkills.length === 0) {
+    return fetchedSkillMdCount > 0 ? { skills: [], tree } : null;
+  }
 
   // Apply skill filter by name if not already filtered by folder name
   let filteredSkills = parsedSkills;

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -28,25 +28,36 @@ async function hasSkillMd(dir: string): Promise<boolean> {
 
 export async function parseSkillMd(
   skillMdPath: string,
-  options?: { includeInternal?: boolean }
+  options?: {
+    includeInternal?: boolean;
+    onInvalid?: (details: { path: string; message: string }) => void;
+  }
 ): Promise<Skill | null> {
   try {
     const content = await readFile(skillMdPath, 'utf-8');
     const { data } = parseFrontmatter(content);
 
     if (!data.name || !data.description) {
+      options?.onInvalid?.({
+        path: skillMdPath,
+        message: 'Missing frontmatter `name` or `description`.',
+      });
       return null;
     }
 
     // Ensure name and description are strings (YAML can parse numbers, booleans, etc.)
     if (typeof data.name !== 'string' || typeof data.description !== 'string') {
+      options?.onInvalid?.({
+        path: skillMdPath,
+        message: 'Frontmatter `name` and `description` must both be strings.',
+      });
       return null;
     }
 
     // Skip internal skills unless:
     // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
     // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const isInternal = data.metadata?.internal === true;
+    const isInternal = (data.metadata as Record<string, unknown> | undefined)?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
     }
@@ -56,9 +67,14 @@ export async function parseSkillMd(
       description: sanitizeMetadata(data.description),
       path: dirname(skillMdPath),
       rawContent: content,
-      metadata: data.metadata,
+      metadata: data.metadata as Record<string, unknown> | undefined,
     };
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options?.onInvalid?.({
+      path: skillMdPath,
+      message: `YAML parse error: ${message}`,
+    });
     return null;
   }
 }
@@ -92,6 +108,8 @@ export interface DiscoverSkillsOptions {
   includeInternal?: boolean;
   /** Search all subdirectories even when a root SKILL.md exists */
   fullDepth?: boolean;
+  /** Report invalid skill metadata discovered during scanning */
+  onInvalid?: (details: { path: string; message: string }) => void;
 }
 
 /**

--- a/tests/blob-install.test.ts
+++ b/tests/blob-install.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tryBlobInstall } from '../src/blob.ts';
+
+describe('tryBlobInstall', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('reports invalid SKILL.md YAML while still returning valid blob-discovered skills', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.includes('/git/trees/')) {
+        return new Response(
+          JSON.stringify({
+            sha: 'tree-sha',
+            tree: [
+              { path: 'skills/valid-skill/SKILL.md', type: 'blob', sha: '1' },
+              { path: 'skills/broken-skill/SKILL.md', type: 'blob', sha: '2' },
+            ],
+          }),
+          { status: 200 }
+        );
+      }
+
+      if (url.endsWith('/skills/valid-skill/SKILL.md')) {
+        return new Response(
+          `---
+name: valid-skill
+description: A valid skill
+---
+
+# Valid Skill
+`,
+          { status: 200 }
+        );
+      }
+
+      if (url.endsWith('/skills/broken-skill/SKILL.md')) {
+        return new Response(
+          `---
+name: broken-skill
+description: Configure the harness: Hooks, MCP Servers, Skills
+---
+
+# Broken Skill
+`,
+          { status: 200 }
+        );
+      }
+
+      if (url.includes('/api/download/owner/repo/valid-skill')) {
+        return new Response(
+          JSON.stringify({
+            hash: 'snapshot-hash',
+            files: [{ path: 'SKILL.md', contents: '# Valid Skill' }],
+          }),
+          { status: 200 }
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const invalid: Array<{ path: string; message: string }> = [];
+    const result = await tryBlobInstall('owner/repo', {
+      onInvalid: (details) => invalid.push(details),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.skills).toHaveLength(1);
+    expect(result?.skills[0]?.name).toBe('valid-skill');
+    expect(invalid).toEqual([
+      expect.objectContaining({
+        path: 'skills/broken-skill/SKILL.md',
+      }),
+    ]);
+    expect(invalid[0]?.message).toContain('YAML parse error:');
+  });
+});

--- a/tests/skill-matching.test.ts
+++ b/tests/skill-matching.test.ts
@@ -189,4 +189,29 @@ description: A valid skill
     expect(result).not.toBeNull();
     expect(result!.name).toBe('valid-skill');
   });
+
+  it('reports YAML parse errors through onInvalid', async () => {
+    const skillPath = join(testDir, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+name: broken-skill
+description: Configure the harness: Hooks, MCP Servers, Skills
+---
+
+# Broken Skill
+`
+    );
+
+    const invalid: Array<{ path: string; message: string }> = [];
+    const result = await parseSkillMd(skillPath, {
+      onInvalid: (details) => invalid.push(details),
+    });
+
+    expect(result).toBeNull();
+    expect(invalid).toHaveLength(1);
+    expect(invalid[0]?.path).toBe(skillPath);
+    expect(invalid[0]?.message).toContain('YAML parse error:');
+    expect(invalid[0]?.message).toContain('Nested mappings are not allowed in compact mappings');
+  });
 });


### PR DESCRIPTION
## Summary
- warn when local or cloned discovery skips an invalid SKILL.md
- surface the same warning during blob-based GitHub installs instead of silently dropping the skill
- add regression coverage for both parseSkillMd and tryBlobInstall

Fixes #1058

## Validation
- corepack pnpm test tests/blob-install.test.ts tests/skill-matching.test.ts
- corepack pnpm type-check *(still fails on pre-existing issues in src/git.ts and src/providers/wellknown.ts)*