### PR TITLE
feat: Add Android Studio to agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [52 more](#supported-agents).
 
 <!-- agent-list:end -->
 
@@ -232,6 +232,7 @@ Skills can be installed to any of these agents:
 | ------------------------------------- | ---------------------------------------- | ------------------------ | ------------------------------- |
 | AiderDesk                             | `aider-desk`                             | `.aider-desk/skills/`    | `~/.aider-desk/skills/`         |
 | Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/`        | `~/.config/agents/skills/`      |
+| Android Studio                        | `android-studio`                         | `.android-studio/skills/` | `~/.android-studio/skills/`    |
 | Antigravity                           | `antigravity`                            | `.agents/skills/`        | `~/.gemini/antigravity/skills/` |
 | Augment                               | `augment`                                | `.augment/skills/`       | `~/.augment/skills/`            |
 | IBM Bob                               | `bob`                                    | `.bob/skills/`           | `~/.bob/skills/`                |
@@ -353,6 +354,7 @@ The CLI searches for skills in these locations within a repository:
 - `skills/.system/`
 - `.aider-desk/skills/`
 - `.agents/skills/`
+- `.android-studio/skills/`
 - `.augment/skills/`
 - `.bob/skills/`
 - `.claude/skills/`

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ai-agents",
     "aider-desk",
     "amp",
+    "android-studio",
     "antigravity",
     "augment",
     "bob",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -46,6 +46,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(configHome, 'amp'));
     },
   },
+  'android-studio': {
+    name: 'android-studio',
+    displayName: 'Android Studio',
+    skillsDir: '.android-studio/skills',
+    globalSkillsDir: join(home, '.android-studio/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.android-studio'));
+    },
+  },
   antigravity: {
     name: 'antigravity',
     displayName: 'Antigravity',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type AgentType =
   | 'aider-desk'
   | 'amp'
+  | 'android-studio'
   | 'antigravity'
   | 'augment'
   | 'bob'


### PR DESCRIPTION
# Summary
Add support for Android Studio agent following the existing pattern
[Android Studio](https://developer.android.com/studio) is the main IDE for Android Developers

# Testing
- `pnpm test`
- `node scripts/validate-agents.ts`
