### PR TITLE
docs: correct install instructions; rewrite README as fork-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+# @juiceboxcreative/skills
+
+> **Internal Juicebox Creative fork of [vercel-labs/skills](https://github.com/vercel-labs/skills).**
+>
+> Identical to upstream except `src/telemetry.ts` is replaced with a no-op stub. Removes phone-home to `add-skill.vercel.sh/t` (install/remove/update/find events) and `add-skill.vercel.sh/audit` (security-audit lookup). Stops auto-publication of agency repo URLs and skill names to the public skills.sh leaderboard.
+>
+> No proprietary changes. Pull upstream periodically with `git fetch upstream && git merge upstream/main` — only `src/telemetry.ts`, `package.json`, and this notice should conflict.
+>
+> Install our skills with:
+>
+> ```bash
+> npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill <slug> -g
+> ```
+>
+> Original upstream README follows.
+
+---
+
 # skills
 
 The CLI for the open agent skills ecosystem.

--- a/README.md
+++ b/README.md
@@ -1,516 +1,159 @@
 # @juiceboxcreative/skills
 
-> **Internal Juicebox Creative fork of [vercel-labs/skills](https://github.com/vercel-labs/skills).**
->
-> Identical to upstream except `src/telemetry.ts` is replaced with a no-op stub. Removes phone-home to `add-skill.vercel.sh/t` (install/remove/update/find events) and `add-skill.vercel.sh/audit` (security-audit lookup). Stops auto-publication of agency repo URLs and skill names to the public skills.sh leaderboard.
->
-> No proprietary changes. Pull upstream periodically with `git fetch upstream && git merge upstream/main` — only `src/telemetry.ts`, `package.json`, and this notice should conflict.
->
-> Install our skills with:
->
-> ```bash
-> npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill <slug> -g
-> ```
->
-> Original upstream README follows.
+The Juicebox install CLI for [`JuiceboxCreative/skills`](https://github.com/JuiceboxCreative/skills) — a thin fork of [`vercel-labs/skills`](https://github.com/vercel-labs/skills) with telemetry stripped.
+
+> **Fork policy.** Identical to upstream except `src/telemetry.ts` is replaced with a no-op stub. Removes phone-home to `add-skill.vercel.sh/t` (install/remove/update/find events) and `add-skill.vercel.sh/audit` (security-audit lookup). Stops auto-publication of agency repo URLs and skill names to the public skills.sh leaderboard. No proprietary changes — pull upstream periodically with `git fetch upstream && git merge upstream/main`; only `src/telemetry.ts`, `package.json`, and this README should ever conflict.
 
 ---
 
-# skills
+## Install a skill
 
-The CLI for the open agent skills ecosystem.
-
-<!-- agent-list:start -->
-
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
-
-<!-- agent-list:end -->
-
-[![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
-
-## Install a Skill
+The canonical install command for any Juicebox skill:
 
 ```bash
-npx skills add vercel-labs/agent-skills
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill <slug> -g
 ```
 
-### Source Formats
-
-```bash
-# GitHub shorthand (owner/repo)
-npx skills add vercel-labs/agent-skills
-
-# Full GitHub URL
-npx skills add https://github.com/vercel-labs/agent-skills
-
-# Direct path to a skill in a repo
-npx skills add https://github.com/vercel-labs/agent-skills/tree/main/skills/web-design-guidelines
-
-# GitLab URL
-npx skills add https://gitlab.com/org/repo
-
-# Any git URL
-npx skills add git@github.com:vercel-labs/agent-skills.git
-
-# Local path
-npx skills add ./my-local-skills
-```
-
-### Options
-
-| Option                    | Description                                                                                                                                        |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-g, --global`            | Install to user directory instead of project                                                                                                       |
-| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Supported Agents](#supported-agents)<!-- agent-names:end --> |
-| `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
-| `-l, --list`              | List available skills without installing                                                                                                           |
-| `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
-| `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
-| `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+`-g` writes the skill to your **global** agent config (e.g. `~/.claude/skills/<slug>/`). Drop the `-g` to install into the current project at `./.claude/skills/<slug>/`.
 
 ### Examples
 
 ```bash
-# List skills in a repository
-npx skills add vercel-labs/agent-skills --list
+# Install one skill globally; the CLI auto-detects which agents you have
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill seo-audit -g
 
-# Install specific skills
-npx skills add vercel-labs/agent-skills --skill frontend-design --skill skill-creator
+# Install for Cursor + Codex instead of Claude Code
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill seo-audit -g -a cursor -a codex
 
-# Install a skill with spaces in the name (must be quoted)
-npx skills add owner/repo --skill "Convex Best Practices"
+# List every skill in the repo without installing
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --list
 
-# Install to specific agents
-npx skills add vercel-labs/agent-skills -a claude-code -a opencode
+# Install several skills at once
+npx @juiceboxcreative/skills add JuiceboxCreative/skills \
+  --skill meeting-agenda \
+  --skill jira-ticket-standard \
+  --skill change-request \
+  -g
 
-# Non-interactive installation (CI/CD friendly)
-npx skills add vercel-labs/agent-skills --skill frontend-design -g -a claude-code -y
+# Install absolutely every skill in the repo (rare; usually overkill)
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill '*' -g
 
-# Install all skills from a repo to all agents
-npx skills add vercel-labs/agent-skills --all
-
-# Install all skills to specific agents
-npx skills add vercel-labs/agent-skills --skill '*' -a claude-code
-
-# Install specific skills to all agents
-npx skills add vercel-labs/agent-skills --agent '*' --skill frontend-design
+# Non-interactive (CI-friendly): skip every confirmation prompt
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill seo-audit -g -a claude-code -y
 ```
 
-### Installation Scope
+The CLI also accepts other source formats (GitHub URLs, GitLab URLs, raw git URLs, local paths) — see `npx @juiceboxcreative/skills add --help` for the full list.
 
-| Scope       | Flag      | Location            | Use Case                                      |
-| ----------- | --------- | ------------------- | --------------------------------------------- |
-| **Project** | (default) | `./<agent>/skills/` | Committed with your project, shared with team |
-| **Global**  | `-g`      | `~/<agent>/skills/` | Available across all projects                 |
+## Install scope
 
-### Installation Methods
+| Scope         | Flag        | Where it goes                  | When to use                                 |
+| ------------- | ----------- | ------------------------------ | ------------------------------------------- |
+| **Global**    | `-g`        | `~/<agent>/skills/<slug>/`     | Available across every project on your machine. The default for most Juicebox use. |
+| **Project**   | *(default)* | `./<agent>/skills/<slug>/`     | Commit alongside the project; teammates pick it up via `git clone`. |
 
-When installing interactively, you can choose:
+## Multi-agent install
 
-| Method                    | Description                                                                                 |
-| ------------------------- | ------------------------------------------------------------------------------------------- |
-| **Symlink** (Recommended) | Creates symlinks from each agent to a canonical copy. Single source of truth, easy updates. |
-| **Copy**                  | Creates independent copies for each agent. Use when symlinks aren't supported.              |
-
-## Other Commands
-
-| Command                      | Description                                   |
-| ---------------------------- | --------------------------------------------- |
-| `npx skills list`            | List installed skills (alias: `ls`)           |
-| `npx skills find [query]`    | Search for skills interactively or by keyword |
-| `npx skills remove [skills]` | Remove installed skills from agents           |
-| `npx skills update [skills]` | Update installed skills to latest versions    |
-| `npx skills init [name]`     | Create a new SKILL.md template                |
-
-### `skills list`
-
-List all installed skills. Similar to `npm ls`.
+By default the CLI walks every agent it finds installed locally (Claude Code, Cursor, Codex, OpenCode, Gemini CLI, and ~50 more). To target a specific subset, use `-a <agent>` one or more times:
 
 ```bash
-# List all installed skills (project and global)
-npx skills list
+# Just Claude Code
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill seo-audit -g -a claude-code
 
-# List only global skills
-npx skills ls -g
+# Cursor + Codex
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill seo-audit -g -a cursor -a codex
 
-# Filter by specific agents
-npx skills ls -a claude-code -a cursor
+# Every supported agent (rarely needed)
+npx @juiceboxcreative/skills add JuiceboxCreative/skills --skill seo-audit -g -a '*'
 ```
 
-### `skills find`
+## Common commands
 
-Search for skills interactively or by keyword.
+| Command                                                | What it does                                  |
+| ------------------------------------------------------ | --------------------------------------------- |
+| `npx @juiceboxcreative/skills add <source>`            | Install one or more skills                    |
+| `npx @juiceboxcreative/skills list`                    | List installed skills (alias: `ls`)           |
+| `npx @juiceboxcreative/skills update [slug]`           | Update installed skills to the latest version |
+| `npx @juiceboxcreative/skills remove [slug]`           | Remove installed skills (alias: `rm`)         |
+| `npx @juiceboxcreative/skills find [query]`            | Search installable skills interactively       |
+| `npx @juiceboxcreative/skills init [name]`             | Scaffold a new local `SKILL.md` template      |
+
+Every command accepts `--help` for the full option list.
+
+### Update everything you've installed
 
 ```bash
-# Interactive search (fzf-style)
-npx skills find
+# Interactive — picks the right scope and confirms each update
+npx @juiceboxcreative/skills update
 
-# Search by keyword
-npx skills find typescript
+# Update one skill by name
+npx @juiceboxcreative/skills update seo-audit
+
+# Update all global skills, no prompts
+npx @juiceboxcreative/skills update -g -y
 ```
 
-### `skills update`
+### Remove a skill
 
 ```bash
-# Update all skills (interactive scope prompt)
-npx skills update
-
-# Update a single skill by name
-npx skills update my-skill
-
-# Update multiple specific skills
-npx skills update frontend-design web-design-guidelines
-
-# Update only global or project skills
-npx skills update -g
-npx skills update -p
-
-# Non-interactive (auto-detects scope: project if in a project, else global)
-npx skills update -y
-```
-
-| Option          | Description                                                               |
-| --------------- | ------------------------------------------------------------------------- |
-| `-g, --global`  | Only update global skills                                                 |
-| `-p, --project` | Only update project skills                                                |
-| `-y, --yes`     | Skip scope prompt (auto-detect: project if in a project dir, else global) |
-| `[skills...]`   | Update specific skills by name instead of all                             |
-
-### `skills init`
-
-```bash
-# Create SKILL.md in current directory
-npx skills init
-
-# Create a new skill in a subdirectory
-npx skills init my-skill
-```
-
-### `skills remove`
-
-Remove installed skills from agents.
-
-```bash
-# Remove interactively (select from installed skills)
-npx skills remove
-
-# Remove specific skill by name
-npx skills remove web-design-guidelines
-
-# Remove multiple skills
-npx skills remove frontend-design web-design-guidelines
-
 # Remove from global scope
-npx skills remove --global web-design-guidelines
+npx @juiceboxcreative/skills remove seo-audit -g
 
-# Remove from specific agents only
-npx skills remove --agent claude-code cursor my-skill
+# Remove from a specific agent only
+npx @juiceboxcreative/skills remove seo-audit -a cursor
 
-# Remove all installed skills without confirmation
-npx skills remove --all
-
-# Remove all skills from a specific agent
-npx skills remove --skill '*' -a cursor
-
-# Remove a specific skill from all agents
-npx skills remove my-skill --agent '*'
-
-# Use 'rm' alias
-npx skills rm my-skill
+# Wipe everything (asks for confirmation)
+npx @juiceboxcreative/skills remove --all
 ```
 
-| Option         | Description                                      |
-| -------------- | ------------------------------------------------ |
-| `-g, --global` | Remove from global scope (~/) instead of project |
-| `-a, --agent`  | Remove from specific agents (use `'*'` for all)  |
-| `-s, --skill`  | Specify skills to remove (use `'*'` for all)     |
-| `-y, --yes`    | Skip confirmation prompts                        |
-| `--all`        | Shorthand for `--skill '*' --agent '*' -y`       |
+## Add a new skill to the Juicebox library
 
-## What are Agent Skills?
+You don't add skills through this CLI. Skills live in [`JuiceboxCreative/skills`](https://github.com/JuiceboxCreative/skills):
 
-Agent skills are reusable instruction sets that extend your coding agent's capabilities. They're defined in `SKILL.md`
-files with YAML frontmatter containing a `name` and `description`.
+1. Branch the skills repo.
+2. Add your `SKILL.md` (and any sidecar `references/` / `assets/` / `scripts/`) under the right category folder.
+3. Open a PR. CI lints the frontmatter; reviewers check the body.
+4. Merge to `main`. The webhook syncs the new skill into [skills-web](https://skills.juicebox.com.au) within seconds.
 
-Skills let agents perform specialized tasks like:
+Read [`JuiceboxCreative/skills` → README](https://github.com/JuiceboxCreative/skills#readme) for the slug rules, frontmatter reference, and the directory layout convention.
 
-- Generating release notes from git history
-- Creating PRs following your team's conventions
-- Integrating with external tools (Linear, Notion, etc.)
+## Maintaining the fork
 
-Discover skills at **[skills.sh](https://skills.sh)**
-
-## Supported Agents
-
-Skills can be installed to any of these agents:
-
-<!-- supported-agents:start -->
-
-| Agent                                 | `--agent`                                | Project Path             | Global Path                     |
-| ------------------------------------- | ---------------------------------------- | ------------------------ | ------------------------------- |
-| AiderDesk                             | `aider-desk`                             | `.aider-desk/skills/`    | `~/.aider-desk/skills/`         |
-| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/`        | `~/.config/agents/skills/`      |
-| Antigravity                           | `antigravity`                            | `.agents/skills/`        | `~/.gemini/antigravity/skills/` |
-| Augment                               | `augment`                                | `.augment/skills/`       | `~/.augment/skills/`            |
-| IBM Bob                               | `bob`                                    | `.bob/skills/`           | `~/.bob/skills/`                |
-| Claude Code                           | `claude-code`                            | `.claude/skills/`        | `~/.claude/skills/`             |
-| OpenClaw                              | `openclaw`                               | `skills/`                | `~/.openclaw/skills/`           |
-| Cline, Dexto, Warp                    | `cline`, `dexto`, `warp`                 | `.agents/skills/`        | `~/.agents/skills/`             |
-| CodeArts Agent                        | `codearts-agent`                         | `.codeartsdoer/skills/`  | `~/.codeartsdoer/skills/`       |
-| CodeBuddy                             | `codebuddy`                              | `.codebuddy/skills/`     | `~/.codebuddy/skills/`          |
-| Codemaker                             | `codemaker`                              | `.codemaker/skills/`     | `~/.codemaker/skills/`          |
-| Code Studio                           | `codestudio`                             | `.codestudio/skills/`    | `~/.codestudio/skills/`         |
-| Codex                                 | `codex`                                  | `.agents/skills/`        | `~/.codex/skills/`              |
-| Command Code                          | `command-code`                           | `.commandcode/skills/`   | `~/.commandcode/skills/`        |
-| Continue                              | `continue`                               | `.continue/skills/`      | `~/.continue/skills/`           |
-| Cortex Code                           | `cortex`                                 | `.cortex/skills/`        | `~/.snowflake/cortex/skills/`   |
-| Crush                                 | `crush`                                  | `.crush/skills/`         | `~/.config/crush/skills/`       |
-| Cursor                                | `cursor`                                 | `.agents/skills/`        | `~/.cursor/skills/`             |
-| Deep Agents                           | `deepagents`                             | `.agents/skills/`        | `~/.deepagents/agent/skills/`   |
-| Devin for Terminal                    | `devin`                                  | `.devin/skills/`         | `~/.config/devin/skills/`       |
-| Droid                                 | `droid`                                  | `.factory/skills/`       | `~/.factory/skills/`            |
-| Firebender                            | `firebender`                             | `.agents/skills/`        | `~/.firebender/skills/`         |
-| ForgeCode                             | `forgecode`                              | `.forge/skills/`         | `~/.forge/skills/`              |
-| Gemini CLI                            | `gemini-cli`                             | `.agents/skills/`        | `~/.gemini/skills/`             |
-| GitHub Copilot                        | `github-copilot`                         | `.agents/skills/`        | `~/.copilot/skills/`            |
-| Goose                                 | `goose`                                  | `.goose/skills/`         | `~/.config/goose/skills/`       |
-| Hermes Agent                          | `hermes-agent`                           | `.hermes/skills/`        | `~/.hermes/skills/`             |
-| Junie                                 | `junie`                                  | `.junie/skills/`         | `~/.junie/skills/`              |
-| iFlow CLI                             | `iflow-cli`                              | `.iflow/skills/`         | `~/.iflow/skills/`              |
-| Kilo Code                             | `kilo`                                   | `.kilocode/skills/`      | `~/.kilocode/skills/`           |
-| Kiro CLI                              | `kiro-cli`                               | `.kiro/skills/`          | `~/.kiro/skills/`               |
-| Kode                                  | `kode`                                   | `.kode/skills/`          | `~/.kode/skills/`               |
-| MCPJam                                | `mcpjam`                                 | `.mcpjam/skills/`        | `~/.mcpjam/skills/`             |
-| Mistral Vibe                          | `mistral-vibe`                           | `.vibe/skills/`          | `~/.vibe/skills/`               |
-| Mux                                   | `mux`                                    | `.mux/skills/`           | `~/.mux/skills/`                |
-| OpenCode                              | `opencode`                               | `.agents/skills/`        | `~/.config/opencode/skills/`    |
-| OpenHands                             | `openhands`                              | `.openhands/skills/`     | `~/.openhands/skills/`          |
-| Pi                                    | `pi`                                     | `.pi/skills/`            | `~/.pi/agent/skills/`           |
-| Qoder                                 | `qoder`                                  | `.qoder/skills/`         | `~/.qoder/skills/`              |
-| Qwen Code                             | `qwen-code`                              | `.qwen/skills/`          | `~/.qwen/skills/`               |
-| Rovo Dev                              | `rovodev`                                | `.rovodev/skills/`       | `~/.rovodev/skills/`            |
-| Roo Code                              | `roo`                                    | `.roo/skills/`           | `~/.roo/skills/`                |
-| Tabnine CLI                           | `tabnine-cli`                            | `.tabnine/agent/skills/` | `~/.tabnine/agent/skills/`      |
-| Trae                                  | `trae`                                   | `.trae/skills/`          | `~/.trae/skills/`               |
-| Trae CN                               | `trae-cn`                                | `.trae/skills/`          | `~/.trae-cn/skills/`            |
-| Windsurf                              | `windsurf`                               | `.windsurf/skills/`      | `~/.codeium/windsurf/skills/`   |
-| Zencoder                              | `zencoder`                               | `.zencoder/skills/`      | `~/.zencoder/skills/`           |
-| Neovate                               | `neovate`                                | `.neovate/skills/`       | `~/.neovate/skills/`            |
-| Pochi                                 | `pochi`                                  | `.pochi/skills/`         | `~/.pochi/skills/`              |
-| AdaL                                  | `adal`                                   | `.adal/skills/`          | `~/.adal/skills/`               |
-
-<!-- supported-agents:end -->
-
-> [!NOTE]
-> **Kiro CLI users:** The default agent automatically loads skills from `.kiro/skills/` and `~/.kiro/skills/` — no
-> configuration needed. If you use a **custom agent**, add skills to its `resources` in `.kiro/agents/<agent>.json`:
->
-> ```json
-> {
->   "resources": ["skill://.kiro/skills/**/SKILL.md"]
-> }
-> ```
-
-The CLI automatically detects which coding agents you have installed. If none are detected, you'll be prompted to select
-which agents to install to.
-
-## Creating Skills
-
-Skills are directories containing a `SKILL.md` file with YAML frontmatter:
-
-```markdown
----
-name: my-skill
-description: What this skill does and when to use it
----
-
-# My Skill
-
-Instructions for the agent to follow when this skill is activated.
-
-## When to Use
-
-Describe the scenarios where this skill should be used.
-
-## Steps
-
-1. First, do this
-2. Then, do that
-```
-
-### Required Fields
-
-- `name`: Unique identifier (lowercase, hyphens allowed)
-- `description`: Brief explanation of what the skill does
-
-### Optional Fields
-
-- `metadata.internal`: Set to `true` to hide the skill from normal discovery. Internal skills are only visible and
-  installable when `INSTALL_INTERNAL_SKILLS=1` is set. Useful for work-in-progress skills or skills meant only for
-  internal tooling.
-
-```markdown
----
-name: my-internal-skill
-description: An internal skill not shown by default
-metadata:
-  internal: true
----
-```
-
-### Skill Discovery
-
-The CLI searches for skills in these locations within a repository:
-
-<!-- skill-discovery:start -->
-
-- Root directory (if it contains `SKILL.md`)
-- `skills/`
-- `skills/.curated/`
-- `skills/.experimental/`
-- `skills/.system/`
-- `.aider-desk/skills/`
-- `.agents/skills/`
-- `.augment/skills/`
-- `.bob/skills/`
-- `.claude/skills/`
-- `.codeartsdoer/skills/`
-- `.codebuddy/skills/`
-- `.codemaker/skills/`
-- `.codestudio/skills/`
-- `.commandcode/skills/`
-- `.continue/skills/`
-- `.cortex/skills/`
-- `.crush/skills/`
-- `.devin/skills/`
-- `.factory/skills/`
-- `.forge/skills/`
-- `.goose/skills/`
-- `.hermes/skills/`
-- `.junie/skills/`
-- `.iflow/skills/`
-- `.kilocode/skills/`
-- `.kiro/skills/`
-- `.kode/skills/`
-- `.mcpjam/skills/`
-- `.vibe/skills/`
-- `.mux/skills/`
-- `.openhands/skills/`
-- `.pi/skills/`
-- `.qoder/skills/`
-- `.qwen/skills/`
-- `.rovodev/skills/`
-- `.roo/skills/`
-- `.tabnine/agent/skills/`
-- `.trae/skills/`
-- `.windsurf/skills/`
-- `.zencoder/skills/`
-- `.neovate/skills/`
-- `.pochi/skills/`
-- `.adal/skills/`
-<!-- skill-discovery:end -->
-
-### Plugin Manifest Discovery
-
-If `.claude-plugin/marketplace.json` or `.claude-plugin/plugin.json` exists, skills declared in those files are also discovered:
-
-```json
-// .claude-plugin/marketplace.json
-{
-  "metadata": { "pluginRoot": "./plugins" },
-  "plugins": [
-    {
-      "name": "my-plugin",
-      "source": "my-plugin",
-      "skills": ["./skills/review", "./skills/test"]
-    }
-  ]
-}
-```
-
-This enables compatibility with the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) ecosystem.
-
-If no skills are found in standard locations, a recursive search is performed.
-
-## Compatibility
-
-Skills are generally compatible across agents since they follow a
-shared [Agent Skills specification](https://agentskills.io). However, some features may be agent-specific:
-
-| Feature         | OpenCode | OpenHands | Claude Code | Cline | CodeBuddy | Codex | Command Code | Kiro CLI | Cursor | Antigravity | Roo Code | Github Copilot | Amp | OpenClaw | Neovate | Pi  | Qoder | Zencoder |
-| --------------- | -------- | --------- | ----------- | ----- | --------- | ----- | ------------ | -------- | ------ | ----------- | -------- | -------------- | --- | -------- | ------- | --- | ----- | -------- |
-| Basic skills    | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | Yes      | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | Yes      |
-| `allowed-tools` | Yes      | Yes       | Yes         | Yes   | Yes       | Yes   | Yes          | No       | Yes    | Yes         | Yes      | Yes            | Yes | Yes      | Yes     | Yes | Yes   | No       |
-| `context: fork` | No       | No        | Yes         | No    | No        | No    | No           | No       | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-| Hooks           | No       | No        | Yes         | Yes   | No        | No    | No           | Yes      | No     | No          | No       | No             | No  | No       | No      | No  | No    | No       |
-
-## Troubleshooting
-
-### "No skills found"
-
-Ensure the repository contains valid `SKILL.md` files with both `name` and `description` in the frontmatter.
-
-### Skill not loading in agent
-
-- Verify the skill was installed to the correct path
-- Check the agent's documentation for skill loading requirements
-- Ensure the `SKILL.md` frontmatter is valid YAML
-
-### Permission errors
-
-Ensure you have write access to the target directory.
-
-## Environment Variables
-
-| Variable                  | Description                                                                |
-| ------------------------- | -------------------------------------------------------------------------- |
-| `INSTALL_INTERNAL_SKILLS` | Set to `1` or `true` to show and install skills marked as `internal: true` |
-| `DISABLE_TELEMETRY`       | Set to disable anonymous usage telemetry                                   |
-| `DO_NOT_TRACK`            | Alternative way to disable telemetry                                       |
+This repo is a thin layer over upstream. Keep that layer thin.
 
 ```bash
-# Install internal skills
-INSTALL_INTERNAL_SKILLS=1 npx skills add vercel-labs/agent-skills --list
+# One-time setup
+git remote add upstream https://github.com/vercel-labs/skills.git
+
+# Periodic upstream pull
+git fetch upstream
+git checkout main
+git merge upstream/main
+# Resolve any conflicts. The only files that should ever conflict are:
+#   - src/telemetry.ts   (we want the no-op stub)
+#   - package.json       (we want the @juiceboxcreative/skills name)
+#   - README.md          (this file)
 ```
 
-## Telemetry
+After a successful merge, bump the version and publish:
 
-This CLI collects anonymous usage data to help improve the tool. No personal information is collected.
+```bash
+pnpm install
+pnpm test          # if there are any local tests
+pnpm publish --access public
+```
 
-Telemetry is automatically disabled in CI environments.
+## Why a fork
 
-## Related Links
+Upstream `vercel-labs/skills` pings `add-skill.vercel.sh/t` on every install/remove/update/find, sending the source repo URL and the skill name. For a private library like ours, that leaks both the repo URL and the names of the skills we ship. The fork swaps the telemetry module for a no-op stub so nothing leaves the user's machine.
 
-- [Agent Skills Specification](https://agentskills.io)
-- [Skills Directory](https://skills.sh)
-- [Amp Skills Documentation](https://ampcode.com/manual#agent-skills)
-- [Antigravity Skills Documentation](https://antigravity.google/docs/skills)
-- [Factory AI / Droid Skills Documentation](https://docs.factory.ai/cli/configuration/skills)
-- [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)
-- [OpenClaw Skills Documentation](https://docs.openclaw.ai/tools/skills)
-- [Cline Skills Documentation](https://docs.cline.bot/features/skills)
-- [CodeBuddy Skills Documentation](https://www.codebuddy.ai/docs/ide/Features/Skills)
-- [Codex Skills Documentation](https://developers.openai.com/codex/skills)
-- [Command Code Skills Documentation](https://commandcode.ai/docs/skills)
-- [Crush Skills Documentation](https://github.com/charmbracelet/crush?tab=readme-ov-file#agent-skills)
-- [Cursor Skills Documentation](https://cursor.com/docs/context/skills)
-- [Firebender Skills Documentation](https://docs.firebender.com/multi-agent/skills)
-- [Gemini CLI Skills Documentation](https://geminicli.com/docs/cli/skills/)
-- [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
-- [iFlow CLI Skills Documentation](https://platform.iflow.cn/en/cli/examples/skill)
-- [Kimi Code CLI Skills Documentation](https://moonshotai.github.io/kimi-cli/en/customization/skills.html)
-- [Kiro CLI Skills Documentation](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources)
-- [Kode Skills Documentation](https://github.com/shareAI-lab/kode/blob/main/docs/skills.md)
-- [OpenCode Skills Documentation](https://opencode.ai/docs/skills)
-- [Qwen Code Skills Documentation](https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/)
-- [OpenHands Skills Documentation](https://docs.openhands.ai/modules/usage/how-to/using-skills)
-- [Pi Skills Documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md)
-- [Qoder Skills Documentation](https://docs.qoder.com/cli/Skills)
-- [Replit Skills Documentation](https://docs.replit.com/replitai/skills)
-- [Roo Code Skills Documentation](https://docs.roocode.com/features/skills)
-- [Trae Skills Documentation](https://docs.trae.ai/ide/skills)
-- [Vercel Agent Skills Repository](https://github.com/vercel-labs/agent-skills)
+## Useful links
 
-## License
+- npm package: <https://www.npmjs.com/package/@juiceboxcreative/skills>
+- Skills repo: <https://github.com/JuiceboxCreative/skills>
+- Web directory (internal): <https://skills.juicebox.com.au>
+- Upstream project: <https://github.com/vercel-labs/skills>
+- Anthropic skills format reference: <https://code.claude.com/docs/en/skills>
 
-MIT
+## Licence
+
+MIT, mirroring upstream. See `LICENSE` and `ThirdPartyNoticeText.txt`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "skills",
-  "version": "1.5.6",
-  "description": "The open agent skills ecosystem",
+  "name": "@juiceboxcreative/skills",
+  "version": "0.1.0",
+  "description": "Internal Juicebox Creative fork of vercel-labs/skills with telemetry and security-audit endpoints removed. Installs SKILL.md files from a private agency repo into Claude Code, Codex, Cursor, and 48 other agents.",
   "type": "module",
   "bin": {
     "skills": "./bin/cli.mjs",
@@ -94,14 +94,17 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vercel-labs/skills.git"
+    "url": "git+https://github.com/JuiceboxCreative/skills-cli.git"
   },
-  "homepage": "https://github.com/vercel-labs/skills#readme",
+  "homepage": "https://github.com/JuiceboxCreative/skills-cli#readme",
   "bugs": {
-    "url": "https://github.com/vercel-labs/skills/issues"
+    "url": "https://github.com/JuiceboxCreative/skills-cli/issues"
   },
-  "author": "",
+  "author": "Juicebox Creative",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@clack/prompts": "^0.11.0",
     "@types/bun": "latest",

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,19 @@
-const TELEMETRY_URL = 'https://add-skill.vercel.sh/t';
-const AUDIT_URL = 'https://add-skill.vercel.sh/audit';
+/**
+ * No-op telemetry stub for the @juiceboxcreative/skills fork.
+ *
+ * The upstream vercel-labs/skills CLI POSTs install/remove/update/find/sync
+ * events plus security-audit lookups to add-skill.vercel.sh. That telemetry
+ * also feeds the public skills.sh leaderboard, which would auto-publish our
+ * private agency repo URL + skill names every time a staff member installed.
+ *
+ * This fork preserves the original API surface so call sites in cli.ts,
+ * add.ts, find.ts, remove.ts, and detect-agent.ts continue to compile and
+ * run, but every entry point is a no-op. No network requests are made; no
+ * data leaves the user's machine.
+ *
+ * Keep this file the single point of difference vs. upstream so periodic
+ * `git merge upstream/main` stays cheap.
+ */
 
 interface InstallTelemetryData {
   event: 'install';
@@ -7,13 +21,7 @@ interface InstallTelemetryData {
   skills: string;
   agents: string;
   global?: '1';
-  skillFiles?: string; // JSON stringified { skillName: relativePath }
-  /**
-   * Source type for different hosts:
-   * - 'github': GitHub repository (default, uses raw.githubusercontent.com)
-   * - 'raw': Direct URL to SKILL.md (generic raw URL)
-   * - Provider IDs like 'mintlify', 'huggingface', etc.
-   */
+  skillFiles?: string;
   sourceType?: string;
 }
 
@@ -55,40 +63,6 @@ type TelemetryData =
   | FindTelemetryData
   | SyncTelemetryData;
 
-let cliVersion: string | null = null;
-let detectedAgentName: string | null = null;
-
-/**
- * Set the detected AI agent name for telemetry tracking.
- * Called once during agent detection, then included in all telemetry events.
- */
-export function setDetectedAgent(agentName: string | null): void {
-  detectedAgentName = agentName;
-}
-
-function isCI(): boolean {
-  return !!(
-    process.env.CI ||
-    process.env.GITHUB_ACTIONS ||
-    process.env.GITLAB_CI ||
-    process.env.CIRCLECI ||
-    process.env.TRAVIS ||
-    process.env.BUILDKITE ||
-    process.env.JENKINS_URL ||
-    process.env.TEAMCITY_VERSION
-  );
-}
-
-function isEnabled(): boolean {
-  return !process.env.DISABLE_TELEMETRY && !process.env.DO_NOT_TRACK;
-}
-
-export function setVersion(version: string): void {
-  cliVersion = version;
-}
-
-// ─── Security audit data ───
-
 export interface PartnerAudit {
   risk: 'safe' | 'low' | 'medium' | 'high' | 'critical' | 'unknown';
   alerts?: number;
@@ -99,88 +73,26 @@ export interface PartnerAudit {
 export type SkillAuditData = Record<string, PartnerAudit>;
 export type AuditResponse = Record<string, SkillAuditData>;
 
-/**
- * Fetch security audit results for skills from the audit API.
- * Returns null on any error or timeout — never blocks installation.
- */
+export function setDetectedAgent(_agentName: string | null): void {
+  // no-op
+}
+
+export function setVersion(_version: string): void {
+  // no-op
+}
+
+export function track(_data: TelemetryData): void {
+  // no-op
+}
+
+export async function flushTelemetry(_timeoutMs: number = 5000): Promise<void> {
+  // no-op
+}
+
 export async function fetchAuditData(
-  source: string,
-  skillSlugs: string[],
-  timeoutMs = 3000
+  _source: string,
+  _skillSlugs: string[],
+  _timeoutMs: number = 3000
 ): Promise<AuditResponse | null> {
-  if (skillSlugs.length === 0) return null;
-
-  try {
-    const params = new URLSearchParams({
-      source,
-      skills: skillSlugs.join(','),
-    });
-
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-    const response = await fetch(`${AUDIT_URL}?${params.toString()}`, {
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-
-    if (!response.ok) return null;
-    return (await response.json()) as AuditResponse;
-  } catch {
-    return null;
-  }
-}
-
-// Pending telemetry promises — awaited before CLI exit so we don't lose data,
-// but never block the main workflow.
-const pendingTelemetry: Promise<void>[] = [];
-
-export function track(data: TelemetryData): void {
-  if (!isEnabled()) return;
-
-  try {
-    const params = new URLSearchParams();
-
-    // Add version
-    if (cliVersion) {
-      params.set('v', cliVersion);
-    }
-
-    // Add CI flag if running in CI
-    if (isCI()) {
-      params.set('ci', '1');
-    }
-
-    // Add detected AI agent name
-    if (detectedAgentName) {
-      params.set('agent', detectedAgentName);
-    }
-
-    // Add event data
-    for (const [key, value] of Object.entries(data)) {
-      if (value !== undefined && value !== null) {
-        params.set(key, String(value));
-      }
-    }
-
-    // Fire and forget during the workflow, but track the promise so
-    // flushTelemetry() can await it before the process exits.
-    const p = fetch(`${TELEMETRY_URL}?${params.toString()}`)
-      .catch(() => {})
-      .then(() => {});
-    pendingTelemetry.push(p);
-  } catch {
-    // Silently fail - telemetry should never break the CLI
-  }
-}
-
-/**
- * Wait for all in-flight telemetry requests to settle.
- * Called once at CLI exit so the process doesn't hang on open sockets
- * but also doesn't drop data by exiting too early.
- */
-export async function flushTelemetry(timeoutMs = 5000): Promise<void> {
-  if (pendingTelemetry.length === 0) return;
-  const timeout = new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
-  await Promise.race([Promise.all(pendingTelemetry), timeout]);
+  return null;
 }


### PR DESCRIPTION
Old README copied upstream verbatim; every example pointed at 'npx skills add vercel-labs/agent-skills'. Replace with a Juicebox-fork-first guide using the @juiceboxcreative/skills binary.