### PR TITLE
fix: honor explicit -a agent selection when creating symlinks

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -268,6 +268,7 @@ function buildResultLines(
     .filter((r) => !r.symlinkFailed && !r.skipped && !universal.includes(r.agent))
     .map((r) => r.agent);
   const failedSymlinks = results.filter((r) => r.symlinkFailed && !r.skipped).map((r) => r.agent);
+  const skippedAgents = results.filter((r) => r.skipped).map((r) => r.agent);
 
   if (universal.length > 0) {
     lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
@@ -277,6 +278,12 @@ function buildResultLines(
   }
   if (failedSymlinks.length > 0) {
     lines.push(`  ${pc.yellow('copied:')} ${formatList(failedSymlinks)}`);
+  }
+  if (skippedAgents.length > 0) {
+    lines.push(`  ${pc.yellow('skipped:')} ${formatList(skippedAgents)}`);
+    lines.push(
+      `  ${pc.dim('  (config dir not present in project; re-run with -a to install anyway)')}`
+    );
   }
 
   return lines;
@@ -538,6 +545,11 @@ async function handleWellKnownSkills(
 
   // Detect agents
   let targetAgents: AgentType[];
+  // True when the user explicitly chose agents via `-a / --agent`.
+  // This is forwarded to the installer so it skips its "don't auto-create
+  // unused agent directories" guard when the user clearly opted in.
+  const explicitlySelectedAgents =
+    !!options.agent && options.agent.length > 0 && !options.agent.includes('*');
   const validAgents = Object.keys(agents);
 
   if (options.agent?.includes('*')) {
@@ -1250,6 +1262,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       : Promise.resolve(null);
 
     let targetAgents: AgentType[];
+    // True when the user explicitly chose agents via `-a / --agent`.
+    // Forwarded to the installer so it skips its "don't auto-create
+    // unused agent directories" guard when the user clearly opted in.
+    const explicitlySelectedAgents =
+      !!options.agent && options.agent.length > 0 && !options.agent.includes('*');
     const validAgents = Object.keys(agents);
 
     if (options.agent?.includes('*')) {
@@ -1524,13 +1541,18 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode }
+            {
+              global: installGlobally,
+              mode: installMode,
+              explicitlySelected: explicitlySelectedAgents,
+            }
           );
         } else {
           // Disk-based install: copy from cloned/local directory
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
+            explicitlySelected: explicitlySelectedAgents,
           });
         }
         results.push({

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -227,11 +227,17 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    explicitlySelected?: boolean;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
+  const explicitlySelected = options.explicitlySelected ?? false;
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -309,7 +315,13 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    //
+    // Exception: when the user explicitly selected this agent (via -a / --agent),
+    // their intent is unambiguous, so always create the symlink even if the
+    // agent's config directory doesn't yet exist. Without this exception, e.g.
+    // `npx skills add <pkg> -a claude-code` in a fresh project silently fails
+    // to install for Claude Code unless the user pre-creates `.claude/`.
+    if (!isGlobal && !isUniversalAgent(agentType) && !explicitlySelected) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir)) {
         return {
@@ -738,11 +750,17 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    explicitlySelected?: boolean;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
+  const explicitlySelected = options.explicitlySelected ?? false;
   const installMode = options.mode ?? 'symlink';
 
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -814,7 +832,11 @@ export async function installBlobSkillForAgent(
 
     // For project-level installs, skip creating symlinks for non-universal agents
     // whose config directory doesn't already exist in the project.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    //
+    // Exception: when the user explicitly selected this agent (via -a / --agent),
+    // their intent is unambiguous, so always create the symlink. See the matching
+    // comment in installSkillForAgent for the full rationale.
+    if (!isGlobal && !isUniversalAgent(agentType) && !explicitlySelected) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir)) {
         return {

--- a/tests/installer-explicit-agent.test.ts
+++ b/tests/installer-explicit-agent.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the `explicitlySelected` option in installSkillForAgent.
+ *
+ * Without this flag, a project-level install for a non-universal agent (e.g.
+ * claude-code) is silently skipped when its config dir (e.g. `.claude/`) is not
+ * present in the project. When the user passes `-a claude-code` explicitly, the
+ * symlink should be created anyway.
+ *
+ * See https://github.com/vercel-labs/skills/issues/744 and #851.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile, lstat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { installSkillForAgent } from '../src/installer.ts';
+
+async function makeSkillSource(root: string, name: string): Promise<string> {
+  const dir = join(root, 'source-skill');
+  await mkdir(dir, { recursive: true });
+  const skillMd = `---\nname: ${name}\ndescription: test\n---\n`;
+  await writeFile(join(dir, 'SKILL.md'), skillMd, 'utf-8');
+  return dir;
+}
+
+describe('installer explicit-agent selection', () => {
+  it('creates the claude-code symlink when explicitlySelected is true, even without a pre-existing .claude/ dir', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-explicit-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'explicit-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      // Sanity: project starts with no .claude/ directory.
+      expect(existsSync(join(projectDir, '.claude'))).toBe(false);
+
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        {
+          cwd: projectDir,
+          mode: 'symlink',
+          global: false,
+          explicitlySelected: true,
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+
+      // Both directories must now exist.
+      const canonicalPath = join(projectDir, '.agents/skills', skillName);
+      const agentPath = join(projectDir, '.claude/skills', skillName);
+      expect(existsSync(canonicalPath)).toBe(true);
+      expect(existsSync(agentPath)).toBe(true);
+
+      // The agent path must be a symlink.
+      const stats = await lstat(agentPath);
+      expect(stats.isSymbolicLink()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still skips when explicitlySelected is false and the agent dir is absent (preserves existing behavior)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-implicit-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'implicit-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      expect(existsSync(join(projectDir, '.claude'))).toBe(false);
+
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      // Canonical store is populated, but the .claude/skills symlink is skipped.
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+
+      expect(existsSync(join(projectDir, '.agents/skills', skillName))).toBe(true);
+      expect(existsSync(join(projectDir, '.claude/skills', skillName))).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates the symlink when explicitlySelected is false but .claude/ already exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-precreated-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, '.claude'), { recursive: true });
+
+    const skillName = 'precreated-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+
+      const agentPath = join(projectDir, '.claude/skills', skillName);
+      expect(existsSync(agentPath)).toBe(true);
+
+      const stats = await lstat(agentPath);
+      expect(stats.isSymbolicLink()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Project-level installs with an explicit -a flag no longer require the agent's config directory to pre-exist. Fixes #744, related to #851, #537.

# Fix: create agent symlink when user explicitly selects an agent

## Problem

`npx skills add <pkg> -a claude-code` in a fresh project silently skips
creating `.claude/skills/<skill>` unless the user pre-creates the `.claude/`
directory by hand. The skill lands in `.agents/skills/<skill>`, but Claude Code
only reads from `.claude/skills/`, so it's invisible to the agent the user
explicitly asked for.

Reported in:
- #744 — "npx skills add" installs to `~/.agents/skills/` but does not create
  symlinks in `~/.claude/skills/`
- #851 — `npx skills add -a claude-code -g` installs to `~/.agents/skills/`
  without creating `~/.claude/skills/` symlink
- #537 — Global install leaves agent skill dir missing; "Agents: not linked"
  until dir exists

## Root cause

`installer.ts` has a guard (~lines 308–323 and the matching block in
`installBlobSkillForAgent`) that intentionally skips creating an agent-specific
symlink when the agent's config dir (e.g. `.claude/`, `.windsurf/`, `.kiro/`)
doesn't already exist in the project. The goal is to avoid polluting projects
with directories for agents that aren't actually used.

That heuristic is reasonable when agents are auto-detected, but it's wrong when
the user explicitly passes `-a <agent>` — their intent is unambiguous. The
guard fires anyway, the install reports success, but the skill is invisible to
the chosen agent and no warning is printed.

## Fix

Add an `explicitlySelected` flag to the install options, propagated from
`add.ts` when `options.agent` was set on the CLI (excluding the `*` wildcard,
which already opts into all agents and shouldn't change behavior).

When `explicitlySelected` is true, the project-level skip-guard is bypassed
and the symlink is created. `createSymlink` already calls
`mkdir(linkDir, { recursive: true })`, so it correctly creates `.claude/skills/`
on demand.

Scope is deliberately narrow:
- Project-level installs only (`!isGlobal`), which is the path the guard already
  gated on.
- Global installs (`-g`) are unchanged — those follow a different code path
  and #851 deserves its own dedicated fix.
- When no `-a` flag is given, behavior is identical to before: incidental
  agents whose dirs don't exist are still skipped.

Also surfaces skipped agents in the install summary so users learn about
the situation instead of silently getting an unreachable skill:

```
  skipped: Claude Code
    (config dir not present in project; re-run with -a to install anyway)
```

## Changes

- `src/installer.ts`:
  - `installSkillForAgent`: add `explicitlySelected?: boolean` option; bypass
    the dir-existence guard when true.
  - `installBlobSkillForAgent`: same change for the blob install path.
  - `installRemoteSkillForAgent` and `installWellKnownSkillForAgent` are
    unchanged — they don't have the skip-guard.
- `src/add.ts`:
  - Derive `explicitlySelectedAgents` from `options.agent` in both code paths
    that use `targetAgents`.
  - Forward the flag to both `installSkillForAgent` and
    `installBlobSkillForAgent` call sites.
  - Add `skipped:` line + hint to `buildResultLines` so the install summary
    tells users when an agent was skipped and how to override.
- `tests/installer-explicit-agent.test.ts` (new): three tests covering
  - explicitly selected agent, no pre-existing `.claude/` → symlink created
  - non-explicitly selected agent, no `.claude/` → still skipped
  - non-explicitly selected agent, `.claude/` exists → symlink created

## Test results

```
Test Files  30 passed (30)
     Tests  458 passed (458)
```

(One pre-existing failure in `tests/dist.test.ts` requires `pnpm` and is
environment-dependent; not affected by this PR.)

## Workaround until merged

```bash
mkdir -p .claude/skills && npx skills add <package> -a claude-code
```

## How to apply this patch locally

```bash
git clone https://github.com/vercel-labs/skills.git
cd skills
git checkout -b fix/explicit-claude-code-symlink
git apply fix-explicit-claude-code-symlink.patch
npm install
npx vitest run --exclude tests/dist.test.ts
```