### PR TITLE
feat: add wavex-os skill suite (6 skills)

### DIFF
--- a/skills/wavex-os-activate-and-ignite/SKILL.md
+++ b/skills/wavex-os-activate-and-ignite/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: wavex-os-activate-and-ignite
+description: Activate a signed WaveX OS company manifest into the runtime and kick off the ignition phase that seeds first tasks.
+---
+
+# wavex-os-activate-and-ignite
+
+The two-step transition from "wizard finished" to "fleet is doing work." Activate bridges the signed manifest into the DB (and optionally a running Paperclip instance). Ignite seeds first-task issues, creates the Goal, and fires the CEO + Chief of Staff kickoff probe so the fleet has something to chew on.
+
+## When to use
+
+- User just finished the wizard and clicked *Finalize + sign*, and now wants the fleet running
+- A previously-activated company never produced any agent activity (ignite never ran or got partial)
+- After importing a manifest from another machine
+
+If the user hasn't completed the wizard yet, use [wavex-os-init](../wavex-os-init/SKILL.md) or [wavex-os-provision-company](../wavex-os-provision-company/SKILL.md) first.
+
+## Preconditions
+
+1. **Signed manifest exists:**
+   ```bash
+   COMPANY_ID="<id>"
+   test -f ~/.wavex-os/instances/default/companies/$COMPANY_ID/onboarding/company.manifest.json
+   test -f ~/.wavex-os/instances/default/companies/$COMPANY_ID/onboarding/manifest.sig
+   ```
+   Both must exist. No sig → wizard wasn't finalized.
+
+2. **Server healthy:**
+   ```bash
+   curl -fsS http://localhost:3101/api/system/health | jq -r .status   # "healthy"
+   ```
+
+3. **Decide whether to hand off to Paperclip.** Set `PAPERCLIP_HANDOFF_URL` env var before activate if yes:
+   ```bash
+   export PAPERCLIP_HANDOFF_URL="http://localhost:3100"
+   ```
+   Without this, agents still activate in the WaveX DB but won't get the Paperclip runtime (heartbeats, board, KPI rollups). For most users you want the handoff.
+
+## Procedure
+
+1. **Activate:**
+   ```bash
+   curl -X POST "http://localhost:3101/api/instance/$COMPANY_ID/activate" \
+     -H 'Content-Type: application/json' | jq
+   ```
+   Expected response:
+   ```json
+   {
+     "ok": true,
+     "companiesRowId": "...",
+     "agentsInserted": <n>,
+     "paperclipHandoff": { "ok": true, "agentsMirrored": <n> }   // present if handoff was configured
+   }
+   ```
+   `agentsInserted` should match the roster size from Phase 3. If it's smaller, the bridge skipped some slots — see Common failures.
+
+2. **Ignite:**
+   ```bash
+   curl -X POST "http://localhost:3101/api/instance/$COMPANY_ID/ignite" \
+     -H 'Content-Type: application/json' | jq
+   ```
+   Expected:
+   ```json
+   {
+     "ok": true,
+     "goalIssueId": "...",
+     "kickoffTasksSeeded": <n>,
+     "heartbeatOffsetsStaggered": true
+   }
+   ```
+   Ignite is idempotent — re-running on an already-ignited company is safe; it'll report `kickoffTasksSeeded: 0`.
+
+3. **Verify the fleet has signs of life within ~6 minutes (one heartbeat cycle):**
+   ```bash
+   sleep 360
+   curl -fsS "http://localhost:3101/api/mission-control/$COMPANY_ID/activity" | jq '.[0:3]'
+   ```
+   Expect at least one comment, KPI snapshot, or run event in the last 6 minutes.
+
+## Success criteria
+
+- `activate` returned `ok: true` with `agentsInserted` equal to roster size
+- `ignite` returned `ok: true` with a non-empty `goalIssueId`
+- `/api/mission-control/<companyId>/activity` shows agent-generated events within one heartbeat
+- `/api/mission-control/<companyId>/health-orb` is GREEN or YELLOW (not RED)
+
+## Common failure modes
+
+- **`activate` returns `manifest.sig invalid`:** the manifest was edited after signing (sometimes by trying to "fix a typo" in the JSON). Re-finalize from the wizard.
+- **`agentsInserted < roster size`:** a slot-to-template mapping is missing in `packages/wavex-os-server/src/bridge/catalog.ts` (`SLOT_TO_TEMPLATE`). Not user-fixable; this is a maintainer issue. File a bug with the unmapped slot name.
+- **Paperclip handoff returns `ok: false`:** `PAPERCLIP_HANDOFF_URL` points at a Paperclip instance that's down or unreachable. Activate still completed in WaveX DB; you can retry handoff later by re-POSTing activate (it's idempotent for the handoff portion).
+- **Ignite seeds 0 tasks even on a fresh company:** workflow manifest didn't pin initial workload to any agent. Check `~/.wavex-os/instances/default/companies/<id>/onboarding/workflow_manifest.json` — `initial_workload` should be non-empty per agent.
+- **No activity 6 minutes after ignite:** check [wavex-os-debug-healing](../wavex-os-debug-healing/SKILL.md). The agents are spawned but the wrapper or OAuth may be failing.
+
+## Re-running on an already-active company
+
+Both endpoints are idempotent:
+- `activate` on a live company → no-ops or only mirrors new agents
+- `ignite` on a live company → no-ops if Goal + kickoff already exist
+
+This is the supported way to recover from "I think the fleet didn't fully start." Don't try to "reset" first unless [wavex-os-audit](../wavex-os-audit/SKILL.md) shows a deeper problem.
+
+## Related skills
+
+- [wavex-os-mission-control](../wavex-os-mission-control/SKILL.md) — verify the fleet is producing real work after ignite.
+- [wavex-os-debug-healing](../wavex-os-debug-healing/SKILL.md) — if activity stays silent past one heartbeat.

