### PR TITLE
Restore trusted publishing for npm releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,6 @@
 name: Publish
 
 on:
-  push:
-    branches: [main]
-    tags:
-      - 'v*'
-    paths-ignore:
-      - '**/*.md'
   workflow_dispatch:
     inputs:
       bump:
@@ -20,6 +14,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: write
       id-token: write
@@ -47,79 +42,27 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Determine version bump type
-        id: version
-        run: |
-          # If tag push, skip version bump (already versioned)
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "bump=skip" >> $GITHUB_OUTPUT
-            echo "Tag push - skipping version bump, will publish directly"
-            exit 0
-          fi
-
-          # If manually triggered, use the input value
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "bump=${{ inputs.bump }}" >> $GITHUB_OUTPUT
-            echo "Manual trigger - will bump ${{ inputs.bump }} version"
-            exit 0
-          fi
-
-          # Get the latest version tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_TAG" ]; then
-            # No tags found, use all commits
-            COMMITS=$(git log --format=%s)
-          else
-            # Get commits since the latest tag
-            COMMITS=$(git log ${LATEST_TAG}..HEAD --format=%s)
-          fi
-
-          echo "Commits since last tag:"
-          echo "$COMMITS"
-
-          # Check for explicit version bump markers
-          if echo "$COMMITS" | grep -q "\[minor\]"; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
-            echo "Found [minor] - will bump minor version"
-          elif echo "$COMMITS" | grep -q "\[patch\]"; then
-            echo "bump=patch" >> $GITHUB_OUTPUT
-            echo "Found [patch] - will bump patch version"
-          else
-            echo "bump=none" >> $GITHUB_OUTPUT
-            echo "No version marker found - skipping release"
-          fi
-
       - name: Configure git
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Reset generated files
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
         run: |
-          # Reset any changes to generated files (e.g., ThirdPartyNoticeText.txt)
-          # that may differ between local and CI builds
           git checkout -- ThirdPartyNoticeText.txt || true
 
       - name: Bump version
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
         run: |
-          npm version ${{ steps.version.outputs.bump }} -m "v%s"
+          npm version ${{ inputs.bump }} -m "v%s"
 
       - name: Push changes
-        if: steps.version.outputs.bump != 'none' && steps.version.outputs.bump != 'skip'
         run: |
           git push
           git push --tags
 
       - name: Publish to npm
         id: publish
-        if: steps.version.outputs.bump != 'none'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.publish.outcome == 'success'


### PR DESCRIPTION
Switch to OIDC trusted publishing (no NPM_TOKEN), gate publishes behind the npm-publish GitHub Environment, and restrict triggers to manual workflow_dispatch only so commits and tags cannot publish.