### PR TITLE
Add Tinycloud agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [52 more](#supported-agents).
 
 <!-- agent-list:end -->
 
@@ -273,6 +273,7 @@ Skills can be installed to any of these agents:
 | Rovo Dev                              | `rovodev`                                | `.rovodev/skills/`       | `~/.rovodev/skills/`            |
 | Roo Code                              | `roo`                                    | `.roo/skills/`           | `~/.roo/skills/`                |
 | Tabnine CLI                           | `tabnine-cli`                            | `.tabnine/agent/skills/` | `~/.tabnine/agent/skills/`      |
+| Tinycloud                             | `tinycloud`                              | `.tinycloud/skills/`     | `~/.tinycloud/skills/`          |
 | Trae                                  | `trae`                                   | `.trae/skills/`          | `~/.trae/skills/`               |
 | Trae CN                               | `trae-cn`                                | `.trae/skills/`          | `~/.trae-cn/skills/`            |
 | Windsurf                              | `windsurf`                               | `.windsurf/skills/`      | `~/.codeium/windsurf/skills/`   |
@@ -384,6 +385,7 @@ The CLI searches for skills in these locations within a repository:
 - `.rovodev/skills/`
 - `.roo/skills/`
 - `.tabnine/agent/skills/`
+- `.tinycloud/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`
 - `.zencoder/skills/`

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "rovodev",
     "roo",
     "tabnine-cli",
+    "tinycloud",
     "trae",
     "trae-cn",
     "warp",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -447,6 +447,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.tabnine'));
     },
   },
+  tinycloud: {
+    name: 'tinycloud',
+    displayName: 'Tinycloud',
+    skillsDir: '.tinycloud/skills',
+    globalSkillsDir: join(home, '.tinycloud/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.tinycloud'));
+    },
+  },
   trae: {
     name: 'trae',
     displayName: 'Trae',

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export type AgentType =
   | 'roo'
   | 'rovodev'
   | 'tabnine-cli'
+  | 'tinycloud'
   | 'trae'
   | 'trae-cn'
   | 'warp'


### PR DESCRIPTION
## Summary
- Add [Tinycloud](https://tinycloud.sh/) to supported agents
- Project skills dir: `.tinycloud/skills/`; global: `~/.tinycloud/skills/`
- Update generated README sections (agent count, supported-agents table, skill-discovery list) and `package.json` keywords

Tinycloud is an agent CLI for deep video work. Its skill loader already discovers `.tinycloud/skills/` (project-local) and `~/.tinycloud/skills/` (global), so this entry lets users install community skills directly from `npx skills add ... -a tinycloud`.

## Testing
- `node scripts/validate-agents.ts` — passes
- `pnpm test` — 444 tests pass across 29 files
- `pnpm build` — succeeds (`./dist/cli.mjs`)