--- a/skills/wavex-os-audit/SKILL.md
+++ b/skills/wavex-os-audit/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: wavex-os-audit
+description: Run WaveX OS diagnostics — disk, RAM, ports, launchd jobs, service health, and Claude CLI prerequisites — in one shot.
+---
+
+# wavex-os-audit
+
+Run the two diagnostic CLIs WaveX OS ships with and interpret their output. Use this whenever something is misbehaving, before opening an issue, or before walking a user through any other wavex-os skill.
+
+## When to use
+
+- User reports "wavex is slow / agents stalled / nothing's happening"
+- Pre-flight before [wavex-os-init](../wavex-os-init/SKILL.md) or [wavex-os-provision-company](../wavex-os-provision-company/SKILL.md)
+- Mission Control shows a RED health orb
+- After a macOS update (launchd plists sometimes get unloaded)
+
+## The two CLIs and how they differ
+
+| CLI | Scope |
+|---|---|
+| `wavex-os doctor` | Environment prerequisites: Node version, Claude CLI presence + OAuth, keychain access, free ports. Run *before* installing or starting. |
+| `wavex-os audit` | Runtime state: disk %, RAM %, launchd job status, service health, inference burn, recent crashes. Run *while* a fleet is supposed to be running. |
+
+Running both is cheap. Default to running both when unsure.
+
+## Procedure
+
+1. **Doctor (env prerequisites):**
+   ```bash
+   wavex-os doctor
+   ```
+   Exit code 0 → all green. Non-zero → at least one prerequisite is failing; the report names which.
+
+2. **Audit (runtime state):**
+   ```bash
+   wavex-os audit
+   ```
+   Reports per-resource state. Codes:
+   - GREEN: < 70% utilization, all services healthy
+   - YELLOW: 70–90% — heads-up, no automatic action
+   - RED: > 90% — the platform-level resource sweeper will throttle spawns; operator gets paged
+
+3. **Cross-check service health via HTTP if the local server is up:**
+   ```bash
+   curl -fsS http://localhost:3101/api/system/health | jq
+   ```
+   This is the same probe the fleet uses internally. If it 404s, the wavex-os-server isn't running — start it with `pnpm dev:core` from the repo root.
+
+4. **If a launchd job is wedged:**
+   ```bash
+   launchctl list | grep wavex
+   launchctl print gui/$(id -u)/com.wavex-os.<jobname>
+   ```
+   The plist source is in `templates/launchd/`. Re-render with `pnpm tuning:map` if anything in the template changed.
+
+## Success criteria
+
+- `wavex-os doctor` exits 0
+- `wavex-os audit` reports all GREEN, or YELLOW with a concrete plan for what to free up
+- `/api/system/health` returns `{ status: "healthy" }`
+
+## Common failure modes
+
+- **Doctor reports "Claude CLI OAuth missing":** user has the binary but never logged in. Run `claude` once and complete the OAuth dance.
+- **Audit reports disk RED but you just provisioned:** WaveX caches Monte Carlo runs + worktree artifacts in `~/.wavex-os/`. Safe to clean: `paperclipai worktree:cleanup` (do **not** `rm -rf` — the System Reliability agent enforces this).
+- **Audit reports inference burn RED:** the tier-router is hitting Anthropic at API rates instead of OAuth. Check `WAVEX_INFERENCE_MODE` env var; should be `oauth` in dev.
+- **launchd shows status `78`:** the plist references a path that doesn't exist (often after a checkout move). Re-render templates.
+
+## Output to relay to the user
+
+When summarizing audit results, lead with the worst-state resource and a one-line fix, not a full dump. Full output is in the user's terminal already.
+
+## Related skills
+
+- If audit surfaces self-healing failures: [wavex-os-debug-healing](../wavex-os-debug-healing/SKILL.md).
+- If audit is clean but the wizard still won't start: [wavex-os-init](../wavex-os-init/SKILL.md) preconditions.

