### PR TITLE
feat: add kimi-code-cli agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ Skills can be installed to any of these agents:
 | Agent                                 | `--agent`                                | Project Path             | Global Path                     |
 | ------------------------------------- | ---------------------------------------- | ------------------------ | ------------------------------- |
 | AiderDesk                             | `aider-desk`                             | `.aider-desk/skills/`    | `~/.aider-desk/skills/`         |
-| Amp, Kimi Code CLI, Replit, Universal | `amp`, `kimi-cli`, `replit`, `universal` | `.agents/skills/`        | `~/.config/agents/skills/`      |
+| Amp, Replit, Universal                | `amp`, `replit`, `universal`             | `.agents/skills/`        | `~/.config/agents/skills/`      |
 | Antigravity                           | `antigravity`                            | `.agents/skills/`        | `~/.gemini/antigravity/skills/` |
 | Augment                               | `augment`                                | `.augment/skills/`       | `~/.augment/skills/`            |
 | IBM Bob                               | `bob`                                    | `.bob/skills/`           | `~/.bob/skills/`                |
 | Claude Code                           | `claude-code`                            | `.claude/skills/`        | `~/.claude/skills/`             |
 | OpenClaw                              | `openclaw`                               | `skills/`                | `~/.openclaw/skills/`           |
-| Cline, Dexto, Warp                    | `cline`, `dexto`, `warp`                 | `.agents/skills/`        | `~/.agents/skills/`             |
+| Cline, Dexto, Kimi Code CLI, Warp     | `cline`, `dexto`, `kimi-code-cli`, `warp` | `.agents/skills/`        | `~/.agents/skills/`             |
 | CodeArts Agent                        | `codearts-agent`                         | `.codeartsdoer/skills/`  | `~/.codeartsdoer/skills/`       |
 | CodeBuddy                             | `codebuddy`                              | `.codebuddy/skills/`     | `~/.codebuddy/skills/`          |
 | Codemaker                             | `codemaker`                              | `.codemaker/skills/`     | `~/.codemaker/skills/`          |
@@ -486,7 +486,7 @@ Telemetry is automatically disabled in CI environments.
 - [Gemini CLI Skills Documentation](https://geminicli.com/docs/cli/skills/)
 - [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
 - [iFlow CLI Skills Documentation](https://platform.iflow.cn/en/cli/examples/skill)
-- [Kimi Code CLI Skills Documentation](https://moonshotai.github.io/kimi-cli/en/customization/skills.html)
+- [Kimi Code CLI Skills Documentation](https://moonshotai.github.io/kimi-code/en/customization/skills)
 - [Kiro CLI Skills Documentation](https://kiro.dev/docs/cli/custom-agents/configuration-reference/#skill-resources)
 - [Kode Skills Documentation](https://github.com/shareAI-lab/kode/blob/main/docs/skills.md)
 - [OpenCode Skills Documentation](https://opencode.ai/docs/skills)

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "junie",
     "iflow-cli",
     "kilo",
-    "kimi-cli",
+    "kimi-code-cli",
     "kiro-cli",
     "kode",
     "mcpjam",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -313,13 +313,13 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.kilocode'));
     },
   },
-  'kimi-cli': {
-    name: 'kimi-cli',
+  'kimi-code-cli': {
+    name: 'kimi-code-cli',
     displayName: 'Kimi Code CLI',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.config/agents/skills'),
+    globalSkillsDir: join(home, '.agents/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.kimi'));
+      return existsSync(join(home, '.kimi-code')) || existsSync(join(home, '.kimi'));
     },
   },
   'kiro-cli': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export type AgentType =
   | 'iflow-cli'
   | 'junie'
   | 'kilo'
-  | 'kimi-cli'
+  | 'kimi-code-cli'
   | 'kiro-cli'
   | 'kode'
   | 'mcpjam'

--- a/tests/list-installed.test.ts
+++ b/tests/list-installed.test.ts
@@ -154,9 +154,9 @@ ${skillData.description}
     const skills = await listInstalledSkills({ global: false, cwd: testDir });
 
     expect(skills).toHaveLength(1);
-    // Should only show amp, not kimi-cli
+    // Should only show amp, not kimi-code-cli
     expect(skills[0]!.agents).toContain('amp');
-    expect(skills[0]!.agents).not.toContain('kimi-cli');
+    expect(skills[0]!.agents).not.toContain('kimi-code-cli');
 
     vi.restoreAllMocks();
   });

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -47,6 +47,18 @@ describe('XDG config paths', () => {
     });
   });
 
+  describe('Kimi Code CLI', () => {
+    it('uses the current agent id', () => {
+      expect('kimi-code-cli' in agents).toBe(true);
+      expect('kimi-cli' in agents).toBe(false);
+    });
+
+    it('uses ~/.agents/skills for global skills', () => {
+      const expected = join(home, '.agents', 'skills');
+      expect(agents['kimi-code-cli'].globalSkillsDir).toBe(expected);
+    });
+  });
+
   describe('Goose', () => {
     it('uses ~/.config/goose/skills for global skills', () => {
       const expected = join(home, '.config', 'goose', 'skills');


### PR DESCRIPTION
## Summary
- Rename the Kimi agent id from `kimi-cli` to `kimi-code-cli`.
- Install Kimi Code CLI skills through the generic `.agents/skills` paths that Kimi Code scans.
- Update README/package metadata and tests for the new agent id.

## Test Plan
- `pnpm exec vitest run tests/xdg-config-paths.test.ts tests/list-installed.test.ts tests/installer-symlink.test.ts tests/installer-copy.test.ts`
- `node scripts/validate-agents.ts`
- `pnpm format:check`
- `git diff --check`