### PR TITLE
feat: add skill-guard — security guard for skill/plugin installations

### DIFF
--- a/skills/skill-guard/SKILL.md
+++ b/skills/skill-guard/SKILL.md
@@ -122,9 +122,37 @@ Look for: hooks, MCP servers, bash scripts, unusual permissions.
 
 For each **skill** (`npx skills add` origin):
 Try `https://skills.sh/<org>/<name>` via WebFetch to retrieve risk scores.
-If unavailable, mark as ❓ Unknown.
+If risk scores are unavailable, mark as ❓ Unknown — but do NOT stop there.
+For every ❓ item, fetch its social proof data (see Step 2b below).
 
 Run checks in parallel to keep the audit fast.
+
+### Step 2b — Social proof for ❓ Unknown items
+
+When risk data is unavailable for a skill or plugin, collect trust signals
+from GitHub to help the user decide. These signals replace missing scanner
+data with real-world adoption evidence.
+
+For GitHub-based skills, query the GitHub API:
+```
+gh api repos/<owner>/<repo>
+```
+Extract and display:
+- **Install count** — from skills.sh page if available (`X installs`)
+- **GitHub stars** — `stargazers_count`
+- **Created** — `created_at` (how old is this project?)
+- **Last updated** — `pushed_at` (is it actively maintained?)
+- **Open issues** — `open_issues_count` (sign of community activity)
+- **Author** — `owner.login` (known maintainer or anonymous?)
+
+Interpret the signals with common sense:
+- 10,000+ installs + 2 years old + recent update = reassuring despite unknown scanner
+- 3 installs + created last week + no updates = treat with caution
+- Well-known author (vercel-labs, anthropics, etc.) = positive signal
+
+For Claude plugins with unknown risk, run `claude plugin details` and report
+the full component inventory (hooks, MCP servers, scripts) as a proxy for
+trust — the structure itself tells a story.
 
 ### Step 3 — Produce the security report
 
@@ -137,7 +165,8 @@ SKILLS
   ✅ <name>  — <source / reason safe>
   ⚠️ <name>  — <scanner> <risk level> — consider removing
   ❌ <name>  — HIGH RISK — strongly recommend removal
-  ❓ <name>  — no risk data available
+  ❓ <name>  — no scanner data — <stars> stars, <installs> installs,
+             created <date>, last update <date>, by @<author>
 
 PLUGINS
   ✅ <name>  — <inventory summary: no hooks, no MCP>
@@ -152,9 +181,9 @@ RECOMMENDED ACTIONS
   - No action: <all-clear items>
 ```
 
-### Step 4 — Offer removal for flagged items
+### Step 4 — Offer actions for flagged items
 
-For each ⚠️ or ❌ item found:
+**For ⚠️ and ❌ items:**
 - Explain clearly why it is flagged
 - Offer the removal command but do NOT run it automatically
 - Let the user decide
@@ -163,6 +192,24 @@ For each ⚠️ or ❌ item found:
 To remove <name>: npx skills remove <name> -y
              or: claude plugin uninstall <name>
 ```
+
+**For ❓ Unknown items:**
+Display the social proof summary and let the user judge:
+
+```
+❓ <name> — no scanner data available
+   Installs  : <number> (skills.sh)
+   Stars     : <number> (GitHub)
+   Created   : <date> (<age>)
+   Updated   : <date> (<time since last update>)
+   Author    : @<owner> (<link>)
+   Verdict   : <one-sentence assessment based on the signals>
+              e.g. "Low adoption + recent creation — treat with caution"
+              e.g. "10k+ installs, actively maintained — likely safe despite no scanner data"
+```
+
+Do not recommend removal for ❓ items based on unknown data alone —
+let the social proof guide the user's own judgment.
 
 ---
 

--- a/skills/skill-guard/SKILL.md
+++ b/skills/skill-guard/SKILL.md
@@ -1,111 +1,172 @@
 ---
 name: skill-guard
 description: >
