### PR TITLE
fix: preserve ssh git urls in lock sources

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import { parseAddOptions } from './add.ts';
+import { parseAddOptions, getLockSource } from './add.ts';
 
 describe('add command', () => {
   let testDir: string;
@@ -293,6 +293,24 @@ metadata:
       const result = runCli(['add', testDir, '--list'], testDir);
       expect(result.stdout).toContain('not-internal-skill');
     });
+  });
+});
+
+describe('getLockSource', () => {
+  it('preserves git@ SSH URLs for lock files', () => {
+    expect(getLockSource('git@github.com:owner/repo.git', 'owner/repo')).toBe(
+      'git@github.com:owner/repo.git'
+    );
+  });
+
+  it('preserves ssh:// SSH URLs for lock files', () => {
+    expect(getLockSource('ssh://git@stash.myrepo.com:7999/my/skills.git', 'my/skills')).toBe(
+      'ssh://git@stash.myrepo.com:7999/my/skills.git'
+    );
+  });
+
+  it('keeps normalized owner/repo for non-SSH remotes', () => {
+    expect(getLockSource('https://github.com/owner/repo.git', 'owner/repo')).toBe('owner/repo');
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -22,6 +22,14 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   }
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
+
+export function getLockSource(parsedUrl: string, normalizedSource: string | null): string | null {
+  // Preserve SSH URLs in lock files instead of normalizing to owner/repo shorthand.
+  // When normalizedSource is used, parseSource() later resolves it to HTTPS,
+  // breaking restore for private repos that require SSH authentication.
+  const isSSH = parsedUrl.startsWith('git@') || parsedUrl.startsWith('ssh://');
+  return isSSH ? parsedUrl : normalizedSource;
+}
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
@@ -1553,11 +1561,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Normalize source to owner/repo format for telemetry
     const normalizedSource = getOwnerRepo(parsed);
 
-    // Preserve SSH URLs in lock files instead of normalizing to owner/repo shorthand.
-    // When normalizedSource is used, parseSource() later resolves it to HTTPS,
-    // breaking restore for private repos that require SSH authentication.
-    const isSSH = parsed.url.startsWith('git@');
-    const lockSource = isSSH ? parsed.url : normalizedSource;
+    const lockSource = getLockSource(parsed.url, normalizedSource);
 
     // Only track if we have a valid remote source and it's not a private repo.
     // repoPrivacyPromise was started early (right after parsing) so it has

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -25,6 +25,22 @@ export function getOwnerRepo(parsed: ParsedSource): string | null {
     return null;
   }
 
+  // Handle SSH URLs with a scheme (e.g., ssh://git@host:7999/owner/repo.git)
+  if (parsed.url.startsWith('ssh://')) {
+    try {
+      const url = new URL(parsed.url);
+      let path = url.pathname.slice(1);
+      path = path.replace(/\.git$/, '');
+
+      if (path.includes('/')) {
+        return path;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
   // Handle HTTP(S) URLs
   if (!parsed.url.startsWith('http://') && !parsed.url.startsWith('https://')) {
     return null;
@@ -144,6 +160,10 @@ function decodeFragmentValue(value: string): string {
 
 function looksLikeGitSource(input: string): boolean {
   if (input.startsWith('github:') || input.startsWith('gitlab:') || input.startsWith('git@')) {
+    return true;
+  }
+
+  if (/^ssh:\/\/.+\.git(?:$|[/?])/i.test(input)) {
     return true;
   }
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -262,6 +262,13 @@ describe('parseSource', () => {
       expect(result.url).toBe('https://git.example.com/owner/repo.git');
       expect(result.ref).toBe('release-2026');
     });
+
+    it('Git URL - ssh scheme with #branch', () => {
+      const result = parseSource('ssh://git@git.example.com:7999/owner/repo.git#release-2026');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('ssh://git@git.example.com:7999/owner/repo.git');
+      expect(result.ref).toBe('release-2026');
+    });
   });
 });
 
@@ -399,6 +406,14 @@ describe('getOwnerRepo', () => {
 
   it('getOwnerRepo - SSH URL (custom host)', () => {
     const parsed = { type: 'git', url: 'git@git.company.com:org/team/repo.git' } as const;
+    expect(getOwnerRepo(parsed)).toBe('org/team/repo');
+  });
+
+  it('getOwnerRepo - SSH URL with scheme and port', () => {
+    const parsed = {
+      type: 'git',
+      url: 'ssh://git@git.company.com:7999/org/team/repo.git',
+    } as const;
     expect(getOwnerRepo(parsed)).toBe('org/team/repo');
   });
 


### PR DESCRIPTION
## Summary
- parse `ssh://...git#ref` sources as git URLs with a detached `ref`
- preserve `ssh://...` source URLs in lock files instead of normalizing them to `owner/repo`
- add regression tests for source parsing and lock source preservation

## Problem
Private/internal repositories accessed through SSH URLs with ports were not handled correctly.

Example source:
`ssh://git@stash.myrepo.com:7999/my/skills.git#v0.0.1`

Two issues followed from that:
1. `#ref` was not extracted correctly for `ssh://...git#ref`
2. `skills-lock.json` stored `my/skills` instead of the original SSH URL

That broke restore/update workflows for private repositories that require the original SSH transport and host.

## Changes
- treat `ssh://...*.git` as a git-like source during fragment ref parsing
- handle `ssh://` URLs in `getOwnerRepo()`
- preserve both `git@...` and `ssh://...` URLs as lock sources
- add tests for both parsing and lock source selection

## Validation
- `pnpm test src/add.test.ts tests/source-parser.test.ts`
- `pnpm build`

Fixes #1097
Related to #567
Related to #997
