### PR TITLE
fix(add): track peer skills in lock files

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
@@ -88,6 +88,51 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('should include peer skills in the project lock file', () => {
+    const routerDir = join(testDir, 'skills', 'router');
+    const authDir = join(testDir, 'skills', 'auth');
+    mkdirSync(routerDir, { recursive: true });
+    mkdirSync(authDir, { recursive: true });
+
+    writeFileSync(
+      join(routerDir, 'SKILL.md'),
+      `---
+name: router
+description: Routes to peer skills
+---
+# Router
+`
+    );
+    writeFileSync(
+      join(routerDir, 'peers.yaml'),
+      `peers:
+  - name: auth
+`
+    );
+    writeFileSync(
+      join(authDir, 'SKILL.md'),
+      `---
+name: auth
+description: Auth peer
+---
+# Auth
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(
+      ['add', testDir, '--skill', 'router', '-y', '--agent', 'cline'],
+      targetDir
+    );
+    const lock = JSON.parse(readFileSync(join(targetDir, 'skills-lock.json'), 'utf-8'));
+
+    expect(result.stdout).toContain('Including 1 peer skill(s)');
+    expect(result.exitCode).toBe(0);
+    expect(Object.keys(lock.skills).sort()).toEqual(['auth', 'router']);
   });
 
   it('should filter skills by name with --skill flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -23,7 +23,12 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
-import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
+import {
+  discoverSkills,
+  getSkillDisplayName,
+  filterSkills,
+  expandSkillsWithPeers,
+} from './skills.ts';
 import {
   installSkillForAgent,
   installBlobSkillForAgent,
@@ -1237,6 +1242,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       selectedSkills = selected as Skill[];
+    }
+
+    const selectedSkillCount = selectedSkills.length;
+    selectedSkills = expandSkillsWithPeers(selectedSkills, skills);
+    if (selectedSkills.length > selectedSkillCount) {
+      p.log.info(`Including ${selectedSkills.length - selectedSkillCount} peer skill(s)`);
     }
 
     // Kick off security audit fetch early (non-blocking) so it runs

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile, stat } from 'fs/promises';
 import { join, basename, dirname, resolve, normalize, sep } from 'path';
+import { parse } from 'yaml';
 import { parseFrontmatter } from './frontmatter.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import type { Skill } from './types.ts';
@@ -26,6 +27,21 @@ async function hasSkillMd(dir: string): Promise<boolean> {
   }
 }
 
+async function readPeerNames(skillDir: string): Promise<string[]> {
+  try {
+    const content = await readFile(join(skillDir, 'peers.yaml'), 'utf-8');
+    const parsed = parse(content) as { peers?: Array<{ name?: unknown }> } | null;
+    const peerNames = parsed?.peers
+      ?.map((peer) => peer.name)
+      .filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
+      .map((name) => sanitizeMetadata(name));
+
+    return [...new Set(peerNames ?? [])];
+  } catch {
+    return [];
+  }
+}
+
 export async function parseSkillMd(
   skillMdPath: string,
   options?: { includeInternal?: boolean }
@@ -46,7 +62,11 @@ export async function parseSkillMd(
     // Skip internal skills unless:
     // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
     // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const isInternal = data.metadata?.internal === true;
+    const metadata =
+      data.metadata && typeof data.metadata === 'object'
+        ? (data.metadata as Record<string, unknown>)
+        : undefined;
+    const isInternal = metadata?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
     }
@@ -56,7 +76,8 @@ export async function parseSkillMd(
       description: sanitizeMetadata(data.description),
       path: dirname(skillMdPath),
       rawContent: content,
-      metadata: data.metadata,
+      peerNames: await readPeerNames(dirname(skillMdPath)),
+      metadata,
     };
   } catch {
     return null;
@@ -242,4 +263,35 @@ export function filterSkills(skills: Skill[], inputNames: string[]): Skill[] {
 
     return normalizedInputs.some((input) => input === name || input === displayName);
   });
+}
+
+/**
+ * Include any local peer skills declared in peers.yaml for selected skills.
+ * Peers are only expanded when the named peer exists in the discovered source.
+ */
+export function expandSkillsWithPeers(selectedSkills: Skill[], allSkills: Skill[]): Skill[] {
+  const skillsByName = new Map(allSkills.map((skill) => [skill.name.toLowerCase(), skill]));
+  const expanded: Skill[] = [];
+  const seenNames = new Set<string>();
+
+  const addSkill = (skill: Skill) => {
+    const normalizedName = skill.name.toLowerCase();
+    if (seenNames.has(normalizedName)) return;
+
+    seenNames.add(normalizedName);
+    expanded.push(skill);
+
+    for (const peerName of skill.peerNames ?? []) {
+      const peer = skillsByName.get(peerName.toLowerCase());
+      if (peer) {
+        addSkill(peer);
+      }
+    }
+  };
+
+  for (const skill of selectedSkills) {
+    addSkill(skill);
+  }
+
+  return expanded;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,8 @@ export interface Skill {
   path: string;
   /** Raw SKILL.md content for hashing */
   rawContent?: string;
+  /** Peer skill names declared by a sibling peers.yaml manifest */
+  peerNames?: string[];
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
   metadata?: Record<string, unknown>;

--- a/tests/full-depth-discovery.test.ts
+++ b/tests/full-depth-discovery.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { discoverSkills } from '../src/skills.ts';
+import { discoverSkills, expandSkillsWithPeers } from '../src/skills.ts';
 
 describe('discoverSkills with fullDepth option', () => {
   let testDir: string;
@@ -200,5 +200,56 @@ description: Nested skill with same name
     // Should only have one skill (deduplication by name)
     expect(skills).toHaveLength(1);
     expect(skills[0].name).toBe('my-skill');
+  });
+
+  it('should parse peer manifests and expand selected peer skills', async () => {
+    mkdirSync(join(testDir, 'skills', 'router'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'router', 'SKILL.md'),
+      `---
+name: router
+description: Routes to peer skills
+---
+# Router
+`
+    );
+    writeFileSync(
+      join(testDir, 'skills', 'router', 'peers.yaml'),
+      `peers:
+  - name: auth
+  - name: send-message
+  - name: missing-peer
+`
+    );
+
+    mkdirSync(join(testDir, 'skills', 'auth'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'auth', 'SKILL.md'),
+      `---
+name: auth
+description: Auth peer
+---
+`
+    );
+
+    mkdirSync(join(testDir, 'skills', 'send-message'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'send-message', 'SKILL.md'),
+      `---
+name: send-message
+description: Send peer
+---
+`
+    );
+
+    const skills = await discoverSkills(testDir);
+    const router = skills.find((skill) => skill.name === 'router');
+
+    expect(router?.peerNames).toEqual(['auth', 'send-message', 'missing-peer']);
+    expect(expandSkillsWithPeers([router!], skills).map((skill) => skill.name)).toEqual([
+      'router',
+      'auth',
+      'send-message',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Parse sibling `peers.yaml` manifests during skill discovery.
- When a selected skill declares local peers, include those peer skills in the install set so the existing install and lock-file paths track them normally.
- Add coverage for peer discovery expansion and project lock-file entries.

Closes #1114.

## Verification

- `pnpm format:check`
- `pnpm test tests/full-depth-discovery.test.ts src/add.test.ts`
- `pnpm test` currently has unrelated/environment-sensitive failures in banner/global-scope/remove prompt tests: 452 passed, 6 failed.
- `pnpm type-check` currently fails on an existing `src/git.ts` simple-git options typing issue unrelated to this change.