-  Garde de sécurité pour toute installation de skill ou plugin Claude.
-  Déclencher OBLIGATOIREMENT dès que l'utilisateur demande d'installer
-  un plugin Claude (`claude plugin install`), un skill (`npx skills add`),
-  ou tout équivalent — même si l'utilisateur tape la commande directement.
-  Affiche un pictogramme de risque (✅ ⚠️ ❌ ❓) et bloque l'installation
-  si un risque est détecté jusqu'à confirmation explicite. Ne jamais laisser
-  passer une installation sans ce rapport.
+  Security guard for Claude Code skill and plugin installations — with two
+  modes. (1) INTERCEPT mode: trigger IMMEDIATELY whenever the user asks to
+  install a Claude plugin (claude plugin install), a skill (npx skills add),
+  or any equivalent — even if the user types the command directly. Display a
+  risk pictogram and block if risk is detected. (2) AUDIT mode: trigger when
+  the user asks "are my skills safe?", "audit my installed skills", "scan my
+  environment for risks", "what did I install?", or just installed skill-guard
+  for the first time. Never let an installation pass without a risk report.
 ---
 
-## Objectif
+## Two modes
 
-Intercepter toute installation de skill ou plugin et évaluer son niveau de
-risque avant d'exécuter quoi que ce soit — ou, pour les skills interactifs,
-pendant l'exécution avant que les fichiers ne soient écrits sur disque.
+skill-guard works in two complementary modes:
 
-## Étape 1 — Identifier la source et le nom du package
+- **Intercept mode** — checks risk BEFORE (or during) a new installation
+- **Audit mode** — scans everything ALREADY installed and flags risks
 
-Extraire depuis la demande :
-- **Nom du package** (ex. `code-review`, `find-skills`)
-- **Source** (ex. `claude-plugins-official`, `vercel-labs/skills`, URL GitHub)
-- **Type de commande** : `claude plugin install` ou `npx skills add`
+---
 
-## Étape 2 — Collecter les informations de risque
+## INTERCEPT MODE — Before a new installation
 
-### Cas A : `claude plugin install X@marketplace`
+### Step 1 — Identify the package
 
-Exécuter **avant** l'installation :
+Extract from the request:
+- **Package name** (e.g. `code-review`, `find-skills`)
+- **Source** (e.g. `claude-plugins-official`, `vercel-labs/skills`, GitHub URL)
+- **Command type**: `claude plugin install` or `npx skills add`
+
+### Step 2 — Collect risk data
+
+**Case A: `claude plugin install X@marketplace`**
+
+Run before installing:
 ```
 claude plugin details X@marketplace
 ```
-Analyser l'inventaire retourné pour détecter des signaux d'alerte :
-- Présence de hooks (exécution automatique)
-- Présence de serveurs MCP (accès réseau)
-- Scripts bash exécutés à l'install
-- Permissions inhabituelles
+Inspect the inventory for red flags:
+- Hooks present (automatic execution)
+- MCP servers present (network access)
+- Bash scripts executed at install time
+- Unusual permissions
 
-Les scores externes (Socket, Snyk) ne sont pas disponibles pour ce canal.
-Compenser par l'analyse structurelle de l'inventaire + recherche web si doute.
+External scanners (Socket, Snyk) are not available for this channel.
+Compensate with structural inventory analysis + web search if in doubt.
 
-### Cas B : `npx skills add <repo> --skill <name>`
+**Case B: `npx skills add <repo> --skill <name>`**
 
-Les scores Socket/Snyk sont fournis par skills.sh **dans la sortie de la
-commande elle-même**, juste avant que les fichiers soient écrits sur disque.
+Socket/Snyk scores appear in the installation output before files are written
+to disk. Two-phase protocol:
 
-Protocole en deux temps :
+Phase 1 — Quick pre-check: WebFetch `https://skills.sh/<org>/<repo>` for
+published risk scores. If unavailable (client-side rendered), go to Phase 2.
 
-**Temps 1 — Pré-check rapide :**
-Tenter un WebFetch sur `https://skills.sh/<org>/<repo>` pour récupérer
-d'éventuels scores publiés. Si les scores ne sont pas disponibles (page
-rendue côté client), passer au Temps 2.
-
-**Temps 2 — Interception pendant l'installation :**
-Lancer la commande normalement et lire attentivement la sortie. La section
-"Security Risk Assessments" apparaît dans la sortie **avant** que
-l'installation ne se finalise. Capturer ces scores immédiatement.
-
-Format attendu dans la sortie :
+Phase 2 — Intercept during install: run the command and watch the output for
+the "Security Risk Assessments" section:
 ```
 Security Risk Assessments
   <skill-name>  <Gen>  <Socket>  <Snyk>
   Details: https://skills.sh/<org>/<repo>
 ```
