### PR TITLE
fix(installer): preserve executable mode on copy

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -9,6 +9,7 @@ import {
   readlink,
   writeFile,
   stat,
+  chmod,
   realpath,
 } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -388,6 +389,8 @@ async function copyDirectory(src: string, dest: string): Promise<void> {
               dereference: true,
               recursive: true,
             });
+            const sourceStats = await stat(srcPath);
+            await chmod(destPath, sourceStats.mode & 0o777);
           } catch (err: unknown) {
             // Skip broken symlinks (e.g., pointing to absolute paths on another machine)
             // instead of aborting the entire install.

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
@@ -40,6 +40,35 @@ describe('installer copy mode', () => {
       );
       await expect(access(join(installedDir, 'metadata.json'))).rejects.toThrow();
       await expect(access(join(installedDir, '.git'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves executable mode bits when copying files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-mode-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'copy-executable-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const scriptPath = join(skillDir, 'scripts', 'hello.sh');
+    await mkdir(join(skillDir, 'scripts'), { recursive: true });
+    await writeFile(scriptPath, '#!/bin/sh\necho hello\n', 'utf-8');
+    await chmod(scriptPath, 0o755);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedScript = join(projectDir, '.agents/skills', skillName, 'scripts', 'hello.sh');
+      const installedMode = (await stat(installedScript)).mode & 0o777;
+      expect(installedMode).toBe(0o755);
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Preserves executable permission bits when installing a skill in copy mode.

Copy-mode installs currently copy file contents but do not reapply the source file mode, which can turn executable helper scripts inside a skill into non-executable files after installation.

## Changes

- Reapply copied file permissions from the source file after `cp` completes.
- Add a copy-mode regression test with an executable `scripts/hello.sh` fixture.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm test tests/installer-copy.test.ts`
- `pnpm format:check`

I also ran `pnpm type-check`, but it currently fails on existing unrelated errors in untouched files:

- `src/git.ts`: `simple-git` options type does not include `env`
- `src/skills.ts`: frontmatter metadata is inferred as `{}` / `unknown`

Closes #1140.
