### PR TITLE
feat: add consolidate command to unify skills across agent directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ When installing interactively, you can choose:
 | `npx skills find [query]`    | Search for skills interactively or by keyword |
 | `npx skills remove [skills]` | Remove installed skills from agents           |
 | `npx skills update [skills]` | Update installed skills to latest versions    |
+| `npx skills consolidate`     | Consolidate skills into canonical with symlinks |
 | `npx skills init [name]`     | Create a new SKILL.md template                |
 
 ### `skills list`
@@ -208,6 +209,29 @@ npx skills rm my-skill
 | `-s, --skill`  | Specify skills to remove (use `'*'` for all)     |
 | `-y, --yes`    | Skip confirmation prompts                        |
 | `--all`        | Shorthand for `--skill '*' --agent '*' -y`       |
+
+### `skills consolidate`
+
+Consolidate skills from multiple agent directories into the canonical `.agents/skills/` location, replacing duplicates with symlinks.
+
+```bash
+# Preview what would happen (no changes)
+npx skills consolidate --dry-run
+
+# Consolidate all agent skills into canonical location
+npx skills consolidate -y
+
+# Consolidate and sync all skills to all installed agents
+npx skills consolidate -y --sync-all
+```
+
+| Option       | Description                                                  |
+| ------------ | ------------------------------------------------------------ |
+| `-y, --yes`  | Skip confirmation prompts                                    |
+| `--dry-run`  | Show plan without making changes                             |
+| `--sync-all` | After consolidating, create symlinks for all canonical skills in all installed agents |
+
+When the same skill exists in multiple agents with different content, it's forked as `<skill>-<agent>` in canonical (e.g., `my-skill-codex`). With `--sync-all`, forked skills are only linked to their designated agent, with the suffix stripped from the link name.
 
 ## What are Agent Skills?
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
 import { removeCommand, parseRemoveOptions } from './remove.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
+import { runConsolidate, parseConsolidateOptions } from './consolidate.ts';
 import { flushTelemetry } from './telemetry.ts';
 import { isRunningInAgent } from './detect-agent.ts';
 import { runUpdate } from './update.ts';
@@ -122,6 +123,7 @@ ${BOLD}Project:${RESET}
   experimental_install Restore skills from skills-lock.json
   init [name]          Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
   experimental_sync    Sync skills from node_modules into agent directories
+  consolidate          Consolidate skills into canonical .agents/skills/ with symlinks
 
 ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
@@ -334,6 +336,15 @@ async function main(): Promise<void> {
       if (!inAgent) showLogo();
       const { options: syncOptions } = parseSyncOptions(restArgs);
       await runSync(restArgs, syncOptions);
+      break;
+    }
+    case 'consolidate':
+    case 'consol':
+    case 'link':
+    case 'ln': {
+      if (!inAgent) showLogo();
+      const consolidateOpts = parseConsolidateOptions(restArgs);
+      await runConsolidate(restArgs, consolidateOpts);
       break;
     }
     case 'list':

