### PR TITLE
fix(update): drop subpath append for non-shorthand sources (Gitea/SSH/self-hosted)

### DIFF
--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -84,5 +84,38 @@ describe('update-source', () => {
       });
       expect(result).toBe('owner/repo#main');
     });
+
+    it('does not append skill folder for SSH sources (would produce unclonable URL)', () => {
+      const result = buildLocalUpdateSource({
+        source: 'git@gitea.example.com:owner/repo.git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('git@gitea.example.com:owner/repo.git');
+    });
+
+    it('keeps ref on SSH sources even when skill folder is dropped', () => {
+      const result = buildLocalUpdateSource({
+        source: 'git@gitea.example.com:owner/repo.git',
+        ref: 'main',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('git@gitea.example.com:owner/repo.git#main');
+    });
+
+    it('does not append skill folder for self-hosted HTTPS .git URLs', () => {
+      const result = buildLocalUpdateSource({
+        source: 'https://gitea.example.com/owner/repo.git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://gitea.example.com/owner/repo.git');
+    });
+
+    it('appends skill folder for github.com HTTPS URLs', () => {
+      const result = buildLocalUpdateSource({
+        source: 'https://github.com/owner/repo',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://github.com/owner/repo/skills/my-skill');
+    });
   });
 });

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -35,7 +35,32 @@ function deriveSkillFolder(skillPath: string): string {
   return folder;
 }
 
+/**
+ * Whether a skill folder can be safely appended to the given source as a
+ * subpath. Only true for sources the source-parser can resolve as a
+ * GitHub/GitLab tree URL — owner/repo shorthand or an HTTPS URL on those
+ * hosts. Full SSH URLs (`git@host:owner/repo.git`) and generic Git URLs
+ * (anything ending in `.git`, or hosts other than github.com/gitlab.com)
+ * cannot have a subpath appended without producing an unclonable URL.
+ */
+function supportsAppendedSubpath(source: string): boolean {
+  if (source.startsWith('git@')) return false;
+  if (source.endsWith('.git')) return false;
+  if (source.startsWith('http://') || source.startsWith('https://')) {
+    try {
+      const host = new URL(source).hostname;
+      return host === 'github.com' || host === 'gitlab.com';
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
 function appendFolderAndRef(source: string, skillPath: string, ref?: string): string {
+  if (!supportsAppendedSubpath(source)) {
+    return formatSourceInput(source, ref);
+  }
   const folder = deriveSkillFolder(skillPath);
   const withFolder = folder ? `${source}/${folder}` : source;
   return ref ? `${withFolder}#${ref}` : withFolder;


### PR DESCRIPTION
## Problem

`buildLocalUpdateSource` in `src/update-source.ts` appends the skill folder unconditionally to the lock-file `source` URL. That works for owner/repo shorthand and `https://github.com/...` / `https://gitlab.com/...` URLs, where the appended path resolves to a valid GitHub/GitLab tree URL. It breaks for any other source.

For SSH URLs, the appended path produces an unclonable string:

```
git@gitea.example.com:owner/repo.git/skills/foo
```

`git clone` rejects this as `error: Invalid repo name`. Same outcome for any HTTPS URL ending in `.git` (self-hosted Gitea/Forgejo/GitLab/Bitbucket via HTTPS), or for SSH-to-GitHub.

## Reproduce

```sh
mkdir /tmp/repro && cd /tmp/repro
npx skills add git@gitea.example.com:owner/repo.git -y
# (skill is installed; skills-lock.json contains source = git@... .git, computedHash = ...)

# upstream: change SKILL.md, push.

npx skills update
# Before this PR: ✗ Failed to update <skill>
# After this PR:  ✓ Updated <skill>
```

The internally-spawned command before the fix is:
```
skills add 'git@gitea.example.com:owner/repo.git/skills/foo' --skill foo -y
```
After the fix:
```
skills add 'git@gitea.example.com:owner/repo.git' --skill foo -y
```

The project-scoped update path already passes `--skill <name>`, so the skill folder is not needed in the source URL to scope the install.

## Fix

`appendFolderAndRef` now consults a small predicate `supportsAppendedSubpath(source)` before appending. The predicate returns false for:

- SSH URLs (`git@…`)
- Anything ending in `.git`
- HTTPS URLs whose host is not `github.com` / `gitlab.com`

In those cases we fall back to `formatSourceInput(source, ref)` — the bare URL with optional ref, no subpath. Existing behaviour for owner/repo shorthand and github.com/gitlab.com HTTPS URLs is unchanged.

## Tests

- All existing tests (in `src/update-source.test.ts`) pass unchanged.
- Four new cases cover the regression and the unaffected paths:
  - SSH source with skillPath → bare URL returned
  - SSH source with skillPath + ref → bare URL with ref
  - Self-hosted HTTPS `.git` source with skillPath → bare URL returned
  - github.com HTTPS URL with skillPath → subpath still appended (regression guard)

`pnpm test`: 448/448 passing on this branch.
`pnpm format:check`: clean.

## Verification

End-to-end on a private Gitea instance (`gitea.timkaufmann.de`):

1. Created a test repo with `skills/test-skill/SKILL.md` (v1).
2. `npx skills add git@gitea.timkaufmann.de:tim/test-repo.git -y` — install works on `main` and on this branch.
3. Bumped the skill content to v2 upstream.
4. `npx skills update` — fails on `main`, succeeds on this branch (skill is updated to v2 on disk).

## Scope notes

This addresses only the project-scoped update path for non-shorthand sources. It is **not** a fix for #997 (self-hosted GitLab installs that store a Short-Slug source without domain) — that bug lives in `src/add.ts:1657` (`source: lockSource || parsed.url`) and is a separate change. It is, however, in the same family of issues as #411 and partially advances the goal of supporting self-hosted Git providers for `update`.

A pleasing side effect: this also fixes the same broken behaviour for SSH-to-GitHub (`git@github.com:owner/repo.git`) installs.