### PR TITLE
fix: prioritize exact matches in skill search

### DIFF
--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { searchSkillsAPI } from './find.ts';
+
+describe('searchSkillsAPI', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('prioritizes exact skill name matches over higher install counts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          skills: [
+            {
+              id: 'example/refactoring/dry-refactoring',
+              name: 'dry-refactoring',
+              installs: 1000,
+              source: 'example/refactoring',
+            },
+            {
+              id: 'kucherenko/jscpd/jscpd',
+              name: 'jscpd',
+              installs: 10,
+              source: 'kucherenko/jscpd',
+            },
+          ],
+        }),
+      }))
+    );
+
+    const results = await searchSkillsAPI('jscpd');
+
+    expect(results.map((skill) => skill.name)).toEqual(['jscpd', 'dry-refactoring']);
+  });
+});

--- a/src/find.ts
+++ b/src/find.ts
@@ -30,6 +30,47 @@ export interface SearchSkill {
   installs: number;
 }
 
+function normalizeSearchValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function lastPathSegment(value: string): string {
+  return value.split('/').filter(Boolean).at(-1) || value;
+}
+
+function getMatchRank(skill: SearchSkill, query: string): number {
+  const normalizedQuery = normalizeSearchValue(query);
+  if (!normalizedQuery) return 3;
+
+  const targets = [
+    skill.name,
+    skill.slug,
+    skill.source,
+    lastPathSegment(skill.slug),
+    lastPathSegment(skill.source),
+  ]
+    .filter(Boolean)
+    .map(normalizeSearchValue);
+
+  if (targets.some((target) => target === normalizedQuery)) return 0;
+  if (targets.some((target) => target.startsWith(normalizedQuery))) return 1;
+  if (targets.some((target) => target.includes(normalizedQuery))) return 2;
+
+  return 3;
+}
+
+function rankSearchResults(results: SearchSkill[], query: string): SearchSkill[] {
+  return [...results].sort((a, b) => {
+    const rankDiff = getMatchRank(a, query) - getMatchRank(b, query);
+    if (rankDiff !== 0) return rankDiff;
+
+    const installDiff = (b.installs || 0) - (a.installs || 0);
+    if (installDiff !== 0) return installDiff;
+
+    return a.name.localeCompare(b.name);
+  });
+}
+
 // Search via API
 export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
   try {
@@ -47,14 +88,14 @@ export async function searchSkillsAPI(query: string): Promise<SearchSkill[]> {
       }>;
     };
 
-    return data.skills
-      .map((skill) => ({
-        name: sanitizeMetadata(skill.name),
-        slug: sanitizeMetadata(skill.id),
-        source: sanitizeMetadata(skill.source || ''),
-        installs: skill.installs,
-      }))
-      .sort((a, b) => (b.installs || 0) - (a.installs || 0));
+    const results = data.skills.map((skill) => ({
+      name: sanitizeMetadata(skill.name),
+      slug: sanitizeMetadata(skill.id),
+      source: sanitizeMetadata(skill.source || ''),
+      installs: skill.installs,
+    }));
+
+    return rankSearchResults(results, query);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- ranks exact skill, slug, and repository-name matches ahead of broad text matches
- keeps install count as the tie-breaker after match quality
- adds a regression test for the `jscpd`-style exact-match case

Closes #1303.

## Validation
- `vitest run src/find.test.ts`
- `prettier --check src/find.ts src/find.test.ts`
- `git diff --check HEAD~1..HEAD`
- `pnpm type-check` was attempted; it still fails on existing unrelated errors in `src/git.ts`, `src/providers/wellknown.ts`, and `src/skills.ts`.