### PR TITLE
fix: default unknown sources to private for telemetry/audit

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -12,13 +12,13 @@ const isCancelled = (value: unknown): value is symbol => typeof value === 'symbo
 
 /**
  * Check if a source identifier (owner/repo format) represents a private GitHub repo.
- * Returns true if private, false if public, null if unable to determine or not a GitHub repo.
+ * Returns true if private or unknown, false if public.
  */
-async function isSourcePrivate(source: string): Promise<boolean | null> {
+async function isSourcePrivate(source: string): Promise<boolean> {
   const ownerRepo = parseOwnerRepo(source);
   if (!ownerRepo) {
-    // Not in owner/repo format, assume not private (could be other providers)
-    return false;
+    // Unknown/non-GitHub sources default to private to avoid metadata leaks.
+    return true;
   }
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
@@ -728,7 +728,7 @@ async function handleWellKnownSkills(
 
   // Kick off privacy check early so it runs in parallel with installation
   const sourceIdentifier = wellKnownProvider.getSourceIdentifier(url);
-  const wellKnownPrivacyPromise = isSourcePrivate(sourceIdentifier).catch(() => null);
+  const wellKnownPrivacyPromise = isSourcePrivate(sourceIdentifier).catch(() => true);
 
   spinner.start('Installing skills...');
 
@@ -771,7 +771,7 @@ async function handleWellKnownSkills(
 
   // Privacy promise was started before installation — should be resolved by now
   const isPrivate = await wellKnownPrivacyPromise;
-  if (isPrivate !== true) {
+  if (!isPrivate) {
     track({
       event: 'install',
       source: sourceIdentifier,
@@ -972,11 +972,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // cloning/discovering/installing. The result is only needed later for
     // telemetry gating — it should never block user-visible output.
     const ownerRepoRaw = getOwnerRepo(parsed);
-    const repoPrivacyPromise: Promise<boolean | null> = (() => {
-      if (!ownerRepoRaw) return Promise.resolve(null);
+    const repoPrivacyPromise: Promise<boolean> = (() => {
+      if (!ownerRepoRaw) return Promise.resolve(true);
       const ownerRepo = parseOwnerRepo(ownerRepoRaw);
-      if (!ownerRepo) return Promise.resolve(null);
-      return isRepoPrivate(ownerRepo.owner, ownerRepo.repo).catch(() => null);
+      if (!ownerRepo) return Promise.resolve(true);
+      return isRepoPrivate(ownerRepo.owner, ownerRepo.repo).catch(() => true);
     })();
 
     // Block openclaw sources unless explicitly opted in
@@ -1244,9 +1244,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // in parallel with agent selection, scope, and mode prompts.
     const ownerRepoForAudit = getOwnerRepo(parsed);
     const auditPromise = ownerRepoForAudit
-      ? fetchAuditData(
-          ownerRepoForAudit,
-          selectedSkills.map((s) => getSkillDisplayName(s))
+      ? repoPrivacyPromise.then((isPrivate) =>
+          isPrivate
+            ? null
+            : fetchAuditData(
+                ownerRepoForAudit,
+                selectedSkills.map((s) => getSkillDisplayName(s))
+              )
         )
       : Promise.resolve(null);
 
@@ -1581,27 +1585,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const isSSH = parsed.url.startsWith('git@');
     const lockSource = isSSH ? parsed.url : normalizedSource;
 
-    // Only track if we have a valid remote source and it's not a private repo.
+    // Only track if we have a valid remote source and it is confirmed public.
     // repoPrivacyPromise was started early (right after parsing) so it has
     // already been running in parallel with the entire install — no stall here.
     if (normalizedSource) {
-      const ownerRepo = parseOwnerRepo(normalizedSource);
-      if (ownerRepo) {
-        const isPrivate = await repoPrivacyPromise;
-        // Only send telemetry if repo is public (isPrivate === false)
-        // If we can't determine (null), err on the side of caution and skip telemetry
-        if (isPrivate === false) {
-          track({
-            event: 'install',
-            source: normalizedSource,
-            skills: selectedSkills.map((s) => s.name).join(','),
-            agents: targetAgents.join(','),
-            ...(installGlobally && { global: '1' }),
-            skillFiles: JSON.stringify(skillFiles),
-          });
-        }
-      } else {
-        // If we can't parse owner/repo, still send telemetry (for non-GitHub sources)
+      const isPrivate = await repoPrivacyPromise;
+      if (!isPrivate) {
         track({
           event: 'install',
           source: normalizedSource,

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -6,6 +6,7 @@ import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -19,6 +20,15 @@ export interface RemoveOptions {
   agent?: string[];
   yes?: boolean;
   all?: boolean;
+}
+
+async function isSourcePrivate(source: string): Promise<boolean> {
+  const ownerRepo = parseOwnerRepo(source);
+  if (!ownerRepo) {
+    // Unknown/non-GitHub sources default to private to avoid metadata leaks.
+    return true;
+  }
+  return isRepoPrivate(ownerRepo.owner, ownerRepo.repo).catch(() => true);
 }
 
 export async function removeCommand(skillNames: string[], options: RemoveOptions) {
@@ -261,14 +271,17 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
 
     for (const [source, data] of bySource) {
-      track({
-        event: 'remove',
-        source,
-        skills: data.skills.join(','),
-        agents: targetAgents.join(','),
-        ...(isGlobal && { global: '1' }),
-        sourceType: data.sourceType,
-      });
+      const isPrivate = await isSourcePrivate(source);
+      if (!isPrivate) {
+        track({
+          event: 'remove',
+          source,
+          skills: data.skills.join(','),
+          agents: targetAgents.join(','),
+          ...(isGlobal && { global: '1' }),
+          sourceType: data.sourceType,
+        });
+      }
     }
   }
 

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { parseSource } from './source-parser.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { parseSource, isRepoPrivate } from './source-parser.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe('source-parser', () => {
   describe('GitLab Custom Domains & Subgroups', () => {
@@ -127,5 +132,47 @@ describe('source-parser', () => {
         ref: 'feature/install',
       });
     });
+  });
+});
+
+describe('isRepoPrivate', () => {
+  it('returns false when GitHub reports a public repo', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ private: false }),
+      })
+    );
+
+    await expect(isRepoPrivate('vercel', 'next.js')).resolves.toBe(false);
+  });
+
+  it('returns true when GitHub reports a private repo', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ private: true }),
+      })
+    );
+
+    await expect(isRepoPrivate('acme', 'internal')).resolves.toBe(true);
+  });
+
+  it('returns true when privacy cannot be determined (non-OK response)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+      })
+    );
+
+    await expect(isRepoPrivate('acme', 'unknown')).resolves.toBe(true);
+  });
+
+  it('returns true on network errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network failure')));
+    await expect(isRepoPrivate('acme', 'unknown')).resolves.toBe(true);
   });
 });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -61,23 +61,23 @@ export function parseOwnerRepo(ownerRepo: string): { owner: string; repo: string
 
 /**
  * Check if a GitHub repository is private.
- * Returns true if private, false if public, null if unable to determine.
+ * Returns true if private OR unable to determine, false if public.
  * Only works for GitHub repositories (GitLab not supported).
  */
-export async function isRepoPrivate(owner: string, repo: string): Promise<boolean | null> {
+export async function isRepoPrivate(owner: string, repo: string): Promise<boolean> {
   try {
     const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
 
     // If repo doesn't exist or we don't have access, assume private to be safe
     if (!res.ok) {
-      return null; // Unable to determine
+      return true;
     }
 
     const data = (await res.json()) as { private?: boolean };
     return data.private === true;
   } catch {
-    // On error, return null to indicate we couldn't determine
-    return null;
+    // On error, assume private to avoid leaking telemetry for unknown sources
+    return true;
   }
 }
 

--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fetchAuditData } from './telemetry.ts';
+
+const originalDisableTelemetry = process.env.DISABLE_TELEMETRY;
+const originalDoNotTrack = process.env.DO_NOT_TRACK;
+
+afterEach(() => {
+  if (originalDisableTelemetry === undefined) {
+    delete process.env.DISABLE_TELEMETRY;
+  } else {
+    process.env.DISABLE_TELEMETRY = originalDisableTelemetry;
+  }
+
+  if (originalDoNotTrack === undefined) {
+    delete process.env.DO_NOT_TRACK;
+  } else {
+    process.env.DO_NOT_TRACK = originalDoNotTrack;
+  }
+
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchAuditData', () => {
+  it('does not call audit endpoint when DISABLE_TELEMETRY is set', async () => {
+    process.env.DISABLE_TELEMETRY = '1';
+    delete process.env.DO_NOT_TRACK;
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAuditData('acme/repo', ['private-skill']);
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call audit endpoint when DO_NOT_TRACK is set', async () => {
+    delete process.env.DISABLE_TELEMETRY;
+    process.env.DO_NOT_TRACK = '1';
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAuditData('acme/repo', ['private-skill']);
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call audit endpoint when skill list is empty', async () => {
+    delete process.env.DISABLE_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAuditData('acme/repo', []);
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calls audit endpoint when telemetry is enabled', async () => {
+    delete process.env.DISABLE_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+
+    const responsePayload = {
+      'my-skill': {
+        ath: {
+          risk: 'safe',
+          analyzedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => responsePayload,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAuditData('owner/repo', ['my-skill']);
+    expect(result).toEqual(responsePayload);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const calledUrl = String(fetchMock.mock.calls[0]?.[0]);
+    expect(calledUrl).toContain('https://add-skill.vercel.sh/audit?');
+    expect(calledUrl).toContain('source=owner%2Frepo');
+    expect(calledUrl).toContain('skills=my-skill');
+  });
+});

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -79,7 +79,7 @@ function isCI(): boolean {
   );
 }
 
-function isEnabled(): boolean {
+export function isTelemetryEnabled(): boolean {
   return !process.env.DISABLE_TELEMETRY && !process.env.DO_NOT_TRACK;
 }
 
@@ -108,6 +108,7 @@ export async function fetchAuditData(
   skillSlugs: string[],
   timeoutMs = 3000
 ): Promise<AuditResponse | null> {
+  if (!isTelemetryEnabled()) return null;
   if (skillSlugs.length === 0) return null;
 
   try {
@@ -136,7 +137,7 @@ export async function fetchAuditData(
 const pendingTelemetry: Promise<void>[] = [];
 
 export function track(data: TelemetryData): void {
-  if (!isEnabled()) return;
+  if (!isTelemetryEnabled()) return;
 
   try {
     const params = new URLSearchParams();


### PR DESCRIPTION
## Summary
- default unknown/inaccessible repo visibility to private in `isRepoPrivate()`
- treat non-`owner/repo` sources as private for telemetry gating
- gate `fetchAuditData()` behind telemetry opt-out env vars and confirmed-public sources only
- apply the same privacy gating to `remove` telemetry events
- add regression tests for repo privacy fallback and audit opt-out behavior

## Why
Issue #699 reports metadata leaks when repo privacy cannot be determined, for non-GitHub source formats, and when audit calls run before privacy checks. This patch switches to safe defaults (private unless confirmed public) and keeps audit calls behind the same privacy/opt-out constraints.

Fixes #699

## Validation
- `npm test -- src/source-parser.test.ts src/telemetry.test.ts`
