### PR TITLE
fix: update kilo code directory to .kilo

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Skills can be installed to any of these agents:
 | Hermes Agent                          | `hermes-agent`                           | `.hermes/skills/`        | `~/.hermes/skills/`             |
 | Junie                                 | `junie`                                  | `.junie/skills/`         | `~/.junie/skills/`              |
 | iFlow CLI                             | `iflow-cli`                              | `.iflow/skills/`         | `~/.iflow/skills/`              |
-| Kilo Code                             | `kilo`                                   | `.kilocode/skills/`      | `~/.kilocode/skills/`           |
+| Kilo Code                             | `kilo`                                   | `.kilo/skills/`          | `~/.kilo/skills/`               |
 | Kiro CLI                              | `kiro-cli`                               | `.kiro/skills/`          | `~/.kiro/skills/`               |
 | Kode                                  | `kode`                                   | `.kode/skills/`          | `~/.kode/skills/`               |
 | MCPJam                                | `mcpjam`                                 | `.mcpjam/skills/`        | `~/.mcpjam/skills/`             |
@@ -371,7 +371,7 @@ The CLI searches for skills in these locations within a repository:
 - `.hermes/skills/`
 - `.junie/skills/`
 - `.iflow/skills/`
-- `.kilocode/skills/`
+- `.kilo/skills/`
 - `.kiro/skills/`
 - `.kode/skills/`
 - `.mcpjam/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -305,10 +305,10 @@ export const agents: Record<AgentType, AgentConfig> = {
   kilo: {
     name: 'kilo',
     displayName: 'Kilo Code',
-    skillsDir: '.kilocode/skills',
-    globalSkillsDir: join(home, '.kilocode/skills'),
+    skillsDir: '.kilo/skills',
+    globalSkillsDir: join(home, '.kilo/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.kilocode'));
+      return existsSync(join(home, '.kilo'));
     },
   },
   'kimi-cli': {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -166,7 +166,7 @@ const PRIORITY_PREFIXES = [
   '.goose/skills/',
   '.iflow/skills/',
   '.junie/skills/',
-  '.kilocode/skills/',
+  '.kilo/skills/',
   '.kiro/skills/',
   '.mux/skills/',
   '.neovate/skills/',


### PR DESCRIPTION
This pull request standardizes the directory naming convention for the "Kilo Code" agent by changing all references from `.kilocode/skills/` to `.kilo/skills/`. This ensures consistency across documentation and the codebase, which helps prevent confusion and potential bugs related to skill discovery and installation paths.

**Directory naming consistency:**

* Updated the "Kilo Code" agent's skill directory from `.kilocode/skills/` to `.kilo/skills/` in the agent configuration in `src/agents.ts`, including both local and global paths, and in the detection logic.
* Changed all references to `.kilocode/skills/` to `.kilo/skills/` in the `PRIORITY_PREFIXES` array in `src/blob.ts`.

**Documentation updates:**

* Updated the skills installation table in `README.md` to use `.kilo/skills/` for the "Kilo Code" agent.
* Updated the list of skill search locations in `README.md` to use `.kilo/skills/` instead of `.kilocode/skills/`.