+As soon as these scores appear, apply the risk rule below.
+If risk detected: show report, ask for confirmation.
+If user declines: immediately run `npx skills remove <name> -y`.
 
-Dès que ces scores apparaissent, appliquer la règle de l'Étape 3.
-Si ⚠️ ou ❌ détecté, afficher le rapport et demander confirmation.
-Si l'utilisateur refuse, exécuter immédiatement `npx skills remove <name> -y`.
-
-### Recherche web complémentaire (si données insuffisantes)
-
+**Web search fallback** (if data is insufficient):
 ```
-<nom-du-package> security vulnerability site:socket.dev OR site:snyk.io
+<package-name> security vulnerability site:socket.dev OR site:snyk.io
 ```
 
-## Étape 3 — Appliquer la règle de risque
+### Step 3 — Apply the risk rule
 
-| Pictogramme | Niveau | Condition |
-|-------------|--------|-----------|
-| ✅ | Sûr | Safe + 0 alertes sur tous les scanners disponibles |
-| ⚠️ | Risque modéré | Medium Risk sur au moins un scanner |
-| ❌ | Risque élevé | High Risk ou Critical sur au moins un scanner |
-| ❓ | Inconnu | Aucune donnée de risque disponible |
+| Icon | Level | Condition |
+|------|-------|-----------|
+| ✅ | Safe | Safe + 0 alerts across all available scanners |
+| ⚠️ | Medium risk | Medium Risk on at least one scanner |
+| ❌ | High risk | High or Critical Risk on at least one scanner |
+| ❓ | Unknown | No risk data available |
 
-## Étape 4 — Afficher le rapport
-
-Format standard du rapport :
+### Step 4 — Display the report and act
 
 ```
-[PICTOGRAMME] <nom-du-package>
-  Source    : <marketplace ou URL>
-  Scanners  : Gen=[résultat] · Socket=[résultat] · Snyk=[résultat]
-  Détails   : <URL si disponible>
+[ICON] <package-name>
+  Source   : <marketplace or URL>
+  Scanners : Gen=[result] - Socket=[result] - Snyk=[result]
+  Details  : <URL if available>
 ```
 
-**Comportement selon le niveau :**
+- **Safe**: proceed with installation.
+- **Medium risk**: ask "A medium risk was detected. Do you still want to install?"
+  Do not proceed without explicit confirmation.
+- **High risk**: warn strongly. Recommend against installing.
+  Ask for explicit confirmation. If already installed, offer immediate removal.
+- **Unknown**: state that risk data is unavailable and ask for confirmation.
 
-- **✅ Sûr** : Procéder ou confirmer l'installation. Aucune action requise.
-- **⚠️ Risque modéré** : Afficher le rapport et demander :
-  > "Un risque modéré a été détecté. Veux-tu quand même installer ce package ?"
-  Ne pas finaliser sans confirmation explicite.
-- **❌ Risque élevé** : Afficher le rapport avec avertissement fort.
-  Déconseiller fortement l'installation. Demander confirmation explicite.
-  Si installé (Cas B), proposer la désinstallation immédiate.
-- **❓ Inconnu** : Indiquer l'absence de données et demander confirmation.
+---
 
-## Règle absolue
+## AUDIT MODE — Scan what is already installed
 
-Ne jamais sauter cette vérification, même si l'utilisateur donne la commande
-directement. La sécurité de l'utilisateur prime sur la rapidité d'exécution.
+Trigger this mode when the user asks about the safety of their current
+environment — especially right after installing skill-guard for the first time.
+
+### Step 1 — Inventory everything installed
+
+Run in parallel:
+```bash
+npx skills list
+claude plugin list
+```
+
+Build a complete list: every installed skill and plugin by name.
+
+### Step 2 — Check each item for risk
+
+For each **plugin** (`claude plugin install` origin):
+```
+claude plugin details <plugin-name>
+```
+Look for: hooks, MCP servers, bash scripts, unusual permissions.
+
+For each **skill** (`npx skills add` origin):
+Try `https://skills.sh/<org>/<name>` via WebFetch to retrieve risk scores.
+If unavailable, mark as ❓ Unknown.
+
+Run checks in parallel to keep the audit fast.
+
+### Step 3 — Produce the security report
+
+```
+[skill-guard] Security Audit
+=================================
+Installed: <N> skills   <M> plugins
+
+SKILLS
+  ✅ <name>  — <source / reason safe>
+  ⚠️ <name>  — <scanner> <risk level> — consider removing
+  ❌ <name>  — HIGH RISK — strongly recommend removal
+  ❓ <name>  — no risk data available
+
+PLUGINS
+  ✅ <name>  — <inventory summary: no hooks, no MCP>
+  ⚠️ <name>  — <red flag found>
+
+SUMMARY
+  <N> safe   <N> medium risk   <N> high risk   <N> unknown
+
+RECOMMENDED ACTIONS
+  - Remove: <list of high-risk items>
+  - Review: <list of medium-risk items>
+  - No action: <all-clear items>
+```
+
+### Step 4 — Offer removal for flagged items
+
+For each ⚠️ or ❌ item found:
+- Explain clearly why it is flagged
+- Offer the removal command but do NOT run it automatically
+- Let the user decide
+
+```
+To remove <name>: npx skills remove <name> -y
+             or: claude plugin uninstall <name>
+```
+
+---
+
+## Absolute rule
+
+Never skip a risk check — whether for a new installation or an audit of
+existing ones. The user's security takes priority over speed.

