### PR TITLE
Add `npm:` source for `skills add`

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -23,6 +23,7 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
+import { npmPackAndExtract, cleanupNpmTempDir, NpmPackError } from './npm.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
   installSkillForAgent,
@@ -998,7 +999,19 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     let skills: Skill[];
     let blobResult: BlobInstallResult | null = null;
 
-    if (parsed.type === 'local') {
+    if (parsed.type === 'npm') {
+      // Download the package via `npm pack` (no install scripts, no deps).
+      // Extracts into <tmp>/skills-npm-XXXX/package/.
+      spinner.start(`Downloading npm package ${pc.cyan(parsed.packageSpec!)}...`);
+      tempDir = await npmPackAndExtract(parsed.packageSpec!);
+      spinner.stop('Package downloaded');
+
+      spinner.start('Discovering skills...');
+      skills = await discoverSkills(tempDir, parsed.subpath, {
+        includeInternal,
+        fullDepth: options.fullDepth,
+      });
+    } else if (parsed.type === 'local') {
       // Use local path directly, no cloning needed
       spinner.start('Validating local path...');
       if (!existsSync(parsed.localPath!)) {
@@ -1556,8 +1569,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Preserve SSH URLs in lock files instead of normalizing to owner/repo shorthand.
     // When normalizedSource is used, parseSource() later resolves it to HTTPS,
     // breaking restore for private repos that require SSH authentication.
+    // For npm sources, fall back to parsed.url ("npm:<spec>") since there is
+    // no owner/repo shorthand to derive.
     const isSSH = parsed.url.startsWith('git@');
-    const lockSource = isSSH ? parsed.url : normalizedSource;
+    const lockSource = isSSH
+      ? parsed.url
+      : (normalizedSource ?? (parsed.type === 'npm' ? parsed.url : null));
 
     // Only track if we have a valid remote source and it's not a private repo.
     // repoPrivacyPromise was started early (right after parsing) so it has
@@ -1592,13 +1609,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Add to skill lock file for update tracking (only for global installs)
-    if (successful.length > 0 && installGlobally && normalizedSource) {
+    if (successful.length > 0 && installGlobally && lockSource) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
 
       // For GitHub clone installs, fetch the repo tree once and reuse it
       // for all skills — avoids N sequential API calls that take ~400ms each.
       let cachedTree: Awaited<ReturnType<typeof fetchRepoTree>> | undefined;
-      if (parsed.type === 'github' && !blobResult) {
+      if (parsed.type === 'github' && !blobResult && normalizedSource) {
         const token = getGitHubToken();
         cachedTree = await fetchRepoTree(normalizedSource, parsed.ref, token);
       }
@@ -1623,7 +1640,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             }
 
             await addSkillToLock(skill.name, {
-              source: lockSource || normalizedSource,
+              source: lockSource,
               sourceType: parsed.type,
               sourceUrl: parsed.url,
               ref: parsed.ref,
@@ -1783,6 +1800,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       for (const line of error.message.split('\n')) {
         p.log.message(pc.dim(line));
       }
+    } else if (error instanceof NpmPackError) {
+      p.log.error(pc.red(`Failed to download npm package ${error.spec}`));
+      for (const line of error.message.split('\n')) {
+        p.log.message(pc.dim(line));
+      }
     } else {
       p.log.error(error instanceof Error ? error.message : 'Unknown error occurred');
     }
@@ -1796,12 +1818,20 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
 // Cleanup helper
 async function cleanup(tempDir: string | null) {
-  if (tempDir) {
-    try {
-      await cleanupTempDir(tempDir);
-    } catch {
-      // Ignore cleanup errors
+  if (!tempDir) return;
+  try {
+    // npm packs land in <tmp>/skills-npm-XXXX/package — delete the whole
+    // skills-npm- root so the tarball and extracted folder go together.
+    const parts = tempDir.split(sep);
+    const last = parts[parts.length - 1];
+    const parent = parts[parts.length - 2];
+    if (last === 'package' && parent && parent.startsWith('skills-npm-')) {
+      await cleanupNpmTempDir(tempDir);
+      return;
     }
+    await cleanupTempDir(tempDir);
+  } catch {
+    // Ignore cleanup errors
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,6 +117,9 @@ ${BOLD}Manage Skills:${RESET}
   add <package>        Add a skill package (alias: a)
                        e.g. vercel-labs/agent-skills
                             https://github.com/vercel-labs/agent-skills
+                            npm:my-skills-package
+                            npm:my-skills-package@1.2.3
+                            npm:@scope/skills@^1.0.0
   remove [skills]      Remove installed skills
   list, ls             List installed skills
   find [query]         Search for skills interactively
@@ -169,6 +172,9 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills add vercel-labs/agent-skills -g
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --agent claude-code cursor
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --skill pr-review commit
+  ${DIM}$${RESET} skills add npm:my-skills-package         ${DIM}# install latest from npm${RESET}
+  ${DIM}$${RESET} skills add npm:my-skills-package@1.2.3   ${DIM}# specific npm version${RESET}
+  ${DIM}$${RESET} skills add npm:@scope/skills@^1.0.0      ${DIM}# scoped npm package${RESET}
   ${DIM}$${RESET} skills remove                        ${DIM}# interactive remove${RESET}
   ${DIM}$${RESET} skills remove web-design             ${DIM}# remove by name${RESET}
   ${DIM}$${RESET} skills rm --global frontend-design

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,0 +1,198 @@
+import { spawn } from 'child_process';
+import { mkdtemp, readdir, rm, stat } from 'fs/promises';
+import { tmpdir, platform } from 'os';
+import { join, normalize, resolve, sep } from 'path';
+
+const DEFAULT_NPM_TIMEOUT_MS = 300_000; // 5 minutes
+const NPM_TIMEOUT_MS = (() => {
+  const raw = process.env.SKILLS_NPM_TIMEOUT_MS;
+  if (!raw) return DEFAULT_NPM_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_NPM_TIMEOUT_MS;
+})();
+
+export class NpmPackError extends Error {
+  readonly spec: string;
+  readonly isTimeout: boolean;
+  readonly isAuthError: boolean;
+
+  constructor(message: string, spec: string, isTimeout = false, isAuthError = false) {
+    super(message);
+    this.name = 'NpmPackError';
+    this.spec = spec;
+    this.isTimeout = isTimeout;
+    this.isAuthError = isAuthError;
+  }
+}
+
+/**
+ * Spawn a child process and resolve with its stdout/stderr/exit info.
+ * Rejects with NpmPackError on timeout or spawn failure.
+ */
+function runCommand(
+  command: string,
+  args: string[],
+  spec: string
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const isWindows = platform() === 'win32';
+    const child = spawn(command, args, {
+      // npm.cmd on Windows requires shell: true to be located on PATH
+      shell: isWindows,
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, NPM_TIMEOUT_MS);
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        rejectPromise(
+          new NpmPackError(
+            `'${command}' not found on PATH. Install Node.js (which provides npm) and tar to use npm: sources.`,
+            spec
+          )
+        );
+        return;
+      }
+      rejectPromise(new NpmPackError(`Failed to run '${command}': ${err.message}`, spec));
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        const seconds = Math.round(NPM_TIMEOUT_MS / 1000);
+        rejectPromise(
+          new NpmPackError(
+            `'${command} ${args.join(' ')}' timed out after ${seconds}s. ` +
+              `Raise the timeout with SKILLS_NPM_TIMEOUT_MS=600000 (10m).`,
+            spec,
+            true
+          )
+        );
+        return;
+      }
+      resolvePromise({ stdout, stderr, code });
+    });
+  });
+}
+
+/**
+ * Download an npm package as a tarball using `npm pack` and extract it
+ * into a fresh temp directory. Returns the path to the extracted package
+ * directory (the "package/" folder inside the tarball).
+ *
+ * Uses the user's npm configuration (registry, auth, proxy). Does NOT
+ * install dependencies and does NOT run install scripts.
+ *
+ * Requires `npm` and `tar` on PATH. Both ship with the standard Node.js
+ * install on macOS/Linux and with Windows 10+ (tar.exe is built in).
+ */
+export async function npmPackAndExtract(spec: string): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'skills-npm-'));
+  try {
+    // 1. Download the tarball into tempDir
+    const packResult = await runCommand(
+      'npm',
+      ['pack', spec, '--pack-destination', tempDir, '--silent'],
+      spec
+    );
+
+    if (packResult.code !== 0) {
+      const stderr = packResult.stderr.trim();
+      const isAuthError = /401|403|EAUTHIP|EAUTH|forbidden|unauthorized|authentication/i.test(
+        stderr
+      );
+      throw new NpmPackError(
+        `'npm pack ${spec}' failed${stderr ? `:\n${stderr}` : ''}`,
+        spec,
+        false,
+        isAuthError
+      );
+    }
+
+    // 2. Locate the .tgz that npm pack wrote
+    const entries = await readdir(tempDir);
+    const tarballName = entries.find((name) => name.endsWith('.tgz'));
+    if (!tarballName) {
+      throw new NpmPackError(
+        `'npm pack ${spec}' completed but no .tgz file was found in ${tempDir}`,
+        spec
+      );
+    }
+    const tarballPath = join(tempDir, tarballName);
+
+    // 3. Validate the tarball is inside tempDir before invoking tar.
+    // Defends against pathological filenames (npm doesn't produce them, but be safe).
+    const normalizedTarball = normalize(resolve(tarballPath));
+    const normalizedTempDir = normalize(resolve(tempDir));
+    if (!normalizedTarball.startsWith(normalizedTempDir + sep)) {
+      throw new NpmPackError(`Tarball path escaped temp dir: ${tarballPath}`, spec);
+    }
+
+    // 4. Extract: tar -xzf <tarball> -C <tempDir>
+    // npm tarballs unpack into a top-level "package/" directory by convention.
+    const tarResult = await runCommand('tar', ['-xzf', tarballPath, '-C', tempDir], spec);
+    if (tarResult.code !== 0) {
+      throw new NpmPackError(
+        `'tar -xzf ${tarballName}' failed${tarResult.stderr ? `:\n${tarResult.stderr.trim()}` : ''}`,
+        spec
+      );
+    }
+
+    // 5. Confirm the expected package/ directory was produced
+    const packageDir = join(tempDir, 'package');
+    try {
+      const stats = await stat(packageDir);
+      if (!stats.isDirectory()) {
+        throw new NpmPackError(`Expected '${packageDir}' to be a directory after extraction`, spec);
+      }
+    } catch (err) {
+      if (err instanceof NpmPackError) throw err;
+      throw new NpmPackError(
+        `Tarball did not contain a 'package/' directory after extraction`,
+        spec
+      );
+    }
+
+    return packageDir;
+  } catch (err) {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * Clean up a temp directory created by npmPackAndExtract.
+ *
+ * The argument is the package/ subdirectory; we walk one level up so the
+ * tarball, the extracted folder, and the mkdtemp root all get removed.
+ */
+export async function cleanupNpmTempDir(packageDir: string): Promise<void> {
+  const normalizedPkg = normalize(resolve(packageDir));
+  const normalizedTmp = normalize(resolve(tmpdir()));
+  if (!normalizedPkg.startsWith(normalizedTmp + sep)) {
+    throw new Error('Attempted to clean up directory outside of temp directory');
+  }
+
+  // packageDir = <tmp>/skills-npm-XXXX/package — clean up the parent
+  const tempRoot = normalize(resolve(packageDir, '..'));
+  if (!tempRoot.startsWith(normalizedTmp + sep)) {
+    throw new Error('Attempted to clean up directory outside of temp directory');
+  }
+  await rm(tempRoot, { recursive: true, force: true });
+}

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSource } from './source-parser.js';
+import { parseSource, parseNpmSpec } from './source-parser.js';
 
 describe('source-parser', () => {
   describe('GitLab Custom Domains & Subgroups', () => {
@@ -125,6 +125,107 @@ describe('source-parser', () => {
         type: 'git',
         url: 'git@github.com:owner/repo.git',
         ref: 'feature/install',
+      });
+    });
+  });
+
+  describe('npm sources', () => {
+    it('parses npm:<pkg> with no version', () => {
+      const result = parseSource('npm:my-skills');
+      expect(result).toEqual({
+        type: 'npm',
+        url: 'npm:my-skills',
+        packageSpec: 'my-skills',
+        packageName: 'my-skills',
+      });
+    });
+
+    it('parses npm:<pkg>@<version>', () => {
+      const result = parseSource('npm:my-skills@1.2.3');
+      expect(result).toEqual({
+        type: 'npm',
+        url: 'npm:my-skills@1.2.3',
+        packageSpec: 'my-skills@1.2.3',
+        packageName: 'my-skills',
+      });
+    });
+
+    it('parses npm:<pkg>@<range>', () => {
+      const result = parseSource('npm:my-skills@^1.0.0');
+      expect(result).toEqual({
+        type: 'npm',
+        url: 'npm:my-skills@^1.0.0',
+        packageSpec: 'my-skills@^1.0.0',
+        packageName: 'my-skills',
+      });
+    });
+
+    it('parses npm:@scope/<pkg>', () => {
+      const result = parseSource('npm:@scope/skills');
+      expect(result).toEqual({
+        type: 'npm',
+        url: 'npm:@scope/skills',
+        packageSpec: '@scope/skills',
+        packageName: '@scope/skills',
+      });
+    });
+
+    it('parses npm:@scope/<pkg>@<version>', () => {
+      const result = parseSource('npm:@scope/skills@1.0.0');
+      expect(result).toEqual({
+        type: 'npm',
+        url: 'npm:@scope/skills@1.0.0',
+        packageSpec: '@scope/skills@1.0.0',
+        packageName: '@scope/skills',
+      });
+    });
+
+    it('parses npm:@scope/<pkg>@<range>', () => {
+      const result = parseSource('npm:@scope/skills@^1.2');
+      expect(result).toEqual({
+        type: 'npm',
+        url: 'npm:@scope/skills@^1.2',
+        packageSpec: '@scope/skills@^1.2',
+        packageName: '@scope/skills',
+      });
+    });
+
+    it('does not set ref for npm sources', () => {
+      const result = parseSource('npm:my-skills@1.2.3');
+      expect(result.ref).toBeUndefined();
+    });
+
+    it('throws when scoped package is missing the package name', () => {
+      // "@bad" is not a valid scoped name (needs a slash: @scope/name)
+      expect(() => parseSource('npm:@bad')).toThrow(/Invalid npm spec/);
+    });
+  });
+
+  describe('parseNpmSpec', () => {
+    it('handles unscoped package without version', () => {
+      expect(parseNpmSpec('foo')).toEqual({ packageName: 'foo' });
+    });
+
+    it('handles unscoped package with version', () => {
+      expect(parseNpmSpec('foo@1.0.0')).toEqual({ packageName: 'foo', version: '1.0.0' });
+    });
+
+    it('handles scoped package without version', () => {
+      expect(parseNpmSpec('@scope/foo')).toEqual({ packageName: '@scope/foo' });
+    });
+
+    it('handles scoped package with version', () => {
+      expect(parseNpmSpec('@scope/foo@1.0.0')).toEqual({
+        packageName: '@scope/foo',
+        version: '1.0.0',
+      });
+    });
+
+    it('handles version ranges', () => {
+      expect(parseNpmSpec('foo@^1.2.3')).toEqual({ packageName: 'foo', version: '^1.2.3' });
+      expect(parseNpmSpec('@scope/foo@~2.0')).toEqual({
+        packageName: '@scope/foo',
+        version: '~2.0',
       });
     });
   });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -217,6 +217,30 @@ function appendFragmentRef(input: string, ref?: string, skillFilter?: string): s
   return `${input}#${ref}${skillFilter ? `@${skillFilter}` : ''}`;
 }
 
+/**
+ * Split an npm package spec into its name and (optional) version.
+ *
+ * Examples:
+ *   "foo"              -> { packageName: "foo" }
+ *   "foo@1.0.0"        -> { packageName: "foo", version: "1.0.0" }
+ *   "@scope/foo"       -> { packageName: "@scope/foo" }
+ *   "@scope/foo@^1.2"  -> { packageName: "@scope/foo", version: "^1.2" }
+ */
+export function parseNpmSpec(spec: string): { packageName: string; version?: string } {
+  if (spec.startsWith('@')) {
+    const match = spec.match(/^(@[^/]+\/[^@]+)(?:@(.+))?$/);
+    if (match) {
+      return { packageName: match[1]!, ...(match[2] ? { version: match[2] } : {}) };
+    }
+    return { packageName: '' };
+  }
+  const match = spec.match(/^([^@/][^@]*)(?:@(.+))?$/);
+  if (match) {
+    return { packageName: match[1]!, ...(match[2] ? { version: match[2] } : {}) };
+  }
+  return { packageName: '' };
+}
+
 export function parseSource(input: string): ParsedSource {
   // Local path: absolute, relative, or current directory
   if (isLocalPath(input)) {
@@ -240,6 +264,29 @@ export function parseSource(input: string): ParsedSource {
   const alias = SOURCE_ALIASES[input];
   if (alias) {
     input = alias;
+  }
+
+  // Prefix shorthand: npm:<pkg>[@version]
+  // Supports unscoped and scoped packages with optional version/range:
+  //   npm:foo, npm:foo@1.0.0, npm:foo@^1.2, npm:@scope/foo, npm:@scope/foo@1.0.0
+  const npmPrefixMatch = input.match(/^npm:(.+)$/);
+  if (npmPrefixMatch) {
+    const spec = npmPrefixMatch[1]!;
+    const { packageName } = parseNpmSpec(spec);
+    if (!packageName) {
+      throw new Error(`Invalid npm spec: "${spec}"`);
+    }
+    // Note: the version (if any) stays embedded in `packageSpec` and `url`.
+    // We deliberately do NOT set `ref` for npm sources — the version is
+    // already part of the spec, so setting ref would duplicate it in
+    // display and lockfile output.
+    return {
+      type: 'npm',
+      url: `npm:${spec}`,
+      packageSpec: spec,
+      packageName,
+      ...(fragmentSkillFilter ? { skillFilter: fragmentSkillFilter } : {}),
+    };
   }
 
   // Prefix shorthand: github:owner/repo -> owner/repo (handled by existing shorthand logic)

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,13 +78,17 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known';
+  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known' | 'npm';
   url: string;
   subpath?: string;
   localPath?: string;
   ref?: string;
   /** Skill name extracted from @skill syntax (e.g., owner/repo@skill-name) */
   skillFilter?: string;
+  /** Full npm package spec for type 'npm' (e.g., "foo", "foo@1.0.0", "@scope/foo@^1.2") */
+  packageSpec?: string;
+  /** Bare package name (without version) for type 'npm' */
+  packageName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds support for `npx skills add npm:<pkg>[@version]`, including scoped packages (`npm:@scope/foo`) and version ranges (`npm:foo@^1.2.3`).
- Downloads via `npm pack` (no install scripts, no deps installed) and respects the user's npm config (registry, auth, proxy). Tarball is extracted with `tar -xzf` into a temp dir, then the existing `discoverSkills` walk runs against the extracted package — same locations `experimental_sync` uses (`SKILL.md` at root, `skills/`, `.agents/skills/`).
- Lockfile entries (global `~/.agents/.skill-lock.json` and project `skills-lock.json`) record the npm source as `npm:<spec>` so re-installs round-trip cleanly through `parseSource`.

## What changed

- `src/types.ts` — `'npm'` added to `ParsedSource.type`; new optional `packageSpec` / `packageName` fields.
- `src/source-parser.ts` — new `parseNpmSpec` helper plus an `npm:<spec>` branch in `parseSource`.
- `src/npm.ts` *(new)* — `npmPackAndExtract(spec)` runs `npm pack` + `tar`, returns the extracted `package/` directory; surfaces `NpmPackError` with `isAuthError` / `isTimeout` flags. Honors `SKILLS_NPM_TIMEOUT_MS` (default 5 min).
- `src/add.ts` — `runAdd` branches on `parsed.type === 'npm'`; `cleanup()` walks up to the npm temp root; `NpmPackError` gets a friendly error path; the global lockfile branch now triggers on `lockSource` (with npm fallback to `parsed.url`) instead of requiring an owner/repo.
- `src/cli.ts` — npm: examples in the help text.
- `src/source-parser.test.ts` — 13 new unit tests covering `parseSource` and `parseNpmSpec`.

## Test plan

- [x] `npx vitest run` — 457/457 pass (29 files), including 13 new npm parser tests.
- [x] `tsc --noEmit` — no new errors introduced (the 4 pre-existing errors in `git.ts`, `skills.ts`, `providers/wellknown.ts` are unchanged).
- [x] End-to-end smoke: `npmPackAndExtract('is-odd@3.0.1')` against the real registry succeeds, extracts to `<tmp>/skills-npm-XXX/package/`, and cleans up.
- [x] Failure path: `npx skills add npm:nonexistent-pkg-…` produces a clean `NpmPackError` ("Failed to download npm package …") instead of crashing.
- [ ] Tested on Windows (`tar.exe` ships with Win10+, but worth a manual run).
- [ ] Tested against a real published package that contains a `SKILL.md`.

## Usage

```sh
npx skills add npm:my-skills-pkg
npx skills add npm:my-skills-pkg@1.2.3
npx skills add npm:@scope/skills@^1.0.0 -g -y
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)