--- a/skills/wavex-os-debug-healing/SKILL.md
+++ b/skills/wavex-os-debug-healing/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: wavex-os-debug-healing
+description: Walk the 3-layer WaveX OS self-healing flow when an agent is stuck — 401 fallback, OAuth refresh, worker restart.
+---
+
+# wavex-os-debug-healing
+
+When a WaveX agent stops making progress, the failure is almost always at one of three layers. This skill walks them in order — cheapest probe first.
+
+The reference implementation lives at [`packages/healing/`](https://github.com/aimerdoux/wavex-os/tree/main/packages/healing) and the architecture is in [`docs/SELF_HEALING.md`](https://github.com/aimerdoux/wavex-os/blob/main/docs/SELF_HEALING.md). **Don't modify those files** — they're a FROZEN path. This skill diagnoses; it doesn't patch the healing layer itself.
+
+## When to use
+
+- Mission Control `/health-orb` returned RED or YELLOW with a healing-related `reason`
+- User reports "agent X stopped commenting" / "fleet is silent" / "spinner stuck"
+- After a Claude Max token rotation
+- After a long sleep/wake cycle on macOS
+
+## Don't pre-emptively use this
+
+The three layers below are **self**-healing. They run on their own schedule. If you're seeing a transient failure that's <2 minutes old, wait — the next heartbeat (every 5 min) usually clears it. Only walk this skill when the issue persists across a heartbeat.
+
+## The three layers
+
+| Layer | What heals | Probe | Auto-recovery cadence |
+|---|---|---|---|
+| L1 | 401 from Claude API → fall back to Sonnet via wrapper | Per-call (synchronous in `claude-anthropic-direct.sh`) | Immediate |
+| L2 | OAuth token expired → refresh via keychain + concurrency lock | Out-of-band, idempotent | On next heartbeat |
+| L3 | Worker process wedged → SIGTERM → SIGKILL → restart | launchd `recovery-on-boot` + 12h `recovery-12h` | Boot + every 12h |
+
+## Procedure
+
+1. **Confirm which layer is implicated.**
+
+   ```bash
+   curl -fsS http://localhost:3101/api/mission-control/<companyId>/health-orb | jq
+   ```
+   The `reason` field is the entry point:
+   - mentions `401` / `unauthorized` → Layer 1
+   - mentions `oauth` / `invalid_grant` / `refresh` → Layer 2
+   - mentions `worker` / `unresponsive` / `heartbeat_missed` → Layer 3
+   - mentions none of the above → not a healing issue; check [wavex-os-audit](../wavex-os-audit/SKILL.md)
+
+2. **Layer 1 — 401 fallback:**
+
+   Tail the wrapper log:
+   ```bash
+   tail -n 200 ~/.wavex-os/logs/wrapper.log | grep -E '401|fallback|sonnet'
+   ```
+   You should see lines like `[wrapper] 401 from opus, falling back to sonnet`. If you see 401s **without** a fallback line, the wrapper isn't catching them — the script may have been overwritten. The canonical version is in `scripts/wrappers/claude-anthropic-direct.sh` (FROZEN).
+
+3. **Layer 2 — OAuth refresh:**
+
+   ```bash
+   security find-generic-password -s "claude.cli.oauth" -w 2>/dev/null | head -c 8 && echo "... (token present)"
+   ```
+   If empty, the keychain entry is gone — user must `claude` login again. If present, look at:
+   ```bash
+   tail -n 200 ~/.wavex-os/logs/healing.log | grep -E 'refresh|invalid_grant'
+   ```
+   `invalid_grant` repeated → token actually revoked upstream; user must re-login. Concurrency lock contention shows as `lock_held_by=<pid>` — usually clears within 60s.
+
+4. **Layer 3 — Worker restart:**
+
+   ```bash
+   launchctl list | grep wavex
+   ps aux | grep -E 'wavex|claude' | grep -v grep
+   ```
+   A worker stuck in uninterruptible sleep won't show up in `launchctl` as failed but will be in `ps`. If you can identify a wedged PID:
+   ```bash
+   # The healing layer's worker-restart does this on a schedule;
+   # nudging it manually is fine if the user is in front of you.
+   launchctl kickstart -k gui/$(id -u)/com.wavex-os.recovery-on-boot
+   ```
+   Then wait ~30s and recheck `/health-orb`.
+
+5. **If all three layers report clean but the fleet is still stalled:** this is *not* a healing failure. Probable causes:
+   - Token budget exhausted — check `GET /api/observability/<companyId>/budget`
+   - No work in the queue — agents have nothing to do; create an issue via the dashboard
+   - Paperclip handoff lost — see [wavex-os-activate-and-ignite](../wavex-os-activate-and-ignite/SKILL.md) for re-handoff
+
+## Success criteria
+
+- `/health-orb` returns GREEN (or YELLOW with a reason unrelated to healing)
+- The next heartbeat (≤5 min) produces a new comment or KPI snapshot in `/activity`
+
+## What NOT to do
+
+- **Do not `rm -rf` anything under `~/.wavex-os/`** — the System Reliability agent will page. Use `paperclipai worktree:cleanup` for artifacts and Mission Control's reset endpoint for company state.
+- **Do not edit `packages/healing/`, `scripts/wrappers/`, or `templates/launchd/`** — FROZEN paths.
+- **Do not bypass the wrapper by calling `claude` directly with `ANTHROPIC_API_KEY`.** The wrapper is what makes 401-fallback work.
+
+## Related skills
+
+- [wavex-os-audit](../wavex-os-audit/SKILL.md) — for non-healing diagnostics.
+- [wavex-os-mission-control](../wavex-os-mission-control/SKILL.md) — to verify recovery landed.

--- a/skills/wavex-os-init/SKILL.md
+++ b/skills/wavex-os-init/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: wavex-os-init
+description: Install WaveX OS and walk a user through the 5-pillar wizard to provision their first AI agent company on localhost.
+---
+
+# wavex-os-init
+
+Install WaveX OS on a user's machine and drive the first-run wizard to a signed `company.manifest.json`. This is the canonical entry point — the user goes from empty machine to an activated 5–35 agent fleet running under their Claude Max OAuth.
+
+## When to use
+
+- User says "set up wavex-os" / "install wavex" / "start a new agent company"
+- User has Node 20+ and a Claude Max subscription but nothing else
+- User has run `wavex-os` before but wants to provision a *new* company on the same install — in that case use [wavex-os-provision-company](../wavex-os-provision-company/SKILL.md) instead
+
+## Preconditions
+
+Verify before starting:
+
+```bash
+node --version          # must be >= 20.10
+which claude            # must resolve to a Claude CLI binary
+claude --version        # confirms OAuth-capable build
+```
+
+If `claude` is missing, point the user at https://docs.anthropic.com/claude/code (Claude Code installs the CLI). Do **not** ask the user for an `ANTHROPIC_API_KEY` — WaveX uses Claude Max OAuth via the system keychain.
+
+## Procedure
+
+1. **Install the CLI globally:**
+   ```bash
+   npm install -g wavex-os-installer
+   ```
+
+2. **Run the doctor first** — this is non-destructive and catches setup issues before the wizard:
+   ```bash
+   wavex-os doctor
+   ```
+   Resolve any red checks before continuing. Common failures:
+   - Port `5173` or `3101` in use → kill the conflicting process or set `WAVEX_UI_PORT` / `WAVEX_API_PORT`
+   - Keychain missing Claude OAuth — user must run `claude` once and complete login
+
+3. **Launch the wizard:**
+   ```bash
+   wavex-os init
+   ```
+   This opens `http://localhost:5173` in the browser. The wizard runs entirely on localhost — no telemetry, no remote inference.
+
+4. **Walk the 5 pillars + 3 phases:**
+   | Step | What the user does |
+   |---|---|
+   | Pillar 1 — Who | One paragraph in plain text describing what they're building. T2 enrichment infers 10 fields. User reviews + corrects. |
+   | Pillar 2 — Setup | Confirms Claude CLI + plan tier (defaults Max 5×). |
+   | Pillar 3 — Product state | pre-product / live / 10K-100K MRR / etc. Drives roster shape. |
+   | Pillar 4 — GTM motion | Lead sources × sales motion. Shapes the KPI tree. |
+   | Pillar 5 — Comms | Telegram / Slack / email destination for board signals. |
+   | Phase 2 — Connectors | Decision matrix proposes integrations; user accepts or skips per-connector. |
+   | Phase 3 — Swarm | Reactflow org chart of the proposed roster. User can swap templates per slot. |
+   | Phase 4 — Workflow | Initial workload + bundle allocation per agent. |
+   | Finalize | Click *Finalize + sign*. Monte Carlo simulation runs. Signed `company.manifest.json` lands on disk. |
+
+5. **Activate the fleet:** click *Activate fleet →* once the signature lands. This is the last point before agents go live.
+
+## Success criteria
+
+- `~/.wavex-os/instances/default/companies/<companyId>/onboarding/company.manifest.json` exists and has a sibling `manifest.sig`
+- Mission Control loads at `http://localhost:5173/mission-control/<companyId>` with the KPI scoreboard populated
+- `GET http://localhost:3101/api/instance/<companyId>/redundancy` returns 200
+
+## Common failure modes
+
+- **Pillar 1 enrichment hangs:** T2 inference call timed out. Check `claude` is callable: `claude -p "hello"`. If that fails, fix Claude CLI first.
+- **Connector concierge can't save credentials:** the vault keychain entry was rejected. Re-run `wavex-os doctor` — the keychain section will show what's wrong.
+- **Activate fails with `manifest.sig invalid`:** the manifest was edited after signing. Re-finalize from the wizard.
+
+## Related skills
+
+- After init, drive a second company through with [wavex-os-provision-company](../wavex-os-provision-company/SKILL.md).
+- For diagnostics: [wavex-os-audit](../wavex-os-audit/SKILL.md).
+- For post-activate work: [wavex-os-activate-and-ignite](../wavex-os-activate-and-ignite/SKILL.md).

--- a/skills/wavex-os-mission-control/SKILL.md
+++ b/skills/wavex-os-mission-control/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: wavex-os-mission-control
+description: Query a live WaveX OS fleet — KPIs, bottlenecks, decision queue, recent activity, budget — via the local HTTP API.
+---
+
+# wavex-os-mission-control
+
+Read-only inspector for a running WaveX OS fleet. All endpoints are local (`http://localhost:3101`) and return JSON; no auth required in dev (`WAVEX_AUTH_MODE=dev`).
+
+## When to use
+
+- User asks "what's my fleet doing right now?" / "show me KPIs" / "why is the dashboard yellow?"
+- You need to verify a claim before reporting it (an agent said "shipped" — check `/decision-queue` and `/activity` for the actual outcome)
+- Before/after running [wavex-os-debug-healing](../wavex-os-debug-healing/SKILL.md), to confirm the issue cleared
+
+## Preconditions
+
+```bash
+curl -fsS http://localhost:3101/api/system/health | jq -r .status   # expect "healthy"
+```
+
+All endpoints take a `:companyId` path parameter. If the user didn't give one, list active companies:
+
+```bash
+ls ~/.wavex-os/instances/default/companies/
+```
+
+## Endpoint reference
+
+All paths are under `http://localhost:3101`.
+
+| Endpoint | Returns | When to use |
+|---|---|---|
+| `GET /api/mission-control/:companyId/headline` | One-sentence fleet status | Start here. Tells you which deeper endpoint to query next. |
+| `GET /api/mission-control/:companyId/health-orb` | `{ color, reason }` (GREEN/YELLOW/RED) | "Why is the dashboard yellow?" |
+| `GET /api/mission-control/:companyId/tab-counts` | Counts per UI tab (queue, alerts, etc.) | Spot which tab has unread items |
+| `GET /api/mission-control/:companyId/decision-queue` | Items awaiting board / operator approval | "Anything waiting for me?" |
+| `GET /api/mission-control/:companyId/activity` | Recent run / comment / KPI events | "What happened in the last hour?" |
+| `GET /api/mission-control/:companyId/scope-tree` | Org chart + agent state | Spot which agent is stalled |
+| `GET /api/observability/:companyId/mission-control` | Aggregated KPI scoreboard | Headline KPI movement |
+| `GET /api/observability/:companyId/budget` | Token budget vs. consumed | "Are we within burn?" |
+| `GET /api/observability/:companyId/bottlenecks` | Bottleneck-scored work items | "What's blocking forward motion?" |
+| `GET /api/instance/:companyId/redundancy` | Slot-by-slot redundancy state | Single point of failure check |
+| `POST /api/mission-control/:companyId/ask` | Ask the fleet a question via the CoS | Operator-style natural-language query |
+
+## Procedure for "give me a fleet summary"
+
+```bash
+COMPANY_ID="<id>"
+
+echo "--- Headline ---"
+curl -fsS "http://localhost:3101/api/mission-control/$COMPANY_ID/headline" | jq -r .text
+
+echo "--- Health orb ---"
+curl -fsS "http://localhost:3101/api/mission-control/$COMPANY_ID/health-orb" | jq
+
+echo "--- Pending decisions ---"
+curl -fsS "http://localhost:3101/api/mission-control/$COMPANY_ID/decision-queue" | jq 'length as $n | "\($n) pending"'
+
+echo "--- Budget ---"
+curl -fsS "http://localhost:3101/api/observability/$COMPANY_ID/budget" | jq '{tokensUsed, tokensBudget, percent: (.tokensUsed/.tokensBudget*100)}'
+
+echo "--- Top bottlenecks (top 3) ---"
+curl -fsS "http://localhost:3101/api/observability/$COMPANY_ID/bottlenecks" | jq '.items[:3]'
+```
+
+## Success criteria
+
+- Every endpoint above returns 200 + non-empty JSON
+- The summary you give the user reflects what those endpoints actually returned (do not paraphrase, do not invent numbers)
+- If anything is RED, you've already followed the `reason` field to the relevant deeper endpoint
+
+## Verify-before-claim
+
+WaveX agents are themselves required to attach independent probes to any "shipped/delivered/applied" claim (see `packages/onboarding-ui/public/agent-templates/_shared/SKILL_VERIFY_BEFORE_CLAIM.md`). When you're inspecting the fleet on behalf of a user, you're operating under the same rule: if you say "the fleet is healthy", paste the actual `/health-orb` response. If you say "no pending decisions", paste the `/decision-queue` count.
+
+## Common failure modes
+
+- **404 on an `:companyId` route:** the company exists on disk but never activated. Check `~/.wavex-os/instances/default/companies/<id>/` for a `company.manifest.json` + `manifest.sig`; if present, run [wavex-os-activate-and-ignite](../wavex-os-activate-and-ignite/SKILL.md).
+- **`/headline` returns "no recent activity":** the fleet was activated but never ignited, or heartbeats are paused. Check `launchctl list | grep wavex` for paused jobs.
+- **`/bottlenecks` empty:** could be genuinely unblocked OR the bottleneck-digest launchd job hasn't run yet (it's 12-hourly). Trigger manually: `POST /api/system/health/run-now`.
+
+## Related skills
+
+- [wavex-os-debug-healing](../wavex-os-debug-healing/SKILL.md) — if `/health-orb` is RED with a healing-related reason.
+- [wavex-os-audit](../wavex-os-audit/SKILL.md) — if the server itself isn't responding.

