### PR TITLE
fix: preserve canonical skill path casing

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -60,6 +60,7 @@ import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import {
   tryBlobInstall,
+  getCanonicalSkillPathFromTree,
   getSkillFolderHashFromTree,
   fetchRepoTree,
   type BlobSkill,
@@ -1592,29 +1593,29 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Add to skill lock file for update tracking (only for global installs)
+    let remoteTree: Awaited<ReturnType<typeof fetchRepoTree>> | undefined = blobResult?.tree;
+    if (successful.length > 0 && !remoteTree && parsed.type === 'github' && normalizedSource) {
+      const token = getGitHubToken();
+      remoteTree = await fetchRepoTree(normalizedSource, parsed.ref, token);
+    }
+
+    const canonicalizeSkillPath = (skillPath: string | undefined): string | undefined => {
+      if (!skillPath || !remoteTree) return skillPath;
+      return getCanonicalSkillPathFromTree(remoteTree, skillPath) ?? skillPath;
+    };
+
     if (successful.length > 0 && installGlobally && normalizedSource) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
-
-      // For GitHub clone installs, fetch the repo tree once and reuse it
-      // for all skills — avoids N sequential API calls that take ~400ms each.
-      let cachedTree: Awaited<ReturnType<typeof fetchRepoTree>> | undefined;
-      if (parsed.type === 'github' && !blobResult) {
-        const token = getGitHubToken();
-        cachedTree = await fetchRepoTree(normalizedSource, parsed.ref, token);
-      }
 
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
             let skillFolderHash = '';
-            const skillPathValue = skillFiles[skill.name];
+            const skillPathValue = canonicalizeSkillPath(skillFiles[skill.name]);
 
-            if (blobResult && skillPathValue) {
-              const hash = getSkillFolderHashFromTree(blobResult.tree, skillPathValue);
-              if (hash) skillFolderHash = hash;
-            } else if (parsed.type === 'github' && skillPathValue && cachedTree) {
-              const hash = getSkillFolderHashFromTree(cachedTree, skillPathValue);
+            if (remoteTree && skillPathValue) {
+              const hash = getSkillFolderHashFromTree(remoteTree, skillPathValue);
               if (hash) skillFolderHash = hash;
             } else if (skillPathValue && tempDir) {
               const skillDir = join(tempDir, dirname(skillPathValue));
@@ -1650,7 +1651,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               blobResult && 'snapshotHash' in skill
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
-            const skillPathValue = skillFiles[skill.name];
+            const skillPathValue = canonicalizeSkillPath(skillFiles[skill.name]);
             await addSkillToLocalLock(
               skill.name,
               {

--- a/src/blob.test.ts
+++ b/src/blob.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCanonicalSkillPathFromTree,
+  getSkillFolderHashFromTree,
+  type RepoTree,
+} from './blob.ts';
+
+describe('repo tree skill paths', () => {
+  const tree: RepoTree = {
+    sha: 'root-tree',
+    branch: 'HEAD',
+    tree: [
+      { path: 'Skills', type: 'tree', sha: 'skills-tree' },
+      { path: 'Skills/ghostty-config', type: 'tree', sha: 'ghostty-tree' },
+      { path: 'Skills/ghostty-config/SKILL.md', type: 'blob', sha: 'ghostty-skill-md' },
+    ],
+  };
+
+  it('returns folder hashes for paths with mismatched casing', () => {
+    expect(getSkillFolderHashFromTree(tree, 'skills/ghostty-config/SKILL.md')).toBe('ghostty-tree');
+  });
+
+  it('returns canonical repo casing for lockfile skill paths', () => {
+    expect(getCanonicalSkillPathFromTree(tree, 'skills/ghostty-config/SKILL.md')).toBe(
+      'Skills/ghostty-config/SKILL.md'
+    );
+  });
+
+  it('does not guess when path casing is ambiguous', () => {
+    const ambiguousTree: RepoTree = {
+      sha: 'root-tree',
+      branch: 'HEAD',
+      tree: [
+        { path: 'Skills', type: 'tree', sha: 'uppercase-skills-tree' },
+        { path: 'Skills/ghostty-config', type: 'tree', sha: 'uppercase-ghostty-tree' },
+        { path: 'Skills/ghostty-config/SKILL.md', type: 'blob', sha: 'uppercase-ghostty-md' },
+        { path: 'skills', type: 'tree', sha: 'lowercase-skills-tree' },
+        { path: 'skills/ghostty-config', type: 'tree', sha: 'lowercase-ghostty-tree' },
+        { path: 'skills/ghostty-config/SKILL.md', type: 'blob', sha: 'lowercase-ghostty-md' },
+      ],
+    };
+
+    expect(getSkillFolderHashFromTree(ambiguousTree, 'SKILLS/ghostty-config/SKILL.md')).toBeNull();
+    expect(
+      getCanonicalSkillPathFromTree(ambiguousTree, 'SKILLS/ghostty-config/SKILL.md')
+    ).toBeNull();
+  });
+
+  it('still prefers exact matches when path casing is otherwise ambiguous', () => {
+    const ambiguousTree: RepoTree = {
+      sha: 'root-tree',
+      branch: 'HEAD',
+      tree: [
+        { path: 'Skills', type: 'tree', sha: 'uppercase-skills-tree' },
+        { path: 'Skills/ghostty-config', type: 'tree', sha: 'uppercase-ghostty-tree' },
+        { path: 'Skills/ghostty-config/SKILL.md', type: 'blob', sha: 'uppercase-ghostty-md' },
+        { path: 'skills', type: 'tree', sha: 'lowercase-skills-tree' },
+        { path: 'skills/ghostty-config', type: 'tree', sha: 'lowercase-ghostty-tree' },
+        { path: 'skills/ghostty-config/SKILL.md', type: 'blob', sha: 'lowercase-ghostty-md' },
+      ],
+    };
+
+    expect(getSkillFolderHashFromTree(ambiguousTree, 'Skills/ghostty-config/SKILL.md')).toBe(
+      'uppercase-ghostty-tree'
+    );
+    expect(getCanonicalSkillPathFromTree(ambiguousTree, 'Skills/ghostty-config/SKILL.md')).toBe(
+      'Skills/ghostty-config/SKILL.md'
+    );
+  });
+
+  it('keeps root-level skill paths stable', () => {
+    expect(getCanonicalSkillPathFromTree(tree, 'SKILL.md')).toBe('SKILL.md');
+    expect(getSkillFolderHashFromTree(tree, 'SKILL.md')).toBe('root-tree');
+  });
+});

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -76,6 +76,39 @@ export interface RepoTree {
   tree: TreeEntry[];
 }
 
+function normalizeRepoPath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\/+/, '');
+}
+
+function skillPathToFolderPath(skillPath: string): string {
+  let folderPath = normalizeRepoPath(skillPath);
+
+  if (folderPath.endsWith('/SKILL.md')) {
+    folderPath = folderPath.slice(0, -9);
+  } else if (folderPath.endsWith('SKILL.md')) {
+    folderPath = folderPath.slice(0, -8);
+  }
+
+  if (folderPath.endsWith('/')) {
+    folderPath = folderPath.slice(0, -1);
+  }
+
+  return folderPath;
+}
+
+function findTreeEntry(
+  tree: RepoTree,
+  type: TreeEntry['type'],
+  path: string
+): TreeEntry | undefined {
+  const exact = tree.tree.find((e) => e.type === type && e.path === path);
+  if (exact) return exact;
+
+  const lowerPath = path.toLowerCase();
+  const matches = tree.tree.filter((e) => e.type === type && e.path.toLowerCase() === lowerPath);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 /**
  * Fetch the full recursive tree for a GitHub repo.
  * Returns the tree data including all entries, or null on failure.
@@ -125,25 +158,41 @@ export async function fetchRepoTree(
  * This replaces the per-skill GitHub API call previously done in fetchSkillFolderHash().
  */
 export function getSkillFolderHashFromTree(tree: RepoTree, skillPath: string): string | null {
-  let folderPath = skillPath.replace(/\\/g, '/');
-
-  // Remove SKILL.md suffix to get folder path
-  if (folderPath.endsWith('/SKILL.md')) {
-    folderPath = folderPath.slice(0, -9);
-  } else if (folderPath.endsWith('SKILL.md')) {
-    folderPath = folderPath.slice(0, -8);
-  }
-  if (folderPath.endsWith('/')) {
-    folderPath = folderPath.slice(0, -1);
-  }
+  const folderPath = skillPathToFolderPath(skillPath);
 
   // Root-level skill
   if (!folderPath) {
     return tree.sha;
   }
 
-  const entry = tree.tree.find((e) => e.type === 'tree' && e.path === folderPath);
+  const entry = findTreeEntry(tree, 'tree', folderPath);
   return entry?.sha ?? null;
+}
+
+/**
+ * Return the repo-canonical SKILL.md path for a lockfile entry.
+ *
+ * Local clones on case-insensitive filesystems can discover a skill through a
+ * differently-cased search path (for example, "skills/..." for upstream
+ * "Skills/..."). GitHub tree paths are case-sensitive, so lock files must keep
+ * the exact upstream casing for future update checks and reinstalls.
+ */
+export function getCanonicalSkillPathFromTree(tree: RepoTree, skillPath: string): string | null {
+  const normalizedPath = normalizeRepoPath(skillPath);
+  if (normalizedPath === 'SKILL.md') {
+    return normalizedPath;
+  }
+
+  const folderPath = skillPathToFolderPath(normalizedPath);
+  const skillMdPath =
+    normalizedPath.endsWith('/SKILL.md') || normalizedPath === 'SKILL.md'
+      ? normalizedPath
+      : folderPath
+        ? `${folderPath}/SKILL.md`
+        : 'SKILL.md';
+
+  const entry = findTreeEntry(tree, 'blob', skillMdPath);
+  return entry?.path ?? null;
 }
 
 // ─── Skill discovery from tree ───


### PR DESCRIPTION
## Summary
- Preserve repo-canonical casing when writing `skillPath` lock entries from GitHub tree data.
- Make tree lookups tolerate case mismatches only when the match is unambiguous.
- Add coverage for canonical casing, ambiguous `skills`/`Skills` paths, and root-level skills.

## Repro
Installing `sammcj/agentic-coding@ghostty-config` now records `Skills/ghostty-config/SKILL.md` with its folder hash instead of a lowercase path with an empty hash.