--- a/skills/skill-guard/SKILL.md
+++ b/skills/skill-guard/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: skill-guard
+description: >
+  Garde de sécurité pour toute installation de skill ou plugin Claude.
+  Déclencher OBLIGATOIREMENT dès que l'utilisateur demande d'installer
+  un plugin Claude (`claude plugin install`), un skill (`npx skills add`),
+  ou tout équivalent — même si l'utilisateur tape la commande directement.
+  Affiche un pictogramme de risque (✅ ⚠️ ❌ ❓) et bloque l'installation
+  si un risque est détecté jusqu'à confirmation explicite. Ne jamais laisser
+  passer une installation sans ce rapport.
+---
+
+## Objectif
+
+Intercepter toute installation de skill ou plugin et évaluer son niveau de
+risque avant d'exécuter quoi que ce soit — ou, pour les skills interactifs,
+pendant l'exécution avant que les fichiers ne soient écrits sur disque.
+
+## Étape 1 — Identifier la source et le nom du package
+
+Extraire depuis la demande :
+- **Nom du package** (ex. `code-review`, `find-skills`)
+- **Source** (ex. `claude-plugins-official`, `vercel-labs/skills`, URL GitHub)
+- **Type de commande** : `claude plugin install` ou `npx skills add`
+
+## Étape 2 — Collecter les informations de risque
+
+### Cas A : `claude plugin install X@marketplace`
+
+Exécuter **avant** l'installation :
+```
+claude plugin details X@marketplace
+```
+Analyser l'inventaire retourné pour détecter des signaux d'alerte :
+- Présence de hooks (exécution automatique)
+- Présence de serveurs MCP (accès réseau)
+- Scripts bash exécutés à l'install
+- Permissions inhabituelles
+
+Les scores externes (Socket, Snyk) ne sont pas disponibles pour ce canal.
+Compenser par l'analyse structurelle de l'inventaire + recherche web si doute.
+
+### Cas B : `npx skills add <repo> --skill <name>`
+
+Les scores Socket/Snyk sont fournis par skills.sh **dans la sortie de la
+commande elle-même**, juste avant que les fichiers soient écrits sur disque.
+
+Protocole en deux temps :
+
+**Temps 1 — Pré-check rapide :**
+Tenter un WebFetch sur `https://skills.sh/<org>/<repo>` pour récupérer
+d'éventuels scores publiés. Si les scores ne sont pas disponibles (page
+rendue côté client), passer au Temps 2.
+
+**Temps 2 — Interception pendant l'installation :**
+Lancer la commande normalement et lire attentivement la sortie. La section
+"Security Risk Assessments" apparaît dans la sortie **avant** que
+l'installation ne se finalise. Capturer ces scores immédiatement.
+
+Format attendu dans la sortie :
+```
+Security Risk Assessments
+  <skill-name>  <Gen>  <Socket>  <Snyk>
+  Details: https://skills.sh/<org>/<repo>
+```
+
+Dès que ces scores apparaissent, appliquer la règle de l'Étape 3.
+Si ⚠️ ou ❌ détecté, afficher le rapport et demander confirmation.
+Si l'utilisateur refuse, exécuter immédiatement `npx skills remove <name> -y`.
+
+### Recherche web complémentaire (si données insuffisantes)
+
+```
+<nom-du-package> security vulnerability site:socket.dev OR site:snyk.io
+```
+
+## Étape 3 — Appliquer la règle de risque
+
+| Pictogramme | Niveau | Condition |
+|-------------|--------|-----------|
+| ✅ | Sûr | Safe + 0 alertes sur tous les scanners disponibles |
+| ⚠️ | Risque modéré | Medium Risk sur au moins un scanner |
+| ❌ | Risque élevé | High Risk ou Critical sur au moins un scanner |
+| ❓ | Inconnu | Aucune donnée de risque disponible |
+
+## Étape 4 — Afficher le rapport
+
+Format standard du rapport :
+
+```
+[PICTOGRAMME] <nom-du-package>
+  Source    : <marketplace ou URL>
+  Scanners  : Gen=[résultat] · Socket=[résultat] · Snyk=[résultat]
+  Détails   : <URL si disponible>
+```
+
+**Comportement selon le niveau :**
+
+- **✅ Sûr** : Procéder ou confirmer l'installation. Aucune action requise.
+- **⚠️ Risque modéré** : Afficher le rapport et demander :
+  > "Un risque modéré a été détecté. Veux-tu quand même installer ce package ?"
+  Ne pas finaliser sans confirmation explicite.
+- **❌ Risque élevé** : Afficher le rapport avec avertissement fort.
+  Déconseiller fortement l'installation. Demander confirmation explicite.
+  Si installé (Cas B), proposer la désinstallation immédiate.
+- **❓ Inconnu** : Indiquer l'absence de données et demander confirmation.
+
+## Règle absolue
+
+Ne jamais sauter cette vérification, même si l'utilisateur donne la commande
+directement. La sécurité de l'utilisateur prime sur la rapidité d'exécution.