--- a/skills/wavex-os-provision-company/SKILL.md
+++ b/skills/wavex-os-provision-company/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: wavex-os-provision-company
+description: Drive a 2nd-or-later AI agent company through the WaveX OS 5-pillar wizard against an already-running install.
+---
+
+# wavex-os-provision-company
+
+Provision an additional company on a WaveX OS install that's already running. Same wizard as first-run, but the user keeps their existing fleet alive — companies are isolated under `~/.wavex-os/instances/default/companies/<companyId>/`.
+
+## When to use
+
+- User already has `wavex-os` installed and a first company live
+- User says "spin up another company" / "add a new tenant" / "I want to try a different roster shape"
+- Use [wavex-os-init](../wavex-os-init/SKILL.md) instead if this is their first time
+
+## Preconditions
+
+```bash
+curl -fsS http://localhost:3101/api/system/health > /dev/null   # server up
+curl -fsS http://localhost:5173 > /dev/null                      # UI up
+```
+
+If either is down, the user needs to `pnpm dev` from the repo root first. Do not try to start it yourself unless asked.
+
+Existing companies use disk + inference quota — confirm headroom by running [wavex-os-audit](../wavex-os-audit/SKILL.md) before adding another company.
+
+## Procedure
+
+1. **Open the wizard at a fresh draft state:**
+   - Browser: `http://localhost:5173/wizard` → "Start new company"
+   - Or POST a draft programmatically:
+     ```bash
+     curl -X POST http://localhost:3101/api/wizard-events \
+       -H 'Content-Type: application/json' \
+       -d '{"event":"start","companyName":"<name>"}'
+     ```
+   The server returns a draft `companyId` (UUID). Persist it — every later call needs it.
+
+2. **Walk the 5 pillars + 3 phases.** Same shape as [wavex-os-init](../wavex-os-init/SKILL.md) but the user can copy answers from a prior company when the new one is structurally similar (same product stage + GTM motion → reuse Phase 3/4).
+
+3. **Watch out for connector collisions.** Pillar 5 + Phase 2 may suggest the same OAuth tokens as an existing company. The vault stores per-company entries — re-pasting is safe but the credential concierge will warn.
+
+4. **Finalize + sign.** A new `company.manifest.json` lands at:
+   ```
+   ~/.wavex-os/instances/default/companies/<companyId>/onboarding/company.manifest.json
+   ```
+
+5. **Activate** — same `POST /api/instance/<companyId>/activate` as first-run. See [wavex-os-activate-and-ignite](../wavex-os-activate-and-ignite/SKILL.md) for the post-activate sequence.
+
+## Roster shape recommendations
+
+The wizard picks a shape from Pillar 3 (product stage). Override only if the user pushes back:
+
+| Pillar 3 answer | Default shape | When to override |
+|---|---|---|
+| pre_product | minimal_kernel (CEO + Chief of Staff) | Override if user has paying customers — they need a real fleet |
+| live_few_customers | collapsed_6 | Rarely overridden |
+| 10k_100k_mrr | hybrid (~12 agents) | Override → formal_9 if the user wants role specialization for compliance |
+| 100k_plus | formal_9 | Override → custom only if the user has named a specific agent they need |
+
+Solo founders get a further-collapsed 5-agent kernel regardless of stage — don't suggest expanding it without checking they have time to manage the extra agents.
+
+## Success criteria
+
+- `~/.wavex-os/instances/default/companies/<new-companyId>/onboarding/company.manifest.json` exists
+- `manifest.sig` is present and the file passes `wavex-os audit --verify-signatures <companyId>`
+- Mission Control at `/mission-control/<new-companyId>` loads independently of the existing company
+
+## Common failure modes
+
+- **Wizard refuses to open a new draft:** an unfinished draft from a prior session is still in the DB. List drafts: `curl http://localhost:3101/api/wizard-metrics`. Either resume it or hard-reset with `DELETE /api/instance/<draftId>/reset`.
+- **Phase 3 swarm generation is empty:** roster matrix had no match for the pillar combo. Lower the roster shape one tier (formal_9 → hybrid).
+- **Finalize hangs at Monte Carlo:** the simulator runs `pnpm diffeq:suite` in the background. If T2 inference is saturated by the existing fleet, this can take 90s. Be patient before retrying.
+
+## Related skills
+
+- [wavex-os-activate-and-ignite](../wavex-os-activate-and-ignite/SKILL.md) — what to do after Finalize.
+- [wavex-os-mission-control](../wavex-os-mission-control/SKILL.md) — verify the new company is live.