--- a/src/consolidate.ts
+++ b/src/consolidate.ts
@@ -1,0 +1,476 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { readdir, lstat, rename, rm, stat, mkdir, cp, readFile, writeFile } from 'fs/promises';
+import { join, dirname, resolve } from 'path';
+import { parseSkillMd } from './skills.ts';
+import { computeSkillFolderHash } from './local-lock.ts';
+import { getCanonicalSkillsDir, sanitizeName, createSymlink } from './installer.ts';
+import { agents, detectInstalledAgents } from './agents.ts';
+import { track } from './telemetry.ts';
+import type { AgentType } from './types.ts';
+
+export interface ConsolidateOptions {
+  global?: boolean;
+  yes?: boolean;
+  dryRun?: boolean;
+  /** Sync all canonical skills to all installed agents after consolidation */
+  syncAll?: boolean;
+  /** @internal For testing — override the canonical directory */
+  _canonicalDir?: string;
+}
+
+interface DiscoveredSkill {
+  name: string;
+  dirName: string;
+  path: string;
+  agent: AgentType;
+  hash: string;
+}
+
+interface ConsolidateAction {
+  type: 'move-and-link' | 'link-only' | 'fork';
+  skill: DiscoveredSkill;
+  canonicalPath: string;
+  canonicalHash?: string;
+}
+
+const SKIP_DIRS = new Set(['vendor_imports', '.git', 'node_modules', '__pycache__']);
+
+export function parseConsolidateOptions(args: string[]): ConsolidateOptions {
+  const options: ConsolidateOptions = { global: true };
+  for (const arg of args) {
+    if (arg === '-g' || arg === '--global') options.global = true;
+    else if (arg === '-y' || arg === '--yes') options.yes = true;
+    else if (arg === '--dry-run') options.dryRun = true;
+    else if (arg === '--sync-all') options.syncAll = true;
+  }
+  return options;
+}
+
+/**
+ * Scan agent global skill directories for real (non-symlink) skill folders.
+ */
+async function scanAgentSkills(canonicalDir: string): Promise<DiscoveredSkill[]> {
+  const discovered: DiscoveredSkill[] = [];
+  const installedAgents = await detectInstalledAgents();
+
+  // Collect unique globalSkillsDir paths to scan (skip universal agents whose dir IS canonical)
+  const dirsToScan = new Map<string, AgentType>();
+  for (const agentType of installedAgents) {
+    const agent = agents[agentType];
+    const globalDir = agent.globalSkillsDir;
+    if (!globalDir) continue;
+    // Skip if this agent's global dir is the canonical dir
+    if (resolve(globalDir) === resolve(canonicalDir)) continue;
+    if (!dirsToScan.has(globalDir)) {
+      dirsToScan.set(globalDir, agentType);
+    }
+  }
+
+  for (const [agentDir, agentType] of dirsToScan) {
+    let entries;
+    try {
+      entries = await readdir(agentDir, { withFileTypes: true });
+    } catch {
+      continue; // Directory doesn't exist
+    }
+
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+
+      const skillPath = join(agentDir, entry.name);
+
+      // Skip symlinks — already consolidated
+      try {
+        const stats = await lstat(skillPath);
+        if (stats.isSymbolicLink()) continue;
+        if (!stats.isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      // Must have SKILL.md
+      try {
+        await stat(join(skillPath, 'SKILL.md'));
+      } catch {
+        continue;
+      }
+
+      const skill = await parseSkillMd(join(skillPath, 'SKILL.md'));
+      if (!skill) continue;
+
+      let hash: string;
+      try {
+        hash = await computeSkillFolderHash(skillPath);
+      } catch {
+        continue;
+      }
+
+      discovered.push({
+        name: skill.name,
+        dirName: entry.name,
+        path: skillPath,
+        agent: agentType,
+        hash,
+      });
+    }
+  }
+
+  return discovered;
+}
+
+/**
+ * Plan consolidation actions by comparing discovered skills with canonical.
+ */
+async function planActions(
+  discovered: DiscoveredSkill[],
+  canonicalDir: string
+): Promise<ConsolidateAction[]> {
+  const actions: ConsolidateAction[] = [];
+
+  // Group by sanitized name to handle duplicates across agents
+  const byName = new Map<string, DiscoveredSkill[]>();
+  for (const skill of discovered) {
+    const key = sanitizeName(skill.name);
+    const group = byName.get(key) || [];
+    group.push(skill);
+    byName.set(key, group);
+  }
+
+  for (const [sanitized, skills] of byName) {
+    const canonicalPath = join(canonicalDir, sanitized);
+
+    // Check if canonical already has this skill
+    let canonicalExists = false;
+    let canonicalHash: string | undefined;
+    try {
+      await stat(join(canonicalPath, 'SKILL.md'));
+      canonicalExists = true;
+      canonicalHash = await computeSkillFolderHash(canonicalPath);
+    } catch {
+      // Doesn't exist in canonical
+    }
+
+    for (const skill of skills) {
+      if (canonicalExists) {
+        if (skill.hash === canonicalHash) {
+          actions.push({ type: 'link-only', skill, canonicalPath });
+        } else {
+          // Conflict: different content — fork into <skill>-<agent>
+          const agentName = agents[skill.agent]?.name || skill.agent;
+          const forkedName = `${sanitized}-${agentName}`;
+          const forkedPath = join(canonicalDir, forkedName);
+          actions.push({ type: 'fork', skill, canonicalPath: forkedPath, canonicalHash });
+        }
+      } else {
+        // First one becomes the canonical version
+        actions.push({ type: 'move-and-link', skill, canonicalPath });
+        canonicalExists = true;
+        canonicalHash = skill.hash;
+      }
+    }
+  }
+
+  return actions;
+}
+
+/**
+ * Move a directory, falling back to copy+delete for cross-device moves.
+ */
+async function moveDir(src: string, dest: string): Promise<void> {
+  try {
+    await rename(src, dest);
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'EXDEV') {
+      await mkdir(dest, { recursive: true });
+      await cp(src, dest, { recursive: true });
+      await rm(src, { recursive: true, force: true });
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
+ * Execute consolidation actions.
+ */
+async function executeActions(actions: ConsolidateAction[]): Promise<{
+  moved: number;
+  linked: number;
+  forked: number;
+  forkRecords: ForkManifest;
+}> {
+  let moved = 0;
+  let linked = 0;
+  let forked = 0;
+  const forkRecords: ForkManifest = {};
+
+  for (const action of actions) {
+    const { skill, canonicalPath } = action;
+
+    try {
+      if (action.type === 'move-and-link') {
+        await mkdir(dirname(canonicalPath), { recursive: true });
+        await moveDir(skill.path, canonicalPath);
+        await createSymlink(canonicalPath, skill.path);
+        moved++;
+      } else if (action.type === 'link-only') {
+        await rm(skill.path, { recursive: true, force: true });
+        await createSymlink(canonicalPath, skill.path);
+        linked++;
+      } else if (action.type === 'fork') {
+        // Move to agent-specific canonical path (e.g. my-skill-codex)
+        await mkdir(dirname(canonicalPath), { recursive: true });
+        await moveDir(skill.path, canonicalPath);
+        await createSymlink(canonicalPath, skill.path);
+        // Record in fork manifest
+        const dirName = canonicalPath.split('/').pop()!;
+        const agentName = agents[skill.agent]?.name || skill.agent;
+        forkRecords[dirName] = agentName;
+        forked++;
+      }
+    } catch (err) {
+      p.log.error(
+        `Failed to consolidate ${pc.cyan(skill.name)} from ${pc.dim(skill.path)}: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  return { moved, linked, forked, forkRecords };
+}
+
+/** Fork manifest: maps canonical dir name → agent name */
+interface ForkManifest {
+  [dirName: string]: string; // e.g. { "my-skill-codex": "codex" }
+}
+
+const FORK_MANIFEST_FILE = '.forks.json';
+
+async function readForkManifest(canonicalDir: string): Promise<ForkManifest> {
+  try {
+    const content = await readFile(join(canonicalDir, FORK_MANIFEST_FILE), 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return {};
+  }
+}
+
+async function writeForkManifest(canonicalDir: string, manifest: ForkManifest): Promise<void> {
+  const sorted = Object.fromEntries(
+    Object.entries(manifest).sort(([a], [b]) => a.localeCompare(b))
+  );
+  await writeFile(join(canonicalDir, FORK_MANIFEST_FILE), JSON.stringify(sorted, null, 2) + '\n');
+}
+
+/**
+ * Sync all skills from canonical to all installed non-universal agents.
+ * Creates symlinks for skills that don't yet exist in each agent's directory.
+ * Agent-specific forks (recorded in .forks.json) are only synced to that agent.
+ */
+async function syncAllToAgents(canonicalDir: string, dryRun?: boolean): Promise<number> {
+  const installedAgents = await detectInstalledAgents();
+  const forkManifest = await readForkManifest(canonicalDir);
+  let created = 0;
+
+  // Get all skill dirs in canonical
+  let canonicalEntries;
+  try {
+    canonicalEntries = await readdir(canonicalDir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  const skillDirs: string[] = [];
+  for (const entry of canonicalEntries) {
+    const entryPath = join(canonicalDir, entry.name);
+    // Include both real dirs and symlinks-to-dirs
+    try {
+      const s = await stat(entryPath);
+      if (!s.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    // Must have SKILL.md
+    try {
+      await stat(join(entryPath, 'SKILL.md'));
+      skillDirs.push(entry.name);
+    } catch {
+      continue;
+    }
+  }
+
+  // For each non-universal agent, create missing symlinks
+  for (const agentType of installedAgents) {
+    const agent = agents[agentType];
+    const globalDir = agent.globalSkillsDir;
+    if (!globalDir) continue;
+    // Skip agents whose dir IS canonical
+    if (resolve(globalDir) === resolve(canonicalDir)) continue;
+
+    // Ensure agent skills dir exists
+    if (!dryRun) {
+      await mkdir(globalDir, { recursive: true });
+    }
+
+    for (const skillName of skillDirs) {
+      // Check fork manifest: if this is a forked skill, only sync to its agent
+      const forkAgent = forkManifest[skillName];
+      if (forkAgent && forkAgent !== agent.name) continue;
+
+      // Strip agent suffix for the link name (my-skill-codex → my-skill)
+      const linkName = forkAgent ? skillName.slice(0, -(forkAgent.length + 1)) : skillName;
+      const agentSkillPath = join(globalDir, linkName);
+
+      // Skip if already exists (real dir or symlink)
+      try {
+        await lstat(agentSkillPath);
+        continue; // Already exists
+      } catch {
+        // Doesn't exist — create symlink
+      }
+
+      if (!dryRun) {
+        const canonicalSkillPath = join(canonicalDir, skillName);
+        const success = await createSymlink(canonicalSkillPath, agentSkillPath);
+        if (success) created++;
+      } else {
+        created++;
+      }
+    }
+  }
+
+  return created;
+}
+
+export async function runConsolidate(
+  _args: string[],
+  options: ConsolidateOptions = {}
+): Promise<void> {
+  const isGlobal = options.global ?? true;
+  const canonicalDir = options._canonicalDir ?? getCanonicalSkillsDir(isGlobal);
+
+  console.log();
+  p.intro(pc.bgCyan(pc.black(' skills consolidate ')));
+
+  // Step 1: Scan
+  const spinner = p.spinner();
+  spinner.start('Scanning agent skill directories...');
+  const discovered = await scanAgentSkills(canonicalDir);
+
+  if (discovered.length === 0) {
+    spinner.stop(pc.green('All skills are already consolidated'));
+
+    // Still run sync-all even if nothing to consolidate
+    if (options.syncAll && !options.dryRun) {
+      spinner.start('Syncing all skills to installed agents...');
+      const synced = await syncAllToAgents(canonicalDir);
+      spinner.stop(
+        synced > 0
+          ? `Synced ${pc.cyan(String(synced))} symlink(s) to agents`
+          : pc.dim('All agents already up to date')
+      );
+    }
+
+    p.outro(pc.dim('Nothing to consolidate.'));
+    return;
+  }
+
+  spinner.stop(
+    `Found ${pc.cyan(String(discovered.length))} skill${discovered.length !== 1 ? 's' : ''} to consolidate`
+  );
+
+  // Step 2: Plan
+  const actions = await planActions(discovered, canonicalDir);
+
+  const moveActions = actions.filter((a) => a.type === 'move-and-link');
+  const linkActions = actions.filter((a) => a.type === 'link-only');
+  const forkActions = actions.filter((a) => a.type === 'fork');
+
+  // Step 3: Display plan
+  const summaryLines: string[] = [];
+
+  if (moveActions.length > 0) {
+    summaryLines.push(pc.green(`${moveActions.length} skill(s) to move to canonical:`));
+    for (const a of moveActions) {
+      summaryLines.push(`  ${pc.cyan(a.skill.name)} ${pc.dim(`← ${a.skill.agent}`)}`);
+    }
+  }
+
+  if (linkActions.length > 0) {
+    summaryLines.push(pc.blue(`${linkActions.length} duplicate(s) to replace with symlinks:`));
+    for (const a of linkActions) {
+      summaryLines.push(`  ${pc.cyan(a.skill.name)} ${pc.dim(`← ${a.skill.agent}`)}`);
+    }
+  }
+
+  if (forkActions.length > 0) {
+    summaryLines.push(pc.yellow(`${forkActions.length} conflict(s) to fork as agent-specific:`));
+    for (const a of forkActions) {
+      const basename = a.canonicalPath.split('/').pop();
+      summaryLines.push(
+        `  ${pc.cyan(a.skill.name)} → ${pc.yellow(basename!)} ${pc.dim(`← ${a.skill.agent}`)}`
+      );
+    }
+  }
+
+  p.note(summaryLines.join('\n'), 'Consolidation Plan');
+
+  if (options.dryRun) {
+    p.outro(pc.dim('Dry run — no changes made.'));
+    return;
+  }
+
+  // Step 4: Confirm
+  if (!options.yes) {
+    const confirmed = await p.confirm({ message: 'Proceed with consolidation?' });
+    if (p.isCancel(confirmed) || !confirmed) {
+      p.cancel('Consolidation cancelled');
+      return;
+    }
+  }
+
+  // Step 5: Execute
+  spinner.start('Consolidating skills...');
+  const { moved, linked, forked, forkRecords } = await executeActions(actions);
+  spinner.stop('Done');
+
+  // Write fork manifest if any forks were created
+  if (Object.keys(forkRecords).length > 0) {
+    const existing = await readForkManifest(canonicalDir);
+    await writeForkManifest(canonicalDir, { ...existing, ...forkRecords });
+  }
+
+  // Step 6: Summary
+  const resultLines: string[] = [];
+  if (moved > 0) resultLines.push(`${pc.green('✓')} ${moved} skill(s) moved to canonical`);
+  if (linked > 0)
+    resultLines.push(`${pc.green('✓')} ${linked} duplicate(s) replaced with symlinks`);
+  if (forked > 0)
+    resultLines.push(`${pc.yellow('✓')} ${forked} conflict(s) forked as agent-specific`);
+
+  if (resultLines.length > 0) {
+    p.note(resultLines.join('\n'), pc.green('Results'));
+  }
+
+  // Step 7: Sync all canonical skills to all agents (optional)
+  let synced = 0;
+  if (options.syncAll) {
+    spinner.start('Syncing all skills to installed agents...');
+    synced = await syncAllToAgents(canonicalDir, options.dryRun);
+    spinner.stop(
+      synced > 0
+        ? `Synced ${pc.cyan(String(synced))} symlink(s) to agents`
+        : pc.dim('All agents already up to date')
+    );
+  }
+
+  track({
+    event: 'consolidate',
+    skillsMoved: String(moved),
+    skillsLinked: String(linked),
+    skillsForked: String(forked),
+  });
+
+  console.log();
+  p.outro(pc.green('Consolidation complete!'));
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -157,7 +157,7 @@ async function resolveParentSymlinks(path: string): Promise<string> {
  * Creates a symlink, handling cross-platform differences
  * Returns true if symlink was created, false if fallback to copy is needed
  */
-async function createSymlink(target: string, linkPath: string): Promise<boolean> {
+export async function createSymlink(target: string, linkPath: string): Promise<boolean> {
   try {
     const resolvedTarget = resolve(target);
     const resolvedLinkPath = resolve(linkPath);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -48,12 +48,20 @@ interface SyncTelemetryData {
   agents: string;
 }
 
+interface ConsolidateTelemetryData {
+  event: 'consolidate';
+  skillsMoved: string;
+  skillsLinked: string;
+  skillsForked: string;
+}
+
 type TelemetryData =
   | InstallTelemetryData
   | RemoveTelemetryData
   | UpdateTelemetryData
   | FindTelemetryData
-  | SyncTelemetryData;
+  | SyncTelemetryData
+  | ConsolidateTelemetryData;
 
 let cliVersion: string | null = null;
 let detectedAgentName: string | null = null;

--- a/tests/consolidate.test.ts
+++ b/tests/consolidate.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdir, rm, writeFile, readFile, lstat, symlink } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import * as agentsModule from '../src/agents.ts';
+
+vi.mock('../src/agents.ts', async () => {
+  const actual = await vi.importActual('../src/agents.ts');
+  return {
+    ...actual,
+    detectInstalledAgents: vi.fn(),
+  };
+});
+
+describe('consolidate command', () => {
+  let tempDir: string;
+  let canonicalDir: string;
+  let claudeSkillsDir: string;
+  let codexSkillsDir: string;
+  let origClaudeGlobal: string | undefined;
+  let origCodexGlobal: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = resolve(join(tmpdir(), 'skills-consolidate-test-' + Date.now()));
+    await mkdir(tempDir, { recursive: true });
+    canonicalDir = join(tempDir, '.agents', 'skills');
+    claudeSkillsDir = join(tempDir, '.claude', 'skills');
+    codexSkillsDir = join(tempDir, '.codex', 'skills');
+
+    await mkdir(canonicalDir, { recursive: true });
+    await mkdir(claudeSkillsDir, { recursive: true });
+    await mkdir(codexSkillsDir, { recursive: true });
+
+    vi.mocked(agentsModule.detectInstalledAgents).mockResolvedValue(['claude-code', 'codex']);
+
+    // Override agents globalSkillsDir for testing
+    const agentsRecord = agentsModule.agents as Record<string, { globalSkillsDir?: string }>;
+    origClaudeGlobal = agentsRecord['claude-code']!.globalSkillsDir;
+    origCodexGlobal = agentsRecord['codex']!.globalSkillsDir;
+    agentsRecord['claude-code']!.globalSkillsDir = claudeSkillsDir;
+    agentsRecord['codex']!.globalSkillsDir = codexSkillsDir;
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    // Restore original values
+    const agentsRecord = agentsModule.agents as Record<string, { globalSkillsDir?: string }>;
+    agentsRecord['claude-code']!.globalSkillsDir = origClaudeGlobal;
+    agentsRecord['codex']!.globalSkillsDir = origCodexGlobal;
+  });
+  it('should move a skill to canonical and create symlink', async () => {
+    // Create a real skill in claude dir
+    const skillDir = join(claudeSkillsDir, 'my-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: my-skill\ndescription: test\n---\n# my-skill'
+    );
+
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], { global: true, yes: true, _canonicalDir: canonicalDir });
+    const stats = await lstat(skillDir);
+    expect(stats.isSymbolicLink()).toBe(true);
+
+    // Canonical should have the skill
+    const canonicalSkill = join(canonicalDir, 'my-skill', 'SKILL.md');
+    const canonicalStats = await lstat(canonicalSkill);
+    expect(canonicalStats.isFile()).toBe(true);
+  });
+
+  it('should skip directories that are already symlinks', async () => {
+    // Create canonical skill
+    const canonicalSkill = join(canonicalDir, 'linked-skill');
+    await mkdir(canonicalSkill, { recursive: true });
+    await writeFile(
+      join(canonicalSkill, 'SKILL.md'),
+      '---\nname: linked-skill\ndescription: test\n---\n# linked-skill'
+    );
+
+    // Create symlink in claude dir
+    const claudeSkill = join(claudeSkillsDir, 'linked-skill');
+    await symlink(canonicalSkill, claudeSkill);
+
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], { global: true, yes: true, _canonicalDir: canonicalDir });
+
+    // Should still be a symlink (unchanged)
+    const stats = await lstat(claudeSkill);
+    expect(stats.isSymbolicLink()).toBe(true);
+  });
+
+  it('should replace duplicate with symlink when canonical already has same content', async () => {
+    // Create skill in canonical
+    const canonicalSkill = join(canonicalDir, 'dup-skill');
+    await mkdir(canonicalSkill, { recursive: true });
+    await writeFile(
+      join(canonicalSkill, 'SKILL.md'),
+      '---\nname: dup-skill\ndescription: test\n---\n# dup-skill'
+    );
+
+    // Create identical skill in codex dir
+    const codexSkill = join(codexSkillsDir, 'dup-skill');
+    await mkdir(codexSkill, { recursive: true });
+    await writeFile(
+      join(codexSkill, 'SKILL.md'),
+      '---\nname: dup-skill\ndescription: test\n---\n# dup-skill'
+    );
+
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], { global: true, yes: true, _canonicalDir: canonicalDir });
+
+    // Codex dir should now be a symlink
+    const stats = await lstat(codexSkill);
+    expect(stats.isSymbolicLink()).toBe(true);
+  });
+
+  it('should fork conflicts as agent-specific skills when content differs', async () => {
+    // Create skill in canonical with different content
+    const canonicalSkill = join(canonicalDir, 'conflict-skill');
+    await mkdir(canonicalSkill, { recursive: true });
+    await writeFile(
+      join(canonicalSkill, 'SKILL.md'),
+      '---\nname: conflict-skill\ndescription: canonical version\n---\n# v1'
+    );
+
+    // Create different skill in claude dir
+    const claudeSkill = join(claudeSkillsDir, 'conflict-skill');
+    await mkdir(claudeSkill, { recursive: true });
+    await writeFile(
+      join(claudeSkill, 'SKILL.md'),
+      '---\nname: conflict-skill\ndescription: claude version\n---\n# v2'
+    );
+
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], { global: true, yes: true, _canonicalDir: canonicalDir });
+
+    // Claude dir should now be a symlink (pointing to forked version)
+    const stats = await lstat(claudeSkill);
+    expect(stats.isSymbolicLink()).toBe(true);
+
+    // Forked version should exist in canonical as conflict-skill-claude-code
+    const forkedSkill = join(canonicalDir, 'conflict-skill-claude-code', 'SKILL.md');
+    const forkedStats = await lstat(forkedSkill);
+    expect(forkedStats.isFile()).toBe(true);
+  });
+
+  it('should not modify filesystem in dry-run mode', async () => {
+    const skillDir = join(claudeSkillsDir, 'dry-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: dry-skill\ndescription: test\n---\n# dry-skill'
+    );
+
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], {
+      global: true,
+      yes: true,
+      dryRun: true,
+      _canonicalDir: canonicalDir,
+    });
+
+    // Should still be a real directory
+    const stats = await lstat(skillDir);
+    expect(stats.isSymbolicLink()).toBe(false);
+    expect(stats.isDirectory()).toBe(true);
+
+    // Canonical should NOT have the skill
+    await expect(lstat(join(canonicalDir, 'dry-skill'))).rejects.toThrow();
+  });
+
+  it('should write fork manifest when conflicts are forked', async () => {
+    // Create skill in canonical
+    const canonicalSkill = join(canonicalDir, 'fork-test');
+    await mkdir(canonicalSkill, { recursive: true });
+    await writeFile(
+      join(canonicalSkill, 'SKILL.md'),
+      '---\nname: fork-test\ndescription: v1\n---\n# v1'
+    );
+
+    // Create different version in codex
+    const codexSkill = join(codexSkillsDir, 'fork-test');
+    await mkdir(codexSkill, { recursive: true });
+    await writeFile(
+      join(codexSkill, 'SKILL.md'),
+      '---\nname: fork-test\ndescription: v2\n---\n# v2'
+    );
+
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], { global: true, yes: true, _canonicalDir: canonicalDir });
+
+    // .forks.json should exist and record the fork
+    const manifest = JSON.parse(await readFile(join(canonicalDir, '.forks.json'), 'utf-8'));
+    expect(manifest['fork-test-codex']).toBe('codex');
+  });
+
+  it('--sync-all should create symlinks for missing skills in agents', async () => {
+    // Create a skill only in canonical
+    const canonicalSkill = join(canonicalDir, 'sync-skill');
+    await mkdir(canonicalSkill, { recursive: true });
+    await writeFile(
+      join(canonicalSkill, 'SKILL.md'),
+      '---\nname: sync-skill\ndescription: test\n---\n# sync-skill'
+    );
+
+    // Neither claude nor codex has it
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], {
+      global: true,
+      yes: true,
+      syncAll: true,
+      _canonicalDir: canonicalDir,
+    });
+
+    // Both agents should now have a symlink
+    expect((await lstat(join(claudeSkillsDir, 'sync-skill'))).isSymbolicLink()).toBe(true);
+    expect((await lstat(join(codexSkillsDir, 'sync-skill'))).isSymbolicLink()).toBe(true);
+  });
+
+  it('--sync-all should only sync forked skills to their designated agent', async () => {
+    // Create a forked skill in canonical with manifest
+    const forkedSkill = join(canonicalDir, 'my-api-claude-code');
+    await mkdir(forkedSkill, { recursive: true });
+    await writeFile(
+      join(forkedSkill, 'SKILL.md'),
+      '---\nname: my-api\ndescription: claude version\n---\n# claude'
+    );
+
+    // Write fork manifest
+    await writeFile(
+      join(canonicalDir, '.forks.json'),
+      JSON.stringify({ 'my-api-claude-code': 'claude-code' })
+    );
+
+    const { runConsolidate } = await import('../src/consolidate.ts');
+    await runConsolidate([], {
+      global: true,
+      yes: true,
+      syncAll: true,
+      _canonicalDir: canonicalDir,
+    });
+
+    // Claude should have it (as "my-api", suffix stripped)
+    expect((await lstat(join(claudeSkillsDir, 'my-api'))).isSymbolicLink()).toBe(true);
+
+    // Codex should NOT have it
+    await expect(lstat(join(codexSkillsDir, 'my-api'))).rejects.toThrow();
+    await expect(lstat(join(codexSkillsDir, 'my-api-claude-code'))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `npx skills consolidate` (aliases: `consol`, `link`, `ln`) command
- Scans all installed agent directories for real (non-symlink) skill folders
- Moves skills to canonical `.agents/skills/` and replaces originals with symlinks
- Handles conflicts by forking into agent-specific names (e.g., `my-skill-codex`)
- `--sync-all` distributes all canonical skills to all installed agents
- Uses `.forks.json` manifest to track fork relationships (avoids false-positive suffix matching)

## Motivation

Users who install skills across multiple agents (Claude Code, Codex, Cursor, etc.) end up with duplicate real directories. This wastes disk space and makes updates painful — changing a skill requires updating it in every agent directory separately.

## Usage

```bash
npx skills consolidate --dry-run    # preview
npx skills consolidate -y           # execute
npx skills consol -y --sync-all     # consolidate + sync to all agents
```

## Test plan

- [x] 8 unit tests covering: move-and-link, skip symlinks, dedup, fork conflicts, dry-run, multi-agent, sync-all, fork manifest
- [x] TypeScript type-check passes
- [x] `obuild` compiles successfully
- [ ] Manual test on macOS with real agent directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)