### PR TITLE
feat(agents): add Tuskr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Skills can be installed to any of these agents:
 | Tabnine CLI                           | `tabnine-cli`                            | `.tabnine/agent/skills/` | `~/.tabnine/agent/skills/`      |
 | Trae                                  | `trae`                                   | `.trae/skills/`          | `~/.trae/skills/`               |
 | Trae CN                               | `trae-cn`                                | `.trae/skills/`          | `~/.trae-cn/skills/`            |
+| Tuskr                                 | `tuskr`                                  | `.tuskr/skills/`         | `~/.config/tuskr/skills/`       |
 | Windsurf                              | `windsurf`                               | `.windsurf/skills/`      | `~/.codeium/windsurf/skills/`   |
 | Zencoder                              | `zencoder`                               | `.zencoder/skills/`      | `~/.zencoder/skills/`           |
 | Neovate                               | `neovate`                                | `.neovate/skills/`       | `~/.neovate/skills/`            |
@@ -385,6 +386,7 @@ The CLI searches for skills in these locations within a repository:
 - `.roo/skills/`
 - `.tabnine/agent/skills/`
 - `.trae/skills/`
+- `.tuskr/skills/`
 - `.windsurf/skills/`
 - `.zencoder/skills/`
 - `.neovate/skills/`

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "tabnine-cli",
     "trae",
     "trae-cn",
+    "tuskr",
     "warp",
     "windsurf",
     "zencoder",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -465,6 +465,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.trae-cn'));
     },
   },
+  tuskr: {
+    name: 'tuskr',
+    displayName: 'Tuskr',
+    skillsDir: '.tuskr/skills',
+    globalSkillsDir: join(configHome, 'tuskr/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(configHome, 'tuskr'));
+    },
+  },
   warp: {
     name: 'warp',
     displayName: 'Warp',

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export type AgentType =
   | 'tabnine-cli'
   | 'trae'
   | 'trae-cn'
+  | 'tuskr'
   | 'warp'
   | 'windsurf'
   | 'zencoder'


### PR DESCRIPTION
Add **Tuskr** as a new supported agent platform.

[Tuskr](https://tuskr.app) is a test management platform with a CLI (`tuskr-cli`) that manages projects, test cases, test runs, and JUnit XML imports. This PR enables users to install and manage skills for Tuskr through the skills CLI.

## Changes

- Add `tuskr` to `AgentType` union in `src/types.ts`
- Add tuskr agent config in `src/agents.ts`
  - Project-level skills directory: `.tuskr/skills/`
  - Global skills directory: `~/.config/tuskr/skills/`
  - Detection: checks for `~/.config/tuskr/` (created by `tuskr config set`)
- Update `README.md` agent table and skills directories list
- Add `tuskr` to `package.json` keywords

## Testing

```bash
# Install tuskr-cli
pipx install tuskr-cli

# Configure (creates ~/.config/tuskr/config.json)
tuskr config set --token TOKEN --tenant-id TENANT_ID

# Install a skill targeting tuskr
npx skills add vercel-labs/skills --skill find-skills -a tuskr -g -y

# Verify skill appears in ~/.config/tuskr/skills/
ls ~/.config/tuskr/skills/
```