### PR TITLE
feat: add Reasonix agent support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -535,6 +535,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.adal'));
     },
   },
+  reasonix: {
+    name: 'reasonix',
+    displayName: 'Reasonix',
+    skillsDir: '.reasonix/skills',
+    globalSkillsDir: join(home, '.reasonix/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.reasonix'));
+    },
+  },
   universal: {
     name: 'universal',
     displayName: 'Universal',

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export type AgentType =
   | 'zencoder'
   | 'pochi'
   | 'adal'
+  | 'reasonix'
   | 'universal';
 
 export interface Skill {


### PR DESCRIPTION
## Summary

- Register Reasonix as a supported agent in the skills.sh ecosystem
- Project skills directory: `.reasonix/skills/`
- Global skills directory: `~/.reasonix/skills/`
- Detection: checks for `~/.reasonix` directory existence

## Motivation

Reasonix uses `~/.reasonix/skills/` as its global skill directory, but the skills.sh CLI doesn't recognize it. When users run `npx skills add`, skills get installed to other agents' paths (e.g., OpenCode) instead of Reasonix's directory.

This change adds Reasonix to the agent registry so `npx skills add -g` correctly installs skills to `~/.reasonix/skills/`.

Closes esengine/DeepSeek-Reasonix#2108

## Test plan

- [ ] Verify `npx skills add -g -a reasonix` installs to `~/.reasonix/skills/`
- [ ] Verify Reasonix appears in the agents list when detected
- [ ] Verify detection works when `~/.reasonix` directory exists