### PR TITLE
feat: add ai-assist agent support with install/uninstall registry hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [52 more](#supported-agents).
 
 <!-- agent-list:end -->
 
@@ -230,6 +230,7 @@ Skills can be installed to any of these agents:
 
 | Agent                                 | `--agent`                                | Project Path             | Global Path                     |
 | ------------------------------------- | ---------------------------------------- | ------------------------ | ------------------------------- |
+| [AI Assist](https://github.com/fredericlepied/ai-assist) | `ai-assist`             | `.agents/skills/`        | `~/.agents/skills/`             |
 | AiderDesk                             | `aider-desk`                             | `.aider-desk/skills/`    | `~/.aider-desk/skills/`         |
 | Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/`        | `~/.config/agents/skills/`      |
 | Antigravity                           | `antigravity`                            | `.agents/skills/`        | `~/.gemini/antigravity/skills/` |

--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,6 +9,23 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
+Package: @clack/core@0.5.0
+License: MIT
+Repository: https://github.com/bombshell-dev/clack
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -55,6 +72,35 @@ Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+Package: sisteransi@1.0.5
+License: MIT
+Repository: https://github.com/terkelg/sisteransi
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/add.ts
+++ b/src/add.ts
@@ -837,6 +837,33 @@ async function handleWellKnownSkills(
     }
   }
 
+  // Call agent postInstall hooks
+  if (successful.length > 0) {
+    const successfulSkillNames = new Set(successful.map((r) => r.skill));
+    for (const agentType of targetAgents) {
+      const agentConfig = agents[agentType];
+      if (!agentConfig.postInstall) continue;
+      for (const skill of selectedSkills) {
+        if (!successfulSkillNames.has(skill.installName)) continue;
+        const result = successful.find(
+          (r) => r.skill === skill.installName && r.agent === agentConfig.displayName
+        );
+        if (!result) continue;
+        try {
+          await agentConfig.postInstall({
+            skillName: skill.name,
+            skillDescription: skill.description,
+            installPath: result.path,
+            source: sourceIdentifier,
+            sourceType: 'well-known',
+          });
+        } catch {
+          // Don't fail installation if postInstall hook fails
+        }
+      }
+    }
+  }
+
   if (successful.length > 0) {
     const bySkill = new Map<string, typeof results>();
     for (const r of successful) {
@@ -1688,6 +1715,36 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             );
           } catch {
             // Don't fail installation if lock file update fails
+          }
+        }
+      }
+    }
+
+    // Call agent postInstall hooks
+    if (successful.length > 0) {
+      const successfulSkillNames = new Set(successful.map((r) => r.skill));
+      for (const agentType of targetAgents) {
+        const agentConfig = agents[agentType];
+        if (!agentConfig.postInstall) continue;
+        for (const skill of selectedSkills) {
+          const skillDisplayName = getSkillDisplayName(skill);
+          if (!successfulSkillNames.has(skillDisplayName)) continue;
+          const result = successful.find(
+            (r) => r.skill === skillDisplayName && r.agent === agentConfig.displayName
+          );
+          if (!result) continue;
+          try {
+            await agentConfig.postInstall({
+              skillName: skill.name,
+              skillDescription: skill.description,
+              installPath: result.path,
+              source: normalizedSource || parsed.url,
+              sourceType: parsed.type,
+              ref: parsed.ref,
+              skillPath: skillFiles[skill.name],
+            });
+          } catch {
+            // Don't fail installation if postInstall hook fails
           }
         }
       }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { xdgConfig } from 'xdg-basedir';
 import type { AgentConfig, AgentType } from './types.ts';
 
@@ -9,6 +10,7 @@ const home = homedir();
 const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
+const aiAssistHome = process.env.AI_ASSIST_CONFIG_DIR?.trim() || join(home, '.ai-assist');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
@@ -30,6 +32,52 @@ export function getOpenClawGlobalSkillsDir(
 }
 
 export const agents: Record<AgentType, AgentConfig> = {
+  'ai-assist': {
+    name: 'ai-assist',
+    displayName: 'AI Assist',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
+    detectInstalled: async () => {
+      return existsSync(aiAssistHome);
+    },
+    postInstall: async ({ skillName, installPath, source, sourceType, ref }) => {
+      const registryFile = join(aiAssistHome, 'installed-skills.json');
+
+      let data: { skills: Array<Record<string, string>> } = { skills: [] };
+      try {
+        const content = await readFile(registryFile, 'utf-8');
+        data = JSON.parse(content);
+      } catch {
+        // File doesn't exist or is invalid
+      }
+
+      data.skills = data.skills.filter((s) => s.name !== skillName);
+      data.skills.push({
+        name: skillName,
+        source,
+        source_type: sourceType === 'github' ? 'git' : sourceType,
+        branch: ref || 'main',
+        installed_at: new Date().toISOString(),
+        cache_path: installPath,
+      });
+
+      await mkdir(aiAssistHome, { recursive: true });
+      await writeFile(registryFile, JSON.stringify(data, null, 2));
+    },
+    postUninstall: async (skillName: string) => {
+      const registryFile = join(aiAssistHome, 'installed-skills.json');
+      try {
+        const content = await readFile(registryFile, 'utf-8');
+        const data = JSON.parse(content);
+        data.skills = (data.skills || []).filter(
+          (s: Record<string, string>) => s.name !== skillName
+        );
+        await writeFile(registryFile, JSON.stringify(data, null, 2));
+      } catch {
+        // File doesn't exist or is invalid — nothing to remove
+      }
+    },
+  },
   'aider-desk': {
     name: 'aider-desk',
     displayName: 'AiderDesk',

--- a/src/git.ts
+++ b/src/git.ts
@@ -27,81 +27,97 @@ export class GitCloneError extends Error {
 
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const git = simpleGit({
+  const baseOptions = {
     timeout: { block: CLONE_TIMEOUT_MS },
     env: {
       ...process.env,
       GIT_TERMINAL_PROMPT: '0',
-      // When git-lfs IS installed, tell it not to download LFS content
-      // during checkout. See #952 for context and empirical impact.
       GIT_LFS_SKIP_SMUDGE: '1',
     },
-    // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect —
-    // git sees `filter=lfs` in .gitattributes, tries to run
-    // `git-lfs filter-process`, and aborts the checkout with:
-    //   git-lfs filter-process: git-lfs: command not found
-    //   fatal: the remote end hung up unexpectedly
-    //   warning: Clone succeeded, but checkout failed.
-    // Overriding filter.lfs.* at the command level disables the filter
-    // entirely for this clone, so checkout succeeds regardless of whether
-    // git-lfs is installed. LFS-tracked files are left as ~130-byte
-    // pointer files, which the skills installer doesn't read anyway
-    // (skills are plain text — HTML/MD/JSON — never LFS-tracked).
-    //
-    // Reported downstream: heygen-com/hyperframes#407.
-    config: [
-      'filter.lfs.required=false',
-      'filter.lfs.smudge=',
-      'filter.lfs.clean=',
-      'filter.lfs.process=',
-    ],
-  });
+  };
+
+  // LFS filter overrides for systems where git-lfs is not installed.
+  // Some git configurations block filter config overrides (allowUnsafeFilter),
+  // so we try without them first and fall back to overrides only if needed.
+  const lfsFilterConfig = [
+    'filter.lfs.required=false',
+    'filter.lfs.smudge=',
+    'filter.lfs.clean=',
+    'filter.lfs.process=',
+  ];
+
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
 
   try {
+    const git = simpleGit(baseOptions);
     await git.clone(url, tempDir, cloneOptions);
     return tempDir;
-  } catch (error) {
+  } catch (firstError) {
+    const firstMessage = firstError instanceof Error ? firstError.message : String(firstError);
+
+    // If checkout failed due to missing git-lfs, retry with filter overrides
+    if (
+      firstMessage.includes('filter-process') ||
+      firstMessage.includes('checkout failed') ||
+      firstMessage.includes('filter.lfs')
+    ) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      const retryDir = await mkdtemp(join(tmpdir(), 'skills-'));
+      try {
+        const gitWithLfs = simpleGit({ ...baseOptions, config: lfsFilterConfig });
+        await gitWithLfs.clone(url, retryDir, cloneOptions);
+        return retryDir;
+      } catch (retryError) {
+        await rm(retryDir, { recursive: true, force: true }).catch(() => {});
+        // Fall through to error handling with the retry error
+        const error = retryError;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw toGitCloneError(url, errorMessage);
+      }
+    }
+
     // Clean up temp dir on failure
     await rm(tempDir, { recursive: true, force: true }).catch(() => {});
-
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
-    const isAuthError =
-      errorMessage.includes('Authentication failed') ||
-      errorMessage.includes('could not read Username') ||
-      errorMessage.includes('Permission denied') ||
-      errorMessage.includes('Repository not found');
-
-    if (isTimeout) {
-      const seconds = Math.round(CLONE_TIMEOUT_MS / 1000);
-      throw new GitCloneError(
-        `Clone timed out after ${seconds}s. Common causes:\n` +
-          `  - Large repository: raise the timeout with SKILLS_CLONE_TIMEOUT_MS=600000 (10m)\n` +
-          `  - Slow network: retry, or clone manually and pass the local path to 'skills add'\n` +
-          `  - Private repo without credentials: ensure auth is configured\n` +
-          `      - For SSH: ssh-add -l (to check loaded keys)\n` +
-          `      - For HTTPS: gh auth status (if using GitHub CLI)`,
-        url,
-        true,
-        false
-      );
-    }
-
-    if (isAuthError) {
-      throw new GitCloneError(
-        `Authentication failed for ${url}.\n` +
-          `  - For private repos, ensure you have access\n` +
-          `  - For SSH: Check your keys with 'ssh -T git@github.com'\n` +
-          `  - For HTTPS: Run 'gh auth login' or configure git credentials`,
-        url,
-        false,
-        true
-      );
-    }
-
-    throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);
+    throw toGitCloneError(url, firstMessage);
   }
+}
+
+function toGitCloneError(url: string, errorMessage: string): GitCloneError {
+  const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
+  const isAuthError =
+    errorMessage.includes('Authentication failed') ||
+    errorMessage.includes('could not read Username') ||
+    errorMessage.includes('Permission denied') ||
+    errorMessage.includes('Repository not found');
+
+  if (isTimeout) {
+    const seconds = Math.round(CLONE_TIMEOUT_MS / 1000);
+    return new GitCloneError(
+      `Clone timed out after ${seconds}s. Common causes:\n` +
+        `  - Large repository: raise the timeout with SKILLS_CLONE_TIMEOUT_MS=600000 (10m)\n` +
+        `  - Slow network: retry, or clone manually and pass the local path to 'skills add'\n` +
+        `  - Private repo without credentials: ensure auth is configured\n` +
+        `      - For SSH: ssh-add -l (to check loaded keys)\n` +
+        `      - For HTTPS: gh auth status (if using GitHub CLI)`,
+      url,
+      true,
+      false
+    );
+  }
+
+  if (isAuthError) {
+    return new GitCloneError(
+      `Authentication failed for ${url}.\n` +
+        `  - For private repos, ensure you have access\n` +
+        `  - For SSH: Check your keys with 'ssh -T git@github.com'\n` +
+        `  - For HTTPS: Run 'gh auth login' or configure git credentials`,
+      url,
+      false,
+      true
+    );
+  }
+
+  return new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);
 }
 
 export async function cleanupTempDir(dir: string): Promise<void> {

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -228,6 +228,18 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         await removeSkillFromLock(skillName);
       }
 
+      // Call agent postUninstall hooks
+      for (const agentKey of targetAgents) {
+        const agent = agents[agentKey];
+        if (agent.postUninstall) {
+          try {
+            await agent.postUninstall(skillName);
+          } catch {
+            // Don't fail removal if postUninstall hook fails
+          }
+        }
+      }
+
       results.push({
         skill: skillName,
         success: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type AgentType =
+  | 'ai-assist'
   | 'aider-desk'
   | 'amp'
   | 'antigravity'
@@ -76,6 +77,18 @@ export interface AgentConfig {
   detectInstalled: () => Promise<boolean>;
   /** Whether to show this agent in the universal agents list. Defaults to true. */
   showInUniversalList?: boolean;
+  /** Called after a skill is successfully installed for this agent. */
+  postInstall?: (info: {
+    skillName: string;
+    skillDescription: string;
+    installPath: string;
+    source: string;
+    sourceType: string;
+    ref?: string;
+    skillPath?: string;
+  }) => Promise<void>;
+  /** Called after a skill is successfully removed for this agent. */
+  postUninstall?: (skillName: string) => Promise<void>;
 }
 
 export interface ParsedSource {


### PR DESCRIPTION
Register ai-assist as a supported agent so `npx skills add` auto-detects
it and updates ~/.ai-assist/installed-skills.json on install/remove.

- Add ai-assist to AgentType and agent config (universal .agents/skills dir)
- Add postInstall/postUninstall hooks to AgentConfig interface
- Implement hooks for ai-assist to maintain installed-skills.json registry
- Wire hooks into add.ts (both runAdd and handleWellKnownSkills flows) and remove.ts
- Fix git clone to try without LFS filter overrides first, falling back
  only when needed (fixes allowUnsafeFilter errors)
