### PR TITLE
fix(update): spawn Node without a shell so Windows paths with spaces don't break updates

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -411,10 +411,13 @@ export async function updateGlobalSkills(
       );
       continue;
     }
+    // Spawn the Node binary directly (no shell). process.execPath can contain
+    // spaces (e.g. "C:\Program Files\nodejs\node.exe"); with shell:true on
+    // Windows the unquoted command line is split by cmd.exe at the space and the
+    // update fails with `'C:\Program' is not recognized`. See #941 / #1119.
     const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
-      shell: process.platform === 'win32',
     });
 
     if (result.status === 0) {
@@ -544,13 +547,14 @@ export async function updateProjectSkills(
       console.log(`${TEXT}Updating ${safeName}...${RESET}`);
       const installUrl = formatSourceInput(skill.entry.source, skill.entry.ref);
 
+      // See note above: spawn the Node binary directly without a shell so that
+      // Windows paths containing spaces don't break the update (#941 / #1119).
       const result = spawnSync(
         process.execPath,
         [cliEntry, 'add', installUrl, '--skill', skill.name, '-y'],
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
-          shell: process.platform === 'win32',
         }
       );
 


### PR DESCRIPTION
## Summary

On Windows, `npx skills update` (global or project) reports `✗ Failed to update` for **every** skill that has a pending update, with no actionable error. The skills themselves are fine — `npx skills add <source>` works on the same machine.

## Root cause

Both update paths in `src/update.ts` re-spawn the CLI like this:

```ts
spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
  stdio: ['inherit', 'pipe', 'pipe'],
  encoding: 'utf-8',
  shell: process.platform === 'win32',
});
```

`process.execPath` is a real binary (`node.exe`), so **no shell is needed**. With `shell: true` on Windows, Node hands the *unquoted* command line to `cmd.exe` — exactly what the `DEP0190` deprecation warning is about ("arguments are not escaped, only concatenated"). When Node is at the default `C:\Program Files\nodejs\node.exe`, `cmd.exe` splits on the space in `Program Files` and tries to run `C:\Program`:

```
'C:\Program' is not recognized as an internal or external command
```

The child exits non-zero, and because `stderr` is piped the real error is swallowed — the user only ever sees `✗ Failed to update`. This affects any skill with a pending update (it is not skill-specific), and reproduces on a stock Windows 11 install with Node from the official installer / winget.

## Fix

Drop `shell` from both `spawnSync` calls. Spawning `process.execPath` directly works on every platform (the `.mjs` is just an argument to `node`), is robust to spaces in the executable/script path, and also resolves the `DEP0190` warning.

## Verification

- Reproduced the exact failing spawn under a space-containing Node path → `'C:\Program' is not recognized`, `status === 1`.
- After removing `shell`, the identical spawn returns `status === 0`.
- End-to-end: `skills update --global` now prints `✓ Updated <skill>` instead of `✗ Failed to update`.

Fixes #941
Fixes #1119
Related to #840

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
