### PR TITLE
Pre-select detected non-universal agents in interactive add prompt

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -356,9 +356,14 @@ export async function promptForAgents(
 /**
  * Interactive agent selection using fuzzy search.
  * Shows universal agents as locked (always selected), and other agents as selectable.
+ *
+ * On first run (no prior history), pre-selects detected non-universal agents so
+ * that users with Claude Code (or any other non-universal agent) installed don't
+ * end up with the skill only in ~/.agents/skills after hitting Enter.
  */
-async function selectAgentsInteractive(options: {
+export async function selectAgentsInteractive(options: {
   global?: boolean;
+  installedAgents?: AgentType[];
 }): Promise<AgentType[] | symbol> {
   // Filter out agents that don't support global installation when --global is used
   const supportsGlobalFilter = (a: AgentType) => !options.global || agents[a].globalSkillsDir;
@@ -390,11 +395,20 @@ async function selectAgentsInteractive(options: {
     // Silently ignore errors
   }
 
-  const initialSelected = lastSelected
-    ? (lastSelected.filter(
-        (a) => otherAgents.includes(a as AgentType) && !universalAgents.includes(a as AgentType)
-      ) as AgentType[])
-    : [];
+  const filterToSelectable = (list: AgentType[]): AgentType[] =>
+    list.filter((a) => otherAgents.includes(a) && !universalAgents.includes(a));
+
+  let initialSelected: AgentType[];
+  if (lastSelected) {
+    // Respect prior selection. Universal agents are already locked, so we only
+    // pre-check non-universal agents the user previously chose.
+    initialSelected = filterToSelectable(lastSelected as AgentType[]);
+  } else {
+    // First run: pre-check detected non-universal agents (e.g. claude-code).
+    // Without this, hitting Enter installs only the locked universal agents and
+    // skips Claude Code entirely.
+    initialSelected = filterToSelectable(options.installedAgents ?? []);
+  }
 
   const selected = await searchMultiselect({
     message: 'Which agents do you want to install to?',
@@ -596,7 +610,10 @@ async function handleWellKnownSkills(
         );
       }
     } else {
-      const selected = await selectAgentsInteractive({ global: options.global });
+      const selected = await selectAgentsInteractive({
+        global: options.global,
+        installedAgents,
+      });
 
       if (p.isCancel(selected)) {
         p.cancel('Installation cancelled');
@@ -1290,7 +1307,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           );
         }
       } else {
-        const selected = await selectAgentsInteractive({ global: options.global });
+        const selected = await selectAgentsInteractive({
+          global: options.global,
+          installedAgents,
+        });
 
         if (p.isCancel(selected)) {
           p.cancel('Installation cancelled');

--- a/src/select-agents-interactive.test.ts
+++ b/src/select-agents-interactive.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { selectAgentsInteractive } from './add.js';
+import * as skillLock from './skill-lock.js';
+import * as searchMultiselectModule from './prompts/search-multiselect.js';
+
+vi.mock('./skill-lock.js');
+vi.mock('./prompts/search-multiselect.js');
+vi.mock('./telemetry.js', () => ({
+  setVersion: vi.fn(),
+  track: vi.fn(),
+}));
+vi.mock('../package.json', () => ({
+  default: { version: '1.0.0' },
+}));
+
+/**
+ * Regression coverage for the bug where users running the interactive add prompt
+ * with Claude Code installed (and no prior agent history) ended up with the skill
+ * only in ~/.agents/skills, because Claude Code was offered as selectable but
+ * never pre-checked. Hitting Enter on the prompt then yielded only the locked
+ * universal agents.
+ */
+describe('selectAgentsInteractive — initial selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pre-selects detected non-universal agents when no prior history exists', async () => {
+    vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(undefined);
+    vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue(['claude-code']);
+
+    await selectAgentsInteractive({ global: true, installedAgents: ['claude-code'] });
+
+    expect(searchMultiselectModule.searchMultiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialSelected: ['claude-code'],
+      })
+    );
+  });
+
+  it('keeps using prior selection when history exists', async () => {
+    vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(['cursor']);
+    vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue(['cursor']);
+
+    await selectAgentsInteractive({ global: true, installedAgents: ['claude-code'] });
+
+    // cursor is universal (.agents/skills); the existing logic filters universal agents
+    // out of initialSelected because they are already locked. Result is the empty list,
+    // so the user's explicit "I selected nothing else last time" is respected and we
+    // do not silently augment with detected agents.
+    expect(searchMultiselectModule.searchMultiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialSelected: [],
+      })
+    );
+  });
+
+  it('pre-selects multiple detected non-universal agents', async () => {
+    vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(undefined);
+    vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue([
+      'claude-code',
+      'aider-desk',
+    ]);
+
+    await selectAgentsInteractive({
+      global: true,
+      installedAgents: ['claude-code', 'aider-desk', 'codex'], // codex is universal — filtered out
+    });
+
+    expect(searchMultiselectModule.searchMultiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialSelected: expect.arrayContaining(['claude-code', 'aider-desk']),
+      })
+    );
+    const call = vi.mocked(searchMultiselectModule.searchMultiselect).mock.calls[0]![0];
+    expect(call.initialSelected).not.toContain('codex');
+  });
+
+  it('falls back to empty selection when no installed agents are passed', async () => {
+    vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(undefined);
+    vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue([]);
+
+    await selectAgentsInteractive({ global: true });
+
+    expect(searchMultiselectModule.searchMultiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialSelected: [],
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Problem

When users run `skills add <name>` interactively with Claude Code (or any other non-universal agent) installed, the prompt shows:

- **Locked section**: \"Universal (.agents/skills) — always included\" listing 13 agents (Amp, Antigravity, Cline, Codex, Cursor, ...).
- **Selectable list**: Claude Code, AiderDesk, OpenClaw, etc. — none pre-checked.

If the user just hits Enter, only the locked universal agents get the skill. Claude Code reads from \`~/.claude/skills\`, not \`~/.agents/skills\`, so the install effectively does nothing for Claude Code users — even though they had Claude Code detected on their machine and could see it in the prompt.

This matches several open reports of \"globally installed skill is invisible to Claude Code\":

- #851 — Claude Code skills land in \`~/.agents/skills\` without the expected \`~/.claude/skills\` symlink.
- #693 — Claude Code cannot read globally installed skills from \`~/.agents/skills\`.
- #1045 — Claude Code needs skills installed to \`.claude\`.
- #744 — same symptom, different repro.
- #1060 — diagnoses why universal classification leaks into the global path.

## Repro (1.5.5)

\`\`\`sh
HOME=/tmp/skills-repro mkdir -p /tmp/skills-repro/.claude
HOME=/tmp/skills-repro npx skills add pbakaus/impeccable -g
# In the prompt, hit Enter without manually checking Claude Code.
ls /tmp/skills-repro/.claude/skills    # empty
ls /tmp/skills-repro/.agents/skills    # impeccable/ landed here only
\`\`\`

Real-world artifact from a user's lock file (only universal agents in \`lastSelectedAgents\`, no \`claude-code\` despite Claude Code being installed):

\`\`\`json
\"lastSelectedAgents\": [\"amp\",\"antigravity\",\"cline\",\"codex\",\"cursor\",\"deepagents\",\"dexto\",\"firebender\",\"gemini-cli\",\"github-copilot\",\"kimi-cli\",\"opencode\",\"warp\"]
\`\`\`

## Fix

When \`lastSelected\` is undefined (first run), pre-check detected non-universal agents in the selectable list. Behavior with prior history is preserved.

- Export \`selectAgentsInteractive\` and add an optional \`installedAgents\` parameter.
- Both call sites in \`add.ts\` (well-known and repository flows) pass the already-computed \`installedAgents\` list.
- Universal agents are still locked; this only changes the *initial check state* of agents the user already has installed.

The existing \`promptForAgents\` (used elsewhere) already pre-selects \`[claude-code, opencode, codex]\` by default — this PR brings \`selectAgentsInteractive\` in line with that intent.

## Test

Added \`src/select-agents-interactive.test.ts\` mirroring \`src/add-prompt.test.ts\`:

- Pre-selects detected non-universal agents when no history.
- Respects prior history when present.
- Filters universal agents out of the initial pre-check (they are locked).
- No installed agents → empty pre-selection.

\`pnpm test\` — 448 tests pass (4 new).

## Notes

This does not fix the symlink-creation logic in \`installer.ts\`. \`installSkillForAgent('claude-code', { global: true })\` already creates a \`~/.claude/skills/<name>\` symlink to \`~/.agents/skills/<name>\` correctly when \`claude-code\` is in the target list. The remaining bug was that \`claude-code\` simply was not making it into the target list from the interactive prompt.

Closes #851
Closes #693
Closes #1045
Refs #744 #1060