### PR TITLE
feat: customizable cli output via environment variables

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { track, flushTelemetry } from './telemetry.ts';
 import { isRunningInAgent } from './detect-agent.ts';
+import { envConfig, installCmd, findCmd } from './env-config.ts';
 import { agents, isUniversalAgent } from './agents.ts';
 import type { AgentType } from './types.ts';
 import { fetchSkillFolderHash, getGitHubToken } from './skill-lock.ts';
@@ -66,47 +67,58 @@ const GRAYS = [
 ];
 
 function showLogo(): void {
+  const customLines = envConfig.logoLines;
   console.log();
-  LOGO_LINES.forEach((line, i) => {
-    console.log(`${GRAYS[i]}${line}${RESET}`);
-  });
+  if (customLines) {
+    // Custom lines may contain pre-colored ANSI codes — print as-is
+    customLines.forEach((line) => console.log(line));
+  } else {
+    LOGO_LINES.forEach((line, i) => {
+      const color = GRAYS[i % GRAYS.length] ?? GRAYS[GRAYS.length - 1]!;
+      console.log(`${color}${line}${RESET}`);
+    });
+  }
 }
 
 function showBanner(): void {
+  const cli = envConfig.cliName;
+  const cmd = installCmd();
+  const find = findCmd();
+  const url = envConfig.apiBase;
   showLogo();
   console.log();
   console.log(`${DIM}The open agent skills ecosystem${RESET}`);
   console.log();
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills add ${DIM}<package>${RESET}        ${DIM}Add a new skill${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${cmd} ${DIM}<package>${RESET}        ${DIM}Add a new skill${RESET}`
   );
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills remove${RESET}               ${DIM}Remove installed skills${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${cli} remove${RESET}               ${DIM}Remove installed skills${RESET}`
   );
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills list${RESET}                 ${DIM}List installed skills${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${cli} list${RESET}                 ${DIM}List installed skills${RESET}`
   );
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills find ${DIM}[query]${RESET}         ${DIM}Search for skills${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${find} ${DIM}[query]${RESET}         ${DIM}Search for skills${RESET}`
   );
   console.log();
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills update${RESET}               ${DIM}Update installed skills${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${cli} update${RESET}               ${DIM}Update installed skills${RESET}`
   );
   console.log();
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills experimental_install${RESET} ${DIM}Restore from skills-lock.json${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${cli} experimental_install${RESET} ${DIM}Restore from skills-lock.json${RESET}`
   );
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills init ${DIM}[name]${RESET}          ${DIM}Create a new skill${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${cli} init ${DIM}[name]${RESET}          ${DIM}Create a new skill${RESET}`
   );
   console.log(
-    `  ${DIM}$${RESET} ${TEXT}npx skills experimental_sync${RESET}    ${DIM}Sync skills from node_modules${RESET}`
+    `  ${DIM}$${RESET} ${TEXT}${cli} experimental_sync${RESET}    ${DIM}Sync skills from node_modules${RESET}`
   );
   console.log();
-  console.log(`${DIM}try:${RESET} npx skills add vercel-labs/agent-skills`);
+  console.log(`${DIM}try:${RESET} ${cmd} vercel-labs/agent-skills`);
   console.log();
-  console.log(`Discover more skills at ${TEXT}https://skills.sh/${RESET}`);
+  console.log(`Discover more skills at ${TEXT}${url}/${RESET}`);
   console.log();
 }
 

--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -1,0 +1,48 @@
+/**
+ * Enterprise customization via environment variables:
+ *
+ * SKILLS_API_URL       — base URL for all skills.sh API calls AND display links
+ *                        (default: "https://skills.sh"). Setting this to a custom
+ *                        host points both the search API and rendered output URLs
+ *                        at that host, so a self-hosted registry needs only this
+ *                        one variable.
+ * SKILLS_LOGO          — newline-separated ASCII art replacing the default logo;
+ *                        lines may contain pre-colored ANSI escape codes (colors
+ *                        are passed through as-is rather than wrapped in grays)
+ * SKILLS_CLI_NAME      — CLI executable name shown in usage hints (default: "npx skills")
+ * SKILLS_INSTALL_VERB  — install sub-command name (default: "add")
+ * SKILLS_FIND_VERB     — find/search sub-command name (default: "find")
+ */
+
+export interface EnvConfig {
+  logoLines: string[] | null;
+  cliName: string;
+  installVerb: string;
+  findVerb: string;
+  apiBase: string;
+}
+
+function parseLogoLines(): string[] | null {
+  const raw = process.env.SKILLS_LOGO;
+  if (!raw) return null;
+  const lines = raw.split('\n');
+  return lines.length > 0 ? lines : null;
+}
+
+export const envConfig: EnvConfig = {
+  logoLines: parseLogoLines(),
+  cliName: process.env.SKILLS_CLI_NAME || 'npx skills',
+  installVerb: process.env.SKILLS_INSTALL_VERB || 'add',
+  findVerb: process.env.SKILLS_FIND_VERB || 'find',
+  apiBase: (process.env.SKILLS_API_URL || 'https://skills.sh').replace(/\/$/, ''),
+};
+
+/** Full install command, e.g. "npx skills add" or "playlist-skills install" */
+export function installCmd(): string {
+  return `${envConfig.cliName} ${envConfig.installVerb}`;
+}
+
+/** Full find command, e.g. "npx skills find" or "playlist-skills search" */
+export function findCmd(): string {
+  return `${envConfig.cliName} ${envConfig.findVerb}`;
+}

--- a/src/find.ts
+++ b/src/find.ts
@@ -4,6 +4,7 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
 import { isRepoPrivate } from './source-parser.ts';
 import { isRunningInAgent } from './detect-agent.ts';
+import { envConfig, installCmd, findCmd } from './env-config.ts';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -12,9 +13,6 @@ const TEXT = '\x1b[38;5;145m';
 const CYAN = '\x1b[36m';
 const MAGENTA = '\x1b[35m';
 const YELLOW = '\x1b[33m';
-
-// API endpoint for skills search
-const SEARCH_API_BASE = process.env.SKILLS_API_URL || 'https://skills.sh';
 
 function formatInstalls(count: number): string {
   if (!count || count <= 0) return '';
@@ -33,7 +31,7 @@ export interface SearchSkill {
 // Search via API
 export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
   try {
-    const url = `${SEARCH_API_BASE}/api/search?q=${encodeURIComponent(query)}&limit=10`;
+    const url = `${envConfig.apiBase}/api/search?q=${encodeURIComponent(query)}&limit=10`;
     const res = await fetch(url);
 
     if (!res.ok) return [];
@@ -271,9 +269,11 @@ async function isRepoPublic(owner: string, repo: string): Promise<boolean> {
 export async function runFind(args: string[]): Promise<void> {
   const query = args.join(' ');
   const isNonInteractive = !process.stdin.isTTY;
+  const cmd = installCmd();
+  const find = findCmd();
   const agentTip = `${DIM}Tip: if running in a coding agent, follow these steps:${RESET}
-${DIM}  1) npx skills find [query]${RESET}
-${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
+${DIM}  1) ${find} [query]${RESET}
+${DIM}  2) ${cmd} <owner/repo@skill>${RESET}`;
 
   // Non-interactive mode: just print results and exit
   if (query) {
@@ -291,7 +291,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
       return;
     }
 
-    console.log(`${DIM}Install with${RESET} npx skills add <owner/repo@skill>`);
+    console.log(`${DIM}Install with${RESET} ${cmd} <owner/repo@skill>`);
     console.log();
 
     for (const skill of results.slice(0, 6)) {
@@ -300,7 +300,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
       console.log(
         `${TEXT}${pkg}@${skill.name}${RESET}${installs ? ` ${CYAN}${installs}${RESET}` : ''}`
       );
-      console.log(`${DIM}└ https://skills.sh/${skill.slug}${RESET}`);
+      console.log(`${DIM}└ ${envConfig.apiBase}/${skill.slug}${RESET}`);
       console.log();
     }
     return;
@@ -310,7 +310,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
   if (isNonInteractive || (await isRunningInAgent())) {
     console.log(agentTip);
     console.log();
-    console.log(`${DIM}Usage: npx skills find <query>${RESET}`);
+    console.log(`${DIM}Usage: ${find} <query>${RESET}`);
     return;
   }
 
@@ -347,10 +347,10 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
   const info = getOwnerRepoFromString(pkg);
   if (info && (await isRepoPublic(info.owner, info.repo))) {
     console.log(
-      `${DIM}View the skill at${RESET} ${TEXT}https://skills.sh/${selected.slug}${RESET}`
+      `${DIM}View the skill at${RESET} ${TEXT}${envConfig.apiBase}/${selected.slug}${RESET}`
     );
   } else {
-    console.log(`${DIM}Discover more skills at${RESET} ${TEXT}https://skills.sh${RESET}`);
+    console.log(`${DIM}Discover more skills at${RESET} ${TEXT}${envConfig.apiBase}${RESET}`);
   }
 
   console.log();


### PR DESCRIPTION
This pull request introduces enterprise customization for the CLI by allowing key branding and API endpoint values to be overridden via environment variables. It centralizes all configurable values (such as logo, CLI name, subcommands, and API base URL) into a new `env-config.ts` module, and updates both the CLI and skill search flows to use these values throughout their output and API calls.

The most important changes are:

**Enterprise customization and configuration:**
* Added a new `src/env-config.ts` module that reads environment variables for logo, CLI name, install/find subcommands, and API base URL, exposing them via the `envConfig` object and helper functions (`installCmd`, `findCmd`). This enables easy enterprise branding and API endpoint customization.

**CLI output and branding:**
* Updated `src/cli.ts` to use values from `envConfig` for logo rendering, CLI name, subcommands, and API links in all banner/help output, allowing dynamic branding and instructions. [[1]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR18) [[2]](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddR70-R121)

**Skill search and API usage:**
* Updated `src/find.ts` to use `envConfig` for API base URL, CLI name, and subcommands in all user-facing output, including API calls, usage tips, and skill links, ensuring consistency and support for custom endpoints. [[1]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cR7) [[2]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cL16-L18) [[3]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cL36-R34) [[4]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cR272-R276) [[5]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cL294-R294) [[6]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cL303-R303) [[7]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cL313-R313) [[8]](diffhunk://#diff-ed7f527377f37f0069f97ed3bc85e387498c75396cf8ad04dd83bc651a65413cL350-R353)

---

Related to #348 and #686 