### PR TITLE
fix(add): discover explicitly named nested skills

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -122,6 +122,54 @@ description: Second skill
     expect(result.stdout).toContain('skill-one');
   });
 
+  it('should discover deeper nested skills when --skill names one explicitly', () => {
+    const shallowSkillDir = join(testDir, 'skills', 'top-level-skill');
+    const deepSkillDir = join(
+      testDir,
+      'skills',
+      'specialized-skills',
+      'migration-and-modernization-skills',
+      'aws-transform'
+    );
+    mkdirSync(shallowSkillDir, { recursive: true });
+    mkdirSync(deepSkillDir, { recursive: true });
+
+    writeFileSync(
+      join(shallowSkillDir, 'SKILL.md'),
+      `---
+name: top-level-skill
+description: Top level skill
+---
+# Top Level Skill
+`
+    );
+
+    writeFileSync(
+      join(deepSkillDir, 'SKILL.md'),
+      `---
+name: aws-transform
+description: AWS Transform skill
+---
+# AWS Transform
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(
+      ['add', testDir, '--skill', 'aws-transform', '-y', '--agent', 'claude-code'],
+      targetDir
+    );
+
+    expect(result.stdout).toContain('Selected 1 skill: aws-transform');
+    expect(result.stdout).toContain('Done!');
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(targetDir, '.claude', 'skills', 'aws-transform', 'SKILL.md'))).toBe(
+      true
+    );
+  });
+
   it('should show error for invalid agent name', () => {
     // Create a test skill
     const skillDir = join(testDir, 'test-skill');

--- a/src/add.ts
+++ b/src/add.ts
@@ -1016,6 +1016,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Include internal skills when a specific skill is explicitly requested
     // (via --skill or @skill syntax)
     const includeInternal = !!(options.skill && options.skill.length > 0);
+    const hasSpecificSkillFilter = !!options.skill?.some((skill) => skill !== '*');
+    const discoveryFullDepth = options.fullDepth || hasSpecificSkillFilter;
 
     let skills: Skill[];
     let blobResult: BlobInstallResult | null = null;
@@ -1033,9 +1035,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       spinner.start('Discovering skills...');
       skills = await discoverSkills(parsed.localPath!, parsed.subpath, {
         includeInternal,
-        fullDepth: options.fullDepth,
+        fullDepth: discoveryFullDepth,
       });
-    } else if (parsed.type === 'github' && !options.fullDepth) {
+    } else if (parsed.type === 'github' && !discoveryFullDepth) {
       // Try blob-based fast install for GitHub sources
       // Only enabled for allowlisted orgs; skip for --full-depth
       const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com'];
@@ -1067,7 +1069,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         spinner.start('Discovering skills...');
         skills = await discoverSkills(tempDir, parsed.subpath, {
           includeInternal,
-          fullDepth: options.fullDepth,
+          fullDepth: discoveryFullDepth,
         });
       }
     } else {
@@ -1079,7 +1081,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       spinner.start('Discovering skills...');
       skills = await discoverSkills(tempDir, parsed.subpath, {
         includeInternal,
-        fullDepth: options.fullDepth,
+        fullDepth: discoveryFullDepth,
       });
     }
 


### PR DESCRIPTION
## Summary
- search full depth when `skills add` has an explicit `--skill` filter
- skip the GitHub blob fast path for those named installs so nested skills are available from the cloned tree
- add a regression test for an AWS-style deeply nested `aws-transform` skill alongside a shallow skill

Fixes #1148.

## Verification
- pnpm install
- pnpm format
- pnpm format:check
- pnpm exec vitest run src/add.test.ts -t "should discover deeper nested skills" --testTimeout=15000
- pnpm exec vitest run src/add.test.ts --testTimeout=15000
- pnpm build

## Blocked / known failing checks
- `pnpm type-check` currently fails on unrelated upstream type errors in `src/git.ts` and `src/skills.ts`.