### PR TITLE
feat(list): --category filter and category-grouped output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,6 +159,7 @@ ${BOLD}Experimental Sync Options:${RESET}
 ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
   -a, --agent <agents>   Filter by specific agents
+  -c, --category <name>  Filter by category (from SKILL.md frontmatter metadata.category)
   --json                 Output as JSON (machine-readable, no ANSI codes)
 
 ${BOLD}Options:${RESET}
@@ -176,6 +177,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills list                          ${DIM}# list project skills${RESET}
   ${DIM}$${RESET} skills ls -g                         ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
+  ${DIM}$${RESET} skills ls -c testing                 ${DIM}# filter by category${RESET}
   ${DIM}$${RESET} skills ls --json                      ${DIM}# JSON output${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -864,6 +864,7 @@ export interface InstalledSkill {
   canonicalPath: string;
   scope: 'project' | 'global';
   agents: AgentType[];
+  category?: string;
 }
 
 /**
@@ -977,6 +978,8 @@ export async function listInstalledSkills(
 
         const scopeKey = scope.global ? 'global' : 'project';
         const skillKey = `${scopeKey}:${skill.name}`;
+        const category =
+          typeof skill.metadata?.category === 'string' ? skill.metadata.category : undefined;
 
         // If scanning an agent-specific directory, attribute directly to that agent
         if (scope.agentType) {
@@ -984,6 +987,9 @@ export async function listInstalledSkills(
             const existing = skillsMap.get(skillKey)!;
             if (!existing.agents.includes(scope.agentType)) {
               existing.agents.push(scope.agentType);
+            }
+            if (existing.category === undefined && category !== undefined) {
+              existing.category = category;
             }
           } else {
             skillsMap.set(skillKey, {
@@ -993,6 +999,7 @@ export async function listInstalledSkills(
               canonicalPath: skillDir,
               scope: scopeKey,
               agents: [scope.agentType],
+              category,
             });
           }
           continue;
@@ -1077,6 +1084,9 @@ export async function listInstalledSkills(
               existing.agents.push(agent);
             }
           }
+          if (existing.category === undefined && category !== undefined) {
+            existing.category = category;
+          }
         } else {
           skillsMap.set(skillKey, {
             name: skill.name,
@@ -1085,6 +1095,7 @@ export async function listInstalledSkills(
             canonicalPath: skillDir,
             scope: scopeKey,
             agents: installedAgents,
+            category,
           });
         }
       }

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -72,6 +72,21 @@ describe('list command', () => {
       expect(options.agent).toEqual(['claude-code']);
       expect(options.global).toBe(true);
     });
+
+    it('should parse -c flag with category', () => {
+      const options = parseListOptions(['-c', 'testing']);
+      expect(options.category).toBe('testing');
+    });
+
+    it('should parse --category flag with space-separated value', () => {
+      const options = parseListOptions(['--category', 'pm']);
+      expect(options.category).toBe('pm');
+    });
+
+    it('should parse --category=value form', () => {
+      const options = parseListOptions(['--category=code']);
+      expect(options.category).toBe('code');
+    });
   });
 
   describe('CLI integration', () => {
@@ -327,6 +342,113 @@ description: A test skill
     });
   });
 
+  describe('category filter', () => {
+    function writeSkill(dir: string, name: string, category?: string): void {
+      const skillDir = join(dir, '.agents', 'skills', name);
+      mkdirSync(skillDir, { recursive: true });
+      const metadata = category ? `metadata:\n  category: ${category}\n` : '';
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: ${name} description\n${metadata}---\n# ${name}\n`
+      );
+    }
+
+    it('groups output by category when categories are present', () => {
+      writeSkill(testDir, 'alpha-skill', 'testing');
+      writeSkill(testDir, 'beta-skill', 'code');
+      writeSkill(testDir, 'gamma-skill', 'testing');
+
+      const result = runCli(['list'], testDir);
+      expect(result.exitCode).toBe(0);
+      // Both category headers should appear
+      expect(result.stdout).toContain('testing');
+      expect(result.stdout).toContain('code');
+      // Skills should appear under their category headers (code sorts before testing)
+      const codeIdx = result.stdout.indexOf('code');
+      const testingIdx = result.stdout.indexOf('testing');
+      expect(codeIdx).toBeGreaterThan(-1);
+      expect(testingIdx).toBeGreaterThan(codeIdx);
+    });
+
+    it('puts skills without a category under Uncategorized', () => {
+      writeSkill(testDir, 'tagged', 'testing');
+      writeSkill(testDir, 'untagged');
+
+      const result = runCli(['list'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Uncategorized');
+      // Uncategorized should appear after categorized header
+      const testingIdx = result.stdout.indexOf('testing');
+      const uncatIdx = result.stdout.indexOf('Uncategorized');
+      expect(testingIdx).toBeGreaterThan(-1);
+      expect(uncatIdx).toBeGreaterThan(testingIdx);
+    });
+
+    it('filters by --category (only matching skills shown)', () => {
+      writeSkill(testDir, 'alpha-skill', 'testing');
+      writeSkill(testDir, 'beta-skill', 'code');
+
+      const result = runCli(['list', '--category', 'testing'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('alpha-skill');
+      expect(result.stdout).not.toContain('beta-skill');
+    });
+
+    it('filters by -c alias', () => {
+      writeSkill(testDir, 'alpha-skill', 'testing');
+      writeSkill(testDir, 'beta-skill', 'code');
+
+      const result = runCli(['list', '-c', 'code'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('beta-skill');
+      expect(result.stdout).not.toContain('alpha-skill');
+    });
+
+    it('category match is case-insensitive', () => {
+      writeSkill(testDir, 'alpha-skill', 'testing');
+      const result = runCli(['list', '--category', 'TESTING'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('alpha-skill');
+    });
+
+    it('reports available categories when filter has no match', () => {
+      writeSkill(testDir, 'alpha-skill', 'testing');
+      writeSkill(testDir, 'beta-skill', 'code');
+
+      const result = runCli(['list', '--category', 'docs'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('No project skills found in category "docs"');
+      expect(result.stdout).toContain('Available categories:');
+      expect(result.stdout).toContain('code');
+      expect(result.stdout).toContain('testing');
+    });
+
+    it('includes category in --json output', () => {
+      writeSkill(testDir, 'alpha-skill', 'testing');
+      writeSkill(testDir, 'untagged');
+
+      const result = runCli(['list', '--json'], testDir);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      const alpha = parsed.find((s: any) => s.name === 'alpha-skill');
+      const untagged = parsed.find((s: any) => s.name === 'untagged');
+      expect(alpha.category).toBe('testing');
+      expect(untagged.category).toBeNull();
+    });
+
+    it('--json + --category filters and includes category', () => {
+      writeSkill(testDir, 'alpha-skill', 'testing');
+      writeSkill(testDir, 'beta-skill', 'code');
+
+      const result = runCli(['list', '--json', '--category', 'testing'], testDir);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].name).toBe('alpha-skill');
+      expect(parsed[0].category).toBe('testing');
+    });
+  });
+
   describe('help output', () => {
     it('should include list command in help', () => {
       const result = runCli(['--help']);
@@ -339,6 +461,7 @@ description: A test skill
       expect(result.stdout).toContain('List Options:');
       expect(result.stdout).toContain('-g, --global');
       expect(result.stdout).toContain('-a, --agent');
+      expect(result.stdout).toContain('-c, --category');
     });
 
     it('should include list examples in help', () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -16,7 +16,10 @@ interface ListOptions {
   global?: boolean;
   agent?: string[];
   json?: boolean;
+  category?: string;
 }
+
+const UNCATEGORIZED_LABEL = 'Uncategorized';
 
 /**
  * Shortens a path for display: replaces homedir with ~ and cwd with .
@@ -59,6 +62,15 @@ export function parseListOptions(args: string[]): ListOptions {
       while (i + 1 < args.length && !args[i + 1]!.startsWith('-')) {
         options.agent.push(args[++i]!);
       }
+    } else if (arg === '-c' || arg === '--category') {
+      // Single category value; supports `--category=foo` and `--category foo`
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        options.category = next;
+        i++;
+      }
+    } else if (arg!.startsWith('--category=')) {
+      options.category = arg!.slice('--category='.length);
     }
   }
 
@@ -86,10 +98,16 @@ export async function runList(args: string[]): Promise<void> {
     agentFilter = options.agent as AgentType[];
   }
 
-  const installedSkills = await listInstalledSkills({
+  const allInstalledSkills = await listInstalledSkills({
     global: scope,
     agentFilter,
   });
+
+  // Apply --category filter if provided (case-insensitive)
+  const categoryFilter = options.category?.toLowerCase();
+  const installedSkills = categoryFilter
+    ? allInstalledSkills.filter((s) => (s.category ?? '').toLowerCase() === categoryFilter)
+    : allInstalledSkills;
 
   // JSON output mode: structured, no ANSI, untruncated agent lists
   if (options.json) {
@@ -98,6 +116,7 @@ export async function runList(args: string[]): Promise<void> {
       path: skill.canonicalPath,
       scope: skill.scope,
       agents: skill.agents.map((a) => agents[a].displayName),
+      category: skill.category ?? null,
     }));
     console.log(JSON.stringify(jsonOutput, null, 2));
     return;
@@ -110,8 +129,16 @@ export async function runList(args: string[]): Promise<void> {
   const scopeLabel = scope ? 'Global' : 'Project';
 
   if (installedSkills.length === 0) {
-    if (options.json) {
-      console.log('[]');
+    if (categoryFilter) {
+      const availableCategories = Array.from(
+        new Set(allInstalledSkills.map((s) => s.category).filter((c): c is string => !!c))
+      ).sort();
+      console.log(
+        `${DIM}No ${scopeLabel.toLowerCase()} skills found in category "${options.category}".${RESET}`
+      );
+      if (availableCategories.length > 0) {
+        console.log(`${DIM}Available categories: ${availableCategories.join(', ')}${RESET}`);
+      }
       return;
     }
     console.log(`${DIM}No ${scopeLabel.toLowerCase()} skills found.${RESET}`);
@@ -137,6 +164,43 @@ export async function runList(args: string[]): Promise<void> {
 
   console.log(`${BOLD}${scopeLabel} Skills${RESET}`);
   console.log();
+
+  // When --category filter is active, print a flat list (all skills share the category)
+  if (categoryFilter) {
+    for (const skill of installedSkills) {
+      printSkill(skill);
+    }
+    console.log();
+    return;
+  }
+
+  // Group by category if any skill exposes one; else fall back to plugin grouping.
+  const hasCategories = installedSkills.some((s) => s.category);
+
+  if (hasCategories) {
+    const byCategory: Record<string, InstalledSkill[]> = {};
+    for (const skill of installedSkills) {
+      const key = skill.category ?? UNCATEGORIZED_LABEL;
+      if (!byCategory[key]) byCategory[key] = [];
+      byCategory[key].push(skill);
+    }
+
+    // Sort category keys alphabetically, with Uncategorized last
+    const sortedCategories = Object.keys(byCategory).sort((a, b) => {
+      if (a === UNCATEGORIZED_LABEL) return 1;
+      if (b === UNCATEGORIZED_LABEL) return -1;
+      return a.localeCompare(b);
+    });
+
+    for (const cat of sortedCategories) {
+      console.log(`${BOLD}${cat}${RESET}`);
+      for (const skill of byCategory[cat]!) {
+        printSkill(skill, true);
+      }
+      console.log();
+    }
+    return;
+  }
 
   // Group skills by plugin
   const groupedSkills: Record<string, InstalledSkill[]> = {};


### PR DESCRIPTION
## Summary

Adds a `--category` / `-c` flag to `npx skills list` and groups the default `list` output by category headers, sourcing the value from `metadata.category` in each SKILL.md frontmatter (already parsed by `parseSkillMd`).

Driven by the PRD at [shaping/skill-namespacing/prd.md](https://github.com/thunter009/agent-skills/blob/main/shaping/skill-namespacing/prd.md) — once a catalog has dozens of skills, scanning a flat list to find a domain-specific one (e.g. "the testing skill I want") is tedious. Categories let users both filter (`-c testing`) and visually scan grouped output.

## Behavior

- **Default `npx skills list`** — when any installed skill exposes `metadata.category`, output is grouped under bold category headers, sorted alphabetically with an `Uncategorized` group at the bottom. Falls back to the existing plugin / flat grouping when no skill has a category, so consumers without categorized skills see no behavior change.
- **`npx skills list -c <name>` / `--category <name>`** — filters to skills whose `metadata.category` matches (case-insensitive), printed as a flat list. Supports `--category=foo` and `--category foo` forms.
- **`npx skills list --json`** — now includes a `category` field (string or `null`) on each entry. Combines with `--category` for machine-readable filtering.
- **Empty-result hint** — when `-c <name>` matches nothing, lists the available categories to aid discovery.

## SKILL.md schema

```yaml
---
name: my-skill
description: ...
metadata:
  category: testing
---
```

No new fields are required — skills without a `category` show under `Uncategorized` in grouped output and are invisible to `-c` filters.

## Implementation notes

- `InstalledSkill` gets an optional `category?: string` field; `listInstalledSkills` populates it from the already-parsed `skill.metadata.category` (no new disk I/O).
- Plugin grouping is preserved as a fallback so existing users with plugin-defined skill bundles see no regression.
- New `--category=value` parser branch lives alongside the existing space-separated parser.

## Test plan

- [x] `pnpm test src/list.test.ts` — 11 new unit + integration tests cover parsing, filter, case-insensitive match, grouped default, `Uncategorized` placement, empty-result hint, and JSON shape (38/39 pass; the one failing case is the pre-existing `banner` test on `main`).
- [x] `pnpm format:check` — clean.
- [x] `pnpm type-check` — no new errors; the four pre-existing type errors on `main` are unchanged.
- [ ] Manual: `pnpm dev list`, `pnpm dev list -c testing`, `pnpm dev list --json | jq '.[].category'` in a project with categorized skills.

## Out of scope

- Validating category values against a canonical taxonomy. Catalog maintainers can layer that in CI; the CLI deliberately stays permissive about category strings so third-party catalogs can use their own vocabularies.
