### PR TITLE
fix(add): label detected platform output

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import { parseAddOptions } from './add.ts';
+import { formatDetectedAgentsMessage, parseAddOptions } from './add.ts';
 
 describe('add command', () => {
   let testDir: string;
@@ -388,6 +388,26 @@ describe('parseAddOptions', () => {
     expect(result.options.fullDepth).toBe(true);
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
+  });
+});
+
+describe('formatDetectedAgentsMessage', () => {
+  it('hides the platform count when no agents are detected', () => {
+    expect(formatDetectedAgentsMessage([])).toBeUndefined();
+  });
+
+  it('hides the platform count when a single agent is detected', () => {
+    expect(formatDetectedAgentsMessage(['claude-code'])).toBeUndefined();
+  });
+
+  it('shows detected platform names for multiple detected agents', () => {
+    const message = formatDetectedAgentsMessage(['claude-code', 'github-copilot']);
+
+    expect(message).toContain('Detected 2 of');
+    expect(message).toContain('supported platforms');
+    expect(message).toContain('Claude Code');
+    expect(message).toContain('GitHub Copilot');
+    expect(message).not.toMatch(/^\d+ agents$/);
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -246,6 +246,16 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
   return result;
 }
 
+export function formatDetectedAgentsMessage(installedAgents: AgentType[]): string | undefined {
+  if (installedAgents.length <= 1) {
+    return undefined;
+  }
+
+  const totalAgents = Object.keys(agents).length;
+  const detectedNames = installedAgents.map((agent) => agents[agent].displayName).join(', ');
+  return `Detected ${installedAgents.length} of ${totalAgents} supported platforms: ${detectedNames}`;
+}
+
 /**
  * Builds result lines from installation results, splitting by universal vs symlinked
  */
@@ -557,8 +567,7 @@ async function handleWellKnownSkills(
   } else {
     spinner.start('Loading agents...');
     const installedAgents = await detectInstalledAgents();
-    const totalAgents = Object.keys(agents).length;
-    spinner.stop(`${totalAgents} agents`);
+    spinner.stop(formatDetectedAgentsMessage(installedAgents));
 
     if (installedAgents.length === 0) {
       if (options.yes) {
@@ -1270,8 +1279,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     } else {
       spinner.start('Loading agents...');
       const installedAgents = await detectInstalledAgents();
-      const totalAgents = Object.keys(agents).length;
-      spinner.stop(`${totalAgents} agents`);
+      spinner.stop(formatDetectedAgentsMessage(installedAgents));
 
       if (installedAgents.length === 0) {
         if (options.yes) {


### PR DESCRIPTION
## Summary
- replace the unlabeled `55 agents` loading result with a labeled detected-platform message
- hide the platform count when zero or one agent is detected, where the line is just noise
- add focused coverage for the new message helper

Closes #1111.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm test src/add.test.ts`
- `pnpm exec prettier --check src/add.ts src/add.test.ts`
- `git diff --check`

`pnpm type-check` still fails on existing upstream errors in `src/git.ts` and `src/skills.ts`, unrelated to this patch.