### PR TITLE
Add AnythingLLM agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,13 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:end -->
 
 > [!NOTE]
+> **AnythingLLM users:** AnythingLLM lists imported custom skills only when each skill folder includes
+> `plugin.json` and `handler.js`. Installing with `--agent anythingllm` writes those wrapper files alongside
+> `SKILL.md` so the skill appears in AnythingLLM's Custom Skills UI. Set `STORAGE_DIR` to an AnythingLLM
+> storage directory to target `$STORAGE_DIR/plugins/agent-skills`; otherwise the CLI falls back to common
+> project storage layouts.
+
+> [!NOTE]
 > **Kiro CLI users:** The default agent automatically loads skills from `.kiro/skills/` and `~/.kiro/skills/` — no
 > configuration needed. If you use a **custom agent**, add skills to its `resources` in `.kiro/agents/<agent>.json`:
 >

--- a/README.md
+++ b/README.md
@@ -40,15 +40,18 @@ npx skills add ./my-local-skills
 
 ### Options
 
-| Option                    | Description                                                                                                                                        |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-g, --global`            | Install to user directory instead of project                                                                                                       |
-| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Supported Agents](#supported-agents)<!-- agent-names:end --> |
-| `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
-| `-l, --list`              | List available skills without installing                                                                                                           |
-| `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
-| `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
-| `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+| Option                             | Description                                                                                                                                        |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-g, --global`                     | Install to user directory instead of project                                                                                                       |
+| `-a, --agent <agents...>`          | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Supported Agents](#supported-agents)<!-- agent-names:end --> |
+| `-s, --skill <skills...>`          | Install specific skills by name (use `'*'` for all skills)                                                                                         |
+| `-l, --list`                       | List available skills without installing                                                                                                           |
+| `--copy`                           | Copy files instead of symlinking to agent directories                                                                                              |
+| `-y, --yes`                        | Skip all confirmation prompts                                                                                                                      |
+| `--all`                            | Install all skills to all agents without prompts                                                                                                   |
+| `--anythingllm-project [project]`  | Select and record an AnythingLLM project by title, slug, or id when installing with `--agent anythingllm`                                          |
+| `--anythingllm-storage-dir <path>` | Override the AnythingLLM storage directory used for detection and installation                                                                     |
+| `--anythingllm-skip-project`       | Skip AnythingLLM project selection                                                                                                                 |
 
 ### Examples
 
@@ -76,6 +79,9 @@ npx skills add vercel-labs/agent-skills --skill '*' -a claude-code
 
 # Install specific skills to all agents
 npx skills add vercel-labs/agent-skills --agent '*' --skill frontend-design
+
+# Install to AnythingLLM and record the target project context
+npx skills add vercel-labs/agent-skills --agent anythingllm --skill frontend-design --anythingllm-project "My Workspace"
 ```
 
 ### Installation Scope
@@ -289,7 +295,10 @@ Skills can be installed to any of these agents:
 > `plugin.json` and `handler.js`. Installing with `--agent anythingllm` writes those wrapper files alongside
 > `SKILL.md` so the skill appears in AnythingLLM's Custom Skills UI. Set `STORAGE_DIR` to an AnythingLLM
 > storage directory to target `$STORAGE_DIR/plugins/agent-skills`; otherwise the CLI falls back to common
-> project storage layouts.
+> project storage layouts and desktop storage locations on macOS, Windows, and Linux. Use
+> `--anythingllm-project [project]` to select a workspace by title, slug, or id. AnythingLLM stores imported
+> skills at the instance level today, so the CLI records the selected project in generated wrapper metadata
+> instead of moving the skill into a project-specific directory.
 
 > [!NOTE]
 > **Kiro CLI users:** The default agent automatically loads skills from `.kiro/skills/` and `~/.kiro/skills/` — no

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [52 more](#supported-agents).
 
 <!-- agent-list:end -->
 
@@ -233,6 +233,7 @@ Skills can be installed to any of these agents:
 | AiderDesk                             | `aider-desk`                             | `.aider-desk/skills/`    | `~/.aider-desk/skills/`         |
 | Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/`        | `~/.config/agents/skills/`      |
 | Antigravity                           | `antigravity`                            | `.agents/skills/`        | `~/.gemini/antigravity/skills/` |
+| AnythingLLM                           | `anythingllm`                            | `plugins/agent-skills/`  | N/A (project-only)              |
 | Augment                               | `augment`                                | `.augment/skills/`       | `~/.augment/skills/`            |
 | IBM Bob                               | `bob`                                    | `.bob/skills/`           | `~/.bob/skills/`                |
 | Claude Code                           | `claude-code`                            | `.claude/skills/`        | `~/.claude/skills/`             |
@@ -353,6 +354,7 @@ The CLI searches for skills in these locations within a repository:
 - `skills/.system/`
 - `.aider-desk/skills/`
 - `.agents/skills/`
+- `plugins/agent-skills/`
 - `.augment/skills/`
 - `.bob/skills/`
 - `.claude/skills/`

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "aider-desk",
     "amp",
     "antigravity",
+    "anythingllm",
     "augment",
     "bob",
     "claude-code",

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -9,6 +9,10 @@ const ROOT = join(import.meta.dirname, '..');
 const README_PATH = join(ROOT, 'README.md');
 const PACKAGE_PATH = join(ROOT, 'package.json');
 
+function toMarkdownPath(path: string): string {
+  return path.replaceAll('\\', '/');
+}
+
 function generateAgentList(): string {
   const agentList = Object.values(agents);
   const count = agentList.length;
@@ -48,7 +52,7 @@ function generateAvailableAgentsTable(): string {
 
   const rows = Array.from(pathGroups.values()).map((group) => {
     const globalPath = group.globalSkillsDir
-      ? `\`${group.globalSkillsDir.replace(homedir(), '~')}/\``
+      ? `\`${toMarkdownPath(group.globalSkillsDir.replace(homedir(), '~'))}/\``
       : 'N/A (project-only)';
     const names = group.displayNames.join(', ');
     const keys = group.keys.map((k) => `\`${k}\``).join(', ');

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -389,6 +389,31 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse AnythingLLM project targeting options', () => {
+    const result = parseAddOptions([
+      'source',
+      '--agent',
+      'anythingllm',
+      '--anythingllm-project',
+      'Customer Ops',
+      '--anythingllm-storage-dir',
+      '/tmp/anythingllm-storage',
+    ]);
+
+    expect(result.source).toEqual(['source']);
+    expect(result.options.agent).toEqual(['anythingllm']);
+    expect(result.options.anythingllmProject).toBe('Customer Ops');
+    expect(result.options.anythingllmStorageDir).toBe('/tmp/anythingllm-storage');
+  });
+
+  it('should parse interactive and skip AnythingLLM project flags', () => {
+    const interactive = parseAddOptions(['source', '--anythingllm-project']);
+    const skipped = parseAddOptions(['source', '--anythingllm-skip-project']);
+
+    expect(interactive.options.anythingllmProject).toBe(true);
+    expect(skipped.options.anythingllmSkipProject).toBe(true);
+  });
 });
 
 describe('openclaw source blocking', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -40,6 +40,12 @@ import {
   isUniversalAgent,
 } from './agents.ts';
 import {
+  listAnythingLLMProjects,
+  resolveAnythingLLMProject,
+  resolveAnythingLLMStorage,
+  type AnythingLLMProject,
+} from './agents/anythingllm.ts';
+import {
   track,
   setVersion,
   fetchAuditData,
@@ -429,6 +435,77 @@ export interface AddOptions {
   fullDepth?: boolean;
   copy?: boolean;
   dangerouslyAcceptOpenclawRisks?: boolean;
+  anythingllmProject?: string | true;
+  anythingllmStorageDir?: string;
+  anythingllmSkipProject?: boolean;
+}
+
+async function resolveAnythingLLMProjectSelection(
+  options: AddOptions,
+  targetAgents: AgentType[],
+  cwd: string
+): Promise<AnythingLLMProject | undefined> {
+  if (!targetAgents.includes('anythingllm')) return undefined;
+
+  if (options.anythingllmStorageDir) {
+    process.env.STORAGE_DIR = options.anythingllmStorageDir;
+  }
+
+  if (options.anythingllmSkipProject || options.anythingllmProject === undefined) {
+    return undefined;
+  }
+
+  const storage = resolveAnythingLLMStorage({
+    cwd,
+    explicitStorageDir: options.anythingllmStorageDir,
+  });
+  const projects = await listAnythingLLMProjects(storage);
+
+  if (typeof options.anythingllmProject === 'string') {
+    if (projects.length === 0) {
+      throw new Error(
+        `Could not discover AnythingLLM projects from ${storage.databasePath}. Install will not guess project state.`
+      );
+    }
+    return resolveAnythingLLMProject(projects, options.anythingllmProject);
+  }
+
+  if (options.yes) {
+    throw new Error(
+      '--anythingllm-project requires a project title, slug, or id in non-interactive mode.'
+    );
+  }
+
+  if (projects.length === 0) {
+    p.log.warn(
+      `No AnythingLLM projects found at ${storage.databasePath}. Installing at the instance level.`
+    );
+    return undefined;
+  }
+
+  const selected = await p.select({
+    message: 'Select AnythingLLM project',
+    options: [
+      ...projects.map((project) => ({
+        value: project.id,
+        label: project.title,
+        hint: project.slug ? `workspace: ${project.slug}` : `id: ${project.id}`,
+      })),
+      {
+        value: '__skip__',
+        label: 'Skip project selection',
+        hint: 'Install at the AnythingLLM instance level',
+      },
+    ],
+  });
+
+  if (p.isCancel(selected)) {
+    p.cancel('Installation cancelled');
+    process.exit(0);
+  }
+
+  if (selected === '__skip__') return undefined;
+  return projects.find((project) => project.id === selected);
 }
 
 /**
@@ -670,6 +747,7 @@ async function handleWellKnownSkills(
   }
 
   const cwd = process.cwd();
+  const anythingllmProject = await resolveAnythingLLMProjectSelection(options, targetAgents, cwd);
 
   // Build installation summary
   const summaryLines: string[] = [];
@@ -702,6 +780,11 @@ async function handleWellKnownSkills(
     summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
+    }
+    if (anythingllmProject && targetAgents.includes('anythingllm')) {
+      summaryLines.push(
+        `  ${pc.dim('AnythingLLM project:')} ${anythingllmProject.title}${anythingllmProject.slug ? pc.dim(` (${anythingllmProject.slug})`) : ''}`
+      );
     }
 
     const skillOverwrites = overwriteStatus.get(skill.installName);
@@ -748,6 +831,7 @@ async function handleWellKnownSkills(
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
+        anythingllmProject: agent === 'anythingllm' ? anythingllmProject : undefined,
       });
       results.push({
         skill: skill.installName,
@@ -1387,6 +1471,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     const cwd = process.cwd();
+    const anythingllmProject = await resolveAnythingLLMProjectSelection(options, targetAgents, cwd);
 
     // Build installation summary
     const summaryLines: string[] = [];
@@ -1433,6 +1518,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const shortCanonical = shortenPath(canonicalPath, cwd);
         summaryLines.push(`${pc.cyan(shortCanonical)}`);
         summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+        if (anythingllmProject && targetAgents.includes('anythingllm')) {
+          summaryLines.push(
+            `  ${pc.dim('AnythingLLM project:')} ${anythingllmProject.title}${anythingllmProject.slug ? pc.dim(` (${anythingllmProject.slug})`) : ''}`
+          );
+        }
 
         const skillOverwrites = overwriteStatus.get(skill.name);
         const overwriteAgents = targetAgents
@@ -1524,13 +1614,18 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode }
+            {
+              global: installGlobally,
+              mode: installMode,
+              anythingllmProject: agent === 'anythingllm' ? anythingllmProject : undefined,
+            }
           );
         } else {
           // Disk-based install: copy from cloned/local directory
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
+            anythingllmProject: agent === 'anythingllm' ? anythingllmProject : undefined,
           });
         }
         results.push({
@@ -1940,6 +2035,22 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--anythingllm-project') {
+      const nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith('-')) {
+        options.anythingllmProject = nextArg;
+        i++;
+      } else {
+        options.anythingllmProject = true;
+      }
+    } else if (arg === '--anythingllm-storage-dir') {
+      const nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith('-')) {
+        options.anythingllmStorageDir = nextArg;
+        i++;
+      }
+    } else if (arg === '--anythingllm-skip-project') {
+      options.anythingllmSkipProject = true;
     } else if (arg === '--dangerously-accept-openclaw-risks') {
       options.dangerouslyAcceptOpenclawRisks = true;
     } else if (arg && !arg.startsWith('-')) {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,5 +1,5 @@
 import { homedir } from 'os';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { existsSync } from 'fs';
 import { xdgConfig } from 'xdg-basedir';
 import type { AgentConfig, AgentType } from './types.ts';
@@ -10,6 +10,46 @@ const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
+
+function nonEmptyEnv(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function getAnythingLLMSkillsDirCandidates(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  const explicitSkillsDir = nonEmptyEnv(env.ANYTHINGLLM_SKILLS_DIR);
+  if (explicitSkillsDir) return [resolve(explicitSkillsDir)];
+
+  const storageDir = nonEmptyEnv(env.STORAGE_DIR);
+  const candidates = [
+    ...(storageDir ? [resolve(storageDir, 'plugins', 'agent-skills')] : []),
+    resolve(cwd, 'plugins', 'agent-skills'),
+    resolve(cwd, 'server', 'storage', 'plugins', 'agent-skills'),
+    resolve(cwd, 'storage', 'plugins', 'agent-skills'),
+  ];
+
+  return [...new Set(candidates)];
+}
+
+export function getAnythingLLMSkillsDir(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync
+): string {
+  const candidates = getAnythingLLMSkillsDirCandidates(cwd, env);
+  return candidates.find(pathExists) ?? candidates[0]!;
+}
+
+export function isAnythingLLMInstalled(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync
+): boolean {
+  return getAnythingLLMSkillsDirCandidates(cwd, env).some(pathExists);
+}
 
 export function getOpenClawGlobalSkillsDir(
   homeDir = home,
@@ -53,6 +93,16 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.gemini/antigravity/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.gemini/antigravity'));
+    },
+  },
+  anythingllm: {
+    name: 'anythingllm',
+    displayName: 'AnythingLLM',
+    skillsDir: 'plugins/agent-skills',
+    globalSkillsDir: undefined,
+    resolveSkillsDir: ({ cwd }) => getAnythingLLMSkillsDir(cwd),
+    detectInstalled: async () => {
+      return isAnythingLLMInstalled();
     },
   },
   augment: {
@@ -541,6 +591,16 @@ export async function detectInstalledAgents(): Promise<AgentType[]> {
 
 export function getAgentConfig(type: AgentType): AgentConfig {
   return agents[type];
+}
+
+export function getAgentSkillsDir(
+  type: AgentType,
+  options: { global?: boolean; cwd?: string } = {}
+): string | undefined {
+  const agent = agents[type];
+  if (options.global) return agent.globalSkillsDir;
+  const cwd = options.cwd || process.cwd();
+  return agent.resolveSkillsDir?.({ cwd }) ?? join(cwd, agent.skillsDir);
 }
 
 /**

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,8 +1,9 @@
 import { homedir } from 'os';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { existsSync } from 'fs';
 import { xdgConfig } from 'xdg-basedir';
 import type { AgentConfig, AgentType } from './types.ts';
+import { getAnythingLLMSkillsDir, isAnythingLLMInstalled } from './agents/anythingllm.ts';
 
 const home = homedir();
 // Use xdg-basedir (not env-paths) to match OpenCode/Amp/Goose behavior on all platforms.
@@ -10,46 +11,6 @@ const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
-
-function nonEmptyEnv(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed || undefined;
-}
-
-function getAnythingLLMSkillsDirCandidates(
-  cwd = process.cwd(),
-  env: NodeJS.ProcessEnv = process.env
-): string[] {
-  const explicitSkillsDir = nonEmptyEnv(env.ANYTHINGLLM_SKILLS_DIR);
-  if (explicitSkillsDir) return [resolve(explicitSkillsDir)];
-
-  const storageDir = nonEmptyEnv(env.STORAGE_DIR);
-  const candidates = [
-    ...(storageDir ? [resolve(storageDir, 'plugins', 'agent-skills')] : []),
-    resolve(cwd, 'plugins', 'agent-skills'),
-    resolve(cwd, 'server', 'storage', 'plugins', 'agent-skills'),
-    resolve(cwd, 'storage', 'plugins', 'agent-skills'),
-  ];
-
-  return [...new Set(candidates)];
-}
-
-export function getAnythingLLMSkillsDir(
-  cwd = process.cwd(),
-  env: NodeJS.ProcessEnv = process.env,
-  pathExists: (path: string) => boolean = existsSync
-): string {
-  const candidates = getAnythingLLMSkillsDirCandidates(cwd, env);
-  return candidates.find(pathExists) ?? candidates[0]!;
-}
-
-export function isAnythingLLMInstalled(
-  cwd = process.cwd(),
-  env: NodeJS.ProcessEnv = process.env,
-  pathExists: (path: string) => boolean = existsSync
-): boolean {
-  return getAnythingLLMSkillsDirCandidates(cwd, env).some(pathExists);
-}
 
 export function getOpenClawGlobalSkillsDir(
   homeDir = home,

--- a/src/agents/anythingllm.ts
+++ b/src/agents/anythingllm.ts
@@ -1,0 +1,212 @@
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { basename, dirname, join, resolve } from 'path';
+
+export interface AnythingLLMProject {
+  id: string;
+  title: string;
+  slug?: string;
+  updatedAt?: string;
+}
+
+export interface AnythingLLMStoragePaths {
+  storageDir: string;
+  skillsDir: string;
+  databasePath: string;
+}
+
+function nonEmptyEnv(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function unique(paths: string[]): string[] {
+  return [...new Set(paths)];
+}
+
+export function getAnythingLLMSkillsDirCandidates(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  const explicitSkillsDir = nonEmptyEnv(env.ANYTHINGLLM_SKILLS_DIR);
+  if (explicitSkillsDir) return [resolve(explicitSkillsDir)];
+
+  const storageDir = nonEmptyEnv(env.STORAGE_DIR);
+  const candidates = [
+    ...(storageDir ? [resolve(storageDir, 'plugins', 'agent-skills')] : []),
+    resolve(cwd, 'plugins', 'agent-skills'),
+    resolve(cwd, 'server', 'storage', 'plugins', 'agent-skills'),
+    resolve(cwd, 'storage', 'plugins', 'agent-skills'),
+    ...desktopStorageCandidates(undefined, env).map((candidate) =>
+      resolve(candidate, 'plugins', 'agent-skills')
+    ),
+  ];
+
+  return unique(candidates);
+}
+
+export function getAnythingLLMSkillsDir(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync
+): string {
+  const candidates = getAnythingLLMSkillsDirCandidates(cwd, env);
+  return candidates.find(pathExists) ?? candidates[0]!;
+}
+
+export function isAnythingLLMInstalled(
+  cwd = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync
+): boolean {
+  return getAnythingLLMSkillsDirCandidates(cwd, env).some(pathExists);
+}
+
+function storageDirFromSkillsDir(skillsDir: string): string | undefined {
+  const normalized = resolve(skillsDir);
+  const pluginsDir = dirname(normalized);
+  if (basename(normalized) !== 'agent-skills' || basename(pluginsDir) !== 'plugins') {
+    return undefined;
+  }
+  return dirname(pluginsDir);
+}
+
+function desktopStorageCandidates(homeDir = homedir(), env: NodeJS.ProcessEnv = process.env) {
+  const appData = nonEmptyEnv(env.APPDATA);
+  const xdgConfigHome = nonEmptyEnv(env.XDG_CONFIG_HOME);
+  const candidates = [
+    ...(appData ? [join(appData, 'anythingllm-desktop', 'storage')] : []),
+    join(homeDir, 'Library', 'Application Support', 'anythingllm-desktop', 'storage'),
+    join(xdgConfigHome || join(homeDir, '.config'), 'anythingllm-desktop', 'storage'),
+  ];
+
+  return unique(candidates);
+}
+
+export function resolveAnythingLLMStorage(
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    explicitStorageDir?: string;
+    pathExists?: (path: string) => boolean;
+  } = {}
+): AnythingLLMStoragePaths {
+  const cwd = options.cwd || process.cwd();
+  const env = options.env || process.env;
+  const pathExists = options.pathExists || existsSync;
+  const explicitStorageDir = nonEmptyEnv(options.explicitStorageDir);
+  const explicitSkillsDir = nonEmptyEnv(env.ANYTHINGLLM_SKILLS_DIR);
+  const envStorageDir = nonEmptyEnv(env.STORAGE_DIR);
+
+  const candidates = unique([
+    ...(explicitStorageDir ? [resolve(explicitStorageDir)] : []),
+    ...(explicitSkillsDir ? [storageDirFromSkillsDir(explicitSkillsDir)].filter(Boolean) : []),
+    ...(envStorageDir ? [resolve(envStorageDir)] : []),
+    resolve(cwd, 'server', 'storage'),
+    resolve(cwd, 'storage'),
+    ...desktopStorageCandidates(undefined, env).filter(pathExists),
+  ] as string[]);
+
+  const storageDir = candidates.find(pathExists) ?? candidates[0] ?? resolve(cwd, 'storage');
+  return {
+    storageDir,
+    skillsDir: resolve(storageDir, 'plugins', 'agent-skills'),
+    databasePath: resolve(storageDir, 'anythingllm.db'),
+  };
+}
+
+export function resolveAnythingLLMProject(
+  projects: AnythingLLMProject[],
+  query: string
+): AnythingLLMProject {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    throw new Error('AnythingLLM project cannot be empty.');
+  }
+  const matches = projects.filter(
+    (project) =>
+      project.id.toLowerCase() === normalizedQuery ||
+      project.slug?.toLowerCase() === normalizedQuery ||
+      project.title.toLowerCase() === normalizedQuery
+  );
+
+  if (matches.length === 1) return matches[0]!;
+  if (matches.length > 1) {
+    throw new Error(`Multiple AnythingLLM projects match "${query}". Use the project id or slug.`);
+  }
+  throw new Error(`No AnythingLLM project found matching "${query}".`);
+}
+
+async function importNodeSqlite(): Promise<{
+  DatabaseSync?: new (path: string, options?: { readOnly?: boolean }) => unknown;
+}> {
+  const dynamicImport = new Function('specifier', 'return import(specifier)') as (
+    specifier: string
+  ) => Promise<{
+    DatabaseSync?: new (path: string, options?: { readOnly?: boolean }) => unknown;
+  }>;
+  const emitWarning = process.emitWarning;
+
+  try {
+    process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
+      const warningName =
+        typeof args[0] === 'string'
+          ? args[0]
+          : typeof args[0] === 'object' && args[0] && 'type' in args[0]
+            ? String((args[0] as { type?: unknown }).type)
+            : undefined;
+      const warningMessage = typeof warning === 'string' ? warning : warning.message;
+
+      if (warningName === 'ExperimentalWarning' && /SQLite/i.test(warningMessage)) {
+        return;
+      }
+
+      return emitWarning.call(process, warning as never, ...(args as never[]));
+    }) as typeof process.emitWarning;
+
+    return await dynamicImport('node:sqlite');
+  } finally {
+    process.emitWarning = emitWarning;
+  }
+}
+
+export async function listAnythingLLMProjects(
+  storage: Pick<AnythingLLMStoragePaths, 'databasePath'>,
+  options: { pathExists?: (path: string) => boolean } = {}
+): Promise<AnythingLLMProject[]> {
+  const pathExists = options.pathExists || existsSync;
+  if (!pathExists(storage.databasePath)) return [];
+
+  try {
+    const sqlite = await importNodeSqlite();
+    if (!sqlite.DatabaseSync) return [];
+
+    const database = new sqlite.DatabaseSync(storage.databasePath, { readOnly: true }) as {
+      prepare(query: string): { all(): Array<Record<string, unknown>> };
+      close(): void;
+    };
+    try {
+      const rows = database
+        .prepare('SELECT id, name, slug, lastUpdatedAt FROM workspaces ORDER BY LOWER(name), id')
+        .all();
+      return rows.flatMap((row) => {
+        const id = typeof row.id === 'string' || typeof row.id === 'number' ? String(row.id) : '';
+        const title = typeof row.name === 'string' ? row.name.trim() : '';
+        if (!id || !title) return [];
+
+        return [
+          {
+            id,
+            title,
+            slug: typeof row.slug === 'string' ? row.slug : undefined,
+            updatedAt: typeof row.lastUpdatedAt === 'string' ? row.lastUpdatedAt : undefined,
+          },
+        ];
+      });
+    } finally {
+      database.close();
+    }
+  } catch {
+    return [];
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,6 +132,12 @@ ${BOLD}Add Options:${RESET}
   --copy                 Copy files instead of symlinking to agent directories
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
+  --anythingllm-project [project]
+                         Select and record an AnythingLLM project by title, slug, or id
+  --anythingllm-storage-dir <path>
+                         Override the AnythingLLM storage directory
+  --anythingllm-skip-project
+                         Skip AnythingLLM project selection
 
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -16,6 +16,7 @@ import { join, basename, normalize, resolve, sep, relative, dirname } from 'path
 import { homedir, platform } from 'os';
 import type { Skill, AgentType, RemoteSkill } from './types.ts';
 import type { WellKnownSkill } from './providers/wellknown.ts';
+import type { AnythingLLMProject } from './agents/anythingllm.ts';
 import { agents, detectInstalledAgents, getAgentSkillsDir, isUniversalAgent } from './agents.ts';
 import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
 import { parseSkillMd } from './skills.ts';
@@ -36,6 +37,7 @@ interface AnythingLLMPluginMetadata {
   hubId: string;
   name: string;
   description: string;
+  project?: AnythingLLMProject;
 }
 
 /**
@@ -186,6 +188,14 @@ async function writeAnythingLLMPluginFiles(
       },
     },
     imported: true,
+    ...(metadata.project
+      ? {
+          skillsCli: {
+            anythingllmProject: metadata.project,
+            note: 'AnythingLLM imported skills are installed at the instance level; project selection is recorded for user context.',
+          },
+        }
+      : {}),
   };
 
   await writeFile(pluginJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
@@ -313,7 +323,12 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    anythingllmProject?: AnythingLLMProject;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -371,6 +386,7 @@ export async function installSkillForAgent(
         hubId: skillName,
         name: skill.name || skillName,
         description: skill.description || `Imported skill: ${skill.name || skillName}`,
+        project: options.anythingllmProject,
       });
 
       return {
@@ -387,6 +403,7 @@ export async function installSkillForAgent(
       hubId: skillName,
       name: skill.name || skillName,
       description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      project: options.anythingllmProject,
     });
 
     // For universal agents with global install, the skill is already in the canonical
@@ -428,6 +445,7 @@ export async function installSkillForAgent(
         hubId: skillName,
         name: skill.name || skillName,
         description: skill.description || `Imported skill: ${skill.name || skillName}`,
+        project: options.anythingllmProject,
       });
 
       return {
@@ -585,7 +603,12 @@ export function getCanonicalPath(
 export async function installRemoteSkillForAgent(
   skill: RemoteSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    anythingllmProject?: AnythingLLMProject;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -642,6 +665,7 @@ export async function installRemoteSkillForAgent(
         hubId: skillName,
         name: skill.name || skillName,
         description: skill.description || `Imported skill: ${skill.name || skillName}`,
+        project: options.anythingllmProject,
       });
 
       return {
@@ -659,6 +683,7 @@ export async function installRemoteSkillForAgent(
       hubId: skillName,
       name: skill.name || skillName,
       description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      project: options.anythingllmProject,
     });
 
     // For universal agents with global install, skip creating agent-specific symlink
@@ -682,6 +707,7 @@ export async function installRemoteSkillForAgent(
         hubId: skillName,
         name: skill.name || skillName,
         description: skill.description || `Imported skill: ${skill.name || skillName}`,
+        project: options.anythingllmProject,
       });
 
       return {
@@ -719,7 +745,12 @@ export async function installRemoteSkillForAgent(
 export async function installWellKnownSkillForAgent(
   skill: WellKnownSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    anythingllmProject?: AnythingLLMProject;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -796,6 +827,7 @@ export async function installWellKnownSkillForAgent(
         hubId: skillName,
         name: skill.name || skillName,
         description: skill.description || `Imported skill: ${skill.name || skillName}`,
+        project: options.anythingllmProject,
       });
 
       return {
@@ -812,6 +844,7 @@ export async function installWellKnownSkillForAgent(
       hubId: skillName,
       name: skill.name || skillName,
       description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      project: options.anythingllmProject,
     });
 
     // For universal agents with global install, skip creating agent-specific symlink
@@ -834,6 +867,7 @@ export async function installWellKnownSkillForAgent(
         hubId: skillName,
         name: skill.name || skillName,
         description: skill.description || `Imported skill: ${skill.name || skillName}`,
+        project: options.anythingllmProject,
       });
 
       return {
@@ -869,7 +903,12 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    anythingllmProject?: AnythingLLMProject;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -931,6 +970,7 @@ export async function installBlobSkillForAgent(
         hubId: skillName,
         name: skill.installName,
         description: `Imported skill: ${skill.installName}`,
+        project: options.anythingllmProject,
       });
       return { success: true, path: agentDir, mode: 'copy' };
     }
@@ -942,6 +982,7 @@ export async function installBlobSkillForAgent(
       hubId: skillName,
       name: skill.installName,
       description: `Imported skill: ${skill.installName}`,
+      project: options.anythingllmProject,
     });
 
     if (isGlobal && isUniversalAgent(agentType)) {
@@ -977,6 +1018,7 @@ export async function installBlobSkillForAgent(
         hubId: skillName,
         name: skill.installName,
         description: `Imported skill: ${skill.installName}`,
+        project: options.anythingllmProject,
       });
       return {
         success: true,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -32,6 +32,12 @@ interface InstallResult {
   error?: string;
 }
 
+interface AnythingLLMPluginMetadata {
+  hubId: string;
+  name: string;
+  description: string;
+}
+
 /**
  * Sanitizes a filename/directory name to prevent path traversal attacks
  * and ensures it follows kebab-case convention
@@ -118,6 +124,81 @@ function getAgentProjectRootDir(agentType: AgentType, cwd: string, agentBase: st
 
 function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
   return resolve(dirname(linkPath), linkTarget);
+}
+
+function anythingLLMHandlerSource(): string {
+  return `const fs = require('fs');
+const path = require('path');
+
+function readSkillMarkdown() {
+  return fs.readFileSync(path.resolve(__dirname, 'SKILL.md'), 'utf8');
+}
+
+module.exports.runtime = {
+  handler: async function ({ request } = {}) {
+    const markdown = readSkillMarkdown();
+    const prefix = request
+      ? \`Use the following imported skill instructions to help with this request: \${request}\\n\\n\`
+      : 'Use the following imported skill instructions when relevant.\\n\\n';
+    return \`\${prefix}\${markdown}\`;
+  },
+};
+`;
+}
+
+async function writeAnythingLLMPluginFiles(
+  targetDir: string,
+  metadata: AnythingLLMPluginMetadata
+): Promise<void> {
+  const pluginJsonPath = join(targetDir, 'plugin.json');
+  const handlerPath = join(targetDir, 'handler.js');
+
+  if (existsSync(pluginJsonPath) && existsSync(handlerPath)) return;
+
+  if (!isPathSafe(targetDir, pluginJsonPath) || !isPathSafe(targetDir, handlerPath)) {
+    throw new Error('Invalid AnythingLLM plugin path: potential path traversal detected');
+  }
+
+  const manifest = {
+    active: false,
+    hubId: metadata.hubId,
+    name: metadata.name,
+    schema: 'skill-1.0.0',
+    version: '1.0.0',
+    description: metadata.description,
+    author: 'skills CLI',
+    author_url: 'https://github.com/vercel-labs/skills',
+    license: 'UNLICENSED',
+    setup_args: {},
+    examples: [
+      {
+        prompt: `Use the ${metadata.name} skill`,
+        call: JSON.stringify({ request: 'Apply this skill to the current task.' }),
+      },
+    ],
+    entrypoint: {
+      file: 'handler.js',
+      params: {
+        request: {
+          type: 'string',
+          description: 'Optional task or context for applying this imported skill.',
+        },
+      },
+    },
+    imported: true,
+  };
+
+  await writeFile(pluginJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+  await writeFile(handlerPath, anythingLLMHandlerSource(), 'utf-8');
+}
+
+async function finalizeAgentSkillInstall(
+  agentType: AgentType,
+  targetDir: string,
+  metadata: AnythingLLMPluginMetadata
+): Promise<void> {
+  if (agentType !== 'anythingllm') return;
+  await writeAnythingLLMPluginFiles(targetDir, metadata);
 }
 
 /**
@@ -286,6 +367,11 @@ export async function installSkillForAgent(
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
       await copyDirectory(skill.path, agentDir);
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.name || skillName,
+        description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      });
 
       return {
         success: true,
@@ -297,6 +383,11 @@ export async function installSkillForAgent(
     // Symlink mode: copy to canonical location and symlink to agent location
     await cleanAndCreateDirectory(canonicalDir);
     await copyDirectory(skill.path, canonicalDir);
+    await finalizeAgentSkillInstall(agentType, canonicalDir, {
+      hubId: skillName,
+      name: skill.name || skillName,
+      description: skill.description || `Imported skill: ${skill.name || skillName}`,
+    });
 
     // For universal agents with global install, the skill is already in the canonical
     // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
@@ -314,7 +405,7 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    if (!isGlobal && !isUniversalAgent(agentType) && agentType !== 'anythingllm') {
       const agentRootDir = getAgentProjectRootDir(agentType, cwd, agentBase);
       if (!existsSync(agentRootDir)) {
         return {
@@ -333,6 +424,11 @@ export async function installSkillForAgent(
       // Symlink failed, fall back to copy
       await cleanAndCreateDirectory(agentDir);
       await copyDirectory(skill.path, agentDir);
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.name || skillName,
+        description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      });
 
       return {
         success: true,
@@ -542,6 +638,11 @@ export async function installRemoteSkillForAgent(
       await cleanAndCreateDirectory(agentDir);
       const skillMdPath = join(agentDir, 'SKILL.md');
       await writeFile(skillMdPath, skill.content, 'utf-8');
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.name || skillName,
+        description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      });
 
       return {
         success: true,
@@ -554,6 +655,11 @@ export async function installRemoteSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     const skillMdPath = join(canonicalDir, 'SKILL.md');
     await writeFile(skillMdPath, skill.content, 'utf-8');
+    await finalizeAgentSkillInstall(agentType, canonicalDir, {
+      hubId: skillName,
+      name: skill.name || skillName,
+      description: skill.description || `Imported skill: ${skill.name || skillName}`,
+    });
 
     // For universal agents with global install, skip creating agent-specific symlink
     if (isGlobal && isUniversalAgent(agentType)) {
@@ -572,6 +678,11 @@ export async function installRemoteSkillForAgent(
       await cleanAndCreateDirectory(agentDir);
       const agentSkillMdPath = join(agentDir, 'SKILL.md');
       await writeFile(agentSkillMdPath, skill.content, 'utf-8');
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.name || skillName,
+        description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      });
 
       return {
         success: true,
@@ -681,6 +792,11 @@ export async function installWellKnownSkillForAgent(
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.name || skillName,
+        description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      });
 
       return {
         success: true,
@@ -692,6 +808,11 @@ export async function installWellKnownSkillForAgent(
     // Symlink mode: write to canonical location and symlink to agent location
     await cleanAndCreateDirectory(canonicalDir);
     await writeSkillFiles(canonicalDir);
+    await finalizeAgentSkillInstall(agentType, canonicalDir, {
+      hubId: skillName,
+      name: skill.name || skillName,
+      description: skill.description || `Imported skill: ${skill.name || skillName}`,
+    });
 
     // For universal agents with global install, skip creating agent-specific symlink
     if (isGlobal && isUniversalAgent(agentType)) {
@@ -709,6 +830,11 @@ export async function installWellKnownSkillForAgent(
       // Symlink failed, fall back to copy
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.name || skillName,
+        description: skill.description || `Imported skill: ${skill.name || skillName}`,
+      });
 
       return {
         success: true,
@@ -801,12 +927,22 @@ export async function installBlobSkillForAgent(
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.installName,
+        description: `Imported skill: ${skill.installName}`,
+      });
       return { success: true, path: agentDir, mode: 'copy' };
     }
 
     // Symlink mode
     await cleanAndCreateDirectory(canonicalDir);
     await writeSkillFiles(canonicalDir);
+    await finalizeAgentSkillInstall(agentType, canonicalDir, {
+      hubId: skillName,
+      name: skill.installName,
+      description: `Imported skill: ${skill.installName}`,
+    });
 
     if (isGlobal && isUniversalAgent(agentType)) {
       return {
@@ -819,7 +955,7 @@ export async function installBlobSkillForAgent(
 
     // For project-level installs, skip creating symlinks for non-universal agents
     // whose config directory doesn't already exist in the project.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    if (!isGlobal && !isUniversalAgent(agentType) && agentType !== 'anythingllm') {
       const agentRootDir = getAgentProjectRootDir(agentType, cwd, agentBase);
       if (!existsSync(agentRootDir)) {
         return {
@@ -837,6 +973,11 @@ export async function installBlobSkillForAgent(
     if (!symlinkCreated) {
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
+      await finalizeAgentSkillInstall(agentType, agentDir, {
+        hubId: skillName,
+        name: skill.installName,
+        description: `Imported skill: ${skill.installName}`,
+      });
       return {
         success: true,
         path: agentDir,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -16,7 +16,7 @@ import { join, basename, normalize, resolve, sep, relative, dirname } from 'path
 import { homedir, platform } from 'os';
 import type { Skill, AgentType, RemoteSkill } from './types.ts';
 import type { WellKnownSkill } from './providers/wellknown.ts';
-import { agents, detectInstalledAgents, isUniversalAgent } from './agents.ts';
+import { agents, detectInstalledAgents, getAgentSkillsDir, isUniversalAgent } from './agents.ts';
 import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
 import { parseSkillMd } from './skills.ts';
 
@@ -108,7 +108,12 @@ export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: str
     return agent.globalSkillsDir;
   }
 
-  return join(baseDir, agent.skillsDir);
+  return getAgentSkillsDir(agentType, { cwd: baseDir })!;
+}
+
+function getAgentProjectRootDir(agentType: AgentType, cwd: string, agentBase: string): string {
+  const agent = agents[agentType];
+  return agent.resolveSkillsDir ? agentBase : join(cwd, agent.skillsDir.split('/')[0]!);
 }
 
 function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
@@ -310,7 +315,7 @@ export async function installSkillForAgent(
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
     if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
+      const agentRootDir = getAgentProjectRootDir(agentType, cwd, agentBase);
       if (!existsSync(agentRootDir)) {
         return {
           success: true,
@@ -422,7 +427,7 @@ export async function isSkillInstalled(
 
   const targetBase = options.global
     ? agent.globalSkillsDir!
-    : join(options.cwd || process.cwd(), agent.skillsDir);
+    : getAgentSkillsDir(agentType, { cwd: options.cwd || process.cwd() })!;
 
   const skillDir = join(targetBase, sanitized);
 
@@ -815,7 +820,7 @@ export async function installBlobSkillForAgent(
     // For project-level installs, skip creating symlinks for non-universal agents
     // whose config directory doesn't already exist in the project.
     if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
+      const agentRootDir = getAgentProjectRootDir(agentType, cwd, agentBase);
       if (!existsSync(agentRootDir)) {
         return {
           success: true,
@@ -927,7 +932,8 @@ export async function listInstalledSkills(
       if (isGlobal && agent.globalSkillsDir === undefined) {
         continue;
       }
-      const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+      const agentDir = getAgentSkillsDir(agentType, { global: isGlobal, cwd });
+      if (!agentDir) continue;
       // Avoid duplicate paths
       if (!scopes.some((s) => s.path === agentDir && s.global === isGlobal)) {
         scopes.push({ global: isGlobal, path: agentDir, agentType });
@@ -943,7 +949,8 @@ export async function listInstalledSkills(
       if (agentsToCheck.includes(agentType)) continue;
       const agent = agents[agentType];
       if (isGlobal && agent.globalSkillsDir === undefined) continue;
-      const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+      const agentDir = getAgentSkillsDir(agentType, { global: isGlobal, cwd });
+      if (!agentDir) continue;
       if (scopes.some((s) => s.path === agentDir && s.global === isGlobal)) continue;
       if (existsSync(agentDir)) {
         scopes.push({ global: isGlobal, path: agentDir, agentType });
@@ -1009,7 +1016,8 @@ export async function listInstalledSkills(
             continue;
           }
 
-          const agentBase = scope.global ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+          const agentBase = getAgentSkillsDir(agentType, { global: scope.global, cwd });
+          if (!agentBase) continue;
           let found = false;
 
           // Try exact directory name matches

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
-import { agents, detectInstalledAgents } from './agents.ts';
+import { agents, detectInstalledAgents, getAgentSkillsDir } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
@@ -65,8 +65,9 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
   } else {
     await scanDir(getCanonicalSkillsDir(false, cwd));
-    for (const agent of Object.values(agents)) {
-      await scanDir(join(cwd, agent.skillsDir));
+    for (const agentKey of Object.keys(agents) as AgentType[]) {
+      const agentSkillsDir = getAgentSkillsDir(agentKey, { cwd });
+      if (agentSkillsDir) await scanDir(agentSkillsDir);
     }
   }
 
@@ -177,7 +178,8 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         if (isGlobal && agent.globalSkillsDir) {
           pathsToCleanup.add(join(agent.globalSkillsDir, sanitizedName));
         } else {
-          pathsToCleanup.add(join(cwd, agent.skillsDir, sanitizedName));
+          const agentSkillsDir = getAgentSkillsDir(agentKey, { cwd });
+          if (agentSkillsDir) pathsToCleanup.add(join(agentSkillsDir, sanitizedName));
         }
 
         for (const pathToCleanup of pathsToCleanup) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type AgentType =
   | 'aider-desk'
   | 'amp'
   | 'antigravity'
+  | 'anythingllm'
   | 'augment'
   | 'bob'
   | 'claude-code'
@@ -72,6 +73,8 @@ export interface AgentConfig {
   skillsDir: string;
   /** Global skills directory. Set to undefined if the agent doesn't support global installation. */
   globalSkillsDir: string | undefined;
+  /** Optional project-scope resolver for agents whose skills directory can vary by environment. */
+  resolveSkillsDir?: (options: { cwd: string }) => string;
   detectInstalled: () => Promise<boolean>;
   /** Whether to show this agent in the universal agents list. Defaults to true. */
   showInUniversalList?: boolean;

--- a/src/update.ts
+++ b/src/update.ts
@@ -23,7 +23,7 @@ import { fetchRepoTree, findSkillMdPaths, getSkillFolderHashFromTree } from './b
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
-import { agents, isUniversalAgent } from './agents.ts';
+import { agents, getAgentSkillsDir, isUniversalAgent } from './agents.ts';
 import type { AgentType } from './types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -466,8 +466,8 @@ export async function updateProjectSkills(
         hasUniversal = true;
       }
     } else {
-      const agentRoot = config.skillsDir.split('/')[0]!;
-      if (existsSync(join(cwd, agentRoot))) {
+      const agentSkillsDir = getAgentSkillsDir(type as AgentType, { cwd });
+      if (agentSkillsDir && existsSync(agentSkillsDir)) {
         targetAgentNames.push(config.displayName);
       }
     }

--- a/tests/anythingllm-agent.test.ts
+++ b/tests/anythingllm-agent.test.ts
@@ -1,15 +1,19 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   agents,
   getAgentSkillsDir,
-  getAnythingLLMSkillsDir,
   getNonUniversalAgents,
   getUniversalAgents,
-  isAnythingLLMInstalled,
 } from '../src/agents.ts';
+import {
+  getAnythingLLMSkillsDir,
+  isAnythingLLMInstalled,
+  resolveAnythingLLMProject,
+  resolveAnythingLLMStorage,
+} from '../src/agents/anythingllm.ts';
 import {
   getAgentBaseDir,
   installRemoteSkillForAgent,
@@ -25,6 +29,13 @@ function readAnythingLLMManifest(skillDir: string) {
     description: string;
     entrypoint: { file: string; params: Record<string, unknown> };
     imported: boolean;
+    skillsCli?: {
+      anythingllmProject?: {
+        id: string;
+        title: string;
+        slug?: string;
+      };
+    };
   };
 }
 
@@ -50,9 +61,14 @@ describe('AnythingLLM agent support', () => {
   const originalCwd = process.cwd();
   const originalStorageDir = process.env.STORAGE_DIR;
   const originalAnythingLLMSkillsDir = process.env.ANYTHINGLLM_SKILLS_DIR;
+  const originalAppData = process.env.APPDATA;
+  const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
   let tempDir: string | undefined;
 
-  function restoreEnv(name: 'STORAGE_DIR' | 'ANYTHINGLLM_SKILLS_DIR', value: string | undefined) {
+  function restoreEnv(
+    name: 'STORAGE_DIR' | 'ANYTHINGLLM_SKILLS_DIR' | 'APPDATA' | 'XDG_CONFIG_HOME',
+    value: string | undefined
+  ) {
     if (value === undefined) {
       delete process.env[name];
       return;
@@ -60,10 +76,19 @@ describe('AnythingLLM agent support', () => {
     process.env[name] = value;
   }
 
+  beforeEach(() => {
+    delete process.env.STORAGE_DIR;
+    delete process.env.ANYTHINGLLM_SKILLS_DIR;
+    process.env.APPDATA = join(tmpdir(), 'skills-empty-appdata');
+    process.env.XDG_CONFIG_HOME = join(tmpdir(), 'skills-empty-xdg-config');
+  });
+
   afterEach(() => {
     process.chdir(originalCwd);
     restoreEnv('STORAGE_DIR', originalStorageDir);
     restoreEnv('ANYTHINGLLM_SKILLS_DIR', originalAnythingLLMSkillsDir);
+    restoreEnv('APPDATA', originalAppData);
+    restoreEnv('XDG_CONFIG_HOME', originalXdgConfigHome);
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
       tempDir = undefined;
@@ -127,6 +152,64 @@ describe('AnythingLLM agent support', () => {
     );
   });
 
+  it('detects desktop AnythingLLM storage locations', () => {
+    const appData = join(tmpdir(), 'anythingllm-appdata');
+    const desktopSkillsDir = join(
+      appData,
+      'anythingllm-desktop',
+      'storage',
+      'plugins',
+      'agent-skills'
+    );
+
+    expect(
+      isAnythingLLMInstalled(
+        join(tmpdir(), 'anythingllm-cwd'),
+        { APPDATA: appData },
+        (path) => path === desktopSkillsDir
+      )
+    ).toBe(true);
+    expect(
+      getAnythingLLMSkillsDir(
+        join(tmpdir(), 'anythingllm-cwd'),
+        { APPDATA: appData },
+        (path) => path === desktopSkillsDir
+      )
+    ).toBe(desktopSkillsDir);
+  });
+
+  it('resolves storage from an explicit AnythingLLM skills directory', () => {
+    const storageDir = join(tmpdir(), 'anythingllm-explicit-storage');
+    const explicitSkillsDir = join(storageDir, 'plugins', 'agent-skills');
+
+    expect(
+      resolveAnythingLLMStorage({
+        cwd: join(tmpdir(), 'anythingllm-cwd'),
+        env: { ANYTHINGLLM_SKILLS_DIR: explicitSkillsDir },
+      })
+    ).toMatchObject({
+      storageDir,
+      skillsDir: explicitSkillsDir,
+      databasePath: join(storageDir, 'anythingllm.db'),
+    });
+  });
+
+  it('resolves AnythingLLM projects by id, title, or slug', () => {
+    const projects = [
+      { id: '1', title: 'Support Desk', slug: 'support-desk' },
+      { id: '2', title: 'Research', slug: 'research' },
+    ];
+
+    expect(resolveAnythingLLMProject(projects, '1')).toMatchObject({ title: 'Support Desk' });
+    expect(resolveAnythingLLMProject(projects, 'research')).toMatchObject({ id: '2' });
+    expect(resolveAnythingLLMProject(projects, 'Support Desk')).toMatchObject({
+      slug: 'support-desk',
+    });
+    expect(() => resolveAnythingLLMProject(projects, 'missing')).toThrow(
+      'No AnythingLLM project found'
+    );
+  });
+
   it('installs project skills into the resolved AnythingLLM storage directory', async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'skills-anythingllm-install-'));
     const skillDir = join(tempDir, 'source-skill');
@@ -171,6 +254,49 @@ describe('AnythingLLM agent support', () => {
       'Example AnythingLLM Skill'
     );
     expect(getAgentSkillsDir('anythingllm', { cwd: tempDir })).toBe(anythingllmSkillsDir);
+  });
+
+  it('records selected AnythingLLM project metadata in generated wrappers', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skills-anythingllm-project-'));
+    const skillDir = join(tempDir, 'source-skill');
+    const storageDir = join(tempDir, 'anythingllm-storage');
+
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      ['---', 'name: Project AnythingLLM Skill', 'description: Project test skill', '---', ''].join(
+        '\n'
+      )
+    );
+    process.env.STORAGE_DIR = storageDir;
+
+    const result = await installSkillForAgent(
+      {
+        name: 'Project AnythingLLM Skill',
+        description: 'Project test skill',
+        path: skillDir,
+      },
+      'anythingllm',
+      {
+        cwd: tempDir,
+        mode: 'copy',
+        anythingllmProject: {
+          id: '42',
+          title: 'Customer Ops',
+          slug: 'customer-ops',
+        },
+      }
+    );
+
+    expect(readAnythingLLMManifest(result.path)).toMatchObject({
+      skillsCli: {
+        anythingllmProject: {
+          id: '42',
+          title: 'Customer Ops',
+          slug: 'customer-ops',
+        },
+      },
+    });
   });
 
   it('creates AnythingLLM wrappers in default symlink mode', async () => {

--- a/tests/anythingllm-agent.test.ts
+++ b/tests/anythingllm-agent.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -10,7 +10,41 @@ import {
   getUniversalAgents,
   isAnythingLLMInstalled,
 } from '../src/agents.ts';
-import { getAgentBaseDir, installSkillForAgent } from '../src/installer.ts';
+import {
+  getAgentBaseDir,
+  installRemoteSkillForAgent,
+  installSkillForAgent,
+} from '../src/installer.ts';
+
+function readAnythingLLMManifest(skillDir: string) {
+  return JSON.parse(readFileSync(join(skillDir, 'plugin.json'), 'utf-8')) as {
+    active: boolean;
+    hubId: string;
+    name: string;
+    schema: string;
+    description: string;
+    entrypoint: { file: string; params: Record<string, unknown> };
+    imported: boolean;
+  };
+}
+
+function expectAnythingLLMPlugin(skillDir: string, hubId: string, name: string) {
+  expect(existsSync(join(skillDir, 'SKILL.md'))).toBe(true);
+  expect(existsSync(join(skillDir, 'handler.js'))).toBe(true);
+
+  const manifest = readAnythingLLMManifest(skillDir);
+  expect(manifest).toMatchObject({
+    active: false,
+    hubId,
+    name,
+    schema: 'skill-1.0.0',
+    entrypoint: {
+      file: 'handler.js',
+    },
+    imported: true,
+  });
+  expect(manifest.entrypoint.params).toHaveProperty('request');
+}
 
 describe('AnythingLLM agent support', () => {
   const originalCwd = process.cwd();
@@ -131,6 +165,135 @@ describe('AnythingLLM agent support', () => {
       path: join(anythingllmSkillsDir, 'example-anythingllm-skill'),
       mode: 'copy',
     });
+    expectAnythingLLMPlugin(
+      join(anythingllmSkillsDir, 'example-anythingllm-skill'),
+      'example-anythingllm-skill',
+      'Example AnythingLLM Skill'
+    );
     expect(getAgentSkillsDir('anythingllm', { cwd: tempDir })).toBe(anythingllmSkillsDir);
+  });
+
+  it('creates AnythingLLM wrappers in default symlink mode', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skills-anythingllm-symlink-'));
+    const skillDir = join(tempDir, 'source-skill');
+    const storageDir = join(tempDir, 'anythingllm-storage');
+    const anythingllmSkillsDir = join(storageDir, 'plugins', 'agent-skills');
+
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      [
+        '---',
+        'name: Linked AnythingLLM Skill',
+        'description: Linked test skill',
+        '---',
+        '',
+        '# Linked AnythingLLM Skill',
+        '',
+      ].join('\n')
+    );
+    process.env.STORAGE_DIR = storageDir;
+
+    const result = await installSkillForAgent(
+      {
+        name: 'Linked AnythingLLM Skill',
+        description: 'Linked test skill',
+        path: skillDir,
+      },
+      'anythingllm',
+      { cwd: tempDir }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      path: join(anythingllmSkillsDir, 'linked-anythingllm-skill'),
+      canonicalPath: join(tempDir, '.agents', 'skills', 'linked-anythingllm-skill'),
+      mode: 'symlink',
+    });
+    expectAnythingLLMPlugin(
+      join(anythingllmSkillsDir, 'linked-anythingllm-skill'),
+      'linked-anythingllm-skill',
+      'Linked AnythingLLM Skill'
+    );
+  });
+
+  it('creates AnythingLLM imported plugin wrappers for remote skills', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skills-anythingllm-remote-'));
+    const storageDir = join(tempDir, 'anythingllm-storage');
+    process.env.STORAGE_DIR = storageDir;
+
+    const result = await installRemoteSkillForAgent(
+      {
+        name: 'Remote AnythingLLM Skill',
+        description: 'Remote test skill',
+        content: [
+          '---',
+          'name: Remote AnythingLLM Skill',
+          'description: Remote test skill',
+          '---',
+          '',
+          '# Remote AnythingLLM Skill',
+          '',
+        ].join('\n'),
+        installName: 'Remote AnythingLLM Skill',
+        sourceUrl: 'https://example.com/skill',
+        providerId: 'test',
+        sourceIdentifier: 'test/example',
+      },
+      'anythingllm',
+      { cwd: tempDir, mode: 'copy' }
+    );
+
+    const skillDir = join(storageDir, 'plugins', 'agent-skills', 'remote-anythingllm-skill');
+    expect(result).toMatchObject({
+      success: true,
+      path: skillDir,
+      mode: 'copy',
+    });
+    expectAnythingLLMPlugin(skillDir, 'remote-anythingllm-skill', 'Remote AnythingLLM Skill');
+  });
+
+  it('preserves native AnythingLLM plugin files when a skill already provides them', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skills-anythingllm-native-'));
+    const skillDir = join(tempDir, 'source-skill');
+    const storageDir = join(tempDir, 'anythingllm-storage');
+    const nativeManifest = {
+      active: true,
+      hubId: 'native-anythingllm-skill',
+      name: 'Native AnythingLLM Skill',
+      schema: 'skill-1.0.0',
+      version: '2.0.0',
+      description: 'Already packaged for AnythingLLM',
+      entrypoint: { file: 'handler.js', params: {} },
+      imported: true,
+    };
+
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      ['---', 'name: Native AnythingLLM Skill', 'description: Native test skill', '---', ''].join(
+        '\n'
+      )
+    );
+    writeFileSync(join(skillDir, 'plugin.json'), `${JSON.stringify(nativeManifest, null, 2)}\n`);
+    writeFileSync(
+      join(skillDir, 'handler.js'),
+      'module.exports.runtime = { handler: async () => "native" };\n'
+    );
+    process.env.STORAGE_DIR = storageDir;
+
+    const result = await installSkillForAgent(
+      {
+        name: 'Native AnythingLLM Skill',
+        description: 'Native test skill',
+        path: skillDir,
+      },
+      'anythingllm',
+      { cwd: tempDir, mode: 'copy' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(readAnythingLLMManifest(result.path)).toMatchObject(nativeManifest);
+    expect(readFileSync(join(result.path, 'handler.js'), 'utf-8')).toContain('"native"');
   });
 });

