### PR TITLE
feat: add Antigravity CLI support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -57,6 +57,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.gemini/antigravity'));
     },
   },
+  'antigravity-cli': {
+    name: 'antigravity-cli',
+    displayName: 'Antigravity CLI',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.gemini/antigravity-cli/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.gemini/antigravity-cli'));
+    },
+  },
   augment: {
     name: 'augment',
     displayName: 'Augment',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type AgentType =
   | 'aider-desk'
   | 'amp'
   | 'antigravity'
+  | 'antigravity-cli'
   | 'augment'
   | 'bob'
   | 'claude-code'

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -60,6 +60,19 @@ describe('XDG config paths', () => {
     });
   });
 
+  describe('Antigravity CLI', () => {
+    it('uses ~/.gemini/antigravity-cli/skills for global skills', () => {
+      const expected = join(home, '.gemini', 'antigravity-cli', 'skills');
+      expect(agents['antigravity-cli'].globalSkillsDir).toBe(expected);
+    });
+
+    it('uses a distinct global directory from the Antigravity IDE', () => {
+      expect(agents['antigravity-cli'].globalSkillsDir).not.toBe(
+        agents.antigravity.globalSkillsDir
+      );
+    });
+  });
+
   describe('skill lock file path', () => {
     function getSkillLockPath(xdgStateHome: string | undefined, homeDir: string): string {
       if (xdgStateHome) {


### PR DESCRIPTION
## What

Adds native support for the **Antigravity CLI** (`agy`) as a new agent (`antigravity-cli`), distinct from the existing Antigravity **IDE** entry.

## Why

The Antigravity CLI stores its skills in a different location than the IDE:

| Scope | Path |
|-------|------|
| Workspace | `.agents/skills/` |
| **Global** | `~/.gemini/antigravity-cli/skills/` |

The existing `antigravity` entry points at `~/.gemini/antigravity/skills` (the IDE). The CLI uses `~/.gemini/antigravity-cli/skills`, so it needs its own registry entry. Giving it a dedicated entry — rather than reusing the shared `~/.gemini/skills` Gemini path — keeps the CLI independent and gives it room to evolve its own conventions.

## Changes

- `src/agents.ts` — new `antigravity-cli` agent entry
- `src/types.ts` — add `'antigravity-cli'` to the `AgentType` union
- `tests/xdg-config-paths.test.ts` — assert the global dir and that it stays distinct from the IDE entry

README and `package.json` keywords are intentionally left untouched — the `sync-agents` workflow regenerates them automatically on merge to `main`.

## Follow-up

`@vercel/detect-agent` mapping in `src/detect-agent.ts` was left as-is, since detection of the `agy` CLI depends on that external dependency. Happy to add the mapping in a follow-up once it's supported upstream.