### PR TITLE
feat: add Qoder CN agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
 
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [51 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [52 more](#supported-agents).
 
 <!-- agent-list:end -->
 
@@ -269,6 +269,7 @@ Skills can be installed to any of these agents:
 | OpenHands                             | `openhands`                              | `.openhands/skills/`     | `~/.openhands/skills/`          |
 | Pi                                    | `pi`                                     | `.pi/skills/`            | `~/.pi/agent/skills/`           |
 | Qoder                                 | `qoder`                                  | `.qoder/skills/`         | `~/.qoder/skills/`              |
+| Qoder CN                              | `qoder-cn`                               | `.qoder/skills/`         | `~/.qoder-cn/skills/`           |
 | Qwen Code                             | `qwen-code`                              | `.qwen/skills/`          | `~/.qwen/skills/`               |
 | Rovo Dev                              | `rovodev`                                | `.rovodev/skills/`       | `~/.rovodev/skills/`            |
 | Roo Code                              | `roo`                                    | `.roo/skills/`           | `~/.roo/skills/`                |

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "openhands",
     "pi",
     "qoder",
+    "qoder-cn",
     "qwen-code",
     "replit",
     "rovodev",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -403,6 +403,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.qoder'));
     },
   },
+  'qoder-cn': {
+    name: 'qoder-cn',
+    displayName: 'Qoder CN',
+    skillsDir: '.qoder/skills',
+    globalSkillsDir: join(home, '.qoder-cn/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.qoder-cn'));
+    },
+  },
   'qwen-code': {
     name: 'qwen-code',
     displayName: 'Qwen Code',

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type AgentType =
   | 'openhands'
   | 'pi'
   | 'qoder'
+  | 'qoder-cn'
   | 'qwen-code'
   | 'replit'
   | 'roo'

--- a/tests/qoder-cn-agent.test.ts
+++ b/tests/qoder-cn-agent.test.ts
@@ -1,0 +1,62 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { describe, it, expect } from 'vitest';
+import { agents, isUniversalAgent } from '../src/agents.ts';
+
+describe('qoder-cn agent', () => {
+  const home = homedir();
+
+  it('has correct config properties', () => {
+    const agent = agents['qoder-cn'];
+    expect(agent.name).toBe('qoder-cn');
+    expect(agent.displayName).toBe('Qoder CN');
+    expect(agent.skillsDir).toBe('.qoder/skills');
+    expect(agent.globalSkillsDir).toBe(join(home, '.qoder-cn/skills'));
+  });
+
+  it('shares project-level skillsDir with qoder', () => {
+    expect(agents['qoder-cn'].skillsDir).toBe(agents.qoder.skillsDir);
+  });
+
+  it('has independent global skillsDir from qoder', () => {
+    expect(agents['qoder-cn'].globalSkillsDir).not.toBe(agents.qoder.globalSkillsDir);
+    expect(agents['qoder-cn'].globalSkillsDir).toBe(join(home, '.qoder-cn/skills'));
+    expect(agents.qoder.globalSkillsDir).toBe(join(home, '.qoder/skills'));
+  });
+
+  it('is a non-universal agent', () => {
+    expect(isUniversalAgent('qoder-cn')).toBe(false);
+  });
+
+  it('detects installed when ~/.qoder-cn exists', async () => {
+    const agent = agents['qoder-cn'];
+    // detectInstalled reads the real filesystem — just verify it's a function
+    expect(typeof agent.detectInstalled).toBe('function');
+  });
+
+  it('does not affect qwen-code agent config', () => {
+    expect(agents['qwen-code'].name).toBe('qwen-code');
+    expect(agents['qwen-code'].displayName).toBe('Qwen Code');
+    expect(agents['qwen-code'].skillsDir).toBe('.qwen/skills');
+    expect(agents['qwen-code'].globalSkillsDir).toBe(join(home, '.qwen/skills'));
+  });
+
+  it('does not affect qoder agent config', () => {
+    expect(agents.qoder.name).toBe('qoder');
+    expect(agents.qoder.displayName).toBe('Qoder');
+    expect(agents.qoder.skillsDir).toBe('.qoder/skills');
+    expect(agents.qoder.globalSkillsDir).toBe(join(home, '.qoder/skills'));
+  });
+});
+
+describe('trae/trae-cn parity', () => {
+  it('qoder-cn follows the same shared-local pattern as trae-cn', () => {
+    // trae and trae-cn share skillsDir but have different globalSkillsDir
+    expect(agents.trae.skillsDir).toBe(agents['trae-cn'].skillsDir);
+    expect(agents.trae.globalSkillsDir).not.toBe(agents['trae-cn'].globalSkillsDir);
+
+    // qoder and qoder-cn should follow the same pattern
+    expect(agents.qoder.skillsDir).toBe(agents['qoder-cn'].skillsDir);
+    expect(agents.qoder.globalSkillsDir).not.toBe(agents['qoder-cn'].globalSkillsDir);
+  });
+});


### PR DESCRIPTION
## Summary

- 新增 `qoder-cn` agent（中国站），与 `qoder`（国际站）共享项目级 skillsDir，独立全局目录（`~/.qoder-cn/skills`）
- 参照 `trae`/`trae-cn` 的国际站/中国站并行模式，不影响存量 `qwen-code` 和 `qoder`

Closes #1319

## Test plan

- [x] `pnpm build` 编译通过
- [x] `pnpm test` 新增 8 个测试全部通过，无新增失败
- [x] `validate-agents.ts` 验证通过
- [x] 验证 `skills add <pkg> -a qoder-cn` 正确安装到 `~/.qoder-cn/skills/`
- [x] 验证 `skills list -a qoder-cn` 正确列出已安装 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)