### PR TITLE
feat: lifecycle hook wiring for agent invocation tracking

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -55,6 +55,7 @@ import {
   type PartnerAudit,
 } from './telemetry.ts';
 import { detectAgent, getAgentType } from './detect-agent.ts';
+import { wireUserPromptHook } from './hooks.ts';
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
@@ -1552,6 +1553,22 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     spinner.stop('Installation complete');
 
+    // Wire per-skill UserPromptSubmit hooks for installed skills (non-fatal)
+    for (const skill of selectedSkills) {
+      const skillId = (skill.metadata?.['skill_id'] ?? skill.metadata?.['id']) as
+        | string
+        | undefined;
+      if (!skillId) continue;
+      const skillName = getSkillDisplayName(skill);
+      for (const agentName of targetAgents) {
+        try {
+          await wireUserPromptHook({ skillName, skillId, agent: agentName });
+        } catch {
+          // Hook wiring is best-effort — never fail an install
+        }
+      }
+    }
+
     console.log();
     const successful = results.filter((r) => r.success);
     const failed = results.filter((r) => !r.success);
@@ -1646,6 +1663,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               if (hash) skillFolderHash = hash;
             }
 
+            const skillIdForLock = (skill.metadata?.['skill_id'] ?? skill.metadata?.['id']) as
+              | string
+              | undefined;
             await addSkillToLock(skill.name, {
               source: lockSource || normalizedSource,
               sourceType: parsed.type,
@@ -1654,6 +1674,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
+              ...(skillIdForLock && { skillId: skillIdForLock }),
             });
           } catch {
             // Don't fail installation if lock file update fails

--- a/src/add.ts
+++ b/src/add.ts
@@ -56,10 +56,10 @@ import {
 } from './telemetry.ts';
 import { detectAgent, getAgentType } from './detect-agent.ts';
 import { wireUserPromptHook } from './hooks.ts';
-import { addHookRef } from './skill-lock.ts';
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
+  addHookRef,
   fetchSkillFolderHash,
   getGitHubToken,
   isPromptDismissed,
@@ -828,6 +828,7 @@ async function handleWellKnownSkills(
                 source: sourceIdentifier,
                 sourceType: 'well-known',
                 computedHash,
+                skillRef: `${sourceIdentifier}/${skill.installName}`,
               },
               cwd
             );

--- a/src/add.ts
+++ b/src/add.ts
@@ -56,6 +56,7 @@ import {
 } from './telemetry.ts';
 import { detectAgent, getAgentType } from './detect-agent.ts';
 import { wireUserPromptHook } from './hooks.ts';
+import { addHookRef } from './skill-lock.ts';
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
@@ -1555,17 +1556,24 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     // Wire per-skill UserPromptSubmit hooks for installed skills (non-fatal)
     for (const skill of selectedSkills) {
-      const skillId = (skill.metadata?.['skill_id'] ?? skill.metadata?.['id']) as
-        | string
-        | undefined;
-      if (!skillId) continue;
       const skillName = getSkillDisplayName(skill);
+      const skillRef = ownerRepoRaw ? `${ownerRepoRaw}/${skillName}` : skillName;
       for (const agentName of targetAgents) {
         try {
-          await wireUserPromptHook({ skillName, skillId, agent: agentName });
+          await wireUserPromptHook({ skillName, skillRef, agent: agentName });
         } catch {
           // Hook wiring is best-effort — never fail an install
         }
+      }
+      // Record ref so `skills remove` knows when it's safe to tear down the hook.
+      try {
+        if (installGlobally) {
+          await addHookRef(skillRef, { global: true });
+        } else {
+          await addHookRef(skillRef, { projectPath: process.cwd() });
+        }
+      } catch {
+        // best-effort
       }
     }
 
@@ -1663,9 +1671,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               if (hash) skillFolderHash = hash;
             }
 
