### PR TITLE
Make GitHub token use lazy, only on rate-limit fallback

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1043,12 +1043,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const owner = ownerRepo?.split('/')[0]?.toLowerCase();
       if (ownerRepo && owner && BLOB_ALLOWED_OWNERS.includes(owner)) {
         spinner.start('Fetching skills...');
-        const token = getGitHubToken();
         blobResult = await tryBlobInstall(ownerRepo, {
           subpath: parsed.subpath,
           skillFilter: parsed.skillFilter,
           ref: parsed.ref,
-          token,
+          getToken: getGitHubToken,
           includeInternal,
         });
         if (!blobResult) {
@@ -1621,8 +1620,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // for all skills — avoids N sequential API calls that take ~400ms each.
       let cachedTree: Awaited<ReturnType<typeof fetchRepoTree>> | undefined;
       if (parsed.type === 'github' && !blobResult) {
-        const token = getGitHubToken();
-        cachedTree = await fetchRepoTree(normalizedSource, parsed.ref, token);
+        cachedTree = await fetchRepoTree(normalizedSource, parsed.ref, getGitHubToken);
       }
 
       for (const skill of selectedSkills) {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -77,46 +77,118 @@ export interface RepoTree {
 }
 
 /**
- * Fetch the full recursive tree for a GitHub repo.
- * Returns the tree data including all entries, or null on failure.
- * Tries branches in order: ref (if specified), then main, then master.
+ * Within-process memo: once we've discovered that the GitHub API has
+ * rate-limited this IP, subsequent calls skip straight to the auth fallback
+ * instead of burning round trips on requests guaranteed to 403.
  */
-export async function fetchRepoTree(
+let _rateLimitedThisSession = false;
+
+/** For tests only. */
+export function resetRepoTreeAuthState(): void {
+  _rateLimitedThisSession = false;
+}
+
+interface BranchFetchResult {
+  tree: RepoTree | null;
+  rateLimited: boolean;
+}
+
+async function fetchTreeBranch(
   ownerRepo: string,
-  ref?: string,
-  token?: string | null
-): Promise<RepoTree | null> {
-  const branches = ref ? [ref] : ['HEAD', 'main', 'master'];
+  branch: string,
+  token: string | null
+): Promise<BranchFetchResult> {
+  try {
+    const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${encodeURIComponent(branch)}?recursive=1`;
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'skills-cli',
+    };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
 
-  for (const branch of branches) {
-    try {
-      const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${encodeURIComponent(branch)}?recursive=1`;
-      const headers: Record<string, string> = {
-        Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'skills-cli',
-      };
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-      }
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+    });
 
-      const response = await fetch(url, {
-        headers,
-        signal: AbortSignal.timeout(FETCH_TIMEOUT),
-      });
-
-      if (!response.ok) continue;
-
+    if (response.ok) {
       const data = (await response.json()) as {
         sha: string;
         tree: TreeEntry[];
       };
+      return {
+        tree: { sha: data.sha, branch, tree: data.tree },
+        rateLimited: false,
+      };
+    }
 
-      return { sha: data.sha, branch, tree: data.tree };
-    } catch {
-      continue;
+    // GitHub signals rate-limit with 403 + X-RateLimit-Remaining: 0.
+    // (A bare 403 means permission denied, which is not retryable here.)
+    const rateLimited =
+      response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0';
+    return { tree: null, rateLimited };
+  } catch {
+    return { tree: null, rateLimited: false };
+  }
+}
+
+/**
+ * Fetch the full recursive tree for a GitHub repo.
+ * Returns the tree data including all entries, or null on failure.
+ * Tries branches in order: ref (if specified), then main, then master.
+ *
+ * Authentication is lazy: by default the call goes out unauthenticated,
+ * which is enough for the vast majority of users (60 req/hr per IP).
+ * Only if GitHub responds with a rate-limit 403 do we ask the optional
+ * `getToken` callback for a token and retry. This avoids invoking
+ * `gh auth token` on every install, which corporate endpoint security
+ * tools flag as suspicious credential extraction. See issue #523.
+ */
+export async function fetchRepoTree(
+  ownerRepo: string,
+  ref?: string,
+  getToken?: () => string | null
+): Promise<RepoTree | null> {
+  const branches = ref ? [ref] : ['HEAD', 'main', 'master'];
+
+  // Fast path: once we've seen a rate limit in this process, don't bother
+  // retrying unauth on subsequent calls. Go straight to auth.
+  if (_rateLimitedThisSession && getToken) {
+    const token = getToken();
+    if (!token) return null;
+    for (const branch of branches) {
+      const result = await fetchTreeBranch(ownerRepo, branch, token);
+      if (result.tree) return result.tree;
+    }
+    return null;
+  }
+
+  // First pass: unauthenticated.
+  let rateLimited = false;
+  for (const branch of branches) {
+    const result = await fetchTreeBranch(ownerRepo, branch, null);
+    if (result.tree) return result.tree;
+    if (result.rateLimited) {
+      // All branches share the same rate-limit bucket on this IP, so it's
+      // pointless to keep trying other branches in this pass.
+      rateLimited = true;
+      break;
     }
   }
 
+  if (!rateLimited || !getToken) return null;
+
+  // Lazy fallback: rate limit hit and a token resolver was provided.
+  _rateLimitedThisSession = true;
+  const token = getToken();
+  if (!token) return null;
+
+  for (const branch of branches) {
+    const result = await fetchTreeBranch(ownerRepo, branch, token);
+    if (result.tree) return result.tree;
+  }
   return null;
 }
 
@@ -312,12 +384,12 @@ export async function tryBlobInstall(
     subpath?: string;
     skillFilter?: string;
     ref?: string;
-    token?: string | null;
+    getToken?: () => string | null;
     includeInternal?: boolean;
   } = {}
 ): Promise<BlobInstallResult | null> {
   // 1. Fetch the full repo tree
-  const tree = await fetchRepoTree(ownerRepo, options.ref, options.token);
+  const tree = await fetchRepoTree(ownerRepo, options.ref, options.getToken);
   if (!tree) return null;
 
   // 2. Discover SKILL.md paths in the tree

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -608,7 +608,6 @@ async function updateGlobalSkills(
     return { successCount, failCount, checkedCount: 0 };
   }
 
-  const token = getGitHubToken();
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
   const checkable: Array<{ name: string; entry: SkillLockEntry }> = [];
@@ -643,7 +642,7 @@ async function updateGlobalSkills(
       const latestHash = await fetchSkillFolderHash(
         entry.source,
         entry.skillPath!,
-        token,
+        getGitHubToken,
         entry.ref
       );
       if (latestHash && latestHash !== entry.skillFolderHash) {

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -123,17 +123,29 @@ export function computeContentHash(content: string): string {
   return createHash('sha256').update(content, 'utf-8').digest('hex');
 }
 
+let _ghWarningShown = false;
+
+/** For tests only. Resets the one-shot warning flag. */
+export function resetGhAuthWarning(): void {
+  _ghWarningShown = false;
+}
+
 /**
  * Get GitHub token from user's environment.
  * Tries in order:
- * 1. GITHUB_TOKEN environment variable
- * 2. GH_TOKEN environment variable
- * 3. gh CLI auth token (if gh is installed)
+ * 1. GITHUB_TOKEN environment variable (silent)
+ * 2. GH_TOKEN environment variable (silent)
+ * 3. gh CLI auth token, if gh is installed. Prints a one-time warning to
+ *    stderr before invoking `gh auth token`, because that subprocess call
+ *    is flagged by some corporate endpoint security tooling (Defender, etc.)
+ *    as credential extraction. Callers should invoke this function lazily
+ *    (e.g. only after an unauthenticated request hits a rate limit) so the
+ *    fallback rarely runs in practice.
  *
  * @returns The token string or null if not available
  */
 export function getGitHubToken(): string | null {
-  // Check environment variables first
+  // Check environment variables first (silent: user has explicitly opted in)
   if (process.env.GITHUB_TOKEN) {
     return process.env.GITHUB_TOKEN;
   }
@@ -141,7 +153,14 @@ export function getGitHubToken(): string | null {
     return process.env.GH_TOKEN;
   }
 
-  // Try gh CLI
+  // Last resort: spawn gh CLI. Warn the user once per process before doing so.
+  if (!_ghWarningShown) {
+    process.stderr.write(
+      'warn: GitHub API rate limit reached; reading a token via `gh auth token`.\n' +
+        '      Set GITHUB_TOKEN in your environment to skip this fallback.\n'
+    );
+    _ghWarningShown = true;
+  }
   try {
     const token = execSync('gh auth token', {
       encoding: 'utf-8',
@@ -164,18 +183,19 @@ export function getGitHubToken(): string | null {
  *
  * @param ownerRepo - GitHub owner/repo (e.g., "vercel-labs/agent-skills")
  * @param skillPath - Path to skill folder or SKILL.md (e.g., "skills/react-best-practices/SKILL.md")
- * @param token - Optional GitHub token for authenticated requests (higher rate limits)
+ * @param getToken - Optional lazy token resolver. Invoked only if the
+ *                   unauthenticated request hits a rate limit.
  * @param ref - Optional branch/tag ref. Defaults to trying main then master.
  * @returns The tree SHA for the skill folder, or null if not found
  */
 export async function fetchSkillFolderHash(
   ownerRepo: string,
   skillPath: string,
-  token?: string | null,
+  getToken?: (() => string | null) | null,
   ref?: string
 ): Promise<string | null> {
   const { fetchRepoTree, getSkillFolderHashFromTree } = await import('./blob.ts');
-  const tree = await fetchRepoTree(ownerRepo, ref, token);
+  const tree = await fetchRepoTree(ownerRepo, ref, getToken ?? undefined);
   if (!tree) return null;
   return getSkillFolderHashFromTree(tree, skillPath);
 }

--- a/tests/blob-fetch-tree-auth.test.ts
+++ b/tests/blob-fetch-tree-auth.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the lazy auth fallback in `fetchRepoTree`.
+ *
+ * The key behavior under test: a token resolver is invoked ONLY after
+ * GitHub returns a rate-limit response (403 + X-RateLimit-Remaining: 0).
+ * On a successful unauth call, or on a non-rate-limit 403, the resolver
+ * must not be called. This is what keeps `gh auth token` from running
+ * during every install. See issue #523.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { fetchRepoTree, resetRepoTreeAuthState } from '../src/blob.ts';
+
+const SAMPLE_TREE = {
+  sha: 'deadbeef',
+  tree: [
+    { path: 'README.md', type: 'blob', sha: 'aaaa' },
+    { path: 'skills', type: 'tree', sha: 'bbbb' },
+  ],
+};
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function rateLimitResponse(): Response {
+  return new Response(JSON.stringify({ message: 'API rate limit exceeded' }), {
+    status: 403,
+    headers: {
+      'content-type': 'application/json',
+      'x-ratelimit-remaining': '0',
+    },
+  });
+}
+
+function permissionDeniedResponse(): Response {
+  return new Response(JSON.stringify({ message: 'Not Found' }), {
+    status: 403,
+    headers: {
+      'content-type': 'application/json',
+      'x-ratelimit-remaining': '59',
+    },
+  });
+}
+
+describe('fetchRepoTree lazy auth fallback', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    resetRepoTreeAuthState();
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('does not invoke the token resolver when the unauth request succeeds', async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(SAMPLE_TREE));
+    const getToken = vi.fn(() => 'should-not-be-called');
+
+    const result = await fetchRepoTree('vercel/skills', 'main', getToken);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(getToken).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const firstCallInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect((firstCallInit.headers as Record<string, string>)['Authorization']).toBeUndefined();
+  });
+
+  it('invokes the token resolver and retries with auth when rate-limited', async () => {
+    fetchMock
+      .mockResolvedValueOnce(rateLimitResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const result = await fetchRepoTree('vercel/skills', 'main', getToken);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer ghp_fake_token'
+    );
+  });
+
+  it('does not invoke the token resolver on a non-rate-limit 403', async () => {
+    // A 403 for a private repo (permission denied) is not retryable.
+    // The fallback should NOT trigger and should NOT spawn `gh auth token`.
+    fetchMock
+      .mockResolvedValueOnce(permissionDeniedResponse())
+      .mockResolvedValueOnce(permissionDeniedResponse())
+      .mockResolvedValueOnce(permissionDeniedResponse());
+    const getToken = vi.fn(() => 'should-not-be-called');
+
+    const result = await fetchRepoTree('private/repo', undefined, getToken);
+
+    expect(result).toBeNull();
+    expect(getToken).not.toHaveBeenCalled();
+  });
+
+  it('returns null gracefully when rate-limited and no token resolver is provided', async () => {
+    fetchMock.mockResolvedValueOnce(rateLimitResponse());
+
+    const result = await fetchRepoTree('vercel/skills', 'main');
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null gracefully when rate-limited and the resolver returns null', async () => {
+    fetchMock.mockResolvedValueOnce(rateLimitResponse());
+    const getToken = vi.fn(() => null);
+
+    const result = await fetchRepoTree('vercel/skills', 'main', getToken);
+
+    expect(result).toBeNull();
+    expect(getToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('after a rate-limit hit, subsequent calls skip straight to authenticated', async () => {
+    // First call: unauth 403 + auth 200
+    fetchMock
+      .mockResolvedValueOnce(rateLimitResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE))
+      // Second call: should go directly to auth, no unauth attempt
+      .mockResolvedValueOnce(okResponse({ ...SAMPLE_TREE, sha: 'cafef00d' }));
+
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const first = await fetchRepoTree('vercel/skills', 'main', getToken);
+    const second = await fetchRepoTree('vercel/agent-skills', 'main', getToken);
+
+    expect(first?.sha).toBe('deadbeef');
+    expect(second?.sha).toBe('cafef00d');
+    // 2 calls for first (unauth then auth) + 1 call for second (auth only) = 3
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // Both of getToken's calls should return the same token; called once per fetchRepoTree
+    expect(getToken).toHaveBeenCalledTimes(2);
+    // Verify the second fetchRepoTree call used Authorization on its FIRST request
+    const secondCallFirstInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect((secondCallFirstInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer ghp_fake_token'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Stops the CLI from calling `gh auth token` via `execSync` on every install and update. The token is now only consulted if GitHub actually responds with a rate-limit 403, which for the typical user installing or updating a few skills never happens.

This addresses the issue surfaced in #523 (and the older #328): the eager subprocess call was being flagged by Microsoft Defender, SOC tooling, and Intune as suspicious credential extraction, in some cases causing machines to be auto-quarantined from the corporate domain.

## What changed

- `fetchRepoTree` in `src/blob.ts` now takes a lazy `getToken?: () => string | null` callback instead of an eager `token` argument. First attempt goes out unauthenticated. Only on a 403 with `X-RateLimit-Remaining: 0` does it call `getToken()` and retry with `Authorization: Bearer …`.
- Within-process memo `_rateLimitedThisSession` so once we know auth is needed in a given process, subsequent calls skip the unauth attempt. Keeps `skills update` over N skills from N extra round trips.
- `getGitHubToken()` in `src/skill-lock.ts` now prints a one-time stderr warning before invoking `gh auth token`. Env-var paths (`GITHUB_TOKEN`, `GH_TOKEN`) stay silent because they're explicit opt-in.
- `tryBlobInstall` and `fetchSkillFolderHash` propagate the lazy resolver. Callers in `src/add.ts` and `src/cli.ts` now pass `getGitHubToken` as a function reference instead of calling it eagerly.

## Why this is safe

- Public repos return the same tree data unauthenticated. The token was never unlocking private repos in any current code path; it was only raising the GitHub Trees API rate limit from 60/hr to 5,000/hr.
- Most users install fewer than 60 skills per hour, so they never hit the rate limit, so the fallback never fires.
- Power users with many tracked skills running `skills update` may hit the limit; for them, the within-process memo means we only pay one extra round trip per process (the one that detects the rate limit), then we go straight to auth for the rest.

## Test plan

- [x] New `tests/blob-fetch-tree-auth.test.ts` covers six cases: unauth success, rate-limit retry with auth, non-rate-limit 403 stays unauth, no resolver provided, resolver returns null, and the session memo.
- [x] Full suite: 444 → 450 passing, same 6 pre-existing failures, no new failures.
- [x] Type check on touched files passes (pre-existing errors in `git.ts`, `wellknown.ts`, `skills.ts` are unrelated).

## Issues closed

Closes #523
Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)