### PR TITLE
Feat/registry spec

### DIFF
--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -66,7 +66,7 @@ Returns detail for a single skill. Two URL forms are supported:
 
 ### `GET /api/plugins/search`
 
-Search for plugins — curated bundles of skills defined by a `plugins/<name>/plugin.yaml` manifest in a repository. Used by `skills plugin search`.
+Search for plugins — curated bundles of skills defined by a `plugins/<name>/plugin.yaml` manifest in a repository. Used by `skills plugin search`. Uses semantic (vector) search when the query can be embedded, falling back to fuzzy text search otherwise — the same two-tier strategy as `GET /api/search`.
 
 **Query parameters**
 
@@ -79,6 +79,7 @@ Search for plugins — curated bundles of skills defined by a `plugins/<name>/pl
 ```json
 {
   "query": "pr review",
+  "searchType": "semantic",
   "plugins": [
     {
       "name": "pbi-to-pr-loop",
@@ -100,6 +101,7 @@ Search for plugins — curated bundles of skills defined by a `plugins/<name>/pl
 |-------|------|----------|-------------|
 | `plugins` | array | yes | Array of plugin results. |
 | `query` | string | no | The search query that produced these results. |
+| `searchType` | string | no | Search strategy used: `"semantic"`, `"fuzzy"`, or `"all"` (empty query). |
 | `count` | number | no | Total number of results returned. |
 | `duration_ms` | number | no | Time taken to execute the search in milliseconds. |
 

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -87,7 +87,8 @@ Search for plugins — curated bundles of skills defined by a `plugins/<name>/pl
       "source": "vercel-labs/skills",
       "version": "0.2.0",
       "installs": 0,
-      "skills": ["write-plan", "review-plan", "implement-plan"]
+      "skills": ["write-plan", "review-plan", "implement-plan"],
+      "tags": ["delivery", "automation"]
     }
   ],
   "count": 1,
@@ -115,6 +116,7 @@ Search for plugins — curated bundles of skills defined by a `plugins/<name>/pl
 | `version` | string | no | Plugin manifest version (semver). |
 | `installs` | number | no | Install count. Use `0` if not tracked. |
 | `skills` | array | no | Member skill names bundled by the plugin. |
+| `tags` | array | no | Discovery keywords for the plugin (e.g. from the plugin manifest's `tags`/`keywords`). Folded into search matching. |
 
 A registry that does not implement this endpoint should return `404`; the CLI treats that as "plugin search not available" and still supports installing a known plugin by name.
 

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -57,7 +57,10 @@ Search for skills by keyword.
 
 ### `GET /{id}`
 
-Returns detail for a single skill. The `id` value from a search result is used as the path.
+Returns detail for a single skill. Two URL forms are supported:
+
+- `GET /{id}` — look up by the `id` field from a search result (e.g. `vercel-labs/skills/find-skills` or a UUID for registries that use opaque identifiers)
+- `GET /{skillId}` — look up by the `skillId` field (e.g. `find-skills`, or a full path slug like `{source}/{name}` for self-hosted registries)
 
 **Response**: the full skill record. Shape is registry-defined; the CLI does not currently consume this endpoint directly but links to it in terminal output.
 

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -64,15 +64,15 @@ Returns detail for a single skill. Two URL forms are supported:
 
 **Response**: the full skill record. Shape is registry-defined; the CLI does not currently consume this endpoint directly but links to it in terminal output.
 
-### `GET /api/plugins/search`
+### `GET /api/bundles/search`
 
-Search for plugins — curated bundles of skills defined by a `plugins/<name>/plugin.yaml` manifest in a repository. Used by `skills plugin search`. Uses semantic (vector) search when the query can be embedded, falling back to fuzzy text search otherwise — the same two-tier strategy as `GET /api/search`.
+Search for bundles — curated sets of skills defined by a `bundles/<name>/bundle.yaml` manifest in a repository. Used by `skills bundle search`. Uses semantic (vector) search when the query can be embedded, falling back to fuzzy text search otherwise — the same two-tier strategy as `GET /api/search`.
 
 **Query parameters**
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `q` | string | Search query. If omitted or empty, returns all plugins. |
+| `q` | string | Search query. If omitted or empty, returns all bundles. |
 
 **Response**
 
@@ -80,14 +80,14 @@ Search for plugins — curated bundles of skills defined by a `plugins/<name>/pl
 {
   "query": "pr review",
   "searchType": "semantic",
-  "plugins": [
+  "bundles": [
     {
       "name": "pbi-to-pr-loop",
       "description": "Autonomous PBI → plan → review → implement → PR loop.",
       "source": "vercel-labs/skills",
       "version": "0.2.0",
       "installs": 0,
-      "skills": ["write-plan", "review-plan", "implement-plan"],
+      "skills": ["skills/community/write-plan", "skills/community/review-plan", "skills/community/implement-plan"],
       "tags": ["delivery", "automation"]
     }
   ],
@@ -100,25 +100,25 @@ Search for plugins — curated bundles of skills defined by a `plugins/<name>/pl
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `plugins` | array | yes | Array of plugin results. |
+| `bundles` | array | yes | Array of bundle results. |
 | `query` | string | no | The search query that produced these results. |
 | `searchType` | string | no | Search strategy used: `"semantic"`, `"fuzzy"`, or `"all"` (empty query). |
 | `count` | number | no | Total number of results returned. |
 | `duration_ms` | number | no | Time taken to execute the search in milliseconds. |
 
-**Plugin fields**
+**Bundle fields**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | yes | Plugin name. Used to install the plugin via `skills plugin install {source}@{name}`. |
+| `name` | string | yes | Bundle name. Used to install the bundle via `skills bundle install {source}@{name}`. |
 | `description` | string | no | Human-readable summary shown in search results. |
-| `source` | string | no | Repository the plugin lives in, in `{org}/{repo}` format. When present, the CLI can print the exact `plugin install {source}@{name}` command. |
-| `version` | string | no | Plugin manifest version (semver). |
+| `source` | string | no | Repository the bundle lives in, in `{org}/{repo}` format. When present, the CLI can print the exact `bundle install {source}@{name}` command. |
+| `version` | string | no | Bundle manifest version (semver). |
 | `installs` | number | no | Install count. Use `0` if not tracked. |
-| `skills` | array | no | Member skill names bundled by the plugin. |
-| `tags` | array | no | Discovery keywords for the plugin (e.g. from the plugin manifest's `tags`/`keywords`). Folded into search matching. |
+| `skills` | array | no | Member skill paths declared by the bundle (repo-relative, e.g. `skills/community/write-plan`). |
+| `tags` | array | no | Discovery keywords for the bundle (e.g. from the bundle manifest's `tags`). Folded into search matching. |
 
-A registry that does not implement this endpoint should return `404`; the CLI treats that as "plugin search not available" and still supports installing a known plugin by name.
+A registry that does not implement this endpoint should return `404`; the CLI treats that as "bundle search not available" and still supports installing a known bundle by name.
 
 ## Self-hosting
 

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -55,7 +55,7 @@ Search for skills by keyword.
 | `installs` | number | yes | Install count. Use `0` if not tracked. |
 | `source` | string | yes | Repository source in `{org}/{repo}` format. |
 
-### `GET /{id}`
+### GET Skill Details
 
 Returns detail for a single skill. Two URL forms are supported:
 

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -1,0 +1,58 @@
+# Skills Registry API Spec
+
+This document defines the API contract for a skills registry compatible with the `skills` CLI. Implementing this spec allows any self-hosted registry to work as a drop-in replacement for skills.sh by setting `SKILLS_API_URL`.
+
+## Endpoints
+
+### `GET /api/search`
+
+Search for skills by keyword.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `q` | string | Search query. If omitted or empty, returns all skills. |
+| `limit` | number | Maximum results to return (optional). |
+
+**Response**
+
+```json
+{
+  "skills": [
+    {
+      "id": "vercel-labs/skills/find-skills",
+      "skillId": "find-skills",
+      "name": "find-skills",
+      "installs": 1591220,
+      "source": "vercel-labs/skills"
+    }
+  ]
+}
+```
+
+**Fields**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Canonical identifier for the skill. Recommended format: `{source}/{name}` (e.g. `vercel-labs/skills/find-skills`). Used as the URL path for the detail page. |
+| `skillId` | string | no | Short skill name slug (e.g. `find-skills`). When present, the CLI uses this as the URL slug in preference to `id`. Self-hosted registries may set this to a different value than `name` (e.g. a full path slug). |
+| `name` | string | yes | Display name of the skill. |
+| `installs` | number | yes | Install count. Use `0` if not tracked. |
+| `source` | string | yes | Repository source in `{org}/{repo}` format. |
+
+### `GET /{id}`
+
+Returns detail for a single skill. The `id` value from a search result is used as the path.
+
+**Response**: the full skill record. Shape is registry-defined; the CLI does not currently consume this endpoint directly but links to it in terminal output.
+
+## Self-hosting
+
+Point the CLI at your registry by setting `SKILLS_API_URL`:
+
+```bash
+SKILLS_API_URL=https://skills.example.com npx skills find <query>
+```
+
+Both the search API calls and rendered detail URLs in terminal output will use this base URL.

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -64,6 +64,58 @@ Returns detail for a single skill. Two URL forms are supported:
 
 **Response**: the full skill record. Shape is registry-defined; the CLI does not currently consume this endpoint directly but links to it in terminal output.
 
+### `GET /api/plugins/search`
+
+Search for plugins — curated bundles of skills defined by a `plugins/<name>/plugin.yaml` manifest in a repository. Used by `skills plugin search`.
+
+**Query parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `q` | string | Search query. If omitted or empty, returns all plugins. |
+
+**Response**
+
+```json
+{
+  "query": "pr review",
+  "plugins": [
+    {
+      "name": "pbi-to-pr-loop",
+      "description": "Autonomous PBI → plan → review → implement → PR loop.",
+      "source": "vercel-labs/skills",
+      "version": "0.2.0",
+      "installs": 0,
+      "skills": ["write-plan", "review-plan", "implement-plan"]
+    }
+  ],
+  "count": 1,
+  "duration_ms": 8
+}
+```
+
+**Envelope fields**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `plugins` | array | yes | Array of plugin results. |
+| `query` | string | no | The search query that produced these results. |
+| `count` | number | no | Total number of results returned. |
+| `duration_ms` | number | no | Time taken to execute the search in milliseconds. |
+
+**Plugin fields**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Plugin name. Used to install the plugin via `skills plugin install {source}@{name}`. |
+| `description` | string | no | Human-readable summary shown in search results. |
+| `source` | string | no | Repository the plugin lives in, in `{org}/{repo}` format. When present, the CLI can print the exact `plugin install {source}@{name}` command. |
+| `version` | string | no | Plugin manifest version (semver). |
+| `installs` | number | no | Install count. Use `0` if not tracked. |
+| `skills` | array | no | Member skill names bundled by the plugin. |
+
+A registry that does not implement this endpoint should return `404`; the CLI treats that as "plugin search not available" and still supports installing a known plugin by name.
+
 ## Self-hosting
 
 Point the CLI at your registry by setting `SKILLS_API_URL`:

--- a/REGISTRY.md
+++ b/REGISTRY.md
@@ -19,6 +19,8 @@ Search for skills by keyword.
 
 ```json
 {
+  "query": "find-skills",
+  "searchType": "fuzzy",
   "skills": [
     {
       "id": "vercel-labs/skills/find-skills",
@@ -27,11 +29,23 @@ Search for skills by keyword.
       "installs": 1591220,
       "source": "vercel-labs/skills"
     }
-  ]
+  ],
+  "count": 1,
+  "duration_ms": 42
 }
 ```
 
-**Fields**
+**Envelope fields**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | string | no | The search query that produced these results. |
+| `searchType` | string | no | Search strategy used (e.g. `"fuzzy"`, `"all"`). |
+| `skills` | array | yes | Array of skill results. |
+| `count` | number | no | Total number of results returned. |
+| `duration_ms` | number | no | Time taken to execute the search in milliseconds. |
+
+**Skill fields**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/src/find.ts
+++ b/src/find.ts
@@ -41,6 +41,7 @@ export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
     const data = (await res.json()) as {
       skills: Array<{
         id: string;
+        skillId?: string;
         name: string;
         installs: number;
         source: string;
@@ -50,7 +51,7 @@ export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
     return data.skills
       .map((skill) => ({
         name: sanitizeMetadata(skill.name),
-        slug: sanitizeMetadata(skill.id),
+        slug: sanitizeMetadata(skill.skillId || skill.id),
         source: sanitizeMetadata(skill.source || ''),
         installs: skill.installs,
       }))


### PR DESCRIPTION
[Claude on behalf of Jacob]

**feat: document registry API spec and prefer `skillId` as URL slug**

Contributes to #348

## Summary

The skills CLI has no documented contract for the `/api/search` response shape, which makes it difficult for self-hosters to build a compatible registry. This PR adds `REGISTRY.md` to define that contract, and makes a small change to `find.ts` to better support the `skillId` field.

## Changes

**`REGISTRY.md`** — defines the `/api/search` request/response spec for skills registries, including field semantics for `id`, `skillId`, `name`, `source`, and `installs`, plus the detail endpoint convention and self-hosting instructions via `SKILLS_API_URL`.

Also documents the **optional `GET /api/bundles/search` endpoint** consumed by `skills bundle search` (see #1562, which adds the `bundle` command for installing curated sets of skills): request/response envelope (`bundles` key), field semantics including repo-relative member `skills` paths and discovery `tags`, and the graceful-degradation convention — a registry that doesn't implement it returns `404` and the CLI treats bundle search as unavailable while still supporting direct `bundle install`. (Earlier revisions of this branch named this endpoint `plugins/search`; it follows #1562's rename — "plugin" now widely means a native agent plugin with MCP servers and hooks, which this is not.)

**`find.ts`** — prefer `skillId` over `id` when building the detail URL slug. Self-hosted registries may return a full path slug in `skillId` (e.g. `{source}/{name}`) that differs from `id`. Falls back to `id` for registries that don't return `skillId`, preserving existing behavior.

## Motivation

Closes the gap for self-hosted registry implementors who need to know what the CLI expects from `/api/search`. The `skillId` field is already returned by skills.sh but unused by the CLI — this makes it the canonical source for detail URLs when present.
