### PR TITLE
Add QoderWork Agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [52 more](#supported-agents).
 
 <!-- agent-list:end -->
 
@@ -269,6 +269,7 @@ Skills can be installed to any of these agents:
 | OpenHands                             | `openhands`                              | `.openhands/skills/`     | `~/.openhands/skills/`          |
 | Pi                                    | `pi`                                     | `.pi/skills/`            | `~/.pi/agent/skills/`           |
 | Qoder                                 | `qoder`                                  | `.qoder/skills/`         | `~/.qoder/skills/`              |
+| QoderWork                             | `qoderwork`                              | `.qoderwork/skills/`     | `~/.qoderwork/skills/`          |
 | Qwen Code                             | `qwen-code`                              | `.qwen/skills/`          | `~/.qwen/skills/`               |
 | Rovo Dev                              | `rovodev`                                | `.rovodev/skills/`       | `~/.rovodev/skills/`            |
 | Roo Code                              | `roo`                                    | `.roo/skills/`           | `~/.roo/skills/`                |
@@ -380,6 +381,7 @@ The CLI searches for skills in these locations within a repository:
 - `.openhands/skills/`
 - `.pi/skills/`
 - `.qoder/skills/`
+- `.qoderwork/skills/`
 - `.qwen/skills/`
 - `.rovodev/skills/`
 - `.roo/skills/`
@@ -488,6 +490,7 @@ Telemetry is automatically disabled in CI environments.
 - [OpenHands Skills Documentation](https://docs.openhands.ai/modules/usage/how-to/using-skills)
 - [Pi Skills Documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md)
 - [Qoder Skills Documentation](https://docs.qoder.com/cli/Skills)
+- [QoderWork](https://qoder.com/qoderwork)
 - [Replit Skills Documentation](https://docs.replit.com/replitai/skills)
 - [Roo Code Skills Documentation](https://docs.roocode.com/features/skills)
 - [Trae Skills Documentation](https://docs.trae.ai/ide/skills)

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "openhands",
     "pi",
     "qoder",
+    "qoderwork",
     "qwen-code",
     "replit",
     "rovodev",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -401,6 +401,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.qoder'));
     },
   },
+  qoderwork: {
+    name: 'qoderwork',
+    displayName: 'QoderWork',
+    skillsDir: '.qoderwork/skills',
+    globalSkillsDir: join(home, '.qoderwork/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.qoderwork'));
+    },
+  },
   'qwen-code': {
     name: 'qwen-code',
     displayName: 'Qwen Code',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -174,6 +174,7 @@ const PRIORITY_PREFIXES = [
   '.openhands/skills/',
   '.pi/skills/',
   '.qoder/skills/',
+  '.qoderwork/skills/',
   '.roo/skills/',
   '.trae/skills/',
   '.windsurf/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -177,6 +177,7 @@ export async function discoverSkills(
     join(searchPath, '.openhands/skills'),
     join(searchPath, '.pi/skills'),
     join(searchPath, '.qoder/skills'),
+    join(searchPath, '.qoderwork/skills'),
     join(searchPath, '.roo/skills'),
     join(searchPath, '.trae/skills'),
     join(searchPath, '.windsurf/skills'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type AgentType =
   | 'openhands'
   | 'pi'
   | 'qoder'
+  | 'qoderwork'
   | 'qwen-code'
   | 'replit'
   | 'roo'


### PR DESCRIPTION
## Summary

- Adds QoderWork ([qoder.com/qoderwork](https://qoder.com/qoderwork)) as a supported agent.
- Project skills dir: `.qoderwork/skills/`; global: `~/.qoderwork/skills/`.
- Detection: presence of `~/.qoderwork`.

Follows the existing pattern used by neighboring agents (e.g. `qoder`). README and `package.json` keywords were synced via `scripts/sync-agents.ts` (only the QoderWork-related additions; original formatting preserved).

## Test plan

- [x] `node scripts/validate-agents.ts` passes
- [x] `npm test` — 443/443 functional tests pass (the unrelated `dist.test.ts` requires `pnpm build` in CI)
- [x] `npm run format:check` clean