### PR TITLE
feat: discover nested catalog skills in priority dirs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,13 @@ metadata:
 
 ### Skill Discovery
 
-The CLI searches for skills in these locations within a repository:
+The CLI searches for skills in these locations within a repository. Each
+skill container directory is walked one level deep for the common flat
+layout (`skills/<name>/SKILL.md`) and one extra level deep for catalog
+layouts (`skills/<category>/<name>/SKILL.md`). A `SKILL.md` discovered at
+the shallower level shadows anything nested below it. Use `--full-depth`
+to also discover `SKILL.md` files outside these container directories
+(e.g. under `examples/` or `tests/`).
 
 <!-- skill-discovery:start -->
 
@@ -410,7 +416,7 @@ If `.claude-plugin/marketplace.json` or `.claude-plugin/plugin.json` exists, ski
 }
 ```
 
-This enables compatibility with the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) ecosystem.
+This enables compatibility with the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) ecosystem. Skill paths declared in a manifest are searched at their declared depth and are not subject to the depth-2 catalog walk described above.
 
 If no skills are found in standard locations, a recursive search is performed.
 

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -271,12 +271,20 @@ export function findSkillMdPaths(tree: RepoTree, subpath?: string): string[] {
 
   if (filtered.length === 0) return [];
 
-  // Check priority directories first (same order as discoverSkills)
+  // Check priority directories first (same order as discoverSkills).
+  // Non-root prefixes also accept depth-2 paths so the blob fast path stays
+  // in sync with the on-disk walk's catalog-layout discovery.
   const priorityResults: string[] = [];
   const seen = new Set<string>();
+  // Mirror of SKIP_DIRS at the top of src/skills.ts. Kept local to avoid
+  // a cross-file import; if these ever drift, update both.
+  const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '__pycache__']);
+  const lowerSkillMdSet = new Set(filtered.map((p) => p.toLowerCase()));
 
   for (const priorityPrefix of PRIORITY_PREFIXES) {
     const fullPrefix = prefix + priorityPrefix;
+    const isContainer = priorityPrefix !== '';
+
     for (const skillMd of filtered) {
       // Check if this SKILL.md is directly inside the priority dir (one level deep)
       if (!skillMd.startsWith(fullPrefix)) continue;
@@ -295,6 +303,25 @@ export function findSkillMdPaths(tree: RepoTree, subpath?: string): string[] {
       const parts = rest.split('/');
       if (parts.length === 2 && parts[1]!.toLowerCase() === 'skill.md') {
         if (!seen.has(skillMd)) {
+          priorityResults.push(skillMd);
+          seen.add(skillMd);
+        }
+        continue;
+      }
+
+      // SKILL.md two levels deep under a known container prefix
+      // (e.g., "skills/<category>/<skill>/SKILL.md"). Skip if the parent
+      // child dir already has its own SKILL.md (no descent past), or if
+      // any path segment is an ignored directory.
+      if (
+        isContainer &&
+        parts.length === 3 &&
+        parts[2]!.toLowerCase() === 'skill.md' &&
+        !SKIP_DIRS.has(parts[0]!) &&
+        !SKIP_DIRS.has(parts[1]!)
+      ) {
+        const parentSkillMd = `${fullPrefix}${parts[0]}/SKILL.md`.toLowerCase();
+        if (!lowerSkillMdSet.has(parentSkillMd) && !seen.has(skillMd)) {
           priorityResults.push(skillMd);
           seen.add(skillMd);
         }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -183,24 +183,54 @@ export async function discoverSkills(
     join(searchPath, '.zencoder/skills'),
   ];
 
+  // Known skill container dirs are walked one extra level deep so layouts
+  // like `skills/<category>/<skill>/SKILL.md` are discovered without
+  // requiring `--full-depth`. The repo root (first entry) keeps its
+  // existing depth-1 behavior to avoid surfacing unrelated `SKILL.md`
+  // files (e.g. `examples/foo/SKILL.md`), and plugin-manifest-declared
+  // dirs (appended below) stay at depth-1 to honor the manifest spec.
+  const deepContainerDirs = new Set(prioritySearchDirs.slice(1));
+
   // Add skill paths declared in plugin manifests
   prioritySearchDirs.push(...(await getPluginSkillPaths(searchPath)));
 
+  const tryAddSkillAt = async (skillDir: string): Promise<boolean> => {
+    if (!(await hasSkillMd(skillDir))) return false;
+    let skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
+    if (!skill || seenNames.has(skill.name)) return true;
+    skill = enhanceSkill(skill);
+    skills.push(skill);
+    seenNames.add(skill.name);
+    return true;
+  };
+
   for (const dir of prioritySearchDirs) {
+    const walkDeep = deepContainerDirs.has(dir);
+
     try {
       const entries = await readdir(dir, { withFileTypes: true });
 
       for (const entry of entries) {
-        if (entry.isDirectory()) {
-          const skillDir = join(dir, entry.name);
-          if (await hasSkillMd(skillDir)) {
-            let skill = await parseSkillMd(join(skillDir, 'SKILL.md'), options);
-            if (skill && !seenNames.has(skill.name)) {
-              skill = enhanceSkill(skill);
-              skills.push(skill);
-              seenNames.add(skill.name);
-            }
+        if (!entry.isDirectory()) continue;
+
+        const childDir = join(dir, entry.name);
+        const foundAtChild = await tryAddSkillAt(childDir);
+
+        // Don't descend past a discovered SKILL.md (matches the existing
+        // flat-layout semantics) and don't go deeper inside non-container
+        // priority dirs.
+        if (foundAtChild || !walkDeep) continue;
+        if (SKIP_DIRS.includes(entry.name)) continue;
+
+        // Walk one extra level for catalog layouts.
+        try {
+          const grandEntries = await readdir(childDir, { withFileTypes: true });
+          for (const grand of grandEntries) {
+            if (!grand.isDirectory() || SKIP_DIRS.includes(grand.name)) continue;
+            await tryAddSkillAt(join(childDir, grand.name));
           }
+        } catch {
+          // Child dir unreadable; skip silently.
         }
       }
     } catch {

--- a/tests/nested-container-discovery.test.ts
+++ b/tests/nested-container-discovery.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for bounded depth-2 discovery inside skill container directories.
+ *
+ * Layouts like `skills/<category>/<skill>/SKILL.md` are common when a repo
+ * groups skills by product or category. They should be discovered by
+ * `discoverSkills()` and `findSkillMdPaths()` without users having to pass
+ * `--full-depth`, while keeping the flat-layout, manifest, and
+ * `examples/` / `tests/` behaviors intact.
+ *
+ * See: https://github.com/vercel-labs/skills/issues/747
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { discoverSkills } from '../src/skills.ts';
+import { findSkillMdPaths, type RepoTree, type TreeEntry } from '../src/blob.ts';
+
+function writeSkill(dir: string, name: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${name} description\n---\n\n# ${name}\n`
+  );
+}
+
+function makeTree(paths: string[]): RepoTree {
+  const entries: TreeEntry[] = paths.map((path) => ({
+    path,
+    type: path.toLowerCase().endsWith('skill.md') ? 'blob' : 'tree',
+    sha: 'sha-' + path.replace(/[^a-z0-9]/gi, '_'),
+  }));
+  return { sha: 'root-sha', branch: 'main', tree: entries };
+}
+
+describe('discoverSkills — bounded depth-2 inside skill container dirs', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-nested-disk-${Date.now()}-${Math.random()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('discovers nested skills under skills/<category>/<skill>/SKILL.md', async () => {
+    writeSkill(join(testDir, 'skills', 'product-a', 'skill-one'), 'skill-one');
+    writeSkill(join(testDir, 'skills', 'product-a', 'skill-two'), 'skill-two');
+    writeSkill(join(testDir, 'skills', 'product-b', 'skill-three'), 'skill-three');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills.map((s) => s.name).sort()).toEqual(['skill-one', 'skill-three', 'skill-two']);
+  });
+
+  it('discovers mixed flat and nested skills in the same container', async () => {
+    writeSkill(join(testDir, 'skills', 'flat-skill'), 'flat-skill');
+    writeSkill(join(testDir, 'skills', 'category', 'nested-skill'), 'nested-skill');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills.map((s) => s.name).sort()).toEqual(['flat-skill', 'nested-skill']);
+  });
+
+  it('does not descend past a SKILL.md found at depth 1', async () => {
+    writeSkill(join(testDir, 'skills', 'foo'), 'outer-skill');
+    writeSkill(join(testDir, 'skills', 'foo', 'inner'), 'inner-skill');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('outer-skill');
+  });
+
+  it('skips ignored directory names during depth-2 descent', async () => {
+    writeSkill(join(testDir, 'skills', 'node_modules', 'inner', 'pkg-skill'), 'pkg-skill');
+    writeSkill(join(testDir, 'skills', 'real-category', 'real-skill'), 'real-skill');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills.map((s) => s.name).sort()).toEqual(['real-skill']);
+  });
+
+  it('discovers nested skills under agent-specific container dirs', async () => {
+    writeSkill(join(testDir, '.agents', 'skills', 'category', 'agent-skill'), 'agent-skill');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills.map((s) => s.name)).toEqual(['agent-skill']);
+  });
+
+  it('does not perform depth-2 descent from the repo root', async () => {
+    // `examples/<x>/<skill>/SKILL.md` must stay invisible without --full-depth.
+    writeSkill(join(testDir, 'examples', 'category', 'example-skill'), 'example-skill');
+    writeSkill(join(testDir, 'skills', 'real-skill'), 'real-skill');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills.map((s) => s.name)).toEqual(['real-skill']);
+  });
+
+  it('still requires --full-depth for skills deeper than two levels in a container', async () => {
+    writeSkill(join(testDir, 'skills', 'level-1', 'level-2', 'deep-skill'), 'deep-skill');
+    writeSkill(join(testDir, 'skills', 'shallow'), 'shallow-skill');
+
+    const defaultSkills = await discoverSkills(testDir);
+    expect(defaultSkills.map((s) => s.name).sort()).toEqual(['shallow-skill']);
+
+    const fullSkills = await discoverSkills(testDir, undefined, { fullDepth: true });
+    expect(fullSkills.map((s) => s.name).sort()).toEqual(['deep-skill', 'shallow-skill']);
+  });
+
+  it('still short-circuits when a root SKILL.md exists (no fullDepth)', async () => {
+    writeSkill(testDir, 'root-skill');
+    writeSkill(join(testDir, 'skills', 'category', 'nested'), 'nested-skill');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe('root-skill');
+  });
+});
+
+describe('findSkillMdPaths — bounded depth-2 inside skill container prefixes', () => {
+  it('returns nested SKILL.md paths under skills/<category>/<skill>/', () => {
+    const tree = makeTree([
+      'skills/product-a/skill-one/SKILL.md',
+      'skills/product-a/skill-two/SKILL.md',
+      'skills/product-b/skill-three/SKILL.md',
+    ]);
+
+    expect(findSkillMdPaths(tree).sort()).toEqual([
+      'skills/product-a/skill-one/SKILL.md',
+      'skills/product-a/skill-two/SKILL.md',
+      'skills/product-b/skill-three/SKILL.md',
+    ]);
+  });
+
+  it('returns mixed flat and nested paths from the same container', () => {
+    const tree = makeTree(['skills/flat-skill/SKILL.md', 'skills/category/nested-skill/SKILL.md']);
+
+    expect(findSkillMdPaths(tree).sort()).toEqual([
+      'skills/category/nested-skill/SKILL.md',
+      'skills/flat-skill/SKILL.md',
+    ]);
+  });
+
+  it('does not descend past a SKILL.md found at depth 1', () => {
+    const tree = makeTree(['skills/foo/SKILL.md', 'skills/foo/inner/SKILL.md']);
+
+    expect(findSkillMdPaths(tree)).toEqual(['skills/foo/SKILL.md']);
+  });
+
+  it('is case-insensitive about the parent SKILL.md when checking for shadowing', () => {
+    const tree = makeTree(['skills/foo/skill.md', 'skills/foo/inner/SKILL.md']);
+
+    expect(findSkillMdPaths(tree)).toEqual(['skills/foo/skill.md']);
+  });
+
+  it('skips depth-2 entries whose intermediate dir is an ignored directory', () => {
+    const tree = makeTree([
+      'skills/node_modules/pkg-skill/SKILL.md',
+      'skills/real-category/real-skill/SKILL.md',
+    ]);
+
+    expect(findSkillMdPaths(tree)).toEqual(['skills/real-category/real-skill/SKILL.md']);
+  });
+
+  it('does not surface depth-2 entries under the root prefix', () => {
+    const tree = makeTree([
+      'examples/category/example-skill/SKILL.md',
+      'skills/real-skill/SKILL.md',
+    ]);
+
+    expect(findSkillMdPaths(tree)).toEqual(['skills/real-skill/SKILL.md']);
+  });
+
+  it('respects the subpath filter while applying depth-2 discovery', () => {
+    const tree = makeTree([
+      'skills/category/in-scope/SKILL.md',
+      'other/category/out-of-scope/SKILL.md',
+    ]);
+
+    expect(findSkillMdPaths(tree, 'skills')).toEqual(['skills/category/in-scope/SKILL.md']);
+  });
+});