--- a/skills/skill-guard/SKILL.md
+++ b/skills/skill-guard/SKILL.md
@@ -145,10 +145,19 @@ Extract and display:
 - **Open issues** — `open_issues_count` (sign of community activity)
 - **Author** — `owner.login` (known maintainer or anonymous?)
 
-Interpret the signals with common sense:
-- 10,000+ installs + 2 years old + recent update = reassuring despite unknown scanner
-- 3 installs + created last week + no updates = treat with caution
-- Well-known author (vercel-labs, anthropics, etc.) = positive signal
+Interpret the signals and assign a confidence tier:
+
+| Tier | Verdict | Signals |
+|------|---------|---------|
+| **Community-trusted** | "Trusted by the community — install with confidence" | 10k+ installs AND 2+ years old AND recent update AND known author |
+| **Promising** | "Good adoption, looks healthy" | 1k+ installs AND 6+ months old AND maintained |
+| **Cautious** | "Low adoption — review before installing" | <1k installs OR <3 months old OR no recent update |
+| **Risky** | "Very new or abandoned — treat with caution" | <100 installs AND <1 month old OR last update >1 year ago |
+
+Well-known authors (vercel-labs, anthropics, google, microsoft, etc.) bump
+the tier up by one level regardless of other signals — reputation matters.
+Never penalize a skill for unknown scanner data if the community signals
+are strongly positive. Social proof at scale IS a form of validation.
 
 For Claude plugins with unknown risk, run `claude plugin details` and report
 the full component inventory (hooks, MCP servers, scripts) as a proxy for
@@ -203,9 +212,10 @@ Display the social proof summary and let the user judge:
    Created   : <date> (<age>)
    Updated   : <date> (<time since last update>)
    Author    : @<owner> (<link>)
