### PR TITLE
fix: include sourceType in install telemetry events

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1601,6 +1601,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             agents: targetAgents.join(','),
             ...(installGlobally && { global: '1' }),
             skillFiles: JSON.stringify(skillFiles),
+            sourceType: parsed.type,
           });
         }
       } else {
@@ -1612,6 +1613,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           agents: targetAgents.join(','),
           ...(installGlobally && { global: '1' }),
           skillFiles: JSON.stringify(skillFiles),
+          sourceType: parsed.type,
         });
       }
     }


### PR DESCRIPTION
# fix: include sourceType in install telemetry events

The `track()` call in the GitHub install path and the non-GitHub fallback path both omitted `sourceType`, so the telemetry endpoint received `undefined` for that field on every install event.

The `sourceType` field is already defined on `InstallTelemetryData` and is populated correctly in the well-known provider path — this just extends it to the main install flow by passing `parsed.type` (e.g. `'github'`, `'raw'`, or a provider ID) at the call site.

No behavior change — telemetry failures are always swallowed. This only affects what data is recorded.