### PR TITLE
fix: skip symlinks when copying skills

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -378,30 +378,10 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
 
         if (entry.isDirectory()) {
           await copyDirectory(srcPath, destPath);
+        } else if (entry.isSymbolicLink()) {
+          console.warn(`Skipping symlink: ${srcPath}`);
         } else {
-          try {
-            await cp(srcPath, destPath, {
-              // If the file is a symlink to elsewhere in a remote skill, it may not
-              // resolve correctly once it has been copied to the local location.
-              // `dereference: true` tells Node to copy the file instead of copying
-              // the symlink. `recursive: true` handles symlinks pointing to directories.
-              dereference: true,
-              recursive: true,
-            });
-          } catch (err: unknown) {
-            // Skip broken symlinks (e.g., pointing to absolute paths on another machine)
-            // instead of aborting the entire install.
-            if (
-              err instanceof Error &&
-              'code' in err &&
-              (err as NodeJS.ErrnoException).code === 'ENOENT' &&
-              entry.isSymbolicLink()
-            ) {
-              console.warn(`Skipping broken symlink: ${srcPath}`);
-            } else {
-              throw err;
-            }
-          }
+          await cp(srcPath, destPath, { recursive: true });
         }
       })
   );

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { platform, tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
@@ -40,6 +40,39 @@ describe('installer copy mode', () => {
       );
       await expect(access(join(installedDir, 'metadata.json'))).rejects.toThrow();
       await expect(access(join(installedDir, '.git'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not dereference directory symlinks that point outside the skill directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'copy-symlink-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const outsideDir = join(root, 'outside-secret');
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(join(outsideDir, 'secret.txt'), 'do-not-copy\n', 'utf-8');
+
+    try {
+      await symlink(
+        outsideDir,
+        join(skillDir, 'leaked-secret-dir'),
+        platform() === 'win32' ? 'junction' : 'dir'
+      );
+
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedDir = join(projectDir, '.agents/skills', skillName);
+      await expect(access(join(installedDir, 'leaked-secret-dir', 'secret.txt'))).rejects.toThrow();
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Skip symbolic links while copying skill directories instead of dereferencing them.
- Add a regression test that creates an external directory symlink/junction and verifies its contents are not copied into the installed skill.

## Validation

- `corepack pnpm lint-staged`
- `corepack pnpm test tests/installer-copy.test.ts --run`
- `corepack pnpm format:check`

## Local verification notes

- `corepack pnpm type-check` currently fails in files outside this change: `src/git.ts`, `src/providers/wellknown.ts`, and `src/skills.ts`.
- `corepack pnpm test --run` passes the new regression but has unrelated local failures in this Windows/Codex environment: symlink `EPERM` tests, banner/confirmation assertions affected by agent detection, and `tests/dist.test.ts` invoking a broken local `pnpm` shim.
- `corepack pnpm build` is blocked locally by `npx license-checker --json` failing with npm `ECOMPROMISED Lock compromised`.