-   Verdict   : <one-sentence assessment based on the signals>
-              e.g. "Low adoption + recent creation — treat with caution"
-              e.g. "10k+ installs, actively maintained — likely safe despite no scanner data"
+   Verdict   : <tier> — <one-sentence assessment>
+              e.g. "⚠️  Cautious   — Only 3 installs, created last week, unknown author"
+              e.g. "👍 Promising  — 2k installs, 8 months old, maintained"
+              e.g. "✅ Trusted    — 45k installs, 2 years old, active, @vercel-labs"
 ```
 
 Do not recommend removal for ❓ items based on unknown data alone —

--- a/skills/skill-guard/SKILL.md
+++ b/skills/skill-guard/SKILL.md
@@ -267,7 +267,33 @@ and acknowledge both the limitations and the intent of the tool.
 
 ---
 
+## On the limits of automated judgment
+
+A risk pictogram measures a narrow slice of reality: code patterns, known
+vulnerability databases, adoption numbers. It cannot measure the years of
+work behind a project, the intent of its author, the quality of its design,
+or the value it brings to the people who use it.
+
+A ⚠️ is not a condemnation. It is an invitation to look closer.
+A ❓ is not a red flag. It is an acknowledgment of what we do not know.
+An ❌ is a serious signal — but even then, context matters.
+
+When displaying any verdict, skill-guard must never present it as final truth.
+Always frame findings as information, not judgment:
+
+- Say "a scanner flagged this" not "this is dangerous"
+- Say "no data available" not "this is suspicious"
+- Say "low adoption so far" not "nobody trusts this"
+
+Behind every skill is a person or a team who built something they believed in.
+Some of the most valuable tools in history started with zero stars and one
+believer. Respect that — and give the user the information they need to decide
+for themselves.
+
+---
+
 ## Absolute rule
 
 Never skip a risk check — whether for a new installation or an audit of
-existing ones. The user's security takes priority over speed.
+existing ones. The user's security takes priority over speed — but so does
+fairness to the people who built the tools being evaluated.

--- a/skills/skill-guard/SKILL.md
+++ b/skills/skill-guard/SKILL.md
@@ -223,6 +223,50 @@ let the social proof guide the user's own judgment.
 
 ---
 
+## Self-assessment — Mandatory closing of every audit
+
+At the end of every audit report, skill-guard must evaluate itself using the
+exact same criteria it just applied to every other skill. No exceptions.
+
+Fetch skill-guard's own live data from GitHub:
+```
+gh api repos/baalyerob/skill-guard
+```
+Apply the full social proof analysis (installs, stars, age, last update,
+author, scanner data) and assign a tier using the same logic as Step 2b.
+
+Then close the report with this block:
+
+```
+---------------------------------------------
+[skill-guard] Honest self-assessment
+---------------------------------------------
+If this evaluation were applied to skill-guard today:
+
+  Scanner data : [result — likely Unknown for now]
+  Installs     : [N from skills.sh]
+  Stars        : [N from GitHub]
+  Created      : [date] ([age])
+  Last update  : [date]
+  Author       : @baalyerob (individual, not an organization)
+
+  Verdict : [tier icon] [tier name] — [honest one-sentence assessment]
+
+  "[A sincere closing sentence in first person — e.g.:
+   'I am a young tool with no scanner validation yet.
+    Use your own judgment — and watch my GitHub for growth.']"
+---------------------------------------------
+```
+
+This self-assessment must be honest even when unflattering. A new skill with
+zero installs and no scanner data should say so clearly. Trust is built through
+transparency, not by hiding inconvenient truths about oneself.
+
+The closing sentence should be written in the first person ("I"), sincere,
+and acknowledge both the limitations and the intent of the tool.
+
+---
+
 ## Absolute rule
 
 Never skip a risk check — whether for a new installation or an audit of


### PR DESCRIPTION
## What is skill-guard?

**skill-guard** is a security skill that intercepts every `claude plugin install` and `npx skills add` command before (or during) installation, evaluates the risk level, and blocks the installation until the user explicitly confirms if any risk is detected.

## Why it's useful

Skills and plugins run with **full agent permissions** — they can read files, make network requests, and more. Right now, nothing stops a user from blindly installing a risky package. skill-guard fills that gap.

## Risk levels

| Icon | Level | Condition |
|------|-------|-----------|
| ✅ | Safe | Safe + 0 alerts across all available scanners |
| ⚠️ | Medium risk | Medium Risk on at least one scanner |
| ❌ | High risk | High or Critical Risk on at least one scanner |
| ❓ | Unknown | No risk data available |

## How it works

### For `claude plugin install`
Runs `claude plugin details` before installing to inspect the plugin inventory: hooks, MCP servers, bash scripts, unusual permissions.

### For `npx skills add`
Two-phase check:
1. **Pre-check** — WebFetch on `skills.sh/<org>/<repo>` for published risk scores
2. **Interception** — reads Socket/Snyk scores from the installation output *before files are written to disk*. If risk is detected, offers immediate rollback via `npx skills remove`.

## Install

```bash
npx skills add https://github.com/baalyerob/skill-guard
```

## Origin

Built with Claude Code after noticing that `find-skills` had a Snyk Medium Risk flag that went unnoticed during a real installation session. Tested against 3 scenarios (safe plugin, medium-risk skill, unknown package) before submission.

Source repo: https://github.com/baalyerob/skill-guard