### PR TITLE
fix: use manifest skill paths directly instead of dirname()

### DIFF
--- a/src/plugin-manifest.ts
+++ b/src/plugin-manifest.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'fs/promises';
-import { join, dirname, resolve, normalize, sep } from 'path';
+import { join, resolve, normalize, sep } from 'path';
 
 /**
  * Check if a path is contained within a base directory.
@@ -45,8 +45,8 @@ interface PluginManifest {
  * Only resolves local paths - remote sources are skipped.
  *
  * Returns directories that CONTAIN skills (to be searched for child SKILL.md files).
- * For explicit skill paths in manifests, adds the parent directory so the
- * existing discovery loop finds them.
+ * Each item in the manifest's skills array is a directory containing
+ * <name>/SKILL.md, so it is added directly as a search directory.
  */
 export async function getPluginSkillPaths(basePath: string): Promise<string[]> {
   const searchDirs: string[] = [];
@@ -58,12 +58,12 @@ export async function getPluginSkillPaths(basePath: string): Promise<string[]> {
     if (!isContainedIn(pluginBase, basePath)) return;
 
     if (skills && skills.length > 0) {
-      // Plugin explicitly declares skill paths - add parent dirs so existing loop finds them
+      // Plugin explicitly declares skills directories - add them directly as search dirs
       for (const skillPath of skills) {
         // Validate skill path starts with './' (per Claude Code convention)
         if (!isValidRelativePath(skillPath)) continue;
 
-        const skillDir = dirname(join(pluginBase, skillPath));
+        const skillDir = join(pluginBase, skillPath);
         if (isContainedIn(skillDir, basePath)) {
           searchDirs.push(skillDir);
         }

--- a/tests/plugin-manifest-discovery.test.ts
+++ b/tests/plugin-manifest-discovery.test.ts
@@ -343,7 +343,7 @@ description: Found via conventional skills/ in plugin
           {
             name: 'mixed-plugin',
             source: './mixed',
-            skills: ['./custom-skills/explicit-skill'], // Explicit path
+            skills: ['./custom-skills/'], // Directory containing <name>/SKILL.md
           },
         ],
       })
@@ -540,7 +540,7 @@ description: Should be found
     writeFileSync(
       join(testDir, '.claude-plugin/plugin.json'),
       JSON.stringify({
-        skills: ['invalid-loc/bare-skill', './valid-loc/valid-skill'], // First lacks ./
+        skills: ['invalid-loc/', './valid-loc/'], // First lacks ./
       })
     );
 
@@ -582,5 +582,33 @@ description: Standard location
     // Should find: valid-skill (via valid manifest path) and standard-skill (via convention)
     // Should NOT find: bare-skill (manifest path lacks ./)
     expect(names).toEqual(['standard-skill', 'valid-skill']);
+  });
+
+  it('should discover skills from nested manifest directories', async () => {
+    // Each skills entry is a directory containing <name>/SKILL.md.
+    // When one entry is a subdirectory of another, both must be scanned.
+    mkdirSync(join(testDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.claude-plugin/plugin.json'),
+      JSON.stringify({
+        name: 'nested-plugin',
+        skills: ['./skills/group-a/', './skills/group-a/subgroup/'],
+      })
+    );
+
+    mkdirSync(join(testDir, 'skills/group-a/skill-1'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills/group-a/skill-1/SKILL.md'),
+      '---\nname: skill-1\ndescription: Test\n---\n'
+    );
+    mkdirSync(join(testDir, 'skills/group-a/subgroup/skill-2'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills/group-a/subgroup/skill-2/SKILL.md'),
+      '---\nname: skill-2\ndescription: Test\n---\n'
+    );
+
+    const skills = await discoverSkills(testDir);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(['skill-1', 'skill-2']);
   });
 });


### PR DESCRIPTION
getPluginSkillPaths() was calling dirname() on each entry in the manifest's skills array, returning the parent directory instead of the directory itself. According to the Claude Code plugin spec [1], each skills entry is a directory containing `<name>/SKILL.md` — so it should be added directly as a search directory.

The dirname() call caused the priority scan to find some skills (preventing the recursive fallback) while silently missing entire directories. For example, given plugin.json with:

    { "skills": ["./skills/group-a/",
                 "./skills/group-a/subgroup/"] }

and skills directory tree:

    skills/group-a/skill-1/SKILL.md
    skills/group-a/subgroup/skill-2/SKILL.md

dirname() turns "./skills/group-a/subgroup/" into "./skills/group-a/", which the priority scan searches — finding skill-1 but not skill-2. Since the priority scan found at least one skill, the recursive fallback never runs, and skill-2 is silently missed.

Related to https://github.com/vercel-labs/skills/pull/259

[1] https://code.claude.com/docs/en/plugins-reference#component-path-fields