### PR TITLE
fix(add): respect pinned refs for GitHub skill installs

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import { parseAddOptions } from './add.ts';
+import { parseAddOptions, shouldUseBlobInstall } from './add.ts';
 
 describe('add command', () => {
   let testDir: string;
@@ -388,6 +388,57 @@ describe('parseAddOptions', () => {
     expect(result.options.fullDepth).toBe(true);
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
+  });
+});
+
+describe('shouldUseBlobInstall', () => {
+  it('uses blob install for allowlisted unpinned GitHub sources', () => {
+    expect(
+      shouldUseBlobInstall(
+        {
+          type: 'github',
+          url: 'https://github.com/vercel-labs/skills.git',
+        },
+        {}
+      )
+    ).toBe(true);
+  });
+
+  it('skips blob install for pinned GitHub refs so checkout integrity is preserved', () => {
+    expect(
+      shouldUseBlobInstall(
+        {
+          type: 'github',
+          url: 'https://github.com/vercel-labs/skills.git',
+          ref: 'v1.4.2',
+        },
+        {}
+      )
+    ).toBe(false);
+  });
+
+  it('skips blob install when full-depth discovery is requested', () => {
+    expect(
+      shouldUseBlobInstall(
+        {
+          type: 'github',
+          url: 'https://github.com/vercel-labs/skills.git',
+        },
+        { fullDepth: true }
+      )
+    ).toBe(false);
+  });
+
+  it('skips blob install for non-allowlisted owners', () => {
+    expect(
+      shouldUseBlobInstall(
+        {
+          type: 'github',
+          url: 'https://github.com/example/skills.git',
+        },
+        {}
+      )
+    ).toBe(false);
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -58,7 +58,7 @@ import {
   saveSelectedAgents,
 } from './skill-lock.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
-import type { Skill, AgentType } from './types.ts';
+import type { Skill, AgentType, ParsedSource } from './types.ts';
 import {
   tryBlobInstall,
   getSkillFolderHashFromTree,
@@ -69,6 +69,21 @@ import {
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
   setVersion(version);
+}
+
+const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com'];
+
+export function shouldUseBlobInstall(
+  parsed: ParsedSource,
+  options: { fullDepth?: boolean }
+): boolean {
+  if (parsed.type !== 'github' || options.fullDepth || parsed.ref) {
+    return false;
+  }
+
+  const ownerRepo = getOwnerRepo(parsed);
+  const owner = ownerRepo?.split('/')[0]?.toLowerCase();
+  return !!owner && BLOB_ALLOWED_OWNERS.includes(owner);
 }
 
 // ─── Security Advisory ───
@@ -1037,11 +1052,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       });
     } else if (parsed.type === 'github' && !options.fullDepth) {
       // Try blob-based fast install for GitHub sources
-      // Only enabled for allowlisted orgs; skip for --full-depth
-      const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com'];
+      // Only enabled for allowlisted orgs; skip for --full-depth and pinned refs
       const ownerRepo = getOwnerRepo(parsed);
-      const owner = ownerRepo?.split('/')[0]?.toLowerCase();
-      if (ownerRepo && owner && BLOB_ALLOWED_OWNERS.includes(owner)) {
+      if (ownerRepo && shouldUseBlobInstall(parsed, options)) {
         spinner.start('Fetching skills...');
         const token = getGitHubToken();
         blobResult = await tryBlobInstall(ownerRepo, {


### PR DESCRIPTION
## Summary

Skip the blob-based GitHub install path when a source includes a pinned ref.

The blob download endpoint is keyed by owner/repo/slug, so pinned branch, tag, or commit installs should fall back to cloning to preserve the requested repository state.

## Validation

```bash
pnpm test src/add.test.ts -t shouldUseBlobInstall
pnpm format:check
```
