### PR TITLE
feat: honor per-provider skill variants on install

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
@@ -88,6 +88,54 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('should copy per-agent variants when installing non-interactively', () => {
+    const claudeSkillDir = join(testDir, '.claude', 'skills', 'variant-skill');
+    const agentsSkillDir = join(testDir, '.agents', 'skills', 'variant-skill');
+    mkdirSync(claudeSkillDir, { recursive: true });
+    mkdirSync(agentsSkillDir, { recursive: true });
+
+    writeFileSync(
+      join(claudeSkillDir, 'SKILL.md'),
+      `---
+name: variant-skill
+description: Variant skill
+---
+
+CLAUDE BUILD
+`
+    );
+    writeFileSync(
+      join(agentsSkillDir, 'SKILL.md'),
+      `---
+name: variant-skill
+description: Variant skill
+---
+
+AGENTS BUILD
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(['add', testDir, '-y', '--agent', 'claude-code', 'codex'], targetDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Done!');
+    expect(
+      readFileSync(join(targetDir, '.claude', 'skills', 'variant-skill', 'SKILL.md'), 'utf-8')
+    ).toContain('CLAUDE BUILD');
+    expect(
+      readFileSync(join(targetDir, '.agents', 'skills', 'variant-skill', 'SKILL.md'), 'utf-8')
+    ).toContain('AGENTS BUILD');
+    expect(existsSync(join(targetDir, '.claude', 'skills', 'variant-skill', 'SKILL.md'))).toBe(
+      true
+    );
+    expect(existsSync(join(targetDir, '.agents', 'skills', 'variant-skill', 'SKILL.md'))).toBe(
+      true
+    );
   });
 
   it('should filter skills by name with --skill flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1376,6 +1376,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
     const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
 
+    if (!options.copy && hasVariantSkill && uniqueDirs.size > 1) {
+      installMode = 'copy';
+    }
+
     if (!options.copy && !options.yes && uniqueDirs.size > 1) {
       const modeChoice = await p.select({
         message: 'Installation method',

--- a/src/add.ts
+++ b/src/add.ts
@@ -1365,6 +1365,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Determine install mode (symlink vs copy)
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
+    // When a selected skill ships per-agent builds (skill.variants), symlinking
+    // every agent to one canonical copy installs a single build everywhere and
+    // overwrites each agent's own variant. Default to copy and warn on symlink.
+    const hasVariantSkill = selectedSkills.some(
+      (s) => s.variants && Object.keys(s.variants).length > 1
+    );
+
     // Only prompt for install mode when there are multiple unique target directories.
     // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
     const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
@@ -1372,13 +1379,20 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     if (!options.copy && !options.yes && uniqueDirs.size > 1) {
       const modeChoice = await p.select({
         message: 'Installation method',
+        initialValue: hasVariantSkill ? 'copy' : 'symlink',
         options: [
           {
             value: 'symlink',
-            label: 'Symlink (Recommended)',
-            hint: 'Single source of truth, easy updates',
+            label: hasVariantSkill ? 'Symlink' : 'Symlink (Recommended)',
+            hint: hasVariantSkill
+              ? "Shares one build across all agents; overwrites each agent's own variant"
+              : 'Single source of truth, easy updates',
           },
-          { value: 'copy', label: 'Copy to all agents', hint: 'Independent copies for each agent' },
+          {
+            value: 'copy',
+            label: hasVariantSkill ? 'Copy to all agents (Recommended)' : 'Copy to all agents',
+            hint: 'Independent copies for each agent',
+          },
         ],
       });
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -257,6 +257,11 @@ export async function installSkillForAgent(
 
   const installMode = options.mode ?? 'symlink';
 
+  // When the source ships a per-agent build of this skill, copy the variant
+  // compiled for THIS agent's skillsDir instead of the single discovered build.
+  // Falls back to skill.path when there is no agent-specific variant.
+  const sourcePath = skill.variants?.[agent.skillsDir] ?? skill.path;
+
   // Validate paths
   if (!isPathSafe(canonicalBase, canonicalDir)) {
     return {
@@ -280,7 +285,7 @@ export async function installSkillForAgent(
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir);
+      await copyDirectory(sourcePath, agentDir);
 
       return {
         success: true,
@@ -325,9 +330,9 @@ export async function installSkillForAgent(
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
 
     if (!symlinkCreated) {
-      // Symlink failed, fall back to copy
+      // Symlink failed, fall back to copy (use this agent's variant if present)
       await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir);
+      await copyDirectory(sourcePath, agentDir);
 
       return {
         success: true,

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -5,6 +5,14 @@ import { sanitizeMetadata } from './sanitize.ts';
 import type { Skill } from './types.ts';
 import { getPluginSkillPaths, getPluginGroupings } from './plugin-manifest.ts';
 import { readLocalLock } from './local-lock.ts';
+import { agents } from './agents.ts';
+
+/**
+ * Every distinct agent skill directory (e.g. ".claude/skills", ".agents/skills",
+ * ".cursor/skills"), derived from the agent registry. Used to detect repos that
+ * ship a separate build of the same skill per agent.
+ */
+const AGENT_SKILL_DIRS: string[] = [...new Set(Object.values(agents).map((a) => a.skillsDir))];
 
 const SKIP_DIRS = ['node_modules', '.git', 'dist', 'build', '__pycache__'];
 
@@ -285,7 +293,32 @@ export async function discoverSkills(
     }
   }
 
+  await attachProviderVariants(skills, searchPath);
   return skills;
+}
+
+/**
+ * When a repo ships a separate build of the same skill per agent (e.g.
+ * `.claude/skills/<name>`, `.agents/skills/<name>`, `.cursor/skills/<name>`),
+ * record each agent `skillsDir` -> that variant's path on the skill. Discovery
+ * otherwise returns a single deduped skill per name; this lets the installer
+ * copy the build compiled for each target agent. Only sets `variants` when 2+
+ * distinct variants exist, so single-build skills are unaffected.
+ */
+async function attachProviderVariants(skills: Skill[], searchPath: string): Promise<void> {
+  for (const skill of skills) {
+    const dirName = basename(skill.path);
+    const variants: Record<string, string> = {};
+    for (const skillsDir of AGENT_SKILL_DIRS) {
+      const candidate = join(searchPath, skillsDir, dirName);
+      if (await hasSkillMd(candidate)) {
+        variants[skillsDir] = candidate;
+      }
+    }
+    if (Object.keys(variants).length >= 2) {
+      skill.variants = variants;
+    }
+  }
 }
 
 export function getSkillDisplayName(skill: Skill): string {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -308,10 +308,12 @@ export async function discoverSkills(
 async function attachProviderVariants(skills: Skill[], searchPath: string): Promise<void> {
   for (const skill of skills) {
     const dirName = basename(skill.path);
+    const skillName = normalizeSkillName(skill.name);
     const variants: Record<string, string> = {};
     for (const skillsDir of AGENT_SKILL_DIRS) {
       const candidate = join(searchPath, skillsDir, dirName);
-      if (await hasSkillMd(candidate)) {
+      const candidateSkill = await parseSkillMd(join(candidate, 'SKILL.md'));
+      if (candidateSkill && normalizeSkillName(candidateSkill.name) === skillName) {
         variants[skillsDir] = candidate;
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,15 @@ export interface Skill {
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
   metadata?: Record<string, unknown>;
+  /**
+   * Per-agent variants of this skill. When a repo ships a separate build of the
+   * same skill for different agents (e.g. `.claude/skills/<name>`,
+   * `.agents/skills/<name>`, `.cursor/skills/<name>`), this maps each agent
+   * `skillsDir` (e.g. `".claude/skills"`) to that variant's absolute path.
+   * Only set when 2+ variants exist. The installer copies the variant matching
+   * the target agent so each agent gets the build compiled for it.
+   */
+  variants?: Record<string, string>;
 }
 
 export interface AgentConfig {

--- a/tests/provider-variants.test.ts
+++ b/tests/provider-variants.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for per-provider skill variants.
+ *
+ * Some repos ship a separate compiled build of the same skill per agent
+ * (e.g. `.claude/skills/<name>`, `.agents/skills/<name>`, with different
+ * command prefixes, model names, or script paths baked in). Discovery records
+ * those as `skill.variants` (agent skillsDir -> path), and copy-mode install
+ * uses the build compiled for each target agent rather than a single shared one.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { discoverSkills } from '../src/skills.ts';
+import { installSkillForAgent } from '../src/installer.ts';
+
+async function writeVariant(
+  root: string,
+  skillsDir: string,
+  name: string,
+  body: string
+): Promise<string> {
+  const dir = join(root, skillsDir, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${name} (${skillsDir})\n---\n\n${body}\n`,
+    'utf-8'
+  );
+  return dir;
+}
+
+describe('per-provider skill variants', () => {
+  it('discovery records a variant per agent skillsDir when a repo ships several builds', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'variants-discover-'));
+    try {
+      await writeVariant(root, '.claude/skills', 'demo', 'claude build');
+      await writeVariant(root, '.agents/skills', 'demo', 'agents build');
+
+      const skills = await discoverSkills(root);
+      const demo = skills.find((s) => s.name === 'demo');
+
+      expect(demo).toBeDefined();
+      expect(demo!.variants).toBeDefined();
+      expect(Object.keys(demo!.variants!).sort()).toEqual(['.agents/skills', '.claude/skills']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not set variants for a single-build skill', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'variants-single-'));
+    try {
+      await writeVariant(root, 'skills', 'solo', 'only build');
+
+      const skills = await discoverSkills(root);
+      const solo = skills.find((s) => s.name === 'solo');
+
+      expect(solo).toBeDefined();
+      expect(solo!.variants).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('copy mode installs the variant compiled for each target agent', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'variants-install-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+    try {
+      const claudePath = await writeVariant(root, 'src/.claude/skills', 'demo', 'CLAUDE BUILD');
+      const agentsPath = await writeVariant(root, 'src/.agents/skills', 'demo', 'AGENTS BUILD');
+      const skill = {
+        name: 'demo',
+        description: 'demo',
+        path: claudePath,
+        variants: { '.claude/skills': claudePath, '.agents/skills': agentsPath },
+      };
+
+      // claude-code -> .claude/skills, codex -> .agents/skills
+      const claudeResult = await installSkillForAgent(skill, 'claude-code', {
+        cwd: projectDir,
+        mode: 'copy',
+      });
+      const codexResult = await installSkillForAgent(skill, 'codex', {
+        cwd: projectDir,
+        mode: 'copy',
+      });
+
+      expect(claudeResult.success).toBe(true);
+      expect(codexResult.success).toBe(true);
+
+      const claudeInstalled = await readFile(
+        join(projectDir, '.claude/skills/demo/SKILL.md'),
+        'utf-8'
+      );
+      const agentsInstalled = await readFile(
+        join(projectDir, '.agents/skills/demo/SKILL.md'),
+        'utf-8'
+      );
+      expect(claudeInstalled).toContain('CLAUDE BUILD');
+      expect(agentsInstalled).toContain('AGENTS BUILD');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('copy mode falls back to skill.path when the target agent has no variant', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'variants-fallback-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+    try {
+      const claudePath = await writeVariant(root, 'src/.claude/skills', 'demo', 'CLAUDE BUILD');
+      const agentsPath = await writeVariant(root, 'src/.agents/skills', 'demo', 'AGENTS BUILD');
+      const skill = {
+        name: 'demo',
+        description: 'demo',
+        path: claudePath, // primary discovered build
+        variants: { '.claude/skills': claudePath, '.agents/skills': agentsPath },
+      };
+
+      // roo -> .roo/skills, which is not in variants, so it uses skill.path.
+      const result = await installSkillForAgent(skill, 'roo', { cwd: projectDir, mode: 'copy' });
+
+      expect(result.success).toBe(true);
+      const installed = await readFile(join(projectDir, '.roo/skills/demo/SKILL.md'), 'utf-8');
+      expect(installed).toContain('CLAUDE BUILD');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/provider-variants.test.ts
+++ b/tests/provider-variants.test.ts
@@ -64,6 +64,27 @@ describe('per-provider skill variants', () => {
     }
   });
 
+  it('does not attach same-directory variants with different skill names', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'variants-name-mismatch-'));
+    try {
+      await writeVariant(root, '.agents/skills', 'demo', 'agents build');
+      await writeVariant(root, '.claude/skills', 'demo', 'different skill build');
+      await writeFile(
+        join(root, '.claude/skills/demo/SKILL.md'),
+        `---\nname: different-demo\ndescription: Different skill\n---\n\ndifferent skill build\n`,
+        'utf-8'
+      );
+
+      const skills = await discoverSkills(root);
+      const demo = skills.find((s) => s.name === 'demo');
+
+      expect(demo).toBeDefined();
+      expect(demo!.variants).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('copy mode installs the variant compiled for each target agent', async () => {
     const root = await mkdtemp(join(tmpdir(), 'variants-install-'));
     const projectDir = join(root, 'project');


### PR DESCRIPTION
Closes #1290.

## Problem

`skills add` treats a skill as one agent-agnostic directory. Repos that publish a different compiled build of the same skill per agent (`.claude/skills/<name>`, `.agents/skills/<name>`, ...) are mishandled: discovery dedupes by name and returns one build, and the default symlink mode points every agent at a single canonical copy. So all agents get one build and each agent's own variant is discarded. Real example: `pbakaus/impeccable` ships ~12 per-agent builds.

## Changes

- **`types.ts`** — add optional `Skill.variants` (agent `skillsDir` → variant path).
- **`skills.ts`** — `discoverSkills` records variants when 2+ agent skillsDirs contain the same-named skill. Additive post-pass; single-build skills are untouched.
- **`installer.ts`** — copy mode copies the variant matching each target agent's `skillsDir`, falling back to `skill.path` when there is no agent-specific build.
- **`add.ts`** — when a selected skill has variants, the install-method prompt defaults to **copy** and the symlink option is labeled with a warning that it shares one build across agents and overwrites each agent's own variant.
- **`tests/provider-variants.test.ts`** — discovery records variants; single-build skills get none; copy installs the per-agent build; falls back to `skill.path` when an agent has no variant.

## Compatibility & testing

- Single-build skills are unaffected — `variants` is only set when 2+ builds exist, and the installer/dialog fall back to current behavior otherwise.
- Full suite: **486 pass** (482 + 4 new). `prettier --check` clean. No new `tsc` errors (the 3 pre-existing ones in `git.ts`/`parseSkillMd` are unchanged).

Happy to iterate on the approach — e.g. a manifest opt-in instead of directory-structure inference, or a different default-variant fallback.