### PR DESCRIPTION
Adds six user-facing skills for **WaveX OS** — open-source operating system for running an AI agent company on localhost.

Upstream repository: https://github.com/aimerdoux/wavex-os

## What's in this PR

| Skill | Drives |
|---|---|
| `wavex-os-init` | Install + run the 5-pillar wizard end-to-end |
| `wavex-os-audit` | `doctor` + `audit` diagnostics (disk, RAM, ports, launchd, services) |
| `wavex-os-provision-company` | Drive a 2nd-or-later company through the wizard |
| `wavex-os-mission-control` | Read-only fleet inspector — KPIs, bottlenecks, decision queue, budget |
| `wavex-os-debug-healing` | Walk the 3-layer self-heal flow (401 fallback / OAuth refresh / worker restart) |
| `wavex-os-activate-and-ignite` | Activate signed manifest + seed first tasks |

## Verification

Every command and HTTP route referenced in each `SKILL.md` is greppable in the upstream repo:

- CLI subcommands (`init|doctor|audit|reset`) → `apps/installer/bin/init.js`
- HTTP routes (`/activate`, `/ignite`, `/mission-control/*`, `/observability/*`, `/system/health`, `/redundancy`) → `packages/wavex-os-server/src/routes/`

End-to-end install works today via the `npx skills` CLI:

