### PR TITLE
optimize skills list output for better alignment

### DIFF
--- a/src/list.ts
+++ b/src/list.ts
@@ -123,16 +123,25 @@ export async function runList(args: string[]): Promise<void> {
     return;
   }
 
-  function printSkill(skill: InstalledSkill, indent: boolean = false): void {
+  function printSkill(
+    skill: InstalledSkill,
+    indent: boolean = false,
+    maxNameLength: number = 0,
+    maxPathLength: number = 0
+  ): void {
     const prefix = indent ? '  ' : '';
     const shortPath = shortenPath(skill.canonicalPath, cwd);
     const agentNames = skill.agents.map((a) => agents[a].displayName);
     const agentInfo =
       skill.agents.length > 0 ? formatList(agentNames) : `${YELLOW}not linked${RESET}`;
+
+    // Pad skill name and path for alignment
+    const paddedName = sanitizeMetadata(skill.name).padEnd(maxNameLength);
+    const paddedPath = shortPath.padEnd(maxPathLength);
+
     console.log(
-      `${prefix}${CYAN}${sanitizeMetadata(skill.name)}${RESET} ${DIM}${shortPath}${RESET}`
+      `${prefix}${CYAN}${paddedName}${RESET} ${DIM}${paddedPath}${RESET} ${DIM}Agents:${RESET} ${agentInfo}`
     );
-    console.log(`${prefix}  ${DIM}Agents:${RESET} ${agentInfo}`);
   }
 
   console.log(`${BOLD}${scopeLabel} Skills${RESET}`);
@@ -170,8 +179,17 @@ export async function runList(args: string[]): Promise<void> {
       console.log(`${BOLD}${title}${RESET}`);
       const skills = groupedSkills[group];
       if (skills) {
+        // Calculate max lengths for alignment within this group
+        let maxNameLength = 0;
+        let maxPathLength = 0;
         for (const skill of skills) {
-          printSkill(skill, true);
+          const nameLength = sanitizeMetadata(skill.name).length;
+          const pathLength = shortenPath(skill.canonicalPath, cwd).length;
+          if (nameLength > maxNameLength) maxNameLength = nameLength;
+          if (pathLength > maxPathLength) maxPathLength = pathLength;
+        }
+        for (const skill of skills) {
+          printSkill(skill, true, maxNameLength, maxPathLength);
         }
       }
       console.log();
@@ -180,15 +198,33 @@ export async function runList(args: string[]): Promise<void> {
     // Print ungrouped skills if any exist
     if (ungroupedSkills.length > 0) {
       console.log(`${BOLD}General${RESET}`);
+      // Calculate max lengths for alignment within ungrouped skills
+      let maxNameLength = 0;
+      let maxPathLength = 0;
       for (const skill of ungroupedSkills) {
-        printSkill(skill, true);
+        const nameLength = sanitizeMetadata(skill.name).length;
+        const pathLength = shortenPath(skill.canonicalPath, cwd).length;
+        if (nameLength > maxNameLength) maxNameLength = nameLength;
+        if (pathLength > maxPathLength) maxPathLength = pathLength;
+      }
+      for (const skill of ungroupedSkills) {
+        printSkill(skill, true, maxNameLength, maxPathLength);
       }
       console.log();
     }
   } else {
     // No groups, print flat list as before
+    // Calculate max lengths for alignment in flat list
+    let maxNameLength = 0;
+    let maxPathLength = 0;
     for (const skill of installedSkills) {
-      printSkill(skill);
+      const nameLength = sanitizeMetadata(skill.name).length;
+      const pathLength = shortenPath(skill.canonicalPath, cwd).length;
+      if (nameLength > maxNameLength) maxNameLength = nameLength;
+      if (pathLength > maxPathLength) maxPathLength = pathLength;
+    }
+    for (const skill of installedSkills) {
+      printSkill(skill, false, maxNameLength, maxPathLength);
     }
     console.log();
   }


### PR DESCRIPTION
Description: This PR improves the visual alignment of the skills list output (skills list and skills list -g) by ensuring skill names and paths are properly padded to create clean columns.

Changes made:

Modified printSkill function to accept maxNameLength and maxPathLength parameters for padding
Added logic to calculate maximum name and path lengths within each skill group (Document Skills, Example Skills, etc.) and General section
Applied padding to skill names and paths for proper column alignment
Maintains existing functionality for JSON output and agent filtering
The output now displays skills in aligned columns, making it much easier to read, especially when skill names or paths vary significantly in length. This affects both grouped skill views (when skills have pluginName in lock file) and flat/views.


previous:
```
╰─ 👉 skills list -g
Global Skills

Document Skills
  docx ~\.agents\skills\docx
    Agents: Claude Code
  pdf ~\.agents\skills\pdf
    Agents: Claude Code
  pptx ~\.agents\skills\pptx
    Agents: Claude Code
  xlsx ~\.agents\skills\xlsx
    Agents: Claude Code

Example Skills
  canvas-design ~\.agents\skills\canvas-design
    Agents: Claude Code
  frontend-design ~\.agents\skills\frontend-design
    Agents: Claude Code
  skill-creator ~\.agents\skills\skill-creator
    Agents: Claude Code

Mattpocock Skills
  grill-me ~\.agents\skills\grill-me
    Agents: Claude Code

General
  1password ~\.agents\skills\1password-1.0.1
    Agents: not linked
  self-reflection ~\.agents\skills\agent-self-reflection-1.0.0
    Agents: not linked
  aminer-data-search ~\.agents\skills\aminer-open-academic-1.0.5
    Agents: not linked
  architecture-designer ~\.agents\skills\architecture-designer-0.1.0
    Agents: not linked
  autoglm-browser-agent ~\.agents\skills\autoglm-browser-agent
    Agents: not linked
  autoglm-deepresearch ~\.agents\skills\autoglm-deepresearch
    Agents: not linked
  autoglm-generate-image ~\.agents\skills\autoglm-generate-image
    Agents: not linked
  autoglm-open-link ~\.agents\skills\autoglm-open-link
    Agents: not linked
  autoglm-search-image ~\.agents\skills\autoglm-search-image
    Agents: not linked
  autoglm-websearch ~\.agents\skills\autoglm-websearch
    Agents: not linked
  automation-workflows ~\.agents\skills\automation-workflows-0.1.0
    Agents: not linked
  backtest-expert ~\.agents\skills\backtest-expert-0.1.0
    Agents: not linked
  blog-writer ~\.agents\skills\blog-writer-0.1.0
    Agents: not linked
  brainstorming ~\.agents\skills\brainstorming
    Agents: Claude Code
  clawdefender ~\.agents\skills\clawdefender-1
    Agents: not linked
  Code ~\.agents\skills\code-1.0.4
    Agents: not linked
  content-strategy ~\.agents\skills\content-strategy-0.1.0
    Agents: not linked
  copywriting ~\.agents\skills\copywriting-0.1.0
    Agents: not linked
  dispatching-parallel-agents ~\.agents\skills\dispatching-parallel-agents
    Agents: Claude Code
  executing-plans ~\.agents\skills\executing-plans
    Agents: Claude Code
  feishu-chat-history ~\.agents\skills\feishu-chat-history
    Agents: not linked
  feishu-cron-reminder ~\.agents\skills\feishu-cron-reminder
    Agents: not linked
  feishu-doc ~\.agents\skills\feishu-doc-1.2.7
    Agents: not linked
  feishu-perm ~\.agents\skills\feishu-perm
    Agents: not linked
  feishu-screenshot ~\.agents\skills\feishu-screenshot
    Agents: not linked
  feishu-send-file ~\.agents\skills\feishu-send-file
    Agents: not linked
  FFmpeg Video Editor ~\.agents\skills\ffmpeg-video-editor-1.0.0
    Agents: not linked
  find-skills ~\.agents\skills\find-skills
    Agents: Claude Code
  finishing-a-development-branch ~\.agents\skills\finishing-a-development-branch
    Agents: Claude Code
  git-essentials ~\.agents\skills\git-essentials-1.0.0
    Agents: not linked
  github-project-workflow ~\.agents\skills\github-project-workflow
    Agents: Claude Code
  interview-designer ~\.agents\skills\interview-designer-1.0.0
    Agents: not linked
  Market Research ~\.agents\skills\market-research-1.0.0
    Agents: not linked
  Memory ~\.agents\skills\memory-1.0.2
    Agents: not linked
  obsidian-ontology-sync ~\.agents\skills\obsidian-ontology-sync-1.0.1
    Agents: not linked
  opencode-controller ~\.agents\skills\opencode-controller-1.0.0
    Agents: not linked
  receiving-code-review ~\.agents\skills\receiving-code-review
    Agents: Claude Code
  remotion-best-practices ~\.agents\skills\remotion-best-practices
    Agents: Claude Code
  requesting-code-review ~\.agents\skills\requesting-code-review
    Agents: Claude Code
  research-paper-writer ~\.agents\skills\research-paper-writer-0.1.0
    Agents: not linked
  security-auditor ~\.agents\skills\security-auditor-1.0.0
    Agents: not linked
  Self-Improving Agent (With Self-Reflection) ~\.agents\skills\self-improving-1.1.3
    Agents: not linked
  SEO (Site Audit + Content Writer + Competitor Analysis) ~\.agents\skills\seo-1.0.3
    Agents: not linked
  seo-content-writer ~\.agents\skills\seo-content-writer-2.0.0
    Agents: not linked
  session-logs ~\.agents\skills\session-logs-1.0.0
    Agents: not linked
  skill-vetter ~\.agents\skills\skill-vetter-1.0.0
    Agents: not linked
  social-content ~\.agents\skills\social-content-generator-0.1.0
    Agents: not linked
  Social Media Scheduler ~\.agents\skills\social-media-scheduler-1.0.0
    Agents: not linked
  subagent-driven-development ~\.agents\skills\subagent-driven-development
    Agents: Claude Code
  supabase-postgres-best-practices ~\.agents\skills\supabase-postgres-best-practices
    Agents: not linked
  systematic-debugging ~\.agents\skills\systematic-debugging
    Agents: Claude Code
  test-driven-development ~\.agents\skills\test-driven-development
    Agents: Claude Code
  tmux ~\.agents\skills\tmux-1.0.0
    Agents: not linked
  ui-ux-pro-max ~\.agents\skills\ui-ux-pro-max-0.1.0
    Agents: not linked
  using-git-worktrees ~\.agents\skills\using-git-worktrees
    Agents: Claude Code
  using-superpowers ~\.agents\skills\using-superpowers
    Agents: Claude Code
  verification-before-completion ~\.agents\skills\verification-before-completion
    Agents: Claude Code
  video-frames ~\.agents\skills\video-frames-1.0.0
    Agents: not linked
  web-design-guidelines ~\.agents\skills\web-design-guidelines
    Agents: Claude Code
  writing-plans ~\.agents\skills\writing-plans
    Agents: Claude Code
  writing-skills ~\.agents\skills\writing-skills
    Agents: Claude Code
```


after:
```
pnpm run dev list -g
╰─ 👉 pnpm run dev list -g

> skills@1.5.7 dev C:\Users\weidows\source\repos\vercel-labs\skills
> node src/cli.ts "list" "-g"

Global Skills

Document Skills
  docx ~\.agents\skills\docx Agents: Claude Code
  pdf  ~\.agents\skills\pdf  Agents: Claude Code
  pptx ~\.agents\skills\pptx Agents: Claude Code
  xlsx ~\.agents\skills\xlsx Agents: Claude Code

Example Skills
  canvas-design   ~\.agents\skills\canvas-design   Agents: Claude Code
  frontend-design ~\.agents\skills\frontend-design Agents: Claude Code
  skill-creator   ~\.agents\skills\skill-creator   Agents: Claude Code

Mattpocock Skills
  grill-me ~\.agents\skills\grill-me Agents: Claude Code

General
  1password                                               ~\.agents\skills\1password-1.0.1                  Agents: not linked
  self-reflection                                         ~\.agents\skills\agent-self-reflection-1.0.0      Agents: not linked
  aminer-data-search                                      ~\.agents\skills\aminer-open-academic-1.0.5       Agents: not linked
  architecture-designer                                   ~\.agents\skills\architecture-designer-0.1.0      Agents: not linked
  autoglm-browser-agent                                   ~\.agents\skills\autoglm-browser-agent            Agents: not linked
  autoglm-deepresearch                                    ~\.agents\skills\autoglm-deepresearch             Agents: not linked
  autoglm-generate-image                                  ~\.agents\skills\autoglm-generate-image           Agents: not linked
  autoglm-open-link                                       ~\.agents\skills\autoglm-open-link                Agents: not linked
  autoglm-search-image                                    ~\.agents\skills\autoglm-search-image             Agents: not linked
  autoglm-websearch                                       ~\.agents\skills\autoglm-websearch                Agents: not linked
  automation-workflows                                    ~\.agents\skills\automation-workflows-0.1.0       Agents: not linked
  backtest-expert                                         ~\.agents\skills\backtest-expert-0.1.0            Agents: not linked
  blog-writer                                             ~\.agents\skills\blog-writer-0.1.0                Agents: not linked
  brainstorming                                           ~\.agents\skills\brainstorming                    Agents: Claude Code
  clawdefender                                            ~\.agents\skills\clawdefender-1                   Agents: not linked
  Code                                                    ~\.agents\skills\code-1.0.4                       Agents: not linked
  content-strategy                                        ~\.agents\skills\content-strategy-0.1.0           Agents: not linked
  copywriting                                             ~\.agents\skills\copywriting-0.1.0                Agents: not linked
  dispatching-parallel-agents                             ~\.agents\skills\dispatching-parallel-agents      Agents: Claude Code
  executing-plans                                         ~\.agents\skills\executing-plans                  Agents: Claude Code
  feishu-chat-history                                     ~\.agents\skills\feishu-chat-history              Agents: not linked
  feishu-cron-reminder                                    ~\.agents\skills\feishu-cron-reminder             Agents: not linked
  feishu-doc                                              ~\.agents\skills\feishu-doc-1.2.7                 Agents: not linked
  feishu-perm                                             ~\.agents\skills\feishu-perm                      Agents: not linked
  feishu-screenshot                                       ~\.agents\skills\feishu-screenshot                Agents: not linked
  feishu-send-file                                        ~\.agents\skills\feishu-send-file                 Agents: not linked
  FFmpeg Video Editor                                     ~\.agents\skills\ffmpeg-video-editor-1.0.0        Agents: not linked
  find-skills                                             ~\.agents\skills\find-skills                      Agents: Claude Code
  finishing-a-development-branch                          ~\.agents\skills\finishing-a-development-branch   Agents: Claude Code
  git-essentials                                          ~\.agents\skills\git-essentials-1.0.0             Agents: not linked
  github-project-workflow                                 ~\.agents\skills\github-project-workflow          Agents: Claude Code
  interview-designer                                      ~\.agents\skills\interview-designer-1.0.0         Agents: not linked
  Market Research                                         ~\.agents\skills\market-research-1.0.0            Agents: not linked
  Memory                                                  ~\.agents\skills\memory-1.0.2                     Agents: not linked
  obsidian-ontology-sync                                  ~\.agents\skills\obsidian-ontology-sync-1.0.1     Agents: not linked
  opencode-controller                                     ~\.agents\skills\opencode-controller-1.0.0        Agents: not linked
  receiving-code-review                                   ~\.agents\skills\receiving-code-review            Agents: Claude Code
  remotion-best-practices                                 ~\.agents\skills\remotion-best-practices          Agents: Claude Code
  requesting-code-review                                  ~\.agents\skills\requesting-code-review           Agents: Claude Code
  research-paper-writer                                   ~\.agents\skills\research-paper-writer-0.1.0      Agents: not linked
  security-auditor                                        ~\.agents\skills\security-auditor-1.0.0           Agents: not linked
  Self-Improving Agent (With Self-Reflection)             ~\.agents\skills\self-improving-1.1.3             Agents: not linked
  SEO (Site Audit + Content Writer + Competitor Analysis) ~\.agents\skills\seo-1.0.3                        Agents: not linked
  seo-content-writer                                      ~\.agents\skills\seo-content-writer-2.0.0         Agents: not linked
  session-logs                                            ~\.agents\skills\session-logs-1.0.0               Agents: not linked
  skill-vetter                                            ~\.agents\skills\skill-vetter-1.0.0               Agents: not linked
  social-content                                          ~\.agents\skills\social-content-generator-0.1.0   Agents: not linked
  Social Media Scheduler                                  ~\.agents\skills\social-media-scheduler-1.0.0     Agents: not linked
  subagent-driven-development                             ~\.agents\skills\subagent-driven-development      Agents: Claude Code
  supabase-postgres-best-practices                        ~\.agents\skills\supabase-postgres-best-practices Agents: not linked
  systematic-debugging                                    ~\.agents\skills\systematic-debugging             Agents: Claude Code
  test-driven-development                                 ~\.agents\skills\test-driven-development          Agents: Claude Code
  tmux                                                    ~\.agents\skills\tmux-1.0.0                       Agents: not linked
  ui-ux-pro-max                                           ~\.agents\skills\ui-ux-pro-max-0.1.0              Agents: not linked
  using-git-worktrees                                     ~\.agents\skills\using-git-worktrees              Agents: Claude Code
  using-superpowers                                       ~\.agents\skills\using-superpowers                Agents: Claude Code
  verification-before-completion                          ~\.agents\skills\verification-before-completion   Agents: Claude Code
  video-frames                                            ~\.agents\skills\video-frames-1.0.0               Agents: not linked
  web-design-guidelines                                   ~\.agents\skills\web-design-guidelines            Agents: Claude Code
  writing-plans                                           ~\.agents\skills\writing-plans                    Agents: Claude Code
  writing-skills                                          ~\.agents\skills\writing-skills                   Agents: Claude Code


```