### PR TITLE
Harden skill installs against external symlinks

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -363,10 +363,39 @@ const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
   return false;
 };
 
-async function copyDirectory(src: string, dest: string): Promise<void> {
+async function copySafeSymlink(
+  srcPath: string,
+  destPath: string,
+  sourceRoot: string
+): Promise<void> {
+  let realTarget: string;
+
+  try {
+    realTarget = await realpath(srcPath);
+  } catch {
+    console.warn(`Skipping broken symlink: ${srcPath}`);
+    return;
+  }
+
+  if (!isPathSafe(sourceRoot, realTarget)) {
+    console.warn(`Skipping symlink outside skill directory: ${srcPath}`);
+    return;
+  }
+
+  const targetStats = await stat(srcPath);
+  if (!targetStats.isFile()) {
+    console.warn(`Skipping non-file symlink: ${srcPath}`);
+    return;
+  }
+
+  await cp(realTarget, destPath);
+}
+
+async function copyDirectory(src: string, dest: string, sourceRoot = src): Promise<void> {
   await mkdir(dest, { recursive: true });
 
   const entries = await readdir(src, { withFileTypes: true });
+  const resolvedSourceRoot = await realpath(sourceRoot).catch(() => resolve(sourceRoot));
 
   // Copy files and directories in parallel
   await Promise.all(
@@ -377,31 +406,11 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
         const destPath = join(dest, entry.name);
 
         if (entry.isDirectory()) {
-          await copyDirectory(srcPath, destPath);
+          await copyDirectory(srcPath, destPath, sourceRoot);
+        } else if (entry.isSymbolicLink()) {
+          await copySafeSymlink(srcPath, destPath, resolvedSourceRoot);
         } else {
-          try {
-            await cp(srcPath, destPath, {
-              // If the file is a symlink to elsewhere in a remote skill, it may not
-              // resolve correctly once it has been copied to the local location.
-              // `dereference: true` tells Node to copy the file instead of copying
-              // the symlink. `recursive: true` handles symlinks pointing to directories.
-              dereference: true,
-              recursive: true,
-            });
-          } catch (err: unknown) {
-            // Skip broken symlinks (e.g., pointing to absolute paths on another machine)
-            // instead of aborting the entire install.
-            if (
-              err instanceof Error &&
-              'code' in err &&
-              (err as NodeJS.ErrnoException).code === 'ENOENT' &&
-              entry.isSymbolicLink()
-            ) {
-              console.warn(`Skipping broken symlink: ${srcPath}`);
-            } else {
-              throw err;
-            }
-          }
+          await cp(srcPath, destPath);
         }
       })
   );

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
@@ -9,6 +9,14 @@ async function makeSkillSource(root: string, name: string): Promise<string> {
   await mkdir(dir, { recursive: true });
   await writeFile(join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: test\n---\n`, 'utf-8');
   return dir;
+}
+
+function isSymlinkUnsupported(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    ['EACCES', 'ENOSYS', 'EPERM'].includes(String((error as NodeJS.ErrnoException).code))
+  );
 }
 
 describe('installer copy mode', () => {
@@ -40,6 +48,80 @@ describe('installer copy mode', () => {
       );
       await expect(access(join(installedDir, 'metadata.json'))).rejects.toThrow();
       await expect(access(join(installedDir, '.git'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not copy symlink targets outside the skill directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-symlink-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'copy-symlink-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const outsideFile = join(root, 'outside-secret.txt');
+    await writeFile(outsideFile, 'sensitive local content\n', 'utf-8');
+
+    try {
+      await symlink(outsideFile, join(skillDir, 'outside-secret'));
+    } catch (error) {
+      if (isSymlinkUnsupported(error)) {
+        await rm(root, { recursive: true, force: true });
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedDir = join(projectDir, '.agents/skills', skillName);
+      await expect(access(join(installedDir, 'outside-secret'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('copies file symlinks that resolve inside the skill directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-internal-symlink-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'copy-internal-symlink-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const sharedFile = join(skillDir, 'shared.md');
+    await writeFile(sharedFile, 'shared instructions\n', 'utf-8');
+
+    try {
+      await symlink(sharedFile, join(skillDir, 'linked.md'));
+    } catch (error) {
+      if (isSymlinkUnsupported(error)) {
+        await rm(root, { recursive: true, force: true });
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedDir = join(projectDir, '.agents/skills', skillName);
+      await expect(readFile(join(installedDir, 'linked.md'), 'utf-8')).resolves.toBe(
+        'shared instructions\n'
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

This PR hardens skill installation when copying files from a skill source directory. It prevents symlinks inside a skill from being dereferenced if their real target resolves outside the skill directory, while preserving regular files, dotfiles, and file symlinks that resolve within the skill directory.

This PR is AI-assisted (submitted via Codex agent).

## Security impact

Before this change, a skill source could include a symlink that points outside the skill directory. During install, the copy routine used symlink dereferencing, so the target file could be copied into `.agents/skills/<skill>/...` as part of installation. That makes install-time local file disclosure possible if a user installs a crafted skill source.

The new behavior is:

- Broken symlinks are skipped.
- Symlinks resolving outside the skill directory are skipped.
- Non-file symlinks are skipped to avoid recursive directory-copy surprises.
- File symlinks resolving inside the skill directory are copied as regular files, preserving the useful existing behavior.

## Reproduction

A minimal local reproduction before this patch:

1. Create a skill directory with a valid `SKILL.md`.
2. Add a symlink inside that skill directory pointing to a file outside the skill directory.
3. Run `skills add <that-directory> --yes --agent codex --copy` from another project directory.
4. Observe that the symlink target is copied into `.agents/skills/<skill-name>/`.

The added regression test covers this path and asserts that external symlink targets are not installed.

## Validation

- `corepack pnpm format:check`
- `corepack pnpm exec vitest run tests/installer-copy.test.ts tests/installer-symlink.test.ts tests/sanitize-name.test.ts tests/subpath-traversal.test.ts`
- `env -u CODEX_THREAD_ID -u CODEX_SANDBOX -u CODEX_CI -u AI_AGENT corepack pnpm test -- --run`
- Manual pre/post reproduction using a crafted local skill with a symlink outside the skill directory
