### PR TITLE
fix(installer): skip local self copy

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -153,6 +153,40 @@ async function resolveParentSymlinks(path: string): Promise<string> {
   }
 }
 
+async function isSameResolvedPath(a: string, b: string): Promise<boolean> {
+  const resolvedA = resolve(a);
+  const resolvedB = resolve(b);
+
+  if (resolvedA === resolvedB) {
+    return true;
+  }
+
+  const [realA, realB] = await Promise.all([
+    realpath(resolvedA).catch(() => resolvedA),
+    realpath(resolvedB).catch(() => resolvedB),
+  ]);
+
+  if (realA === realB) {
+    return true;
+  }
+
+  const [parentResolvedA, parentResolvedB] = await Promise.all([
+    resolveParentSymlinks(resolvedA),
+    resolveParentSymlinks(resolvedB),
+  ]);
+
+  return parentResolvedA === parentResolvedB;
+}
+
+async function copyLocalSkillDirectory(src: string, dest: string): Promise<void> {
+  if (await isSameResolvedPath(src, dest)) {
+    return;
+  }
+
+  await cleanAndCreateDirectory(dest);
+  await copyDirectory(src, dest);
+}
+
 /**
  * Creates a symlink, handling cross-platform differences
  * Returns true if symlink was created, false if fallback to copy is needed
@@ -279,8 +313,7 @@ export async function installSkillForAgent(
   try {
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
-      await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir);
+      await copyLocalSkillDirectory(skill.path, agentDir);
 
       return {
         success: true,
@@ -290,8 +323,7 @@ export async function installSkillForAgent(
     }
 
     // Symlink mode: copy to canonical location and symlink to agent location
-    await cleanAndCreateDirectory(canonicalDir);
-    await copyDirectory(skill.path, canonicalDir);
+    await copyLocalSkillDirectory(skill.path, canonicalDir);
 
     // For universal agents with global install, the skill is already in the canonical
     // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
@@ -326,8 +358,7 @@ export async function installSkillForAgent(
 
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
-      await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir);
+      await copyLocalSkillDirectory(skill.path, agentDir);
 
       return {
         success: true,

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -12,6 +12,35 @@ async function makeSkillSource(root: string, name: string): Promise<string> {
 }
 
 describe('installer copy mode', () => {
+  it('does not delete a local skill already at the universal agent path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-'));
+    const projectDir = join(root, 'project');
+    const skillName = 'canonical-copy-skill';
+    const skillDir = join(projectDir, '.agents/skills', skillName);
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: test\n---\n`
+    );
+    await writeFile(join(skillDir, 'README.md'), '# keep me\n');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'cursor',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      await expect(readFile(join(skillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+      await expect(readFile(join(skillDir, 'README.md'), 'utf-8')).resolves.toBe('# keep me\n');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('preserves dotfiles while keeping explicit exclusions', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-'));
     const projectDir = join(root, 'project');

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -27,6 +27,36 @@ async function makeSkillSource(root: string, name: string): Promise<string> {
 }
 
 describe('installer symlink regression', () => {
+  it('does not delete a local skill already at the canonical path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    const skillName = 'canonical-source-skill';
+    const skillDir = join(projectDir, '.agents/skills', skillName);
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: test\n---\n`
+    );
+    await writeFile(join(skillDir, 'notes.md'), 'still here\n');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'cursor',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBeUndefined();
+      await expect(readFile(join(skillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+      await expect(readFile(join(skillDir, 'notes.md'), 'utf-8')).resolves.toBe('still here\n');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('does not create self-loop when canonical and agent paths match', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
     const projectDir = join(root, 'project');


### PR DESCRIPTION
## Summary

Fixes #1093.

When a local skill is already located at the canonical universal-agent path, installing it again can make the source and destination the same directory. The local installer previously cleaned the destination before copying, which deleted the source files first.

This change adds a resolved-path guard for local skill directory copies. If the source and destination resolve to the same physical path, the installer treats the copy as a no-op instead of deleting and recreating the directory. The guard is used for copy mode, symlink-mode canonical copies, and symlink fallback copies.

## Tests

- pnpm test tests/installer-copy.test.ts tests/installer-symlink.test.ts
- pnpm exec prettier --check src/installer.ts tests/installer-copy.test.ts tests/installer-symlink.test.ts
- git diff --check

## Note

- pnpm type-check currently fails on existing upstream errors in src/git.ts and src/skills.ts, unrelated to this installer change.