### PR TITLE
docs: replace non-existent skill names in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npx skills add ./my-local-skills
 npx skills add vercel-labs/agent-skills --list
 
 # Install specific skills
-npx skills add vercel-labs/agent-skills --skill frontend-design --skill skill-creator
+npx skills add vercel-labs/agent-skills --skill web-design-guidelines --skill deploy-to-vercel
 
 # Install a skill with spaces in the name (must be quoted)
 npx skills add owner/repo --skill "Convex Best Practices"
@@ -66,7 +66,7 @@ npx skills add owner/repo --skill "Convex Best Practices"
 npx skills add vercel-labs/agent-skills -a claude-code -a opencode
 
 # Non-interactive installation (CI/CD friendly)
-npx skills add vercel-labs/agent-skills --skill frontend-design -g -a claude-code -y
+npx skills add vercel-labs/agent-skills --skill web-design-guidelines -g -a claude-code -y
 
 # Install all skills from a repo to all agents
 npx skills add vercel-labs/agent-skills --all
@@ -75,7 +75,7 @@ npx skills add vercel-labs/agent-skills --all
 npx skills add vercel-labs/agent-skills --skill '*' -a claude-code
 
 # Install specific skills to all agents
-npx skills add vercel-labs/agent-skills --agent '*' --skill frontend-design
+npx skills add vercel-labs/agent-skills --agent '*' --skill web-design-guidelines
 ```
 
 ### Installation Scope
@@ -141,7 +141,7 @@ npx skills update
 npx skills update my-skill
 
 # Update multiple specific skills
-npx skills update frontend-design web-design-guidelines
+npx skills update deploy-to-vercel web-design-guidelines
 
 # Update only global or project skills
 npx skills update -g
@@ -180,7 +180,7 @@ npx skills remove
 npx skills remove web-design-guidelines
 
 # Remove multiple skills
-npx skills remove frontend-design web-design-guidelines
+npx skills remove deploy-to-vercel web-design-guidelines
 
 # Remove from global scope
 npx skills remove --global web-design-guidelines

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,7 +172,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --skill pr-review commit
   ${DIM}$${RESET} skills remove                        ${DIM}# interactive remove${RESET}
   ${DIM}$${RESET} skills remove web-design             ${DIM}# remove by name${RESET}
-  ${DIM}$${RESET} skills rm --global frontend-design
+  ${DIM}$${RESET} skills rm --global web-design-guidelines
   ${DIM}$${RESET} skills list                          ${DIM}# list project skills${RESET}
   ${DIM}$${RESET} skills ls -g                         ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}


### PR DESCRIPTION
The README and CLI help text reference frontend-design and skill-creator as example skills for vercel-labs/agent-skills, but neither exists in that repo. The install commands using these names throw errors when copied as-is. 

This replaces all 6 remaining references with actual skill names (web-design-guidelines, deploy-to-vercel) in vercel-labs/agent-skills for correctness and consistency.