### PR TITLE
fix(installer): create Claude project symlinks

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -311,7 +311,7 @@ export async function installSkillForAgent(
     // actually used in this project. The skill is already available in .agents/skills/.
     if (!isGlobal && !isUniversalAgent(agentType)) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir)) {
+      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
         return {
           success: true,
           path: canonicalDir,

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -147,6 +147,38 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('creates project-local Claude Code symlinks when .claude does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'fresh-claude-project-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      const claudeSkillDir = join(projectDir, '.claude/skills', skillName);
+
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+      expect((await lstat(claudeSkillDir)).isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Regression test for #294: universal-only global install should not create agent-specific symlinks
   it('does not create agent-specific symlinks for universal agents on global install', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));


### PR DESCRIPTION
## Summary

Fixes project-local Claude Code installs in fresh repositories that do not already have a `.claude/` directory.

Previously, project-local symlink installs skipped non-universal agents when the agent root directory was missing. That made sense for avoiding unrelated agent directories, but it also caused Claude Code installs to silently skip `.claude/skills/<name>` even when Claude Code was the selected target.

## Changes

- Allow Claude Code project-local symlink installs to continue when `.claude/` does not exist yet.
- Keep the existing skip behavior for other non-universal agents.
- Add a regression test that installs a skill for Claude Code in a fresh project and verifies `.claude/skills/<name>` is created as a symlink.

## Validation

- `pnpm format`
- `pnpm test tests/installer-symlink.test.ts`
- `pnpm format:check`

I also ran `pnpm type-check`, but it currently fails on existing unrelated errors in untouched files:

- `src/git.ts`: `simple-git` options type does not include `env`
- `src/skills.ts`: frontmatter metadata is inferred as `{}` / `unknown`

Closes #1138.
