### PR TITLE
cli: Show skill descriptions in list output

### DIFF
--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -115,6 +115,7 @@ description: A skill for JSON testing
       expect(Array.isArray(parsed)).toBe(true);
       expect(parsed.length).toBe(1);
       expect(parsed[0].name).toBe('json-skill');
+      expect(parsed[0].description).toBe('A skill for JSON testing');
       expect(parsed[0].path).toContain('json-skill');
       expect(parsed[0].scope).toBe('project');
       expect(Array.isArray(parsed[0].agents)).toBe(true);
@@ -173,8 +174,8 @@ This is a test skill.
       const result = runCli(['list'], testDir);
       expect(result.stdout).toContain('test-skill');
       expect(result.stdout).toContain('Project Skills');
-      // Description should not be shown
-      expect(result.stdout).not.toContain('A test skill for listing');
+      expect(result.stdout).toContain('Description:');
+      expect(result.stdout).toContain('A test skill for listing');
       expect(result.exitCode).toBe(0);
     });
 

--- a/src/list.ts
+++ b/src/list.ts
@@ -95,6 +95,7 @@ export async function runList(args: string[]): Promise<void> {
   if (options.json) {
     const jsonOutput = installedSkills.map((skill) => ({
       name: skill.name,
+      description: skill.description,
       path: skill.canonicalPath,
       scope: skill.scope,
       agents: skill.agents.map((a) => agents[a].displayName),
@@ -132,6 +133,7 @@ export async function runList(args: string[]): Promise<void> {
     console.log(
       `${prefix}${CYAN}${sanitizeMetadata(skill.name)}${RESET} ${DIM}${shortPath}${RESET}`
     );
+    console.log(`${prefix}  ${DIM}Description:${RESET} ${sanitizeMetadata(skill.description)}`);
     console.log(`${prefix}  ${DIM}Agents:${RESET} ${agentInfo}`);
   }
 


### PR DESCRIPTION
## Summary
- Show each installed skill's frontmatter description in `skills list` output alongside the existing Agents line.
- Include `description` in `skills list --json` so structured consumers can access the same summary.
- Update list command tests to cover both text and JSON description output.

## Test plan
- `pnpm test src/list.test.ts -t "should output valid JSON with --json flag|should list project skills"`
- `pnpm format:check`
- `pnpm test src/list.test.ts tests/list-installed.test.ts` currently has one unrelated failure in `should include list command in banner`; all other focused list tests passed.
- `pnpm type-check` currently fails on existing unrelated TypeScript errors in `src/git.ts`, `src/providers/wellknown.ts`, and `src/skills.ts`.