### PR TITLE
feat: add Ona agent support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -517,6 +517,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.neovate'));
     },
   },
+  ona: {
+    name: 'ona',
+    displayName: 'Ona',
+    skillsDir: '.ona/skills',
+    globalSkillsDir: join(home, '.ona/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.ona'));
+    },
+  },
   pochi: {
     name: 'pochi',
     displayName: 'Pochi',

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type AgentType =
   | 'mistral-vibe'
   | 'mux'
   | 'neovate'
+  | 'ona'
   | 'opencode'
   | 'openhands'
   | 'pi'


### PR DESCRIPTION
Hi! I'm Aminur from the [Ona](https://ona.com) team. Raising this on behalf of the team — feel free to reach out if you have any questions.

## Summary

Add [Ona](https://ona.com) as a supported agent.

- **Workspace skills dir**: `.ona/skills/`
- **Global skills dir**: `~/.ona/skills/`
- **Detection**: `~/.ona/` directory (created by the Ona CLI on first use)

Ona also recognizes `.agents/skills/` (the universal directory), so skills installed via `skills install` already work. This entry enables direct installation into `.ona/skills/` and proper agent detection.