### PR DESCRIPTION
## Summary

Skill repos that organize skills by product or category — `skills/<category>/<skill>/SKILL.md` — silently miss skills today unless users pass `--full-depth`. This PR walks each **known skill container directory** one additional level so catalog layouts work out of the box, without broadening discovery to unrelated parts of the repo (no `examples/`, `tests/`, etc.).

Closes #747.

## Motivation

The original priority pass only walks one level deep inside `prioritySearchDirs`. When a repo has *only* nested skills under `skills/<category>/<skill>/`, the priority pass finds nothing and the recursive fallback (`findSkillDirs`, depth 5) catches them — so pure-nested layouts happen to work. But **mixed flat + nested layouts** in the same `skills/` dir are silently broken: the priority pass adds the flat skill, `skills.length > 0` short-circuits the fallback, and the nested ones are silently dropped.

Real-world example: [jasonnvidia/skills](https://github.com/jasonnvidia/skills) has skills under both `plugins/nvidia-skills/skills/<skill>/SKILL.md` (declared via plugin manifest, discovered fine) and `skills/cuopt/<skill>/SKILL.md` (catalog layout, **9 skills silently missed** on `main`). Verified with the local repro below.

## What changed semantically

| Layout | Before (default) | After (default) | `--full-depth` |
|---|---|---|---|
| `SKILL.md` at repo root | found, short-circuits | found, short-circuits | full walk (unchanged) |
| `skills/<skill>/SKILL.md` (flat) | found via priority depth-1 | found via priority depth-1 (unchanged) | also found |
| `skills/<category>/<skill>/SKILL.md` (catalog) | **missed** when mixed with a flat skill; otherwise found via fallback | **found** via priority depth-2 | found |
| `skills/<a>/<b>/<c>/SKILL.md` (3+ levels) | found via fallback only when no shallower skill exists | unchanged | found |
| `skills/<skill>/SKILL.md` + `skills/<skill>/inner/SKILL.md` | parent shadows `inner/` | parent shadows `inner/` (unchanged) | both found |
| `skills/node_modules/<x>/SKILL.md` | walked at depth-1 (unchanged) | walked at depth-1 (unchanged); depth-2 descent skipped | depth-2 descent skipped |
| `examples/<x>/<y>/SKILL.md`, `tests/<x>/<y>/SKILL.md` | missed (no root container walk) | missed (no root container walk) (unchanged) | found |
| Plugin-manifest-declared paths (`marketplace.json` / `plugin.json`) | discovered at declared depth | discovered at declared depth (unchanged — explicitly excluded from depth-2 walk) | unchanged |
| Blob fast path (`findSkillMdPaths`) | same priority + depth-≤5 fallback | same priority + depth-2 inside container prefixes, parent-shadow honored | unchanged |

Key invariants preserved:
- The repo root keeps its existing depth-1 behavior (no surprise discovery of `examples/foo/SKILL.md`).
- Plugin-manifest paths stay at depth-1 (`deepContainerDirs` is snapshotted *before* manifest paths are appended in `src/skills.ts`).
- `SKIP_DIRS` (`node_modules`, `.git`, `dist`, `build`, `__pycache__`) is honored for the new depth-2 descent on both disk and blob paths.
- Name-based dedup (`seenNames`) means manifest-declared and catalog-discovered duplicates collapse to one entry.

## Files changed

- `src/skills.ts` — priority pass walks known container dirs (`prioritySearchDirs.slice(1)`) one extra level via a small helper `tryAddSkillAt`; depth-2 descent stops at a discovered `SKILL.md` and honors `SKIP_DIRS`. Root and manifest paths intentionally excluded from the deeper walk.
- `src/blob.ts` — `findSkillMdPaths` mirrors the disk semantics: accepts depth-2 entries under non-root priority prefixes only when the parent has no `SKILL.md` and neither intermediate dir name is in `SKIP_DIRS`. Comment points back to `SKIP_DIRS` in `src/skills.ts`.
- `tests/nested-container-discovery.test.ts` — new file, 15 focused assertions across disk and blob discovery.
- `README.md` — "Skill Discovery" section explains the depth-2 behavior, shadowing, and that `--full-depth` is still the way to surface `SKILL.md` files outside container dirs. "Plugin Manifest Discovery" section clarifies manifest paths are not subject to the depth-2 walk.

## Test plan

- [x] **New focused tests** — `tests/nested-container-discovery.test.ts` covers both `discoverSkills` (disk) and `findSkillMdPaths` (blob):
  - nested `skills/<category>/<skill>/SKILL.md`
  - mixed flat + nested in the same container (the bug)
  - no descent past a `SKILL.md` at depth 1 (parent shadows child) — incl. case-insensitive `skill.md` shadowing
  - `SKIP_DIRS` honored during depth-2 descent (`node_modules`)
  - `.agents/skills/<category>/<skill>/` (other priority prefix)
  - no depth-2 walk from the repo root (`examples/<category>/<skill>/` stays invisible by default)
  - 3+-level skills still require `--full-depth`
  - root `SKILL.md` still short-circuits without `--full-depth`
  - blob subpath filter still applied
- [x] **Regression suites pass** — `tests/full-depth-discovery.test.ts` (5 tests), `tests/plugin-manifest-discovery.test.ts` (19 tests), `tests/skill-matching.test.ts`, `tests/skill-path.test.ts`. 66/66 in the discovery surface.
- [x] **Type-check** — clean for this PR. (Three pre-existing TS errors in `src/git.ts` and `src/skills.ts` are confirmed to exist on `main` independent of this branch.)
- [x] **Synthetic end-to-end** via `node src/cli.ts add /tmp/repo --list` against a fixture with flat + nested + shadowing + `node_modules` + 3-level-deep + `examples/`. Default finds 4, `--full-depth` finds 7; `node_modules`-located `SKILL.md` is never returned, even with `--full-depth`.
- [x] **Real repo end-to-end** against `jasonnvidia/skills` (catalog layout under `skills/cuopt/`, plus 2 plugin-manifest-declared skills under `plugins/nvidia-skills/skills/`):
  - **Pre-PR on-disk**: 2 skills (only the manifest-declared ones — the 9 `skills/cuopt/*` ones silently dropped).
  - **Post-PR on-disk**: 9 unique skills (catalog ones found, manifest duplicates deduped by name).
  - **Pre-PR blob**: 11 paths via the depth-≤5 fallback (catalog + plugin paths leaked through the same channel).
  - **Post-PR blob**: 9 paths via the new bounded depth-2 priority pass (plugin paths go through the manifest channel as intended).

## Not in scope

- Adding new priority dirs (e.g. `agent-skills/`). The discussion in #452 looks like a separate fix.
- Frontmatter parsing / silent-drop behavior — see #1058, #1094, #1240.
- Anything beyond two levels under a container. Repos that genuinely need deeper structures still pass `--full-depth`, and the README continues to point users there.