-            const skillIdForLock = (skill.metadata?.['skill_id'] ?? skill.metadata?.['id']) as
-              | string
-              | undefined;
+            const lockSkillRef = ownerRepoRaw ? `${ownerRepoRaw}/${skill.name}` : skill.name;
             await addSkillToLock(skill.name, {
               source: lockSource || normalizedSource,
               sourceType: parsed.type,
@@ -1674,7 +1680,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
-              ...(skillIdForLock && { skillId: skillIdForLock }),
+              skillRef: lockSkillRef,
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -1696,6 +1702,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
             const skillPathValue = skillFiles[skill.name];
+            const localSkillRef = ownerRepoRaw ? `${ownerRepoRaw}/${skill.name}` : skill.name;
             await addSkillToLocalLock(
               skill.name,
               {
@@ -1704,6 +1711,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
+                skillRef: localSkillRef,
               },
               cwd
             );

--- a/src/add.ts
+++ b/src/add.ts
@@ -1556,12 +1556,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     spinner.stop('Installation complete');
 
     // Wire per-skill UserPromptSubmit hooks for installed skills (non-fatal)
+    let hooksWired = false;
     for (const skill of selectedSkills) {
       const skillName = getSkillDisplayName(skill);
       const skillRef = ownerRepoRaw ? `${ownerRepoRaw}/${skillName}` : skillName;
       for (const agentName of targetAgents) {
         try {
-          await wireUserPromptHook({ skillName, skillRef, agent: agentName });
+          const changed = await wireUserPromptHook({ skillName, skillRef, agent: agentName });
+          if (changed) hooksWired = true;
         } catch {
           // Hook wiring is best-effort — never fail an install
         }
@@ -1576,6 +1578,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       } catch {
         // best-effort
       }
+    }
+    if (hooksWired) {
+      console.log(
+        'Hooks were written as part of install — you may need to trust them and restart your AI tools before they take effect.'
+      );
     }
 
     console.log();

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -81,6 +81,11 @@ export const agents: Record<AgentType, AgentConfig> = {
     detectInstalled: async () => {
       return existsSync(claudeHome);
     },
+    hooksFile: '.claude/settings.json',
+    stopEvent: 'Stop',
+    failEvent: 'StopFailure',
+    promptEvent: 'UserPromptSubmit',
+    hookSchema: 'nested',
   },
   openclaw: {
     name: 'openclaw',
@@ -148,6 +153,10 @@ export const agents: Record<AgentType, AgentConfig> = {
     detectInstalled: async () => {
       return existsSync(codexHome) || existsSync('/etc/codex');
     },
+    hooksFile: '.codex/hooks.json',
+    stopEvent: 'Stop',
+    promptEvent: 'UserPromptSubmit',
+    hookSchema: 'nested',
   },
   'command-code': {
     name: 'command-code',
@@ -193,6 +202,10 @@ export const agents: Record<AgentType, AgentConfig> = {
     detectInstalled: async () => {
       return existsSync(join(home, '.cursor'));
     },
+    hooksFile: '.cursor/hooks.json',
+    stopEvent: 'stop',
+    promptEvent: 'beforeSubmitPrompt',
+    hookSchema: 'flat',
   },
   deepagents: {
     name: 'deepagents',
@@ -265,6 +278,11 @@ export const agents: Record<AgentType, AgentConfig> = {
     detectInstalled: async () => {
       return existsSync(join(home, '.copilot'));
     },
+    hooksFile: '.copilot/hooks/skills.json',
+    stopEvent: 'agentStop',
+    failEvent: 'errorOccurred',
+    promptEvent: 'userPromptSubmitted',
+    hookSchema: 'flat',
   },
   goose: {
     name: 'goose',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,10 @@
 
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
 import { basename, join, dirname } from 'path';
+import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
+import { wireStopHook, isHookSetupDone } from './hooks.ts';
 import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
@@ -11,6 +13,8 @@ import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { flushTelemetry } from './telemetry.ts';
 import { isRunningInAgent } from './detect-agent.ts';
+import { agents } from './agents.ts';
+import type { AgentType } from './types.ts';
 import { runUpdate } from './update.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -345,6 +349,9 @@ async function main(): Promise<void> {
     case 'upgrade':
       await runUpdate(restArgs);
       break;
+    case 'setup':
+      await runSetup();
+      break;
     case '--help':
     case '-h':
       showHelp();
@@ -357,6 +364,51 @@ async function main(): Promise<void> {
     default:
       console.log(`Unknown command: ${command}`);
       console.log(`Run ${BOLD}skills --help${RESET} for usage.`);
+  }
+}
+
+async function runSetup(): Promise<void> {
+  const home = homedir();
+  const hookableAgents = (Object.keys(agents) as AgentType[]).filter(
+    (a) => agents[a].hooksFile !== undefined
+  );
+
+  let configured = 0;
+  let skipped = 0;
+
+  for (const agentName of hookableAgents) {
+    const config = agents[agentName];
+
+    // Detect the agent by checking if its config dir root exists
+    const hooksFile = config.hooksFile!;
+    const configDirRoot = join(home, hooksFile.split('/')[0]!);
+    if (!existsSync(configDirRoot)) continue;
+
+    try {
+      const changed = await wireStopHook(agentName, { home });
+      if (changed) {
+        console.log(`  configured: ${config.displayName}`);
+        configured++;
+      } else {
+        skipped++;
+      }
+    } catch (err) {
+      console.error(
+        `  warning: could not configure ${config.displayName}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  if (configured + skipped === 0) {
+    console.log('No supported AI tools detected.');
+    console.log('Install Claude Code, Cursor, Codex, or GitHub Copilot and re-run skills setup.');
+    return;
+  }
+
+  if (configured > 0) {
+    console.log(`\nDone. ${configured} tool(s) configured, ${skipped} already set up.`);
+  } else {
+    console.log('\nAll tools already set up.');
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { basename, join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
-import { wireStopHook, isHookSetupDone } from './hooks.ts';
+import { wireStopHook, isHookSetupDone, repairHooks } from './hooks.ts';
 import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
@@ -126,6 +126,7 @@ ${BOLD}Project:${RESET}
   experimental_install Restore skills from skills-lock.json
   init [name]          Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
   experimental_sync    Sync skills from node_modules into agent directories
+  hooks repair         Repair missing and remove orphaned prompt hooks
 
 ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
@@ -352,6 +353,16 @@ async function main(): Promise<void> {
     case 'setup':
       await runSetup();
       break;
+    case 'hooks': {
+      const subcommand = restArgs[0];
+      if (subcommand === 'repair') {
+        await runHooksRepair();
+      } else {
+        console.log(`Unknown hooks subcommand: ${subcommand ?? '(none)'}`);
+        console.log(`Available: ${BOLD}repair${RESET}`);
+      }
+      break;
+    }
     case '--help':
     case '-h':
       showHelp();
@@ -410,6 +421,37 @@ async function runSetup(): Promise<void> {
   } else {
     console.log('\nAll tools already set up.');
   }
+}
+
+async function runHooksRepair(): Promise<void> {
+  const home = homedir();
+  const cwd = process.cwd();
+
+  // Note: SKILLS_HOOK_START_CMD being unset only disables wiring — orphan
+  // removal runs regardless so stale hooks are always cleaned up.
+  const projectPaths: string[] = [];
+  if (existsSync(join(cwd, 'skills-lock.json'))) {
+    projectPaths.push(cwd);
+  }
+
+  console.log('Repairing hooks...');
+  const result = await repairHooks({ home, projectPaths });
+
+  if (result.wired === 0 && result.removed === 0) {
+    console.log('All hooks are already correct — nothing to do.');
+    return;
+  }
+
+  if (result.wired > 0) {
+    console.log(`  wired: ${result.wired} missing hook(s)`);
+  }
+  if (result.removed > 0) {
+    console.log(`  removed: ${result.removed} orphaned hook(s)`);
+  }
+  if (result.agentsRepaired.length > 0) {
+    console.log(`  agents updated: ${result.agentsRepaired.join(', ')}`);
+  }
+  console.log('\nDone.');
 }
 
 main().finally(() => flushTelemetry().then(() => process.exit(0)));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -418,6 +418,9 @@ async function runSetup(): Promise<void> {
 
   if (configured > 0) {
     console.log(`\nDone. ${configured} tool(s) configured, ${skipped} already set up.`);
+    console.log(
+      'Hooks were written as part of setup — you may need to trust them and restart your AI tools before they take effect.'
+    );
   } else {
     console.log('\nAll tools already set up.');
   }

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -564,6 +564,58 @@ describe('repairHooks', () => {
     expect(cmd).toContain('--skill-ref acme/skills/new-skill');
     expect(cmd).not.toContain('old-skill');
   });
+
+  it('wires hooks for skills found on disk but absent from the lock file', async () => {
+    // Simulate a post-lock-migration state: skill dir exists, lock is empty.
+    writeGlobalLock({});
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    mkdirSync(join(home, '.agents', 'skills', 'gh-ship'), { recursive: true });
+
+    const result = await repairHooks({ home });
+
+    expect(result.wired).toBeGreaterThanOrEqual(1);
+    expect(result.agentsRepaired).toContain('Claude Code');
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    const cmds = promptHooks.flatMap((e) =>
+      ((e as Record<string, unknown>)['hooks'] as unknown[]).map(
+        (h) => (h as Record<string, unknown>)['command'] as string
+      )
+    );
+    expect(cmds.some((c) => c.includes('--skill-ref gh-ship'))).toBe(true);
+  });
+
+  it('prefers lock entry ref over disk-only fallback when both exist', async () => {
+    // Lock has the canonical full ref; disk dir also present — lock ref wins.
+    writeGlobalLock({
+      'gh-ship': {
+        source: 'acme/skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/acme/skills',
+        skillFolderHash: 'abc123',
+        installedAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        skillRef: 'acme/skills/gh-ship',
+      },
+    });
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    mkdirSync(join(home, '.agents', 'skills', 'gh-ship'), { recursive: true });
+
+    await repairHooks({ home });
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(1);
+    const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
+    expect((inner[0] as Record<string, unknown>)['command']).toContain(
+      '--skill-ref acme/skills/gh-ship'
+    );
+  });
 });
 
 // ─── isHookSetupDone ───────────────────────────────────────────────────────

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -7,12 +7,8 @@ import {
   wireUserPromptHook,
   removeUserPromptHook,
   isHookSetupDone,
+  repairHooks,
 } from './hooks.ts';
-
-// @vercel/detect-agent is mocked so tests don't depend on actual env vars
-vi.mock('@vercel/detect-agent', () => ({
-  determineAgent: vi.fn(() => ({ isAgent: true, agent: { name: 'claude-code' } })),
-}));
 
 // ─── helpers ───────────────────────────────────────────────────────────────
 
@@ -87,6 +83,23 @@ describe('wireStopHook', () => {
     );
   });
 
+  it('writes nested stop + StopFailure hooks for claude-code', async () => {
+    const changed = await wireStopHook('claude-code', { home });
+    expect(changed).toBe(true);
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const hooks = settings['hooks'] as Record<string, unknown>;
+    expect(hooks['Stop'] as unknown[]).toHaveLength(1);
+    expect(((hooks['Stop'] as unknown[])[0] as Record<string, unknown>)['hooks']).toBeDefined();
+    expect(hooks['StopFailure'] as unknown[]).toHaveLength(1);
+    const failInner = ((hooks['StopFailure'] as unknown[])[0] as Record<string, unknown>)[
+      'hooks'
+    ] as unknown[];
+    expect((failInner[0] as Record<string, unknown>)['command']).toBe(
+      'playlist-skills track stop --succeeded=false'
+    );
+  });
+
   it('is idempotent — second call returns false and does not duplicate entries', async () => {
     await wireStopHook('claude-code', { home });
     const changed = await wireStopHook('claude-code', { home });
@@ -127,7 +140,7 @@ describe('wireUserPromptHook', () => {
   beforeEach(() => {
     home = makeHome();
     process.env['SKILLS_HOOK_START_CMD'] =
-      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+      'playlist-skills track start --skill-ref {{skill_ref}} --agent {{agent}} --match-prompt /{{skill_name}}';
     delete process.env['SKILLS_HOOK_STOP_CMD'];
   });
 
@@ -140,17 +153,28 @@ describe('wireUserPromptHook', () => {
     delete process.env['SKILLS_HOOK_START_CMD'];
     const changed = await wireUserPromptHook({
       skillName: 'my-skill',
-      skillId: 'abc-123',
+      skillRef: 'owner/repo/my-skill',
       agent: 'claude-code',
       home,
     });
     expect(changed).toBe(false);
   });
 
-  it('substitutes {{skill_id}}, {{skill_name}}, {{agent}} tokens', async () => {
+  it('returns false when SKILLS_HOOK_START_CMD does not contain {{skill_name}}', async () => {
+    process.env['SKILLS_HOOK_START_CMD'] = 'my-tracker --agent {{agent}}';
+    const changed = await wireUserPromptHook({
+      skillName: 'my-skill',
+      skillRef: 'owner/repo/my-skill',
+      agent: 'claude-code',
+      home,
+    });
+    expect(changed).toBe(false);
+  });
+
+  it('substitutes {{skill_ref}}, {{skill_name}}, {{agent}} tokens', async () => {
     await wireUserPromptHook({
       skillName: 'pr-review',
-      skillId: 'skill-uuid-001',
+      skillRef: 'acme/skills/pr-review',
       agent: 'claude-code',
       home,
     });
@@ -162,7 +186,7 @@ describe('wireUserPromptHook', () => {
     const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
     const cmd = (inner[0] as Record<string, unknown>)['command'] as string;
 
-    expect(cmd).toContain('--skill-id skill-uuid-001');
+    expect(cmd).toContain('--skill-ref acme/skills/pr-review');
     expect(cmd).toContain('--agent claude-code');
     expect(cmd).toContain('--match-prompt /pr-review');
   });
@@ -170,7 +194,7 @@ describe('wireUserPromptHook', () => {
   it('uses flat schema for cursor', async () => {
     await wireUserPromptHook({
       skillName: 'pr-review',
-      skillId: 'skill-uuid-002',
+      skillRef: 'acme/skills/pr-review',
       agent: 'cursor',
       home,
     });
@@ -181,24 +205,24 @@ describe('wireUserPromptHook', () => {
     ] as unknown[];
     expect(promptHooks).toHaveLength(1);
     expect((promptHooks[0] as Record<string, unknown>)['command']).toContain(
-      '--skill-id skill-uuid-002'
+      '--skill-ref acme/skills/pr-review'
     );
   });
 
-  it('replaces existing entry for same skill-id on reinstall', async () => {
+  it('replaces existing entry for same skillRef on reinstall', async () => {
     const opts = {
       skillName: 'pr-review',
-      skillId: 'skill-uuid-003',
+      skillRef: 'acme/skills/pr-review',
       agent: 'claude-code' as const,
       home,
     };
 
     process.env['SKILLS_HOOK_START_CMD'] =
-      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+      'playlist-skills track start --skill-ref {{skill_ref}} --agent {{agent}} --match-prompt /{{skill_name}}';
     await wireUserPromptHook(opts);
 
     process.env['SKILLS_HOOK_START_CMD'] =
-      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}} --extra-flag';
+      'playlist-skills track start --skill-ref {{skill_ref}} --agent {{agent}} --match-prompt /{{skill_name}} --extra-flag';
     await wireUserPromptHook(opts);
 
     const settings = readJson(join(home, '.claude', 'settings.json'));
@@ -210,19 +234,19 @@ describe('wireUserPromptHook', () => {
     expect((inner[0] as Record<string, unknown>)['command']).toContain('--extra-flag');
   });
 
-  it('keeps entries for different skill-ids when adding a second skill', async () => {
+  it('keeps entries for different skillRefs when adding a second skill', async () => {
     process.env['SKILLS_HOOK_START_CMD'] =
-      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+      'playlist-skills track start --skill-ref {{skill_ref}} --agent {{agent}} --match-prompt /{{skill_name}}';
 
     await wireUserPromptHook({
       skillName: 'skill-a',
-      skillId: 'id-aaa',
+      skillRef: 'acme/skills/skill-a',
       agent: 'claude-code',
       home,
     });
     await wireUserPromptHook({
       skillName: 'skill-b',
-      skillId: 'id-bbb',
+      skillRef: 'acme/skills/skill-b',
       agent: 'claude-code',
       home,
     });
@@ -243,7 +267,7 @@ describe('removeUserPromptHook', () => {
   beforeEach(() => {
     home = makeHome();
     process.env['SKILLS_HOOK_START_CMD'] =
-      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+      'playlist-skills track start --skill-ref {{skill_ref}} --agent {{agent}} --match-prompt /{{skill_name}}';
   });
 
   afterEach(() => {
@@ -254,18 +278,22 @@ describe('removeUserPromptHook', () => {
   it('removes the correct entry and leaves others intact', async () => {
     await wireUserPromptHook({
       skillName: 'skill-a',
-      skillId: 'id-aaa',
+      skillRef: 'acme/skills/skill-a',
       agent: 'claude-code',
       home,
     });
     await wireUserPromptHook({
       skillName: 'skill-b',
-      skillId: 'id-bbb',
+      skillRef: 'acme/skills/skill-b',
       agent: 'claude-code',
       home,
     });
 
-    const removed = await removeUserPromptHook({ skillId: 'id-aaa', agent: 'claude-code', home });
+    const removed = await removeUserPromptHook({
+      skillRef: 'acme/skills/skill-a',
+      agent: 'claude-code',
+      home,
+    });
     expect(removed).toBe(true);
 
     const settings = readJson(join(home, '.claude', 'settings.json'));
@@ -274,19 +302,19 @@ describe('removeUserPromptHook', () => {
     ] as unknown[];
     expect(promptHooks).toHaveLength(1);
     const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
-    expect((inner[0] as Record<string, unknown>)['command']).toContain('--skill-id id-bbb');
+    expect((inner[0] as Record<string, unknown>)['command']).toContain('acme/skills/skill-b');
   });
 
-  it('returns false when skill-id is not present', async () => {
+  it('returns false when skillRef is not present', async () => {
     await wireUserPromptHook({
       skillName: 'skill-a',
-      skillId: 'id-aaa',
+      skillRef: 'acme/skills/skill-a',
       agent: 'claude-code',
       home,
     });
 
     const removed = await removeUserPromptHook({
-      skillId: 'nonexistent-id',
+      skillRef: 'acme/skills/nonexistent',
       agent: 'claude-code',
       home,
     });
@@ -294,18 +322,26 @@ describe('removeUserPromptHook', () => {
   });
 
   it('returns false when hooks file does not exist', async () => {
-    const removed = await removeUserPromptHook({ skillId: 'any-id', agent: 'claude-code', home });
+    const removed = await removeUserPromptHook({
+      skillRef: 'acme/skills/any',
+      agent: 'claude-code',
+      home,
+    });
     expect(removed).toBe(false);
   });
 
   it('removes flat-schema entry for cursor', async () => {
     await wireUserPromptHook({
       skillName: 'my-skill',
-      skillId: 'flat-id-001',
+      skillRef: 'acme/skills/my-skill',
       agent: 'cursor',
       home,
     });
-    const removed = await removeUserPromptHook({ skillId: 'flat-id-001', agent: 'cursor', home });
+    const removed = await removeUserPromptHook({
+      skillRef: 'acme/skills/my-skill',
+      agent: 'cursor',
+      home,
+    });
     expect(removed).toBe(true);
 
     const settings = readJson(join(home, '.cursor', 'hooks.json'));
@@ -313,6 +349,220 @@ describe('removeUserPromptHook', () => {
       'beforeSubmitPrompt'
     ] as unknown[];
     expect(promptHooks).toHaveLength(0);
+  });
+});
+
+// ─── repairHooks ──────────────────────────────────────────────────────────
+
+describe('repairHooks', () => {
+  let home: string;
+  let xdgStateDir: string;
+
+  function writeGlobalLock(skills: Record<string, unknown>): void {
+    const lockDir = join(xdgStateDir, 'skills');
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(
+      join(lockDir, '.skill-lock.json'),
+      JSON.stringify({ version: 3, skills }),
+      'utf-8'
+    );
+  }
+
+  beforeEach(() => {
+    home = makeHome();
+    xdgStateDir = makeHome();
+    process.env['XDG_STATE_HOME'] = xdgStateDir;
+    process.env['SKILLS_HOOK_START_CMD'] =
+      'playlist-skills track start --skill-ref {{skill_ref}} --agent {{agent}} --match-prompt /{{skill_name}}';
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(xdgStateDir, { recursive: true, force: true });
+    delete process.env['XDG_STATE_HOME'];
+    delete process.env['SKILLS_HOOK_START_CMD'];
+  });
+
+  it('returns zero counts when no skills are installed and no agent config dirs exist', async () => {
+    writeGlobalLock({});
+    const result = await repairHooks({ home });
+    expect(result).toEqual({ wired: 0, removed: 0, agentsRepaired: [] });
+  });
+
+  it('skips agents whose config dir does not exist', async () => {
+    writeGlobalLock({
+      'my-skill': {
+        source: 'acme/skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/acme/skills',
+        skillFolderHash: 'abc123',
+        installedAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        skillRef: 'acme/skills/my-skill',
+      },
+    });
+    // Deliberately do NOT create .claude or any other agent config dir
+    const result = await repairHooks({ home });
+    expect(result.wired).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.agentsRepaired).toHaveLength(0);
+  });
+
+  it('wires a missing hook for a globally installed skill', async () => {
+    writeGlobalLock({
+      'my-skill': {
+        source: 'acme/skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/acme/skills',
+        skillFolderHash: 'abc123',
+        installedAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        skillRef: 'acme/skills/my-skill',
+      },
+    });
+    mkdirSync(join(home, '.claude'), { recursive: true });
+
+    const result = await repairHooks({ home });
+
+    expect(result.wired).toBeGreaterThanOrEqual(1);
+    expect(result.agentsRepaired).toContain('Claude Code');
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(1);
+    const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
+    expect((inner[0] as Record<string, unknown>)['command']).toContain(
+      '--skill-ref acme/skills/my-skill'
+    );
+  });
+
+  it('removes an orphaned hook whose skillRef is no longer in any lock', async () => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+
+    const orphanCmd =
+      'playlist-skills track start --skill-ref acme/skills/ghost-skill --agent claude-code --match-prompt /ghost-skill';
+    const settingsPath = join(home, '.claude', 'settings.json');
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [{ hooks: [{ type: 'command', command: orphanCmd, timeout: 5 }] }],
+        },
+      }),
+      'utf-8'
+    );
+
+    writeGlobalLock({});
+
+    const result = await repairHooks({ home });
+
+    expect(result.removed).toBe(1);
+    expect(result.agentsRepaired).toContain('Claude Code');
+
+    const settings = readJson(settingsPath);
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(0);
+  });
+
+  it('is idempotent — calling repair twice does not duplicate hook entries', async () => {
+    writeGlobalLock({
+      'my-skill': {
+        source: 'acme/skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/acme/skills',
+        skillFolderHash: 'abc123',
+        installedAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        skillRef: 'acme/skills/my-skill',
+      },
+    });
+    mkdirSync(join(home, '.claude'), { recursive: true });
+
+    const first = await repairHooks({ home });
+    const second = await repairHooks({ home });
+
+    expect(first.wired).toBe(1);
+    expect(second.wired).toBe(0);
+    expect(second.removed).toBe(0);
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(1);
+  });
+
+  it('rebuilds hookRefs in the global lock after repair', async () => {
+    writeGlobalLock({
+      'my-skill': {
+        source: 'acme/skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/acme/skills',
+        skillFolderHash: 'abc123',
+        installedAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        skillRef: 'acme/skills/my-skill',
+      },
+    });
+    mkdirSync(join(home, '.claude'), { recursive: true });
+
+    await repairHooks({ home });
+
+    const lockPath = join(xdgStateDir, 'skills', '.skill-lock.json');
+    const lock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+    expect(lock.hookRefs?.['acme/skills/my-skill']).toEqual({
+      globalInstall: true,
+      projectPaths: [],
+    });
+  });
+
+  it('wires missing and removes orphaned in a single run', async () => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+
+    const orphanCmd =
+      'playlist-skills track start --skill-ref acme/skills/old-skill --agent claude-code --match-prompt /old-skill';
+    const settingsPath = join(home, '.claude', 'settings.json');
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [{ hooks: [{ type: 'command', command: orphanCmd, timeout: 5 }] }],
+        },
+      }),
+      'utf-8'
+    );
+
+    writeGlobalLock({
+      'new-skill': {
+        source: 'acme/skills',
+        sourceType: 'github',
+        sourceUrl: 'https://github.com/acme/skills',
+        skillFolderHash: 'def456',
+        installedAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        skillRef: 'acme/skills/new-skill',
+      },
+    });
+
+    const result = await repairHooks({ home });
+
+    expect(result.wired).toBe(1);
+    expect(result.removed).toBe(1);
+    expect(result.agentsRepaired).toContain('Claude Code');
+
+    const settings = readJson(settingsPath);
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(1);
+    const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
+    const cmd = (inner[0] as Record<string, unknown>)['command'] as string;
+    expect(cmd).toContain('--skill-ref acme/skills/new-skill');
+    expect(cmd).not.toContain('old-skill');
   });
 });
 

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  wireStopHook,
+  wireUserPromptHook,
+  removeUserPromptHook,
+  isHookSetupDone,
+} from './hooks.ts';
+
+// @vercel/detect-agent is mocked so tests don't depend on actual env vars
+vi.mock('@vercel/detect-agent', () => ({
+  determineAgent: vi.fn(() => ({ isAgent: true, agent: { name: 'claude-code' } })),
+}));
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function makeHome(): string {
+  const dir = join(tmpdir(), `hooks-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ─── wireStopHook ──────────────────────────────────────────────────────────
+
+describe('wireStopHook', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = makeHome();
+    process.env['SKILLS_HOOK_STOP_CMD'] = 'playlist-skills track stop';
+    process.env['SKILLS_HOOK_FAIL_CMD'] = 'playlist-skills track stop --succeeded=false';
+    delete process.env['SKILLS_HOOK_START_CMD'];
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env['SKILLS_HOOK_STOP_CMD'];
+    delete process.env['SKILLS_HOOK_FAIL_CMD'];
+  });
+
+  it('returns false when SKILLS_HOOK_STOP_CMD is unset', async () => {
+    delete process.env['SKILLS_HOOK_STOP_CMD'];
+    const changed = await wireStopHook('claude-code', { home });
+    expect(changed).toBe(false);
+  });
+
+  it('writes nested stop hook for claude-code', async () => {
+    const changed = await wireStopHook('claude-code', { home });
+    expect(changed).toBe(true);
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const stopHooks = (settings['hooks'] as Record<string, unknown>)['Stop'] as unknown[];
+    expect(stopHooks).toHaveLength(1);
+    const inner = (stopHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
+    expect((inner[0] as Record<string, unknown>)['command']).toBe('playlist-skills track stop');
+  });
+
+  it('writes flat stop hook for cursor', async () => {
+    const changed = await wireStopHook('cursor', { home });
+    expect(changed).toBe(true);
+
+    const settings = readJson(join(home, '.cursor', 'hooks.json'));
+    expect((settings as Record<string, unknown>)['version']).toBe(1);
+    const stopHooks = (settings['hooks'] as Record<string, unknown>)['stop'] as unknown[];
+    expect((stopHooks[0] as Record<string, unknown>)['command']).toBe('playlist-skills track stop');
+  });
+
+  it('writes flat stop + fail hooks for github-copilot', async () => {
+    const changed = await wireStopHook('github-copilot', { home });
+    expect(changed).toBe(true);
+
+    const settings = readJson(join(home, '.copilot', 'hooks', 'skills.json'));
+    const hooks = settings['hooks'] as Record<string, unknown>;
+    expect(hooks['agentStop'] as unknown[]).toHaveLength(1);
+    expect(((hooks['agentStop'] as unknown[])[0] as Record<string, unknown>)['command']).toBe(
+      'playlist-skills track stop'
+    );
+    expect(hooks['errorOccurred'] as unknown[]).toHaveLength(1);
+    expect(((hooks['errorOccurred'] as unknown[])[0] as Record<string, unknown>)['command']).toBe(
+      'playlist-skills track stop --succeeded=false'
+    );
+  });
+
+  it('is idempotent — second call returns false and does not duplicate entries', async () => {
+    await wireStopHook('claude-code', { home });
+    const changed = await wireStopHook('claude-code', { home });
+    expect(changed).toBe(false);
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const stopHooks = (settings['hooks'] as Record<string, unknown>)['Stop'] as unknown[];
+    expect(stopHooks).toHaveLength(1);
+  });
+
+  it('merges into an existing settings file without clobbering other keys', async () => {
+    const claudeDir = join(home, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      join(claudeDir, 'settings.json'),
+      JSON.stringify({ model: 'claude-opus-4-5', hooks: { PreToolUse: [] } })
+    );
+
+    await wireStopHook('claude-code', { home });
+
+    const settings = readJson(join(claudeDir, 'settings.json'));
+    expect(settings['model']).toBe('claude-opus-4-5');
+    expect((settings['hooks'] as Record<string, unknown>)['PreToolUse']).toEqual([]);
+    expect((settings['hooks'] as Record<string, unknown>)['Stop']).toHaveLength(1);
+  });
+
+  it('returns false for an agent without hook support (windsurf)', async () => {
+    const changed = await wireStopHook('windsurf' as never, { home });
+    expect(changed).toBe(false);
+  });
+});
+
+// ─── wireUserPromptHook ────────────────────────────────────────────────────
+
+describe('wireUserPromptHook', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = makeHome();
+    process.env['SKILLS_HOOK_START_CMD'] =
+      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+    delete process.env['SKILLS_HOOK_STOP_CMD'];
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env['SKILLS_HOOK_START_CMD'];
+  });
+
+  it('returns false when SKILLS_HOOK_START_CMD is unset', async () => {
+    delete process.env['SKILLS_HOOK_START_CMD'];
+    const changed = await wireUserPromptHook({
+      skillName: 'my-skill',
+      skillId: 'abc-123',
+      agent: 'claude-code',
+      home,
+    });
+    expect(changed).toBe(false);
+  });
+
+  it('substitutes {{skill_id}}, {{skill_name}}, {{agent}} tokens', async () => {
+    await wireUserPromptHook({
+      skillName: 'pr-review',
+      skillId: 'skill-uuid-001',
+      agent: 'claude-code',
+      home,
+    });
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
+    const cmd = (inner[0] as Record<string, unknown>)['command'] as string;
+
+    expect(cmd).toContain('--skill-id skill-uuid-001');
+    expect(cmd).toContain('--agent claude-code');
+    expect(cmd).toContain('--match-prompt /pr-review');
+  });
+
+  it('uses flat schema for cursor', async () => {
+    await wireUserPromptHook({
+      skillName: 'pr-review',
+      skillId: 'skill-uuid-002',
+      agent: 'cursor',
+      home,
+    });
+
+    const settings = readJson(join(home, '.cursor', 'hooks.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'beforeSubmitPrompt'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(1);
+    expect((promptHooks[0] as Record<string, unknown>)['command']).toContain(
+      '--skill-id skill-uuid-002'
+    );
+  });
+
+  it('replaces existing entry for same skill-id on reinstall', async () => {
+    const opts = {
+      skillName: 'pr-review',
+      skillId: 'skill-uuid-003',
+      agent: 'claude-code' as const,
+      home,
+    };
+
+    process.env['SKILLS_HOOK_START_CMD'] =
+      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+    await wireUserPromptHook(opts);
+
+    process.env['SKILLS_HOOK_START_CMD'] =
+      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}} --extra-flag';
+    await wireUserPromptHook(opts);
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(1);
+    const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
+    expect((inner[0] as Record<string, unknown>)['command']).toContain('--extra-flag');
+  });
+
+  it('keeps entries for different skill-ids when adding a second skill', async () => {
+    process.env['SKILLS_HOOK_START_CMD'] =
+      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+
+    await wireUserPromptHook({
+      skillName: 'skill-a',
+      skillId: 'id-aaa',
+      agent: 'claude-code',
+      home,
+    });
+    await wireUserPromptHook({
+      skillName: 'skill-b',
+      skillId: 'id-bbb',
+      agent: 'claude-code',
+      home,
+    });
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(2);
+  });
+});
+
+// ─── removeUserPromptHook ──────────────────────────────────────────────────
+
+describe('removeUserPromptHook', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = makeHome();
+    process.env['SKILLS_HOOK_START_CMD'] =
+      'playlist-skills track start --skill-id {{skill_id}} --agent {{agent}} --match-prompt /{{skill_name}}';
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env['SKILLS_HOOK_START_CMD'];
+  });
+
+  it('removes the correct entry and leaves others intact', async () => {
+    await wireUserPromptHook({
+      skillName: 'skill-a',
+      skillId: 'id-aaa',
+      agent: 'claude-code',
+      home,
+    });
+    await wireUserPromptHook({
+      skillName: 'skill-b',
+      skillId: 'id-bbb',
+      agent: 'claude-code',
+      home,
+    });
+
+    const removed = await removeUserPromptHook({ skillId: 'id-aaa', agent: 'claude-code', home });
+    expect(removed).toBe(true);
+
+    const settings = readJson(join(home, '.claude', 'settings.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'UserPromptSubmit'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(1);
+    const inner = (promptHooks[0] as Record<string, unknown>)['hooks'] as unknown[];
+    expect((inner[0] as Record<string, unknown>)['command']).toContain('--skill-id id-bbb');
+  });
+
+  it('returns false when skill-id is not present', async () => {
+    await wireUserPromptHook({
+      skillName: 'skill-a',
+      skillId: 'id-aaa',
+      agent: 'claude-code',
+      home,
+    });
+
+    const removed = await removeUserPromptHook({
+      skillId: 'nonexistent-id',
+      agent: 'claude-code',
+      home,
+    });
+    expect(removed).toBe(false);
+  });
+
+  it('returns false when hooks file does not exist', async () => {
+    const removed = await removeUserPromptHook({ skillId: 'any-id', agent: 'claude-code', home });
+    expect(removed).toBe(false);
+  });
+
+  it('removes flat-schema entry for cursor', async () => {
+    await wireUserPromptHook({
+      skillName: 'my-skill',
+      skillId: 'flat-id-001',
+      agent: 'cursor',
+      home,
+    });
+    const removed = await removeUserPromptHook({ skillId: 'flat-id-001', agent: 'cursor', home });
+    expect(removed).toBe(true);
+
+    const settings = readJson(join(home, '.cursor', 'hooks.json'));
+    const promptHooks = (settings['hooks'] as Record<string, unknown>)[
+      'beforeSubmitPrompt'
+    ] as unknown[];
+    expect(promptHooks).toHaveLength(0);
+  });
+});
+
+// ─── isHookSetupDone ───────────────────────────────────────────────────────
+
+describe('isHookSetupDone', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = makeHome();
+    process.env['SKILLS_HOOK_STOP_CMD'] = 'playlist-skills track stop';
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    delete process.env['SKILLS_HOOK_STOP_CMD'];
+  });
+
+  it('returns false when no hooks files exist', () => {
+    expect(isHookSetupDone(home)).toBe(false);
+  });
+
+  it('returns true after wireStopHook has been called', async () => {
+    await wireStopHook('claude-code', { home });
+    expect(isHookSetupDone(home)).toBe(true);
+  });
+
+  it('returns false when SKILLS_HOOK_STOP_CMD is unset', async () => {
+    await wireStopHook('claude-code', { home });
+    delete process.env['SKILLS_HOOK_STOP_CMD'];
+    expect(isHookSetupDone(home)).toBe(false);
+  });
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,294 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { determineAgent } from '@vercel/detect-agent';
+import { agents } from './agents.ts';
+import type { AgentType, HookSchema } from './types.ts';
+
+export type { HookSchema };
+
+export interface HookWiringOptions {
+  skillName: string;
+  skillId: string;
+  agent: AgentType;
+  home?: string;
+}
+
+// Read hook command templates from env vars at call time (not module load time)
+// so that callers can override them in tests or via wrapper injection.
+function getHookStartCmd(): string | null {
+  const raw = process.env['SKILLS_HOOK_START_CMD'];
+  return raw && raw.trim() ? raw.trim() : null;
+}
+
+function getHookStopCmd(): string | null {
+  const raw = process.env['SKILLS_HOOK_STOP_CMD'];
+  return raw && raw.trim() ? raw.trim() : null;
+}
+
+function getHookFailCmd(): string | null {
+  const raw = process.env['SKILLS_HOOK_FAIL_CMD'];
+  return raw && raw.trim() ? raw.trim() : null;
+}
+
+/**
+ * Wire the global stop (and optional fail) hooks for a detected agent.
+ * Called once by `skills setup`. Returns true if any change was made.
+ */
+export async function wireStopHook(
+  agentName: AgentType,
+  options?: { home?: string }
+): Promise<boolean> {
+  const config = agents[agentName];
+  if (!config.hooksFile || !config.stopEvent || !config.hookSchema) return false;
+
+  const stopCmd = getHookStopCmd();
+  if (!stopCmd) return false;
+
+  const home = options?.home ?? homedir();
+  const hooksPath = join(home, config.hooksFile);
+  const schema = config.hookSchema;
+
+  let changed = false;
+
+  if (writeEventHook(hooksPath, schema, config.stopEvent, stopCmd)) changed = true;
+
+  const failCmd = getHookFailCmd();
+  if (failCmd && config.failEvent) {
+    if (writeEventHook(hooksPath, schema, config.failEvent, failCmd)) changed = true;
+  }
+
+  return changed;
+}
+
+/**
+ * Wire a per-skill UserPromptSubmit hook for the given agent.
+ * Called by `skills add` after installation. Returns true if a change was made.
+ */
+export async function wireUserPromptHook(options: HookWiringOptions): Promise<boolean> {
+  const { skillName, skillId, agent: agentName } = options;
+  const config = agents[agentName];
+  if (!config.hooksFile || !config.promptEvent || !config.hookSchema) return false;
+
+  const startCmdTemplate = getHookStartCmd();
+  if (!startCmdTemplate) return false;
+
+  const home = options.home ?? homedir();
+  const hooksPath = join(home, config.hooksFile);
+
+  // Detect the running agent at install time to bake into the command string.
+  // Copilot env vars are absent at hook execution time, so agent identity must
+  // be resolved now, not at hook runtime.
+  const agentResult = await determineAgent();
+  const resolvedAgent = agentResult.isAgent ? agentResult.agent.name : config.name;
+
+  const startCmd = startCmdTemplate
+    .replace('{{skill_id}}', skillId)
+    .replace('{{skill_name}}', skillName)
+    .replace('{{agent}}', resolvedAgent);
+
+  return writePromptHook(hooksPath, config.hookSchema, config.promptEvent, startCmd, skillId);
+}
+
+/**
+ * Remove the per-skill UserPromptSubmit hook for the given agent.
+ * Called by `skills remove`. Returns true if an entry was removed.
+ */
+export async function removeUserPromptHook(
+  options: Pick<HookWiringOptions, 'skillId' | 'agent' | 'home'>
+): Promise<boolean> {
+  const { skillId, agent: agentName } = options;
+  const config = agents[agentName];
+  if (!config.hooksFile || !config.promptEvent || !config.hookSchema) return false;
+
+  const home = options.home ?? homedir();
+  const hooksPath = join(home, config.hooksFile);
+
+  if (!existsSync(hooksPath)) return false;
+
+  let settings: Record<string, unknown>;
+  try {
+    settings = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+  } catch {
+    return false;
+  }
+
+  const hooks = settings['hooks'] as Record<string, unknown> | undefined;
+  if (!hooks) return false;
+
+  const needle = `--skill-id ${skillId}`;
+  const promptHooks = hooks[config.promptEvent];
+  if (!Array.isArray(promptHooks)) return false;
+
+  const filtered = promptHooks.filter(
+    (entry) => !entryContainsCommand(entry, needle, config.hookSchema!)
+  );
+
+  if (filtered.length === promptHooks.length) return false;
+
+  hooks[config.promptEvent] = filtered;
+  settings['hooks'] = hooks;
+  writeJSON(hooksPath, settings);
+  return true;
+}
+
+/**
+ * Returns true if the global stop hook is already wired for at least one detected agent.
+ */
+export function isHookSetupDone(home?: string): boolean {
+  const stopCmd = getHookStopCmd();
+  if (!stopCmd) return false;
+
+  const resolvedHome = home ?? homedir();
+  for (const config of Object.values(agents)) {
+    if (!config.hooksFile) continue;
+    const hooksPath = join(resolvedHome, config.hooksFile);
+    try {
+      const content = readFileSync(hooksPath, 'utf-8');
+      if (content.includes(stopCmd)) return true;
+    } catch {
+      // file doesn't exist — skip
+    }
+  }
+  return false;
+}
+
+// ─── Private helpers ───────────────────────────────────────────────────────
+
+function readSettings(hooksPath: string, schema: HookSchema): Record<string, unknown> {
+  const base: Record<string, unknown> = schema === 'flat' ? { version: 1 } : {};
+  try {
+    const parsed = JSON.parse(readFileSync(hooksPath, 'utf-8')) as Record<string, unknown>;
+    if (schema === 'flat' && parsed['version'] === undefined) {
+      parsed['version'] = 1;
+    }
+    return parsed;
+  } catch {
+    return base;
+  }
+}
+
+function writeJSON(hooksPath: string, settings: Record<string, unknown>): void {
+  mkdirSync(dirname(hooksPath), { recursive: true });
+  writeFileSync(hooksPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+}
+
+function getOrCreateHooks(settings: Record<string, unknown>): Record<string, unknown> {
+  if (
+    typeof settings['hooks'] !== 'object' ||
+    settings['hooks'] === null ||
+    Array.isArray(settings['hooks'])
+  ) {
+    settings['hooks'] = {};
+  }
+  return settings['hooks'] as Record<string, unknown>;
+}
+
+function getEventEntries(hooks: Record<string, unknown>, event: string): unknown[] {
+  if (!Array.isArray(hooks[event])) hooks[event] = [];
+  return hooks[event] as unknown[];
+}
+
+function nestedEntry(command: string): Record<string, unknown> {
+  return {
+    hooks: [{ type: 'command', command, timeout: 5 }],
+  };
+}
+
+function flatEntry(command: string): Record<string, unknown> {
+  return { type: 'command', command, timeout: 5 };
+}
+
+function writeEventHook(
+  hooksPath: string,
+  schema: HookSchema,
+  event: string,
+  command: string
+): boolean {
+  const settings = readSettings(hooksPath, schema);
+  const hooks = getOrCreateHooks(settings);
+  const entries = getEventEntries(hooks, event);
+
+  if (schema === 'flat') {
+    if (entries.some((e) => (e as Record<string, unknown>)['command'] === command)) return false;
+    entries.push(flatEntry(command));
+  } else {
+    if (entries.some((e) => commandInNestedEntry(e, command))) return false;
+    entries.push(nestedEntry(command));
+  }
+
+  hooks[event] = entries;
+  settings['hooks'] = hooks;
+  writeJSON(hooksPath, settings);
+  return true;
+}
+
+function writePromptHook(
+  hooksPath: string,
+  schema: HookSchema,
+  event: string,
+  command: string,
+  skillId: string
+): boolean {
+  const settings = readSettings(hooksPath, schema);
+  const hooks = getOrCreateHooks(settings);
+  const entries = getEventEntries(hooks, event);
+
+  const needle = `--skill-id ${skillId}`;
+  const others = entries.filter((e) => !entryContainsCommand(e, needle, schema));
+
+  // If there's an existing entry for this skill-id that already has the right command, no-op.
+  if (others.length < entries.length) {
+    const existing = entries.find((e) => entryContainsCommand(e, needle, schema));
+    if (existing) {
+      const existingCmd =
+        schema === 'flat'
+          ? (existing as Record<string, unknown>)['command']
+          : getNestedCommand(existing);
+      if (existingCmd === command) return false;
+    }
+  }
+
+  const newEntry = schema === 'flat' ? flatEntry(command) : nestedEntry(command);
+  hooks[event] = [...others, newEntry];
+  settings['hooks'] = hooks;
+  writeJSON(hooksPath, settings);
+  return true;
+}
+
+function entryContainsCommand(entry: unknown, needle: string, schema: HookSchema): boolean {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const m = entry as Record<string, unknown>;
+  if (schema === 'flat') {
+    return typeof m['command'] === 'string' && m['command'].includes(needle);
+  }
+  const inner = m['hooks'];
+  if (!Array.isArray(inner)) return false;
+  return inner.some(
+    (h) =>
+      typeof h === 'object' &&
+      h !== null &&
+      typeof (h as Record<string, unknown>)['command'] === 'string' &&
+      ((h as Record<string, unknown>)['command'] as string).includes(needle)
+  );
+}
+
+function commandInNestedEntry(entry: unknown, command: string): boolean {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const inner = (entry as Record<string, unknown>)['hooks'];
+  if (!Array.isArray(inner)) return false;
+  return inner.some(
+    (h) =>
+      typeof h === 'object' && h !== null && (h as Record<string, unknown>)['command'] === command
+  );
+}
+
+function getNestedCommand(entry: unknown): string | undefined {
+  if (typeof entry !== 'object' || entry === null) return undefined;
+  const inner = (entry as Record<string, unknown>)['hooks'];
+  if (!Array.isArray(inner) || inner.length === 0) return undefined;
+  const first = inner[0];
+  if (typeof first !== 'object' || first === null) return undefined;
+  const cmd = (first as Record<string, unknown>)['command'];
+  return typeof cmd === 'string' ? cmd : undefined;
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -334,6 +334,7 @@ export async function repairHooks(options?: {
   // Collect installed skillRefs, tracking scope so we can rebuild hookRefs.
   const installedRefs = new Set<string>();
   const installedSkillsByRef = new Map<string, { skillName: string }>();
+  const installedSkillNames = new Set<string>();
   const globalRefs = new Set<string>();
   const projectRefsByPath = new Map<string, Set<string>>();
 
@@ -341,7 +342,31 @@ export async function repairHooks(options?: {
     const ref = entry.skillRef ?? skillName;
     installedRefs.add(ref);
     installedSkillsByRef.set(ref, { skillName });
+    installedSkillNames.add(skillName);
     globalRefs.add(ref);
+  }
+
+  // Also pick up skills that exist on disk but have no lock entry — this covers
+  // skills installed before the lock file was introduced, or after a lock wipe
+  // due to a version migration. Use the directory name as both skillName and
+  // skillRef (bare-name ref). Hook wiring still works; reinstalling the skill
+  // later will overwrite with the canonical full ref.
+  const globalSkillsDir = join(home, '.agents', 'skills');
+  if (existsSync(globalSkillsDir)) {
+    try {
+      for (const entry of readdirSync(globalSkillsDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const skillName = entry.name;
+        if (!installedSkillNames.has(skillName)) {
+          installedRefs.add(skillName);
+          installedSkillsByRef.set(skillName, { skillName });
+          installedSkillNames.add(skillName);
+          globalRefs.add(skillName);
+        }
+      }
+    } catch {
+      // best-effort
+    }
   }
 
   for (const projectPath of projectPaths) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,6 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
-import { determineAgent } from '@vercel/detect-agent';
 import { agents } from './agents.ts';
 import type { AgentType, HookSchema } from './types.ts';
 
@@ -9,7 +8,9 @@ export type { HookSchema };
 
 export interface HookWiringOptions {
   skillName: string;
-  skillId: string;
+  /** Stable identity key for dedup/removal — typically "owner/repo/skillName" for GitHub sources,
+   *  or just "skillName" for local/URL installs. Embedded in the hook command at wire time. */
+  skillRef: string;
   agent: AgentType;
   home?: string;
 }
@@ -66,28 +67,23 @@ export async function wireStopHook(
  * Called by `skills add` after installation. Returns true if a change was made.
  */
 export async function wireUserPromptHook(options: HookWiringOptions): Promise<boolean> {
-  const { skillName, skillId, agent: agentName } = options;
+  const { skillName, skillRef, agent: agentName } = options;
   const config = agents[agentName];
   if (!config.hooksFile || !config.promptEvent || !config.hookSchema) return false;
 
   const startCmdTemplate = getHookStartCmd();
   if (!startCmdTemplate) return false;
+  if (!startCmdTemplate.includes('{{skill_name}}')) return false;
 
   const home = options.home ?? homedir();
   const hooksPath = join(home, config.hooksFile);
 
-  // Detect the running agent at install time to bake into the command string.
-  // Copilot env vars are absent at hook execution time, so agent identity must
-  // be resolved now, not at hook runtime.
-  const agentResult = await determineAgent();
-  const resolvedAgent = agentResult.isAgent ? agentResult.agent.name : config.name;
-
   const startCmd = startCmdTemplate
-    .replace('{{skill_id}}', skillId)
-    .replace('{{skill_name}}', skillName)
-    .replace('{{agent}}', resolvedAgent);
+    .replaceAll('{{skill_ref}}', skillRef)
+    .replaceAll('{{skill_name}}', skillName)
+    .replaceAll('{{agent}}', config.name);
 
-  return writePromptHook(hooksPath, config.hookSchema, config.promptEvent, startCmd, skillId);
+  return writePromptHook(hooksPath, config.hookSchema, config.promptEvent, startCmd, skillRef);
 }
 
 /**
@@ -95,9 +91,9 @@ export async function wireUserPromptHook(options: HookWiringOptions): Promise<bo
  * Called by `skills remove`. Returns true if an entry was removed.
  */
 export async function removeUserPromptHook(
-  options: Pick<HookWiringOptions, 'skillId' | 'agent' | 'home'>
+  options: Pick<HookWiringOptions, 'skillRef' | 'agent' | 'home'>
 ): Promise<boolean> {
-  const { skillId, agent: agentName } = options;
+  const { skillRef, agent: agentName } = options;
   const config = agents[agentName];
   if (!config.hooksFile || !config.promptEvent || !config.hookSchema) return false;
 
@@ -116,7 +112,7 @@ export async function removeUserPromptHook(
   const hooks = settings['hooks'] as Record<string, unknown> | undefined;
   if (!hooks) return false;
 
-  const needle = `--skill-id ${skillId}`;
+  const needle = skillRef;
   const promptHooks = hooks[config.promptEvent];
   if (!Array.isArray(promptHooks)) return false;
 
@@ -234,10 +230,10 @@ function writePromptHook(
   const hooks = getOrCreateHooks(settings);
   const entries = getEventEntries(hooks, event);
 
-  const needle = `--skill-id ${skillId}`;
+  const needle = skillId;
   const others = entries.filter((e) => !entryContainsCommand(e, needle, schema));
 
-  // If there's an existing entry for this skill-id that already has the right command, no-op.
+  // If there's an existing entry for this skill that already has the right command, no-op.
   if (others.length < entries.length) {
     const existing = entries.find((e) => entryContainsCommand(e, needle, schema));
     if (existing) {
@@ -291,4 +287,180 @@ function getNestedCommand(entry: unknown): string | undefined {
   if (typeof first !== 'object' || first === null) return undefined;
   const cmd = (first as Record<string, unknown>)['command'];
   return typeof cmd === 'string' ? cmd : undefined;
+}
+
+// ─── repairHooks ───────────────────────────────────────────────────────────
+
+export interface RepairHooksResult {
+  wired: number;
+  removed: number;
+  agentsRepaired: string[];
+}
+
+/**
+ * Reconcile agent hook config files against installed skills.
+ *
+ * Wire missing: for each installed skill, ensure all hook-capable detected
+ * agents have a prompt hook entry for it. Delegates to wireUserPromptHook so
+ * template expansion and env-var guards are handled in one place.
+ *
+ * Remove orphaned: for each hook-capable agent's promptEvent entries, extract
+ * the embedded --skill-ref token and remove entries whose ref is no longer
+ * in any installed lock. This runs regardless of SKILLS_HOOK_START_CMD.
+ *
+ * Rebuilds hookRefs in the global lock from scratch so future `skills remove`
+ * calls have accurate ref counts.
+ *
+ * The set of "installed" skillRefs is derived from the global lock (global
+ * installs) and any skills-lock.json files found in the provided project paths.
+ */
+export async function repairHooks(options?: {
+  home?: string;
+  projectPaths?: string[];
+}): Promise<RepairHooksResult> {
+  const home = options?.home ?? homedir();
+  const projectPaths = options?.projectPaths ?? [];
+
+  const { readSkillLock, writeSkillLock } = await import('./skill-lock.ts');
+  const { readLocalLock } = await import('./local-lock.ts');
+
+  // Read the global lock once — reused both for populating installedRefs and
+  // for the hookRefs rebuild at the end, avoiding a TOCTOU double-read.
+  const globalLock = await readSkillLock();
+
+  // Collect installed skillRefs, tracking scope so we can rebuild hookRefs.
+  const installedRefs = new Set<string>();
+  const installedSkillsByRef = new Map<string, { skillName: string }>();
+  const globalRefs = new Set<string>();
+  const projectRefsByPath = new Map<string, Set<string>>();
+
+  for (const [skillName, entry] of Object.entries(globalLock.skills)) {
+    const ref = entry.skillRef ?? skillName;
+    installedRefs.add(ref);
+    installedSkillsByRef.set(ref, { skillName });
+    globalRefs.add(ref);
+  }
+
+  for (const projectPath of projectPaths) {
+    try {
+      const localLock = await readLocalLock(projectPath);
+      const refsHere = new Set<string>();
+      for (const [skillName, entry] of Object.entries(localLock.skills)) {
+        const ref = entry.skillRef ?? skillName;
+        installedRefs.add(ref);
+        installedSkillsByRef.set(ref, { skillName });
+        refsHere.add(ref);
+      }
+      projectRefsByPath.set(projectPath, refsHere);
+    } catch {
+      // best-effort
+    }
+  }
+
+  const hookableAgents = (Object.keys(agents) as AgentType[]).filter(
+    (a) => agents[a].hooksFile && agents[a].promptEvent && agents[a].hookSchema
+  );
+
+  let wired = 0;
+  let removed = 0;
+  const repairedSet = new Set<string>();
+
+  for (const agentName of hookableAgents) {
+    const config = agents[agentName];
+    const hooksPath = join(home, config.hooksFile!);
+    const configDirRoot = join(home, config.hooksFile!.split('/')[0]!);
+
+    if (!existsSync(configDirRoot)) continue;
+
+    // ── Wire missing ──────────────────────────────────────────────────────
+    // Delegate to wireUserPromptHook — it handles SKILLS_HOOK_START_CMD checks
+    // and token expansion, keeping that logic in one place.
+    for (const [skillRef, { skillName }] of installedSkillsByRef) {
+      const changed = await wireUserPromptHook({ skillName, skillRef, agent: agentName, home });
+      if (changed) {
+        wired++;
+        repairedSet.add(config.displayName);
+      }
+    }
+
+    // ── Remove orphaned ───────────────────────────────────────────────────
+    if (!existsSync(hooksPath)) continue;
+
+    let settings: Record<string, unknown>;
+    try {
+      settings = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+    } catch {
+      continue;
+    }
+
+    const hooks = settings['hooks'] as Record<string, unknown> | undefined;
+    if (!hooks) continue;
+
+    const promptHooks = hooks[config.promptEvent!];
+    if (!Array.isArray(promptHooks)) continue;
+
+    const before = promptHooks.length;
+    const filtered = promptHooks.filter((entry) => {
+      const cmd =
+        config.hookSchema === 'flat'
+          ? (entry as Record<string, unknown>)['command']
+          : getNestedCommand(entry);
+      if (typeof cmd !== 'string') return true; // keep entries we can't parse
+
+      const m = cmd.match(/--skill-ref\s+(\S+)/);
+      if (!m) return true; // not one of ours — keep it
+
+      return installedRefs.has(m[1]!);
+    });
+
+    if (filtered.length < before) {
+      hooks[config.promptEvent!] = filtered;
+      settings['hooks'] = hooks;
+      writeJSON(hooksPath, settings);
+      removed += before - filtered.length;
+      repairedSet.add(config.displayName);
+    }
+  }
+
+  // Rebuild hookRefs from scratch to match installed reality so that future
+  // `skills remove` calls have accurate ref counts. Reuse the lock object
+  // already in memory rather than re-reading from disk.
+  globalLock.hookRefs = {};
+  for (const ref of globalRefs) {
+    globalLock.hookRefs[ref] = { globalInstall: true, projectPaths: [] };
+  }
+  for (const [projectPath, refs] of projectRefsByPath) {
+    for (const ref of refs) {
+      const existing = globalLock.hookRefs[ref];
+      if (existing) {
+        existing.projectPaths.push(projectPath);
+      } else {
+        globalLock.hookRefs[ref] = { globalInstall: false, projectPaths: [projectPath] };
+      }
+    }
+  }
+  await writeSkillLock(globalLock);
+
+  return { wired, removed, agentsRepaired: Array.from(repairedSet) };
+}
+
+/**
+ * Scan a directory for project directories that contain a skills-lock.json.
+ * Useful for callers who want to include local installs in repairHooks.
+ */
+export function findProjectsWithLocalLock(searchPaths: string[]): string[] {
+  const found: string[] = [];
+  for (const base of searchPaths) {
+    if (!existsSync(base)) continue;
+    try {
+      for (const entry of readdirSync(base, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const candidate = join(base, entry.name, 'skills-lock.json');
+        if (existsSync(candidate)) found.push(join(base, entry.name));
+      }
+    } catch {
+      // skip
+    }
+  }
+  return found;
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -224,13 +224,13 @@ function writePromptHook(
   schema: HookSchema,
   event: string,
   command: string,
-  skillId: string
+  skillRef: string
 ): boolean {
   const settings = readSettings(hooksPath, schema);
   const hooks = getOrCreateHooks(settings);
   const entries = getEventEntries(hooks, event);
 
-  const needle = skillId;
+  const needle = skillRef;
   const others = entries.filter((e) => !entryContainsCommand(e, needle, schema));
 
   // If there's an existing entry for this skill that already has the right command, no-op.
@@ -255,8 +255,11 @@ function writePromptHook(
 function entryContainsCommand(entry: unknown, needle: string, schema: HookSchema): boolean {
   if (typeof entry !== 'object' || entry === null) return false;
   const m = entry as Record<string, unknown>;
+  // Anchor on --skill-ref <value> so a short ref like "foo" doesn't substring-match "foobar"
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`--skill-ref\\s+${escaped}(?:\\s|$)`);
   if (schema === 'flat') {
-    return typeof m['command'] === 'string' && m['command'].includes(needle);
+    return typeof m['command'] === 'string' && pattern.test(m['command']);
   }
   const inner = m['hooks'];
   if (!Array.isArray(inner)) return false;
@@ -265,7 +268,7 @@ function entryContainsCommand(entry: unknown, needle: string, schema: HookSchema
       typeof h === 'object' &&
       h !== null &&
       typeof (h as Record<string, unknown>)['command'] === 'string' &&
-      ((h as Record<string, unknown>)['command'] as string).includes(needle)
+      pattern.test((h as Record<string, unknown>)['command'] as string)
   );
 }
 

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -33,6 +33,8 @@ export interface LocalSkillLockEntry {
    * computes the hash from actual file contents on disk.
    */
   computedHash: string;
+  /** Stable hook identity key (e.g. "owner/repo/skillName") — stored so project-scoped removes can unref prompt hooks */
+  skillRef?: string;
 }
 
 /**

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -5,8 +5,9 @@ import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
-import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLock, getSkillFromLock, removeHookRef } from './skill-lock.ts';
 import { removeUserPromptHook } from './hooks.ts';
+import { readLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -225,14 +226,39 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
       const effectiveSource = lockEntry?.source || 'local';
       const effectiveSourceType = lockEntry?.sourceType || 'local';
 
-      // Remove per-skill prompt hooks if we have the skill UUID (non-fatal)
-      if (lockEntry?.skillId) {
-        for (const agentKey of targetAgents) {
-          try {
-            await removeUserPromptHook({ skillId: lockEntry.skillId, agent: agentKey });
-          } catch {
-            // Hook removal is best-effort — never fail an uninstall
+      // Resolve skillRef from global lock (global install) or local lock (project install).
+      let skillRef: string | undefined = lockEntry?.skillRef;
+      if (!skillRef && !isGlobal) {
+        try {
+          const localLock = await readLocalLock(cwd);
+          skillRef = localLock.skills[skillName]?.skillRef;
+        } catch {
+          // best-effort
+        }
+      }
+      if (!skillRef) {
+        const src = lockEntry?.source;
+        skillRef = src ? `${src}/${skillName}` : skillName;
+      }
+
+      // Only unref / remove hooks when the skill is fully gone from this scope.
+      if (!isStillUsed) {
+        try {
+          const shouldRemove = await removeHookRef(
+            skillRef,
+            isGlobal ? { global: true } : { projectPath: cwd }
+          );
+          if (shouldRemove) {
+            for (const agentKey of targetAgents) {
+              try {
+                await removeUserPromptHook({ skillRef, agent: agentKey });
+              } catch {
+                // Hook removal is best-effort — never fail an uninstall
+              }
+            }
           }
+        } catch {
+          // ref tracking is best-effort
         }
       }
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -6,6 +6,7 @@ import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeUserPromptHook } from './hooks.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -223,6 +224,17 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
       const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
       const effectiveSource = lockEntry?.source || 'local';
       const effectiveSourceType = lockEntry?.sourceType || 'local';
+
+      // Remove per-skill prompt hooks if we have the skill UUID (non-fatal)
+      if (lockEntry?.skillId) {
+        for (const agentKey of targetAgents) {
+          try {
+            await removeUserPromptHook({ skillId: lockEntry.skillId, agent: agentKey });
+          } catch {
+            // Hook removal is best-effort — never fail an uninstall
+          }
+        }
+      }
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -370,9 +370,12 @@ export async function removeHookRef(
   scope: { global: true } | { projectPath: string }
 ): Promise<boolean> {
   const lock = await readSkillLock();
-  if (!lock.hookRefs) return true;
+  // No hookRefs entry means the skill was installed before ref-counting was introduced.
+  // Default to false (keep the hook) — a stale hook is safer than a premature removal,
+  // and `skills hooks repair` will clean up orphans on the next run.
+  if (!lock.hookRefs) return false;
   const ref = lock.hookRefs[skillRef];
-  if (!ref) return true;
+  if (!ref) return false;
 
   if ('global' in scope) {
     ref.globalInstall = false;

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -35,6 +35,8 @@ export interface SkillLockEntry {
   updatedAt: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  /** Skill UUID from the registry, stored at install time for hook unwiring */
+  skillId?: string;
 }
 
 /**

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -35,8 +35,8 @@ export interface SkillLockEntry {
   updatedAt: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
-  /** Skill UUID from the registry, stored at install time for hook unwiring */
-  skillId?: string;
+  /** Stable hook identity key (e.g. "owner/repo/skillName") stored at install time for hook unwiring */
+  skillRef?: string;
 }
 
 /**
@@ -45,6 +45,15 @@ export interface SkillLockEntry {
 export interface DismissedPrompts {
   /** Dismissed the find-skills skill installation prompt */
   findSkillsPrompt?: boolean;
+}
+
+/**
+ * Tracks which installs (global or per-project) are keeping a skill's prompt hook alive.
+ * The hook is removed only when both globalInstall is false and projectPaths is empty.
+ */
+export interface HookRef {
+  globalInstall: boolean;
+  projectPaths: string[];
 }
 
 /**
@@ -59,6 +68,8 @@ export interface SkillLockFile {
   dismissed?: DismissedPrompts;
   /** Last selected agents for installation */
   lastSelectedAgents?: string[];
+  /** Ref-counts active installations keyed by skillRef — drives hook lifecycle */
+  hookRefs?: Record<string, HookRef>;
 }
 
 /**
@@ -322,4 +333,60 @@ export async function saveSelectedAgents(agents: string[]): Promise<void> {
   const lock = await readSkillLock();
   lock.lastSelectedAgents = agents;
   await writeSkillLock(lock);
+}
+
+/**
+ * Record that a skill's prompt hook is desired for a global or project-scoped install.
+ * Called whenever hook wiring is enabled and the agent supports prompt hooks, regardless
+ * of whether the wire call was a no-op (idempotent reinstall). This ensures ref counts
+ * stay accurate across reinstalls.
+ */
+export async function addHookRef(
+  skillRef: string,
+  scope: { global: true } | { projectPath: string }
+): Promise<void> {
+  const lock = await readSkillLock();
+  if (!lock.hookRefs) lock.hookRefs = {};
+  const ref = lock.hookRefs[skillRef] ?? { globalInstall: false, projectPaths: [] };
+
+  if ('global' in scope) {
+    ref.globalInstall = true;
+  } else {
+    if (!ref.projectPaths.includes(scope.projectPath)) {
+      ref.projectPaths.push(scope.projectPath);
+    }
+  }
+
+  lock.hookRefs[skillRef] = ref;
+  await writeSkillLock(lock);
+}
+
+/**
+ * Remove one reference to a skill's prompt hook.
+ * Returns true if the hook should now be removed (no remaining refs).
+ */
+export async function removeHookRef(
+  skillRef: string,
+  scope: { global: true } | { projectPath: string }
+): Promise<boolean> {
+  const lock = await readSkillLock();
+  if (!lock.hookRefs) return true;
+  const ref = lock.hookRefs[skillRef];
+  if (!ref) return true;
+
+  if ('global' in scope) {
+    ref.globalInstall = false;
+  } else {
+    ref.projectPaths = ref.projectPaths.filter((p) => p !== scope.projectPath);
+  }
+
+  const shouldRemove = !ref.globalInstall && ref.projectPaths.length === 0;
+  if (shouldRemove) {
+    delete lock.hookRefs[skillRef];
+  } else {
+    lock.hookRefs[skillRef] = ref;
+  }
+
+  await writeSkillLock(lock);
+  return shouldRemove;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,8 @@ export interface Skill {
   metadata?: Record<string, unknown>;
 }
 
+export type HookSchema = 'nested' | 'flat';
+
 export interface AgentConfig {
   name: string;
   displayName: string;
@@ -75,6 +77,16 @@ export interface AgentConfig {
   detectInstalled: () => Promise<boolean>;
   /** Whether to show this agent in the universal agents list. Defaults to true. */
   showInUniversalList?: boolean;
+  /** Path to the hooks config file, relative to home. Undefined = no hook support. */
+  hooksFile?: string;
+  /** Agent-specific name for the clean Stop lifecycle event. */
+  stopEvent?: string;
+  /** Agent-specific name for the failure lifecycle event (optional). */
+  failEvent?: string;
+  /** Agent-specific name for the UserPromptSubmit event. */
+  promptEvent?: string;
+  /** How to write hook entries for this agent. */
+  hookSchema?: HookSchema;
 }
 
 export interface ParsedSource {


### PR DESCRIPTION
## Summary

Contributes to https://github.com/vercel-labs/skills/issues/348

Builds on:
#1076 , #1162 , and #1195

Adds opt-in lifecycle hook wiring to `skills add`, `skills remove`, and a new `skills setup` command. When configured, hooks are written into each installed agent's settings file so that external tooling can track when a skill-guided session starts and stops.

Hook wiring is disabled by default — it activates only when `SKILLS_HOOK_START_CMD` / `SKILLS_HOOK_STOP_CMD` / `SKILLS_HOOK_FAIL_CMD` environment variables are set. Unset = zero behaviour change for anyone not using this feature.

## Changes

- `src/hooks.ts` — all wiring logic: `wireStopHook`, `wireUserPromptHook`, `removeUserPromptHook`, `isHookSetupDone`, `repairHooks`, `findProjectsWithLocalLock`
- `src/agents.ts` — four agents gain hook config: `claude-code`, `cursor`, `codex`, `github-copilot`
- `src/types.ts` — `HookSchema = 'nested' | 'flat'` type + optional hook fields on `AgentConfig`
- `src/skill-lock.ts` — `skillRef?: string` added to `SkillLockEntry`; `HookRef` interface, `hookRefs` field on `SkillLockFile`, `addHookRef()` and `removeHookRef()` for ref-counted hook lifecycle management
- `src/local-lock.ts` — `skillRef?: string` added to `LocalSkillLockEntry`
- `src/add.ts` — calls `wireUserPromptHook` per agent after install and `addHookRef` to record the install scope (non-fatal)
- `src/remove.ts` — resolves `skillRef` from lock, calls `removeHookRef` to drain the ref count, and only calls `removeUserPromptHook` when all refs are gone (non-fatal)
- `src/cli.ts` — `skills setup` command wires global stop hooks for all detected agents; `skills hooks repair` command reconciles hook files against installed skills
- `src/hooks.test.ts` — 28 unit tests covering both schema shapes, idempotency, skillRef-keyed replace-on-reinstall, removal, repair (wire missing + remove orphaned + hookRefs rebuild)

## Hook identity: `skillRef` instead of UUID

Hook entries are identified by a stable `skillRef` string — `"owner/repo/skillName"` for GitHub sources, or bare `"skillName"` for local/URL installs. This is derivable from disk without any API calls or frontmatter parsing, which enables the repair command and keeps the library self-contained.

The `skillRef` is embedded in every hook command via the `{{skill_ref}}` token and anchored with a `--skill-ref <value>` flag, so the orphan-removal scan can extract and match it with a simple regex.

## Hook command parameterisation

Commands are fully configurable via env vars — no hardcoded values in this package:

```
SKILLS_HOOK_START_CMD   # written for UserPromptSubmit hooks; supports {{skill_ref}}, {{skill_name}}, {{agent}} tokens
SKILLS_HOOK_STOP_CMD    # written for Stop/clean-exit hooks
SKILLS_HOOK_FAIL_CMD    # written for failure hooks (StopFailure, errorOccurred); optional
```

The `{{agent}}` token is substituted using the agent config name at wire time (`config.name`), which is always the agent type string (e.g. `claude-code`, `cursor`). This eliminates a class of problem for agents like GitHub Copilot whose identifying env vars are present in the agent process but not inherited by hook subprocesses.

## Ref-counted hook lifecycle

`hookRefs` in the global lock tracks how many install scopes (global or per-project path) are holding a skill's prompt hook alive:

- `addHookRef(skillRef, scope)` — called by `skills add` after wiring
- `removeHookRef(skillRef, scope)` — called by `skills remove`; returns `true` only when the last ref is gone
- `removeUserPromptHook` is only called when `removeHookRef` returns `true`, so a globally-installed skill's hook survives a project-scoped uninstall
- Default when no `hookRefs` entry exists (pre-feature installs): `false` — keep the hook; `skills hooks repair` will clean up any genuine orphans

## `skills hooks repair`

A new `skills hooks repair` command reconciles agent hook config files against the installed skill state:

1. **Wire missing** — for each skill in any lock file, calls `wireUserPromptHook` for every hook-capable detected agent
2. **Remove orphaned** — for each agent's `promptEvent` entries, extracts the `--skill-ref` token and removes entries whose ref isn't in any lock
3. **Rebuild `hookRefs`** — rewrites the global lock's `hookRefs` from scratch to match installed reality, so ref counts stay accurate after any out-of-band changes

## Per-agent hook details

| Agent          | File                         | Schema | Stop event  | Fail event       | Prompt event          |
| -------------- | ---------------------------- | ------ | ----------- | ---------------- | --------------------- |
| claude-code    | `.claude/settings.json`      | nested | `Stop`      | `StopFailure`    | `UserPromptSubmit`    |
| cursor         | `.cursor/hooks.json`         | flat   | `stop`      | — (status field) | `beforeSubmitPrompt`  |
| codex          | `.codex/hooks.json`          | nested | `Stop`      | —                | `UserPromptSubmit`    |
| github-copilot | `.copilot/hooks/skills.json` | flat   | `agentStop` | `errorOccurred`  | `userPromptSubmitted` |

## Test plan

- [x] `npx vitest run src/hooks.test.ts` passes (28 tests)
- [x] `skills add <local-skill> -y` with `SKILLS_HOOK_START_CMD` set writes a hook entry to the agent's settings file
- [x] Re-running `skills add` with the same skill replaces the hook entry rather than appending
- [x] `skills remove <skill> -y` removes the hook entry only when the last install scope is gone
- [x] `skills setup` wires the stop hook; second run prints "already set up"
- [x] `skills hooks repair` wires missing entries, removes orphans, and rebuilds `hookRefs`
- [x] Without any `SKILLS_HOOK_*` vars set, `skills add` completes with no changes to any settings files