### PR TITLE
Allow custom telemetry URL and introduce skill source visibility for checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,9 +437,11 @@ Ensure you have write access to the target directory.
 
 | Variable                  | Description                                                                |
 | ------------------------- | -------------------------------------------------------------------------- |
-| `INSTALL_INTERNAL_SKILLS` | Set to `1` or `true` to show and install skills marked as `internal: true` |
-| `DISABLE_TELEMETRY`       | Set to disable anonymous usage telemetry                                   |
-| `DO_NOT_TRACK`            | Alternative way to disable telemetry                                       |
+| `INSTALL_INTERNAL_SKILLS`        | Set to `1` or `true` to show and install skills marked as `internal: true`                                        |
+| `DISABLE_TELEMETRY`              | Set to disable anonymous usage telemetry                                                                          |
+| `DO_NOT_TRACK`                   | Alternative way to disable telemetry                                                                              |
+| `SKILLS_TELEMETRY_URL`           | Override the telemetry endpoint (e.g. for self-hosted/internal install metrics)                                   |
+| `SKILLS_TELEMETRY_ALLOW_PRIVATE` | Set to `1` to allow install/remove events from private/internal sources (only honored with a custom endpoint)     |
 
 ```bash
 # Install internal skills

--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -139,7 +139,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ================================================================================
-Package: yaml@2.8.3
+Package: yaml@2.8.4
 License: ISC
 Repository: https://github.com/eemeli/yaml
 --------------------------------------------------------------------------------

--- a/src/add.ts
+++ b/src/add.ts
@@ -3,24 +3,23 @@ import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { sep, join, dirname } from 'path';
-import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
+import {
+  parseSource,
+  getOwnerRepo,
+  parseOwnerRepo,
+  getRepoVisibility,
+  type SourceVisibility,
+} from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
 // Helper to check if a value is a cancel symbol (works with both clack and our custom prompts)
 const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
 
-/**
- * Check if a source identifier (owner/repo format) represents a private GitHub repo.
- * Returns true if private, false if public, null if unable to determine or not a GitHub repo.
- */
-async function isSourcePrivate(source: string): Promise<boolean | null> {
+async function getSourceVisibility(source: string): Promise<SourceVisibility> {
   const ownerRepo = parseOwnerRepo(source);
-  if (!ownerRepo) {
-    // Not in owner/repo format, assume not private (could be other providers)
-    return false;
-  }
-  return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
+  if (!ownerRepo) return 'unknown';
+  return getRepoVisibility(ownerRepo.owner, ownerRepo.repo);
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
@@ -41,6 +40,7 @@ import {
 } from './agents.ts';
 import {
   track,
+  shouldSendTelemetry,
   setVersion,
   fetchAuditData,
   type AuditResponse,
@@ -725,7 +725,9 @@ async function handleWellKnownSkills(
 
   // Kick off privacy check early so it runs in parallel with installation
   const sourceIdentifier = wellKnownProvider.getSourceIdentifier(url);
-  const wellKnownPrivacyPromise = isSourcePrivate(sourceIdentifier).catch(() => null);
+  const wellKnownPrivacyPromise = getSourceVisibility(sourceIdentifier).catch(
+    (): SourceVisibility => 'unknown'
+  );
 
   spinner.start('Installing skills...');
 
@@ -766,9 +768,8 @@ async function handleWellKnownSkills(
     skillFiles[skill.installName] = skill.sourceUrl;
   }
 
-  // Privacy promise was started before installation — should be resolved by now
-  const isPrivate = await wellKnownPrivacyPromise;
-  if (isPrivate !== true) {
+  const visibility = await wellKnownPrivacyPromise;
+  if (shouldSendTelemetry(visibility)) {
     track({
       event: 'install',
       source: sourceIdentifier,
@@ -948,11 +949,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // cloning/discovering/installing. The result is only needed later for
     // telemetry gating — it should never block user-visible output.
     const ownerRepoRaw = getOwnerRepo(parsed);
-    const repoPrivacyPromise: Promise<boolean | null> = (() => {
-      if (!ownerRepoRaw) return Promise.resolve(null);
+    const repoPrivacyPromise: Promise<SourceVisibility> = (() => {
+      if (!ownerRepoRaw) return Promise.resolve<SourceVisibility>('unknown');
       const ownerRepo = parseOwnerRepo(ownerRepoRaw);
-      if (!ownerRepo) return Promise.resolve(null);
-      return isRepoPrivate(ownerRepo.owner, ownerRepo.repo).catch(() => null);
+      if (!ownerRepo) return Promise.resolve<SourceVisibility>('unknown');
+      return getRepoVisibility(ownerRepo.owner, ownerRepo.repo).catch(
+        (): SourceVisibility => 'unknown'
+      );
     })();
 
     // Block openclaw sources unless explicitly opted in
@@ -1557,27 +1560,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const isSSH = parsed.url.startsWith('git@');
     const lockSource = isSSH ? parsed.url : normalizedSource;
 
-    // Only track if we have a valid remote source and it's not a private repo.
-    // repoPrivacyPromise was started early (right after parsing) so it has
-    // already been running in parallel with the entire install — no stall here.
+    // Only track if we have a valid remote source. repoPrivacyPromise was
+    // started early (right after parsing) so it has already been running in
+    // parallel with the entire install — no stall here. For non-owner/repo
+    // sources we have no privacy signal, so we treat them as 'unknown'.
     if (normalizedSource) {
       const ownerRepo = parseOwnerRepo(normalizedSource);
-      if (ownerRepo) {
-        const isPrivate = await repoPrivacyPromise;
-        // Only send telemetry if repo is public (isPrivate === false)
-        // If we can't determine (null), err on the side of caution and skip telemetry
-        if (isPrivate === false) {
-          track({
-            event: 'install',
-            source: normalizedSource,
-            skills: selectedSkills.map((s) => s.name).join(','),
-            agents: targetAgents.join(','),
-            ...(installGlobally && { global: '1' }),
-            skillFiles: JSON.stringify(skillFiles),
-          });
-        }
-      } else {
-        // If we can't parse owner/repo, still send telemetry (for non-GitHub sources)
+      const visibility = ownerRepo ? await repoPrivacyPromise : 'unknown';
+      if (shouldSendTelemetry(visibility)) {
         track({
           event: 'install',
           source: normalizedSource,

--- a/src/add.ts
+++ b/src/add.ts
@@ -12,15 +12,6 @@ import {
 } from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
-
-// Helper to check if a value is a cancel symbol (works with both clack and our custom prompts)
-const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
-
-async function getSourceVisibility(source: string): Promise<SourceVisibility> {
-  const ownerRepo = parseOwnerRepo(source);
-  if (!ownerRepo) return 'unknown';
-  return getRepoVisibility(ownerRepo.owner, ownerRepo.repo);
-}
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
@@ -67,6 +58,16 @@ import {
   type BlobInstallResult,
 } from './blob.ts';
 import packageJson from '../package.json' with { type: 'json' };
+
+// Helper to check if a value is a cancel symbol (works with both clack and our custom prompts)
+const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
+
+async function getSourceVisibility(source: string): Promise<SourceVisibility> {
+  const ownerRepo = parseOwnerRepo(source);
+  if (!ownerRepo) return 'unknown';
+  return getRepoVisibility(ownerRepo.owner, ownerRepo.repo);
+}
+
 export function initTelemetry(version: string): void {
   setVersion(version);
 }

--- a/src/find.ts
+++ b/src/find.ts
@@ -2,7 +2,7 @@ import * as readline from 'readline';
 import { runAdd, parseAddOptions } from './add.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
-import { isRepoPrivate } from './source-parser.ts';
+import { getRepoVisibility } from './source-parser.ts';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -261,10 +261,7 @@ function getOwnerRepoFromString(pkg: string): { owner: string; repo: string } | 
 }
 
 async function isRepoPublic(owner: string, repo: string): Promise<boolean> {
-  const isPrivate = await isRepoPrivate(owner, repo);
-  // Return true only if we know it's public (isPrivate === false)
-  // Return false if private or unable to determine
-  return isPrivate === false;
+  return (await getRepoVisibility(owner, repo)) === 'public';
 }
 
 export async function runFind(args: string[]): Promise<void> {

--- a/src/find.ts
+++ b/src/find.ts
@@ -69,6 +69,11 @@ const MOVE_TO_COL = (n: number) => `\x1b[${n}G`;
 
 // Custom fzf-style search prompt using raw readline
 async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
+  // VT escape codes only work when the terminal has ANSI/VT processing enabled.
+  // On Windows without VT mode, escape sequences print as literal text, causing
+  // each render to append new lines instead of overwriting the previous frame.
+  const vtSupported = process.stdout.isTTY && (process.stdout.getColorDepth?.() ?? 1) > 1;
+
   let results: SearchSkill[] = [];
   let selectedIndex = 0;
   let query = initialQuery;
@@ -87,17 +92,21 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
   // Resume stdin to start receiving events
   process.stdin.resume();
 
-  // Hide cursor during selection
-  process.stdout.write(HIDE_CURSOR);
+  // Hide cursor during selection (only when VT is supported)
+  if (vtSupported) {
+    process.stdout.write(HIDE_CURSOR);
+  }
 
   function render(): void {
-    // Move cursor up to overwrite previous render
-    if (lastRenderedLines > 0) {
+    // Move cursor up to overwrite previous render (only when VT is supported)
+    if (vtSupported && lastRenderedLines > 0) {
       process.stdout.write(MOVE_UP(lastRenderedLines) + MOVE_TO_COL(1));
     }
 
-    // Clear from cursor to end of screen (removes ghost trails)
-    process.stdout.write(CLEAR_DOWN);
+    // Clear from cursor to end of screen (only when VT is supported)
+    if (vtSupported) {
+      process.stdout.write(CLEAR_DOWN);
+    }
 
     const lines: string[] = [];
 
@@ -139,7 +148,8 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
       process.stdout.write(line + '\n');
     }
 
-    lastRenderedLines = lines.length;
+    // Only track height for overwriting when VT is supported
+    lastRenderedLines = vtSupported ? lines.length : 0;
   }
 
   function triggerSearch(q: string): void {
@@ -193,7 +203,9 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
       if (process.stdin.isTTY) {
         process.stdin.setRawMode(false);
       }
-      process.stdout.write(SHOW_CURSOR);
+      if (vtSupported) {
+        process.stdout.write(SHOW_CURSOR);
+      }
       // Pause stdin to fully release it for child processes
       process.stdin.pause();
     }

--- a/src/find.ts
+++ b/src/find.ts
@@ -69,11 +69,6 @@ const MOVE_TO_COL = (n: number) => `\x1b[${n}G`;
 
 // Custom fzf-style search prompt using raw readline
 async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
-  // VT escape codes only work when the terminal has ANSI/VT processing enabled.
-  // On Windows without VT mode, escape sequences print as literal text, causing
-  // each render to append new lines instead of overwriting the previous frame.
-  const vtSupported = process.stdout.isTTY && (process.stdout.getColorDepth?.() ?? 1) > 1;
-
   let results: SearchSkill[] = [];
   let selectedIndex = 0;
   let query = initialQuery;
@@ -92,21 +87,17 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
   // Resume stdin to start receiving events
   process.stdin.resume();
 
-  // Hide cursor during selection (only when VT is supported)
-  if (vtSupported) {
-    process.stdout.write(HIDE_CURSOR);
-  }
+  // Hide cursor during selection
+  process.stdout.write(HIDE_CURSOR);
 
   function render(): void {
-    // Move cursor up to overwrite previous render (only when VT is supported)
-    if (vtSupported && lastRenderedLines > 0) {
+    // Move cursor up to overwrite previous render
+    if (lastRenderedLines > 0) {
       process.stdout.write(MOVE_UP(lastRenderedLines) + MOVE_TO_COL(1));
     }
 
-    // Clear from cursor to end of screen (only when VT is supported)
-    if (vtSupported) {
-      process.stdout.write(CLEAR_DOWN);
-    }
+    // Clear from cursor to end of screen (removes ghost trails)
+    process.stdout.write(CLEAR_DOWN);
 
     const lines: string[] = [];
 
@@ -148,8 +139,7 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
       process.stdout.write(line + '\n');
     }
 
-    // Only track height for overwriting when VT is supported
-    lastRenderedLines = vtSupported ? lines.length : 0;
+    lastRenderedLines = lines.length;
   }
 
   function triggerSearch(q: string): void {
@@ -203,9 +193,7 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
       if (process.stdin.isTTY) {
         process.stdin.setRawMode(false);
       }
-      if (vtSupported) {
-        process.stdout.write(SHOW_CURSOR);
-      }
+      process.stdout.write(SHOW_CURSOR);
       // Pause stdin to fully release it for child processes
       process.stdin.pause();
     }

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -143,6 +143,13 @@ export async function searchMultiselect<T>(
     lockedSection,
   } = options;
 
+  // VT escape codes (cursor movement, line erase) only work when the terminal
+  // has ANSI/VT processing enabled. On Windows cmd/PowerShell without VT mode,
+  // escape sequences print as literal text, causing each render to append a new
+  // frame instead of overwriting the previous one. Use color depth as a proxy:
+  // depth > 1 means the terminal processes ANSI escapes.
+  const vtSupported = process.stdout.isTTY && (process.stdout.getColorDepth?.() ?? 1) > 1;
+
   return new Promise((resolve) => {
     const rl = readline.createInterface({
       input: process.stdin,
@@ -178,14 +185,13 @@ export async function searchMultiselect<T>(
     };
 
     const clearRender = (): void => {
-      if (lastRenderHeight > 0) {
-        // Move up and clear each line
-        process.stdout.write(`\x1b[${lastRenderHeight}A`);
-        for (let i = 0; i < lastRenderHeight; i++) {
-          process.stdout.write('\x1b[2K\x1b[1B');
-        }
-        process.stdout.write(`\x1b[${lastRenderHeight}A`);
+      if (!vtSupported || lastRenderHeight === 0) return;
+      // Move up and clear each line
+      process.stdout.write(`\x1b[${lastRenderHeight}A`);
+      for (let i = 0; i < lastRenderHeight; i++) {
+        process.stdout.write('\x1b[2K\x1b[1B');
       }
+      process.stdout.write(`\x1b[${lastRenderHeight}A`);
     };
 
     const render = (state: 'active' | 'submit' | 'cancel' = 'active'): void => {

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -143,13 +143,6 @@ export async function searchMultiselect<T>(
     lockedSection,
   } = options;
 
-  // VT escape codes (cursor movement, line erase) only work when the terminal
-  // has ANSI/VT processing enabled. On Windows cmd/PowerShell without VT mode,
-  // escape sequences print as literal text, causing each render to append a new
-  // frame instead of overwriting the previous one. Use color depth as a proxy:
-  // depth > 1 means the terminal processes ANSI escapes.
-  const vtSupported = process.stdout.isTTY && (process.stdout.getColorDepth?.() ?? 1) > 1;
-
   return new Promise((resolve) => {
     const rl = readline.createInterface({
       input: process.stdin,
@@ -185,13 +178,14 @@ export async function searchMultiselect<T>(
     };
 
     const clearRender = (): void => {
-      if (!vtSupported || lastRenderHeight === 0) return;
-      // Move up and clear each line
-      process.stdout.write(`\x1b[${lastRenderHeight}A`);
-      for (let i = 0; i < lastRenderHeight; i++) {
-        process.stdout.write('\x1b[2K\x1b[1B');
+      if (lastRenderHeight > 0) {
+        // Move up and clear each line
+        process.stdout.write(`\x1b[${lastRenderHeight}A`);
+        for (let i = 0; i < lastRenderHeight; i++) {
+          process.stdout.write('\x1b[2K\x1b[1B');
+        }
+        process.stdout.write(`\x1b[${lastRenderHeight}A`);
       }
-      process.stdout.write(`\x1b[${lastRenderHeight}A`);
     };
 
     const render = (state: 'active' | 'submit' | 'cancel' = 'active'): void => {

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -3,8 +3,9 @@ import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
-import { track } from './telemetry.ts';
+import { track, shouldSendTelemetry } from './telemetry.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { parseOwnerRepo, getRepoVisibility } from './source-parser.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -249,14 +250,20 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
 
     for (const [source, data] of bySource) {
-      track({
-        event: 'remove',
-        source,
-        skills: data.skills.join(','),
-        agents: targetAgents.join(','),
-        ...(isGlobal && { global: '1' }),
-        sourceType: data.sourceType,
-      });
+      const ownerRepo = parseOwnerRepo(source);
+      const visibility = ownerRepo
+        ? await getRepoVisibility(ownerRepo.owner, ownerRepo.repo).catch(() => 'unknown' as const)
+        : 'unknown';
+      if (shouldSendTelemetry(visibility)) {
+        track({
+          event: 'remove',
+          source,
+          skills: data.skills.join(','),
+          agents: targetAgents.join(','),
+          ...(isGlobal && { global: '1' }),
+          sourceType: data.sourceType,
+        });
+      }
     }
   }
 

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseSource } from './source-parser.js';
+import { describe, it, expect, vi } from 'vitest';
+import { parseSource, getRepoVisibility } from './source-parser.js';
 
 describe('source-parser', () => {
   describe('GitLab Custom Domains & Subgroups', () => {
@@ -69,6 +69,44 @@ describe('source-parser', () => {
         type: 'gitlab',
         url: 'https://gitlab.com/owner/repo.git',
       });
+    });
+  });
+
+  describe('getRepoVisibility', () => {
+    it('returns "public" for a confirmed public repo', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ private: false }),
+        })
+      );
+      expect(await getRepoVisibility('vercel', 'next.js')).toBe('public');
+      vi.unstubAllGlobals();
+    });
+
+    it('returns "private" for a confirmed private repo', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ private: true }),
+        })
+      );
+      expect(await getRepoVisibility('owner', 'private-repo')).toBe('private');
+      vi.unstubAllGlobals();
+    });
+
+    it('returns "unknown" when API returns non-OK status', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+      expect(await getRepoVisibility('owner', 'nonexistent')).toBe('unknown');
+      vi.unstubAllGlobals();
+    });
+
+    it('returns "unknown" when fetch throws', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+      expect(await getRepoVisibility('owner', 'repo')).toBe('unknown');
+      vi.unstubAllGlobals();
     });
   });
 

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -60,24 +60,30 @@ export function parseOwnerRepo(ownerRepo: string): { owner: string; repo: string
 }
 
 /**
- * Check if a GitHub repository is private.
- * Returns true if private, false if public, null if unable to determine.
+ * A skill source's visibility.
+ * 'public'  — confirmed public via GitHub API
+ * 'private' — confirmed private via GitHub API
+ * 'unknown' — couldn't determine (API error, non-GitHub host, non-owner/repo URL)
+ */
+export type SourceVisibility = 'public' | 'private' | 'unknown';
+
+/**
+ * Check the visibility of a GitHub repository.
+ * Returns 'public' or 'private' when confirmed, 'unknown' on any failure.
  * Only works for GitHub repositories (GitLab not supported).
  */
-export async function isRepoPrivate(owner: string, repo: string): Promise<boolean | null> {
+export async function getRepoVisibility(owner: string, repo: string): Promise<SourceVisibility> {
   try {
     const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
 
-    // If repo doesn't exist or we don't have access, assume private to be safe
     if (!res.ok) {
-      return null; // Unable to determine
+      return 'unknown';
     }
 
     const data = (await res.json()) as { private?: boolean };
-    return data.private === true;
+    return data.private === true ? 'private' : 'public';
   } catch {
-    // On error, return null to indicate we couldn't determine
-    return null;
+    return 'unknown';
   }
 }
 

--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { shouldSendTelemetry, track } from './telemetry.ts';
+
+const mockFetch = vi.fn((..._args: unknown[]) => Promise.resolve(new Response()));
+vi.stubGlobal('fetch', mockFetch);
+
+const TELEMETRY_ENV_VARS = [
+  'SKILLS_TELEMETRY_URL',
+  'npm_config_skills_telemetry_url',
+  'SKILLS_TELEMETRY_ALLOW_PRIVATE',
+  'DISABLE_TELEMETRY',
+  'DO_NOT_TRACK',
+];
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  for (const key of TELEMETRY_ENV_VARS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of TELEMETRY_ENV_VARS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+const payload = {
+  event: 'install' as const,
+  source: 'owner/repo',
+  skills: 'a',
+  agents: 'cursor',
+};
+
+describe('telemetry URL resolution', () => {
+  it('sends to the default URL when no overrides are set', () => {
+    track(payload);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/add-skill\.vercel\.sh\/t\?/);
+  });
+
+  it('uses SKILLS_TELEMETRY_URL when set', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    track(payload);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/custom\.example\.com\/t\?/);
+  });
+
+  it('uses npm_config_skills_telemetry_url (.npmrc) when set', () => {
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    track(payload);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/npmrc\.example\.com\/t\?/);
+  });
+
+  it('prefers SKILLS_TELEMETRY_URL over npm_config_skills_telemetry_url', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://envvar.example.com/t';
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    track(payload);
+    const url = String(mockFetch.mock.calls[0]?.[0]);
+    expect(url).toMatch(/^https:\/\/envvar\.example\.com\/t\?/);
+  });
+});
+
+describe('telemetry opt-out', () => {
+  it('does not send when DISABLE_TELEMETRY is set', () => {
+    process.env.DISABLE_TELEMETRY = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not send when DO_NOT_TRACK is set', () => {
+    process.env.DO_NOT_TRACK = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('opt-out wins over a custom endpoint', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    process.env.DO_NOT_TRACK = '1';
+    track(payload);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldSendTelemetry', () => {
+  it('always sends for public sources', () => {
+    expect(shouldSendTelemetry('public')).toBe(true);
+  });
+
+  it('skips private sources with no custom endpoint', () => {
+    expect(shouldSendTelemetry('private')).toBe(false);
+  });
+
+  it('skips unknown sources with no custom endpoint', () => {
+    expect(shouldSendTelemetry('unknown')).toBe(false);
+  });
+
+  it('skips private sources with custom endpoint but no opt-in', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    expect(shouldSendTelemetry('private')).toBe(false);
+  });
+
+  it('skips private sources with opt-in but no custom endpoint', () => {
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendTelemetry('private')).toBe(false);
+  });
+
+  it('sends private sources when both custom endpoint and opt-in are set', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendTelemetry('private')).toBe(true);
+  });
+
+  it('sends unknown sources when both custom endpoint and opt-in are set', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://custom.example.com/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendTelemetry('unknown')).toBe(true);
+  });
+
+  it('treats npm_config_skills_telemetry_url as a custom endpoint for opt-in', () => {
+    process.env.npm_config_skills_telemetry_url = 'https://npmrc.example.com/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendTelemetry('private')).toBe(true);
+  });
+
+  it('does not honor opt-in when SKILLS_TELEMETRY_URL equals the default endpoint', () => {
+    process.env.SKILLS_TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
+    process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE = '1';
+    expect(shouldSendTelemetry('private')).toBe(false);
+  });
+});

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,35 @@
-const TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
+import type { SourceVisibility } from './source-parser.ts';
+
+const DEFAULT_TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
 const AUDIT_URL = 'https://add-skill.vercel.sh/audit';
+
+// npm/npx auto-inject `skills_telemetry_url` from .npmrc as
+// `npm_config_skills_telemetry_url` — supports centrally deployed config.
+function getTelemetryUrl(): string {
+  return (
+    process.env.SKILLS_TELEMETRY_URL ||
+    process.env.npm_config_skills_telemetry_url ||
+    DEFAULT_TELEMETRY_URL
+  );
+}
+
+function hasCustomTelemetryEndpoint(): boolean {
+  return getTelemetryUrl() !== DEFAULT_TELEMETRY_URL;
+}
+
+/**
+ * Decide whether to emit an install/remove telemetry event for a given source.
+ *
+ * Policy:
+ *  - 'public'           → always send (to default or custom endpoint)
+ *  - 'private'/'unknown → only send when operator has configured a custom
+ *                         endpoint AND explicitly set SKILLS_TELEMETRY_ALLOW_PRIVATE=1
+ *                         (private data never reaches the default Vercel endpoint)
+ */
+export function shouldSendTelemetry(visibility: SourceVisibility): boolean {
+  if (visibility === 'public') return true;
+  return hasCustomTelemetryEndpoint() && process.env.SKILLS_TELEMETRY_ALLOW_PRIVATE === '1';
+}
 
 interface InstallTelemetryData {
   event: 'install';
@@ -151,7 +181,7 @@ export function track(data: TelemetryData): void {
 
     // Fire and forget during the workflow, but track the promise so
     // flushTelemetry() can await it before the process exits.
-    const p = fetch(`${TELEMETRY_URL}?${params.toString()}`)
+    const p = fetch(`${getTelemetryUrl()}?${params.toString()}`)
       .catch(() => {})
       .then(() => {});
     pendingTelemetry.push(p);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -211,6 +211,13 @@ export function track(data: TelemetryData): void {
  */
 export async function flushTelemetry(timeoutMs = 5000): Promise<void> {
   if (pendingTelemetry.length === 0) return;
-  const timeout = new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
-  await Promise.race([Promise.all(pendingTelemetry), timeout]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  try {
+    await Promise.race([Promise.all(pendingTelemetry), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -211,13 +211,6 @@ export function track(data: TelemetryData): void {
  */
 export async function flushTelemetry(timeoutMs = 5000): Promise<void> {
   if (pendingTelemetry.length === 0) return;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<void>((resolve) => {
-    timer = setTimeout(resolve, timeoutMs);
-  });
-  try {
-    await Promise.race([Promise.all(pendingTelemetry), timeout]);
-  } finally {
-    clearTimeout(timer);
-  }
+  const timeout = new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
+  await Promise.race([Promise.all(pendingTelemetry), timeout]);
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -149,15 +149,13 @@ export async function fetchAuditData(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-    try {
-      const response = await fetch(`${AUDIT_URL}?${params.toString()}`, {
-        signal: controller.signal,
-      });
-      if (!response.ok) return null;
-      return (await response.json()) as AuditResponse;
-    } finally {
-      clearTimeout(timeout);
-    }
+    const response = await fetch(`${AUDIT_URL}?${params.toString()}`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (!response.ok) return null;
+    return (await response.json()) as AuditResponse;
   } catch {
     return null;
   }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -149,13 +149,15 @@ export async function fetchAuditData(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-    const response = await fetch(`${AUDIT_URL}?${params.toString()}`, {
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-
-    if (!response.ok) return null;
-    return (await response.json()) as AuditResponse;
+    try {
+      const response = await fetch(`${AUDIT_URL}?${params.toString()}`, {
+        signal: controller.signal,
+      });
+      if (!response.ok) return null;
+      return (await response.json()) as AuditResponse;
+    } finally {
+      clearTimeout(timeout);
+    }
   } catch {
     return null;
   }


### PR DESCRIPTION
Attempts to close #349 and fix #699. Incorporates and extends both #721 and #1064 — adds a `SourceVisibility` type to eliminate `null` from the privacy probe, and extends privacy gating to `remove` events.

## Summary

- Custom telemetry endpoint via `SKILLS_TELEMETRY_URL` or `skills_telemetry_url` in `.npmrc` (injected by npm/npx as `npm_config_skills_telemetry_url`)
- Opt-in `SKILLS_TELEMETRY_ALLOW_PRIVATE=1` to send install/remove events for private sources — only honored against a custom endpoint, never the default
- Introduces `SourceVisibility = 'public' | 'private' | 'unknown'` to replace `boolean | null` from `isRepoPrivate`, making all three states explicit and impossible to accidentally mishandle
- Renames `isRepoPrivate` → `getRepoVisibility` to match the non-boolean return
- Centralizes gating in `shouldSendTelemetry(SourceVisibility)` and applies it to both `install` and `remove` events (`remove` payloads include the source from the lock file, which can be a private repo name)

## Gating policy

| Visibility | Default endpoint | Custom endpoint | Custom endpoint + `ALLOW_PRIVATE=1` |
| ---------- | ---------------- | --------------- | ----------------------------------- |
| `public`   | send             | send            | send                                |
| `private`  | skip             | skip            | send                                |
| `unknown`  | skip             | skip            | send                                |

`DISABLE_TELEMETRY` / `DO_NOT_TRACK` suppress everything regardless.

## Changes

- `src/source-parser.ts` — add `SourceVisibility` type; `getRepoVisibility()` returns `'unknown'` instead of `null` on API error or non-OK response
- `src/telemetry.ts` — `getTelemetryUrl()` resolver, `hasCustomTelemetryEndpoint()`, export `shouldSendTelemetry(SourceVisibility)`
- `src/add.ts` — both install paths use `shouldSendTelemetry()`; local `isSourcePrivate` replaced with `getSourceVisibility()`
- `src/find.ts` — `isRepoPublic()` updated to `=== 'public'`
- `src/remove.ts` — `remove` events now gated via `shouldSendTelemetry()`, re-checking visibility per source at remove time
- `src/source-parser.test.ts` — new `getRepoVisibility` tests: confirmed-public, confirmed-private, API 404, network error
- `src/telemetry.test.ts` — 16 tests covering URL resolution priority, opt-out vars, and full gating matrix for all three visibility states
- `README.md` — document `SKILLS_TELEMETRY_URL` and `SKILLS_TELEMETRY_ALLOW_PRIVATE`

## Test plan

- [x] Default endpoint unchanged when no overrides set
- [x] `SKILLS_TELEMETRY_URL` overrides default
- [x] `npm_config_skills_telemetry_url` (`.npmrc`) overrides default
- [x] `SKILLS_TELEMETRY_URL` wins over `npm_config_skills_telemetry_url`
- [x] `DISABLE_TELEMETRY` / `DO_NOT_TRACK` suppress everything including against a custom endpoint
- [x] `shouldSendTelemetry`: `'public'` always sends; `'private'`/`'unknown'` skip unless custom endpoint + `ALLOW_PRIVATE=1`
- [x] `ALLOW_PRIVATE=1` ignored when resolved URL equals the default
- [x] `remove` events respect the same gating as `install`
- [x] Full test suite passes