```bash
$ npx -y skills add aimerdoux/wavex-os
◇  Installed 6 skills
   ✓ ./.agents/skills/wavex-os-activate-and-ignite
   ✓ ./.agents/skills/wavex-os-audit
   ✓ ./.agents/skills/wavex-os-debug-healing
   ✓ ./.agents/skills/wavex-os-init
   ✓ ./.agents/skills/wavex-os-mission-control
   ✓ ./.agents/skills/wavex-os-provision-company
```

Compatible with Antigravity, Codex, Cursor, Gemini CLI, OpenCode, Claude Code, OpenClaw, Hermes Agent, Pi, and 4 more (per CLI's compatibility report).

## What this skill suite is *not*

WaveX OS has its own internal *agent-runtime* skills (loaded into agent prompts at heartbeat — `SKILL_VERIFY_BEFORE_CLAIM`, `SKILL_KERNEL_LESSONS`, etc.). Those are NOT in this PR. This PR ships the *user-facing* skills that drive WaveX OS from outside.

## Why six instead of one umbrella

Each skill covers a distinct user task with its own preconditions, success criteria, and failure modes. An umbrella skill would either (a) bury the procedures behind a router or (b) ship a 30KB monolith. The six-skill layout matches the upstream `/skills/` directory and lets users install only the parts they need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)