### PR TITLE
fix(installer): create explicitly selected agent dirs

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1503,6 +1503,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     spinner.start('Installing skills...');
 
+    const createMissingAgentDirs = Boolean(options.agent?.length) || !options.yes;
+
     const results: {
       skill: string;
       agent: string;
@@ -1524,13 +1526,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode }
+            { global: installGlobally, mode: installMode, createMissingAgentDirs }
           );
         } else {
           // Disk-based install: copy from cloned/local directory
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
+            createMissingAgentDirs,
           });
         }
         results.push({

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -227,7 +227,12 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    createMissingAgentDirs?: boolean;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -309,7 +314,7 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    if (!isGlobal && !isUniversalAgent(agentType) && !options.createMissingAgentDirs) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir)) {
         return {
@@ -738,7 +743,12 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    createMissingAgentDirs?: boolean;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -814,7 +824,7 @@ export async function installBlobSkillForAgent(
 
     // For project-level installs, skip creating symlinks for non-universal agents
     // whose config directory doesn't already exist in the project.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    if (!isGlobal && !isUniversalAgent(agentType) && !options.createMissingAgentDirs) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir)) {
         return {

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installSkillForAgent } from '../src/installer.ts';
+import { installBlobSkillForAgent, installSkillForAgent } from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
   const dir = join(root, 'source-skill');
@@ -142,6 +142,102 @@ describe('installer symlink regression', () => {
           expect(entryStats.isDirectory()).toBe(true);
         }
       }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips missing project agent dirs unless explicitly requested', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'junie-skip-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'junie',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+
+      await expect(lstat(join(projectDir, '.junie'))).rejects.toThrow();
+      await expect(lstat(join(projectDir, '.agents/skills', skillName))).resolves.toBeDefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates a missing project agent dir when the agent was explicitly selected', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'junie-explicit-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'junie',
+        {
+          cwd: projectDir,
+          mode: 'symlink',
+          global: false,
+          createMissingAgentDirs: true,
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+
+      const junieSkillDir = join(projectDir, '.junie/skills', skillName);
+      const stats = await lstat(junieSkillDir);
+      expect(stats.isSymbolicLink()).toBe(true);
+      await expect(readFile(join(junieSkillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates missing project agent dirs for explicitly selected blob installs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'junie-blob-skill';
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            {
+              path: 'SKILL.md',
+              contents: `---\nname: ${skillName}\ndescription: test\n---\n`,
+            },
+          ],
+        },
+        'junie',
+        {
+          cwd: projectDir,
+          mode: 'symlink',
+          global: false,
+          createMissingAgentDirs: true,
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      await expect(
+        readFile(join(projectDir, '.junie/skills', skillName, 'SKILL.md'), 'utf-8')
+      ).resolves.toContain(`name: ${skillName}`);
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Preserve the existing safety behavior that skips creating missing project agent directories during automatic installs.
- Create missing non-universal agent directories when the agent was explicitly selected, including blob-based installs used by allowlisted sources.
- Add regression coverage for Junie-style project symlink installs and blob installs.

Fixes #1107.

## Verification
- pnpm vitest run tests/installer-symlink.test.ts
- pnpm format:check
- git diff --check

## Notes
- pnpm type-check currently fails on unrelated upstream errors in src/git.ts and src/skills.ts before this patch.