### PR TITLE
feat: add `--skills-dir <path>` flag for custom install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npx skills add ./my-local-skills
 | `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
 | `-l, --list`              | List available skills without installing                                                                                                           |
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
+| `--skills-dir <path>`     | Install directly to `<path>/<skill-name>/` (custom location). See [Custom install directory](#custom-install-directory).                           |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
 
@@ -93,6 +94,31 @@ When installing interactively, you can choose:
 | ------------------------- | ------------------------------------------------------------------------------------------- |
 | **Symlink** (Recommended) | Creates symlinks from each agent to a canonical copy. Single source of truth, easy updates. |
 | **Copy**                  | Creates independent copies for each agent. Use when symlinks aren't supported.              |
+
+### Custom install directory
+
+The `--skills-dir <path>` flag installs skills directly into a directory you choose, bypassing
+the canonical `.agents/skills/` tree and any agent-specific symlink/copy logic. This is intended
+for clients that read skills from their own folder structure and aren't (yet) part of the agent
+registry — e.g. a desktop app that loads skills from `~/my-app/skills/`.
+
+```bash
+# Install a skill pack directly into a custom skills folder
+npx skills add owner/my-skills --skills-dir ~/my-app/skills -y
+
+# Result:
+#   ~/my-app/skills/<skill-name>/SKILL.md
+#   ~/my-app/skills/<skill-name>/...
+```
+
+Notes:
+
+- The path is created if it doesn't exist (`mkdir -p`).
+- `~`, `$HOME`, and relative paths are expanded automatically.
+- Files are always copied (no symlinks), regardless of `--copy`.
+- Mutually exclusive with `--global` (the path **is** the install location).
+- Lock files are skipped, so `skills update` and `skills remove` don't track skills installed
+  this way. Re-run `skills add ... --skills-dir ...` to update.
 
 ## Other Commands
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -2,13 +2,37 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { sep, join, dirname } from 'path';
+import { sep, join, dirname, resolve, isAbsolute } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
 // Helper to check if a value is a cancel symbol (works with both clack and our custom prompts)
 const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
+
+/**
+ * Expands a user-supplied path argument:
+ *   - leading `~`              → user's home directory
+ *   - leading `$HOME` / `${HOME}` → user's home directory
+ *   - relative paths           → resolved against process.cwd()
+ *
+ * Returns an absolute, resolved path. Used to support friendly inputs like
+ * `~/my-skills` for the `--skills-dir` flag.
+ */
+export function expandPath(input: string): string {
+  if (!input) return input;
+  let p = input;
+
+  // ~ or ~/foo  →  $HOME or $HOME/foo
+  if (p === '~' || p.startsWith('~/') || p.startsWith('~\\')) {
+    p = homedir() + p.slice(1);
+  }
+
+  // $HOME, ${HOME}, $HOME/foo, ${HOME}/foo
+  p = p.replace(/^\$\{?HOME\}?(?=$|[/\\])/, homedir());
+
+  return isAbsolute(p) ? resolve(p) : resolve(process.cwd(), p);
+}
 
 /**
  * Check if a source identifier (owner/repo format) represents a private GitHub repo.
@@ -30,6 +54,7 @@ import {
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
+  sanitizeName,
   type InstallMode,
 } from './installer.ts';
 import {
@@ -429,6 +454,15 @@ export interface AddOptions {
   fullDepth?: boolean;
   copy?: boolean;
   dangerouslyAcceptOpenclawRisks?: boolean;
+  /**
+   * Custom installation directory. When set, skills are copied directly into
+   * `<skillsDir>/<skill-name>/`, bypassing the canonical `.agents/skills` dir
+   * and any agent-specific symlink/copy logic. Mutually exclusive with `--global`.
+   *
+   * Used by clients that read skills from their own folder structure and don't
+   * want to be added to the agent registry.
+   */
+  skillsDir?: string;
 }
 
 /**
@@ -540,7 +574,12 @@ async function handleWellKnownSkills(
   let targetAgents: AgentType[];
   const validAgents = Object.keys(agents);
 
-  if (options.agent?.includes('*')) {
+  if (options.skillsDir) {
+    // Custom skillsDir install: agent is a label only — the install path is
+    // fully determined by skillsDir.
+    targetAgents = ['universal' as AgentType];
+    p.log.info(`Installing to: ${pc.cyan(options.skillsDir)}`);
+  } else if (options.agent?.includes('*')) {
     // --agent '*' selects all agents
     targetAgents = validAgents as AgentType[];
     p.log.info(`Installing to all ${targetAgents.length} agents`);
@@ -613,7 +652,7 @@ async function handleWellKnownSkills(
   // Check if any selected agents support global installation
   const supportsGlobal = targetAgents.some((a) => agents[a].globalSkillsDir !== undefined);
 
-  if (options.global === undefined && !options.yes && supportsGlobal) {
+  if (options.global === undefined && !options.yes && supportsGlobal && !options.skillsDir) {
     const scope = await p.select({
       message: 'Installation scope',
       options: [
@@ -696,10 +735,14 @@ async function handleWellKnownSkills(
   for (const skill of selectedSkills) {
     if (summaryLines.length > 0) summaryLines.push('');
 
-    const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
-    const shortCanonical = shortenPath(canonicalPath, cwd);
-    summaryLines.push(`${pc.cyan(shortCanonical)}`);
-    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+    const displayPath = options.skillsDir
+      ? join(options.skillsDir, sanitizeName(skill.installName))
+      : getCanonicalPath(skill.installName, { global: installGlobally });
+    const shortDisplay = shortenPath(displayPath, cwd);
+    summaryLines.push(`${pc.cyan(shortDisplay)}`);
+    if (!options.skillsDir) {
+      summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+    }
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
     }
@@ -709,7 +752,7 @@ async function handleWellKnownSkills(
       .filter((a) => skillOverwrites?.get(a))
       .map((a) => agents[a].displayName);
 
-    if (overwriteAgents.length > 0) {
+    if (overwriteAgents.length > 0 && !options.skillsDir) {
       summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
     }
   }
@@ -748,6 +791,7 @@ async function handleWellKnownSkills(
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
+        skillsDir: options.skillsDir,
       });
       results.push({
         skill: skill.installName,
@@ -802,8 +846,9 @@ async function handleWellKnownSkills(
     }
   }
 
-  // Add to local lock file for project-scoped installs
-  if (successful.length > 0 && !installGlobally) {
+  // Add to local lock file for project-scoped installs.
+  // Skip when --skills-dir is set (custom path is outside the lock-file scope).
+  if (successful.length > 0 && !installGlobally && !options.skillsDir) {
     const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
       if (successfulSkillNames.has(skill.installName)) {
@@ -920,6 +965,45 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     console.log(`    ${pc.cyan('npx skills add')} ${pc.yellow('vercel-labs/agent-skills')}`);
     console.log();
     process.exit(1);
+  }
+
+  // --skills-dir validation:
+  //   - parseAddOptions sets it to '' when the user passed `--skills-dir`
+  //     without an argument (sentinel).
+  //   - it's mutually exclusive with --global (the path IS the global path).
+  if (options.skillsDir !== undefined) {
+    if (options.skillsDir === '') {
+      console.log();
+      console.log(
+        pc.bgRed(pc.white(pc.bold(' ERROR '))) +
+          ' ' +
+          pc.red('--skills-dir requires a path argument')
+      );
+      console.log();
+      console.log(pc.dim('  Example:'));
+      console.log(
+        `    ${pc.cyan('npx skills add')} ${pc.yellow('owner/repo')} ${pc.cyan('--skills-dir')} ${pc.yellow('~/my-skills')}`
+      );
+      console.log();
+      process.exit(1);
+    }
+    if (options.global) {
+      console.log();
+      console.log(
+        pc.bgRed(pc.white(pc.bold(' ERROR '))) +
+          ' ' +
+          pc.red('--skills-dir cannot be combined with --global')
+      );
+      console.log(
+        pc.dim('  --skills-dir already specifies an absolute install path; --global is redundant.')
+      );
+      console.log();
+      process.exit(1);
+    }
+    // Resolve to absolute path early so downstream code is unambiguous.
+    options.skillsDir = expandPath(options.skillsDir);
+    // Custom skillsDir always copies (no symlink dance).
+    options.copy = true;
   }
 
   // --all implies --skill '*' and --agent '*' and -y
@@ -1252,7 +1336,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     let targetAgents: AgentType[];
     const validAgents = Object.keys(agents);
 
-    if (options.agent?.includes('*')) {
+    if (options.skillsDir) {
+      // Custom skillsDir install: agent is a label only — the install path is
+      // fully determined by skillsDir. Use a single placeholder agent to drive
+      // the install loop; the installer ignores agentType when skillsDir is set.
+      targetAgents = ['universal' as AgentType];
+      p.log.info(`Installing to: ${pc.cyan(options.skillsDir)}`);
+    } else if (options.agent?.includes('*')) {
       // --agent '*' selects all agents
       targetAgents = validAgents as AgentType[];
       p.log.info(`Installing to all ${targetAgents.length} agents`);
@@ -1328,7 +1418,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Check if any selected agents support global installation
     const supportsGlobal = targetAgents.some((a) => agents[a].globalSkillsDir !== undefined);
 
-    if (options.global === undefined && !options.yes && supportsGlobal) {
+    // Skip the project/global scope prompt when --skills-dir is set (the path
+    // IS the install destination — global vs project doesn't apply).
+    if (options.global === undefined && !options.yes && supportsGlobal && !options.skillsDir) {
       const scope = await p.select({
         message: 'Installation scope',
         options: [
@@ -1429,17 +1521,23 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       for (const skill of skills) {
         if (summaryLines.length > 0) summaryLines.push('');
 
-        const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally });
-        const shortCanonical = shortenPath(canonicalPath, cwd);
-        summaryLines.push(`${pc.cyan(shortCanonical)}`);
-        summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+        // For --skills-dir installs, show the actual destination
+        // (<skillsDir>/<skill-name>) instead of the canonical .agents/skills path.
+        const displayPath = options.skillsDir
+          ? join(options.skillsDir, sanitizeName(skill.name))
+          : getCanonicalPath(skill.name, { global: installGlobally });
+        const shortDisplay = shortenPath(displayPath, cwd);
+        summaryLines.push(`${pc.cyan(shortDisplay)}`);
+        if (!options.skillsDir) {
+          summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+        }
 
         const skillOverwrites = overwriteStatus.get(skill.name);
         const overwriteAgents = targetAgents
           .filter((a) => skillOverwrites?.get(a))
           .map((a) => agents[a].displayName);
 
-        if (overwriteAgents.length > 0) {
+        if (overwriteAgents.length > 0 && !options.skillsDir) {
           summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
         }
       }
@@ -1524,13 +1622,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode }
+            { global: installGlobally, mode: installMode, skillsDir: options.skillsDir }
           );
         } else {
           // Disk-based install: copy from cloned/local directory
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
+            skillsDir: options.skillsDir,
           });
         }
         results.push({
@@ -1658,8 +1757,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Add to local lock file for project-scoped installs
-    if (successful.length > 0 && !installGlobally) {
+    // Add to local lock file for project-scoped installs.
+    // Skip when --skills-dir is set: the skill lives outside any
+    // project/global scope tracked by the lock files. Treat it like a
+    // one-off install — `skills update` won't see it (documented in README).
+    if (successful.length > 0 && !installGlobally && !options.skillsDir) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
@@ -1940,6 +2042,18 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--skills-dir') {
+      // --skills-dir <path>  (consumes next arg)
+      const next = args[i + 1];
+      if (!next || next.startsWith('-')) {
+        // Defer the user-facing error to runAdd so we can use the same
+        // error formatting as other validation failures. Mark it with a
+        // sentinel that runAdd checks for.
+        options.skillsDir = '';
+      } else {
+        options.skillsDir = next;
+        i++;
+      }
     } else if (arg === '--dangerously-accept-openclaw-risks') {
       options.dangerouslyAcceptOpenclawRisks = true;
     } else if (arg && !arg.startsWith('-')) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,6 +142,9 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
+  --skills-dir <path>    Install directly into <path>/<skill-name>/ (custom location).
+                         Skips agent registry; useful for clients with their own
+                         skills folder. Mutually exclusive with --global.
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 
@@ -170,6 +173,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills add vercel-labs/agent-skills -g
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --agent claude-code cursor
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --skill pr-review commit
+  ${DIM}$${RESET} skills add owner/repo --skills-dir ~/my-skills -y  ${DIM}# install to a custom dir${RESET}
   ${DIM}$${RESET} skills remove                        ${DIM}# interactive remove${RESET}
   ${DIM}$${RESET} skills remove web-design             ${DIM}# remove by name${RESET}
   ${DIM}$${RESET} skills rm --global frontend-design

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -68,6 +68,26 @@ function isPathSafe(basePath: string, targetPath: string): boolean {
   return normalizedTarget.startsWith(normalizedBase + sep) || normalizedTarget === normalizedBase;
 }
 
+/**
+ * Compute the install directory for a custom `skillsDir` install.
+ *
+ * Returns `<skillsDir>/<sanitized skill name>`, after validating that the
+ * resulting path stays inside `skillsDir` (defends against path-traversal
+ * via crafted skill names like `../etc`).
+ *
+ * The caller is responsible for resolving / expanding the input `skillsDir`
+ * before passing it in (see `expandPath` in add.ts).
+ */
+export function getCustomSkillDir(skillsDir: string, rawSkillName: string): string {
+  const skillName = sanitizeName(rawSkillName);
+  const base = resolve(skillsDir);
+  const target = join(base, skillName);
+  if (!isPathSafe(base, target)) {
+    throw new Error('Invalid skill name: potential path traversal detected');
+  }
+  return target;
+}
+
 // Dirent.isDirectory() is false for symlinks; follow and verify the target is a directory.
 async function isDirEntryOrSymlinkToDir(
   entry: { isDirectory(): boolean; isSymbolicLink(): boolean },
@@ -227,11 +247,42 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; skillsDir?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
+
+  // Custom skillsDir: install directly to <skillsDir>/<skill-name>, skipping
+  // the canonical .agents/skills dir and any agent-specific symlinks.
+  // Always copies (no symlinks). Used by the `--skills-dir` CLI flag.
+  if (options.skillsDir) {
+    const rawSkillName = skill.name || basename(skill.path);
+    let targetDir: string;
+    try {
+      targetDir = getCustomSkillDir(options.skillsDir, rawSkillName);
+    } catch (err) {
+      return {
+        success: false,
+        path: '',
+        mode: 'copy',
+        error: err instanceof Error ? err.message : 'Invalid skill name',
+      };
+    }
+    try {
+      await mkdir(resolve(options.skillsDir), { recursive: true });
+      await cleanAndCreateDirectory(targetDir);
+      await copyDirectory(skill.path, targetDir);
+      return { success: true, path: targetDir, mode: 'copy' };
+    } catch (error) {
+      return {
+        success: false,
+        path: targetDir,
+        mode: 'copy',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -484,12 +535,41 @@ export function getCanonicalPath(
 export async function installRemoteSkillForAgent(
   skill: RemoteSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; skillsDir?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+
+  // Custom skillsDir: install directly to <skillsDir>/<skill-name>, skipping
+  // the canonical .agents/skills dir and any agent-specific symlinks.
+  if (options.skillsDir) {
+    let targetDir: string;
+    try {
+      targetDir = getCustomSkillDir(options.skillsDir, skill.installName);
+    } catch (err) {
+      return {
+        success: false,
+        path: '',
+        mode: 'copy',
+        error: err instanceof Error ? err.message : 'Invalid skill name',
+      };
+    }
+    try {
+      await mkdir(resolve(options.skillsDir), { recursive: true });
+      await cleanAndCreateDirectory(targetDir);
+      await writeFile(join(targetDir, 'SKILL.md'), skill.content, 'utf-8');
+      return { success: true, path: targetDir, mode: 'copy' };
+    } catch (error) {
+      return {
+        success: false,
+        path: targetDir,
+        mode: 'copy',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -603,12 +683,49 @@ export async function installRemoteSkillForAgent(
 export async function installWellKnownSkillForAgent(
   skill: WellKnownSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; skillsDir?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+
+  // Custom skillsDir: install directly to <skillsDir>/<skill-name>, skipping
+  // the canonical .agents/skills dir and any agent-specific symlinks.
+  if (options.skillsDir) {
+    let targetDir: string;
+    try {
+      targetDir = getCustomSkillDir(options.skillsDir, skill.installName);
+    } catch (err) {
+      return {
+        success: false,
+        path: '',
+        mode: 'copy',
+        error: err instanceof Error ? err.message : 'Invalid skill name',
+      };
+    }
+    try {
+      await mkdir(resolve(options.skillsDir), { recursive: true });
+      await cleanAndCreateDirectory(targetDir);
+      for (const [filePath, content] of skill.files) {
+        const fullPath = join(targetDir, filePath);
+        if (!isPathSafe(targetDir, fullPath)) continue;
+        const parentDir = dirname(fullPath);
+        if (parentDir !== targetDir) {
+          await mkdir(parentDir, { recursive: true });
+        }
+        await writeFile(fullPath, content);
+      }
+      return { success: true, path: targetDir, mode: 'copy' };
+    } catch (error) {
+      return {
+        success: false,
+        path: targetDir,
+        mode: 'copy',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -738,12 +855,49 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; skillsDir?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+
+  // Custom skillsDir: install directly to <skillsDir>/<skill-name>, skipping
+  // the canonical .agents/skills dir and any agent-specific symlinks.
+  if (options.skillsDir) {
+    let targetDir: string;
+    try {
+      targetDir = getCustomSkillDir(options.skillsDir, skill.installName);
+    } catch (err) {
+      return {
+        success: false,
+        path: '',
+        mode: 'copy',
+        error: err instanceof Error ? err.message : 'Invalid skill name',
+      };
+    }
+    try {
+      await mkdir(resolve(options.skillsDir), { recursive: true });
+      await cleanAndCreateDirectory(targetDir);
+      for (const file of skill.files) {
+        const fullPath = join(targetDir, file.path);
+        if (!isPathSafe(targetDir, fullPath)) continue;
+        const parentDir = dirname(fullPath);
+        if (parentDir !== targetDir) {
+          await mkdir(parentDir, { recursive: true });
+        }
+        await writeFile(fullPath, file.contents, 'utf-8');
+      }
+      return { success: true, path: targetDir, mode: 'copy' };
+    } catch (error) {
+      return {
+        success: false,
+        path: targetDir,
+        mode: 'copy',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
 
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {

--- a/tests/skills-dir-flag.test.ts
+++ b/tests/skills-dir-flag.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for the `--skills-dir <path>` flag.
+ *
+ * The flag tells `skills add` to install directly to a caller-supplied directory
+ * (e.g. ~/my-app/skills) instead of routing through the canonical
+ * .agents/skills + agent-symlink scheme. Mutually exclusive with --global;
+ * forces copy-mode internally.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { expandPath, parseAddOptions } from '../src/add.ts';
+import { installSkillForAgent } from '../src/installer.ts';
+import { runCli } from '../src/test-utils.ts';
+
+async function makeSkillSource(root: string, name: string): Promise<string> {
+  const dir = join(root, 'source-skill');
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: test\n---\n`, 'utf-8');
+  return dir;
+}
+
+describe('--skills-dir flag', () => {
+  describe('parseAddOptions', () => {
+    it('recognizes --skills-dir <path> and stores it on options', () => {
+      const { source, options } = parseAddOptions([
+        'owner/repo',
+        '--skills-dir',
+        '/tmp/my-skills',
+        '-y',
+      ]);
+      expect(source).toEqual(['owner/repo']);
+      expect(options.skillsDir).toBe('/tmp/my-skills');
+      expect(options.yes).toBe(true);
+    });
+
+    it('marks --skills-dir as the empty-string sentinel when no argument follows', () => {
+      // parseAddOptions delegates the user-facing error to runAdd; it just
+      // marks the flag as present-but-empty.
+      const { options } = parseAddOptions(['owner/repo', '--skills-dir']);
+      expect(options.skillsDir).toBe('');
+    });
+
+    it('treats next-arg-as-flag (-y) as missing argument for --skills-dir', () => {
+      const { options } = parseAddOptions(['owner/repo', '--skills-dir', '-y']);
+      expect(options.skillsDir).toBe('');
+      // -y should still be parsed normally because we did not consume it.
+      expect(options.yes).toBe(true);
+    });
+
+    it('keeps source positional and other flags intact alongside --skills-dir', () => {
+      const { source, options } = parseAddOptions([
+        '--skills-dir',
+        '~/foo',
+        'owner/repo',
+        '--skill',
+        'one',
+        'two',
+      ]);
+      expect(source).toEqual(['owner/repo']);
+      expect(options.skillsDir).toBe('~/foo');
+      expect(options.skill).toEqual(['one', 'two']);
+    });
+  });
+
+  describe('expandPath', () => {
+    it('expands a leading ~ to the user home directory', () => {
+      expect(expandPath('~/foo/bar')).toBe(join(homedir(), 'foo', 'bar'));
+      expect(expandPath('~')).toBe(homedir());
+    });
+
+    it('expands a leading $HOME / ${HOME} token', () => {
+      expect(expandPath('$HOME/foo')).toBe(join(homedir(), 'foo'));
+      expect(expandPath('${HOME}/foo')).toBe(join(homedir(), 'foo'));
+      expect(expandPath('$HOME')).toBe(homedir());
+    });
+
+    it('resolves relative paths against process.cwd()', () => {
+      const result = expandPath('./somewhere');
+      expect(result.startsWith('/')).toBe(true);
+      expect(result.endsWith('somewhere')).toBe(true);
+    });
+
+    it('returns absolute paths unchanged (after normalization)', () => {
+      expect(expandPath('/tmp/already-absolute')).toBe('/tmp/already-absolute');
+    });
+
+    it('does not mangle a path that merely contains ~ in the middle', () => {
+      // We only expand a leading ~, not embedded ones.
+      expect(expandPath('/tmp/ab~cd')).toBe('/tmp/ab~cd');
+    });
+  });
+
+  describe('installSkillForAgent (skillsDir option)', () => {
+    it('writes to <skillsDir>/<skill-name> and skips canonical .agents/skills', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'skills-dir-flag-'));
+      const projectDir = join(root, 'project');
+      const customDir = join(root, 'custom-skills');
+      await mkdir(projectDir, { recursive: true });
+
+      const skillName = 'my-custom-skill';
+      const skillSrc = await makeSkillSource(root, skillName);
+
+      try {
+        const result = await installSkillForAgent(
+          { name: skillName, description: 'test', path: skillSrc },
+          'universal',
+          { cwd: projectDir, skillsDir: customDir }
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.mode).toBe('copy');
+        expect(result.path).toBe(join(customDir, skillName));
+
+        // Verify SKILL.md landed in the custom dir
+        await expect(readFile(join(customDir, skillName, 'SKILL.md'), 'utf-8')).resolves.toContain(
+          skillName
+        );
+
+        // Verify the canonical .agents/skills tree was NOT created
+        await expect(access(join(projectDir, '.agents', 'skills'))).rejects.toThrow();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it('auto-creates the parent skillsDir if it does not exist', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'skills-dir-flag-mkdir-'));
+      // Note: customDir nested 3 levels deep, none of which exist yet.
+      const customDir = join(root, 'a', 'b', 'c');
+
+      const skillName = 'auto-mkdir-skill';
+      const skillSrc = await makeSkillSource(root, skillName);
+
+      try {
+        const result = await installSkillForAgent(
+          { name: skillName, description: 'test', path: skillSrc },
+          'universal',
+          { skillsDir: customDir }
+        );
+
+        expect(result.success).toBe(true);
+        await expect(access(join(customDir, skillName, 'SKILL.md'))).resolves.toBeUndefined();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects skill names that would escape skillsDir (path traversal)', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'skills-dir-flag-traversal-'));
+      const customDir = join(root, 'safe-zone');
+      await mkdir(customDir, { recursive: true });
+
+      const skillSrc = await makeSkillSource(root, 'whatever');
+
+      try {
+        const result = await installSkillForAgent(
+          { name: '../../../../etc/evil', description: 'malicious', path: skillSrc },
+          'universal',
+          { skillsDir: customDir }
+        );
+
+        // sanitizeName strips leading dots/slashes, so this shouldn't actually
+        // escape — but the result must still land inside customDir, never above it.
+        if (result.success) {
+          const resolved = result.path;
+          expect(resolved.startsWith(customDir)).toBe(true);
+        }
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it('overwrites existing skill content when re-installing to the same skillsDir', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'skills-dir-flag-overwrite-'));
+      const customDir = join(root, 'custom-skills');
+      const skillName = 'reinstall-skill';
+      const skillSrc = await makeSkillSource(root, skillName);
+
+      try {
+        // First install
+        await installSkillForAgent(
+          { name: skillName, description: 'v1', path: skillSrc },
+          'universal',
+          { skillsDir: customDir }
+        );
+
+        // Stale file from a previous install that should be wiped out.
+        await writeFile(join(customDir, skillName, 'STALE.txt'), 'old', 'utf-8');
+
+        // Update skill source and reinstall
+        await writeFile(
+          join(skillSrc, 'SKILL.md'),
+          `---\nname: ${skillName}\ndescription: v2\n---\n`,
+          'utf-8'
+        );
+
+        const result = await installSkillForAgent(
+          { name: skillName, description: 'v2', path: skillSrc },
+          'universal',
+          { skillsDir: customDir }
+        );
+
+        expect(result.success).toBe(true);
+        const content = await readFile(join(customDir, skillName, 'SKILL.md'), 'utf-8');
+        expect(content).toContain('description: v2');
+        // Stale file is gone
+        await expect(access(join(customDir, skillName, 'STALE.txt'))).rejects.toThrow();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('CLI integration', () => {
+    it('errors when --skills-dir is given without an argument', () => {
+      const root = tmpdir();
+      const result = runCli(['add', 'owner/repo', '--skills-dir', '-y'], root);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('--skills-dir requires a path argument');
+    });
+
+    it('errors when --skills-dir is combined with --global', () => {
+      const result = runCli(
+        ['add', 'owner/repo', '--skills-dir', '/tmp/x', '--global', '-y'],
+        tmpdir()
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('--skills-dir cannot be combined with --global');
+    });
+
+    it('installs a local skill into a custom dir without prompting for an agent', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'skills-dir-flag-cli-'));
+      const sourceDir = join(root, 'source');
+      const customDir = join(root, 'target');
+      await mkdir(sourceDir, { recursive: true });
+
+      // Create a self-contained local skill source
+      const skillName = 'cli-skill';
+      const skillDir = join(sourceDir, skillName);
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${skillName}\ndescription: test\n---\n`,
+        'utf-8'
+      );
+
+      try {
+        const result = runCli(['add', sourceDir, '--skills-dir', customDir, '-y'], root);
+
+        expect(result.exitCode).toBe(0);
+        await expect(readFile(join(customDir, skillName, 'SKILL.md'), 'utf-8')).resolves.toContain(
+          skillName
+        );
+
+        // Confirm we did NOT also write to the canonical project location
+        // or to any agent-specific dir under cwd.
+        await expect(access(join(root, '.agents', 'skills'))).rejects.toThrow();
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a generic `--skills-dir <path>` flag to `skills add` that installs skills directly into a caller-specified directory, bypassing the canonical `.agents/skills/` tree and any agent-specific symlink/copy logic.

```bash
# Install a skill pack directly into a custom skills folder
npx -y skills add owner/my-skills --skills-dir ~/my-app/skills -y

# Files land in:
#   ~/my-app/skills/<skill-name>/SKILL.md
#   ~/my-app/skills/<skill-name>/...
```

## Why

This isn't about adding one more agent to the registry. It's about giving the `skills` CLI a clean way to serve clients that aren't, and may never be, registered agents — desktop apps, IDE extensions, in-house tools — without forcing every such client to upstream a registry entry just to consume the ecosystem.

Concrete motivating case: an AI desktop app that already loads skills from `~/<app>/skills/`. Today, `npx skills add owner/skill-pack --skills-dir ~/<app>/skills` isn't possible — `skills add` always routes through the canonical `.agents/skills/` + agent-symlink path. Adding every such app to the agent registry feels disproportionate; opening a generic escape hatch is more useful long-term.

The flag is purely additive: existing flows are unchanged when `--skills-dir` isn't passed.

## Behaviour

- `--skills-dir <path>` writes skills directly to `<path>/<sanitized-skill-name>/`.
- `~`, `$HOME`, `${HOME}`, and relative paths are expanded automatically.
- Always copies (no symlinks); `--copy` is implied internally.
- Mutually exclusive with `--global` (clear, friendly error). The path IS the install location.
- The parent directory is auto-created (`mkdir -p`).
- Path traversal is rejected via the existing `sanitizeName` + `isPathSafe` helpers.
- The agent-selection prompt is skipped; the CLI prints `Installing to: <path>` and proceeds.
- Compatible with all source types: GitHub blob fast-path, GitHub clone, GitLab, local, well-known URLs.
- Plays nicely with `--skill <name>`, `--all`, `-y`, etc.

## What's deliberately out of scope

**Lock-file integration.** Skills installed via `--skills-dir` are not written to `.agents/.skill-lock.json` or the local lock file, so `skills update` and `skills remove` won't see them. To update, the user re-runs `skills add ... --skills-dir <path>` (idempotent — overwrites cleanly).

I considered adding a third "custom" scope to the lock format keyed by absolute path, but it'd touch `skill-lock.ts`, `local-lock.ts`, `list.ts`, `update.ts`, and `remove.ts` and ship a lot of surface area for what's essentially a power-user flag. Happy to do that as a follow-up if you'd like — wanted to keep this PR focused first.

The README documents this trade-off.

## Files changed

| File                                | Why                                                                                  |
| ----------------------------------- | ------------------------------------------------------------------------------------ |
| `src/installer.ts`                  | New `getCustomSkillDir()` helper; `skillsDir?` short-circuit in all 4 install funcs |
| `src/add.ts`                        | New `expandPath()` helper; `skillsDir?` on `AddOptions`; parsing in `parseAddOptions`; validation + agent-loop bypass + summary path + lock-file skip in both `runAdd` and `handleWellKnownSkills` |
| `src/cli.ts`                        | `--skills-dir` in `Add Options` block + example in help banner                       |
| `tests/skills-dir-flag.test.ts`     | 16 new test cases (see below)                                                        |
| `README.md`                         | New "Custom install directory" section under "Install a Skill"                       |

## Tests

New file: [`tests/skills-dir-flag.test.ts`](tests/skills-dir-flag.test.ts) — 16 cases:

- `parseAddOptions` recognizes `--skills-dir <path>`, including next-arg-is-flag handling
- `expandPath` covers `~`, `~/foo`, `$HOME`, `${HOME}`, relative paths, and the "embedded ~" non-case
- `installSkillForAgent` with `skillsDir`:
  - writes to `<skillsDir>/<skill-name>/` and **does not** create canonical `.agents/skills`
  - auto-creates a deeply nested parent dir (`mkdir -p`)
  - rejects path-traversal attempts (skill name `../../../etc/evil` stays inside `skillsDir` after sanitization)
  - cleanly overwrites stale files on reinstall
- CLI integration via `runCli`:
  - errors when `--skills-dir` is given without an argument
  - errors when `--skills-dir` is combined with `--global`
  - end-to-end install of a local skill into a custom dir without prompting for an agent

```
✓ tests/skills-dir-flag.test.ts (16 tests) 561ms

Test Files  31 passed (31)
Tests       472 passed (472)
```

Format check: clean. Type-check: clean for the new code (the 3 pre-existing errors in `git.ts`/`skills.ts` on `main` are untouched).

## Reviewer-friendly examples

```bash
# Help text
npx skills add --help    # see new --skills-dir entry under Add Options

# Happy path
npx skills add vercel-labs/agent-skills --skills-dir ~/my-skills --skill frontend-design -y

# Friendly errors
npx skills add owner/repo --skills-dir          # → "--skills-dir requires a path argument"
npx skills add owner/repo --skills-dir /tmp/x --global   # → "--skills-dir cannot be combined with --global"

# Tilde expansion works
npx skills add owner/repo --skills-dir '~/foo' -y    # → /home/<user>/foo/<skill>/
```