--- a/tests/anythingllm-agent.test.ts
+++ b/tests/anythingllm-agent.test.ts
@@ -1,0 +1,136 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  agents,
+  getAgentSkillsDir,
+  getAnythingLLMSkillsDir,
+  getNonUniversalAgents,
+  getUniversalAgents,
+  isAnythingLLMInstalled,
+} from '../src/agents.ts';
+import { getAgentBaseDir, installSkillForAgent } from '../src/installer.ts';
+
+describe('AnythingLLM agent support', () => {
+  const originalCwd = process.cwd();
+  const originalStorageDir = process.env.STORAGE_DIR;
+  const originalAnythingLLMSkillsDir = process.env.ANYTHINGLLM_SKILLS_DIR;
+  let tempDir: string | undefined;
+
+  function restoreEnv(name: 'STORAGE_DIR' | 'ANYTHINGLLM_SKILLS_DIR', value: string | undefined) {
+    if (value === undefined) {
+      delete process.env[name];
+      return;
+    }
+    process.env[name] = value;
+  }
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    restoreEnv('STORAGE_DIR', originalStorageDir);
+    restoreEnv('ANYTHINGLLM_SKILLS_DIR', originalAnythingLLMSkillsDir);
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('uses the AnythingLLM custom agent skills project directory', () => {
+    expect(agents.anythingllm).toMatchObject({
+      name: 'anythingllm',
+      displayName: 'AnythingLLM',
+      skillsDir: 'plugins/agent-skills',
+      globalSkillsDir: undefined,
+    });
+  });
+
+  it('is selectable as an agent-specific target', () => {
+    expect(getNonUniversalAgents()).toContain('anythingllm');
+    expect(getUniversalAgents()).not.toContain('anythingllm');
+  });
+
+  it('detects and resolves a project-level plugins/agent-skills directory', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skills-anythingllm-'));
+    process.chdir(tempDir);
+
+    expect(await agents.anythingllm.detectInstalled()).toBe(false);
+
+    mkdirSync(join(tempDir, 'plugins', 'agent-skills'), { recursive: true });
+
+    expect(await agents.anythingllm.detectInstalled()).toBe(true);
+    expect(getAgentSkillsDir('anythingllm', { cwd: tempDir })).toBe(
+      join(tempDir, 'plugins', 'agent-skills')
+    );
+    expect(getAgentBaseDir('anythingllm', false, tempDir)).toBe(
+      join(tempDir, 'plugins', 'agent-skills')
+    );
+  });
+
+  it('resolves AnythingLLM development storage under server/storage', () => {
+    const cwd = join(tmpdir(), 'anythingllm-dev');
+    const devSkillsDir = join(cwd, 'server', 'storage', 'plugins', 'agent-skills');
+    const exists = (path: string) => path === devSkillsDir;
+
+    expect(isAnythingLLMInstalled(cwd, {}, exists)).toBe(true);
+    expect(getAnythingLLMSkillsDir(cwd, {}, exists)).toBe(devSkillsDir);
+  });
+
+  it('prefers explicit AnythingLLM and STORAGE_DIR environment paths', () => {
+    const cwd = join(tmpdir(), 'anythingllm-env');
+    const explicitSkillsDir = join(tmpdir(), 'custom-anythingllm-skills');
+    const storageDir = join(tmpdir(), 'anythingllm-storage');
+
+    expect(
+      getAnythingLLMSkillsDir(cwd, {
+        ANYTHINGLLM_SKILLS_DIR: explicitSkillsDir,
+        STORAGE_DIR: storageDir,
+      })
+    ).toBe(explicitSkillsDir);
+
+    expect(getAnythingLLMSkillsDir(cwd, { STORAGE_DIR: storageDir })).toBe(
+      join(storageDir, 'plugins', 'agent-skills')
+    );
+  });
+
+  it('installs project skills into the resolved AnythingLLM storage directory', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'skills-anythingllm-install-'));
+    const skillDir = join(tempDir, 'source-skill');
+    const storageDir = join(tempDir, 'anythingllm-storage');
+    const anythingllmSkillsDir = join(storageDir, 'plugins', 'agent-skills');
+
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(anythingllmSkillsDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      [
+        '---',
+        'name: Example AnythingLLM Skill',
+        'description: Test skill',
+        '---',
+        '',
+        '# Example AnythingLLM Skill',
+        '',
+      ].join('\n')
+    );
+
+    process.env.STORAGE_DIR = storageDir;
+
+    const result = await installSkillForAgent(
+      {
+        name: 'Example AnythingLLM Skill',
+        description: 'Test skill',
+        path: skillDir,
+      },
+      'anythingllm',
+      { cwd: tempDir, mode: 'copy' }
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      path: join(anythingllmSkillsDir, 'example-anythingllm-skill'),
+      mode: 'copy',
+    });
+    expect(getAgentSkillsDir('anythingllm', { cwd: tempDir })).toBe(anythingllmSkillsDir);
+  });
+});


### PR DESCRIPTION
## Summary
- add AnythingLLM as a selectable project-scoped agent target (`--agent anythingllm`)
- auto-detect AnythingLLM when its custom agent skills directory exists
- resolve AnythingLLM skill paths from `ANYTHINGLLM_SKILLS_DIR`, `STORAGE_DIR/plugins/agent-skills`, and common project storage layouts
- generate AnythingLLM `plugin.json` and `handler.js` wrappers so installed `SKILL.md` folders appear in AnythingLLM's Custom Skills UI
- preserve native AnythingLLM plugin packages that already provide `plugin.json` and `handler.js`
- route install/list/remove/update logic through the agent path resolver for env-dependent skill directories

## Validation
- `pnpm exec vitest run tests/anythingllm-agent.test.ts`
- `pnpm exec vitest run tests/anythingllm-agent.test.ts tests/installer-copy.test.ts src/add.test.ts src/list.test.ts`
- `node scripts/validate-agents.ts`
- `pnpm build`
- targeted Prettier check
- `git diff --check`

Note: full local `pnpm test` on Windows is still blocked by existing environment-specific symlink permission failures and Codex non-interactive banner behavior. The AnythingLLM-specific coverage, touched-path tests, build, formatting, and agent validation pass.