### PR TITLE
Add Autohand Code CLI agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "aider-desk",
     "amp",
     "antigravity",
+    "autohand-code",
     "augment",
     "bob",
     "claude-code",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -10,6 +10,7 @@ const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
+const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 
 export function getOpenClawGlobalSkillsDir(
   homeDir = home,
@@ -53,6 +54,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.gemini/antigravity/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.gemini/antigravity'));
+    },
+  },
+  'autohand-code': {
+    name: 'autohand-code',
+    displayName: 'Autohand Code CLI',
+    skillsDir: '.autohand/skills',
+    globalSkillsDir: join(autohandHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(autohandHome);
     },
   },
   augment: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type AgentType =
   | 'aider-desk'
   | 'amp'
   | 'antigravity'
+  | 'autohand-code'
   | 'augment'
   | 'bob'
   | 'claude-code'

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -80,6 +80,11 @@ describe('XDG config paths', () => {
   });
 
   describe('non-XDG agents', () => {
+    it('autohand code uses ~/.autohand/skills (home-based, not XDG)', () => {
+      const expected = join(home, '.autohand', 'skills');
+      expect(agents['autohand-code'].globalSkillsDir).toBe(expected);
+    });
+
     it('cursor uses ~/.cursor/skills (home-based, not XDG)', () => {
       const expected = join(home, '.cursor', 'skills');
       expect(agents.cursor.globalSkillsDir).toBe(expected);


### PR DESCRIPTION
## Summary

Adds Autohand Code CLI as a supported skills target.

This wires Autohand into the same agent registry used by the interactive installer, including:

- `autohand-code` as a valid `AgentType`
- `Autohand Code CLI` in the agent picker
- project installs under `.autohand/skills`
- global installs under `AUTOHAND_HOME/skills`, falling back to `~/.autohand/skills`
- a focused path test covering the global install location

The intent is to let Autohand users install skills from the shared ecosystem without needing to select a generic or unrelated target.

## Validation

- `pnpm format:check`
- `pnpm exec vitest tests/xdg-config-paths.test.ts`
- `env -u CODEX_CI -u CODEX_SHELL -u CODEX_INTERNAL_ORIGINATOR_OVERRIDE -u CODEX_THREAD_ID pnpm test`
- `pnpm build`

Note: `pnpm type-check` currently fails on existing issues in `src/git.ts` and `src/skills.ts` that are unrelated to this registry addition.
