### PR TITLE
fix(frontmatter): tolerate leading HTML comments + blank lines before ---

### DIFF
--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,15 +1,47 @@
 import { parse as parseYaml } from 'yaml';
 
 /**
+ * Strip leading HTML comments + blank lines so frontmatter can be preceded by
+ * provenance / attribution / license headers without breaking the parser.
+ *
+ * Without this, a SKILL.md like:
+ *
+ *   <!-- Absorbed from upstream/repo (MIT). -->
+ *   ---
+ *   name: my-skill
+ *   description: ...
+ *   ---
+ *
+ * is silently skipped: the regex below anchors `---` at byte 0, so the leading
+ * comment kills the match and the file is treated as body-only with no
+ * extracted name/description. Downstream that means the skill never surfaces
+ * in the install picker.
+ *
+ * Matches: leading whitespace, any number of `<!-- ... -->` blocks (single- or
+ * multi-line), and any blank lines between them. Stops as soon as it hits the
+ * first non-comment / non-whitespace character.
+ */
+function stripLeadingCommentsAndWhitespace(raw: string): string {
+  // Repeated whitespace runs OR HTML-comment blocks. `+` lets us no-op when the
+  // file already starts with `---` (no match -> replace returns input unchanged).
+  return raw.replace(/^(?:\s+|<!--[\s\S]*?-->)+/, '');
+}
+
+/**
  * Minimal frontmatter parser. Only supports YAML (the `---` delimiter).
  * Does NOT support `---js` / `---javascript` to avoid eval()-based RCE
  * that exists in gray-matter's built-in JS engine.
+ *
+ * Tolerates leading HTML comments + blank lines before the frontmatter so
+ * authors can preserve provenance / attribution / license headers above the
+ * frontmatter without the parser silently skipping the skill.
  */
 export function parseFrontmatter(raw: string): {
   data: Record<string, unknown>;
   content: string;
 } {
-  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  const stripped = stripLeadingCommentsAndWhitespace(raw);
+  const match = stripped.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   if (!match) return { data: {}, content: raw };
   const data = (parseYaml(match[1]!) as Record<string, unknown>) ?? {};
   return { data, content: match[2] ?? '' };

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from '../src/frontmatter';
+
+describe('parseFrontmatter', () => {
+  it('parses a SKILL.md whose frontmatter is on line 1 (happy path, unchanged)', () => {
+    const raw = ['---', 'name: my-skill', 'description: A skill.', '---', '', '# Body', ''].join(
+      '\n'
+    );
+    const { data, content } = parseFrontmatter(raw);
+    expect(data.name).toBe('my-skill');
+    expect(data.description).toBe('A skill.');
+    expect(content.includes('# Body')).toBe(true);
+  });
+
+  it('tolerates a single-line HTML comment above the frontmatter', () => {
+    const raw = [
+      '<!-- Absorbed from upstream/repo (MIT). -->',
+      '---',
+      'name: my-skill',
+      'description: A skill with provenance.',
+      '---',
+      '',
+      '# Body',
+      '',
+    ].join('\n');
+    const { data, content } = parseFrontmatter(raw);
+    expect(data.name).toBe('my-skill');
+    expect(data.description).toBe('A skill with provenance.');
+    expect(content.includes('# Body')).toBe(true);
+  });
+
+  it('tolerates a multi-line HTML comment above the frontmatter', () => {
+    const raw = [
+      '<!--',
+      '  Absorbed from upstream/repo (MIT).',
+      '  Provenance preserved across the absorption boundary.',
+      '-->',
+      '---',
+      'name: my-skill',
+      'description: A skill.',
+      '---',
+      '# Body',
+      '',
+    ].join('\n');
+    const { data } = parseFrontmatter(raw);
+    expect(data.name).toBe('my-skill');
+  });
+
+  it('tolerates several stacked HTML comments before the frontmatter', () => {
+    const raw = [
+      '<!-- Comment A -->',
+      '<!-- Comment B -->',
+      '<!-- Comment C -->',
+      '',
+      '---',
+      'name: my-skill',
+      'description: A skill.',
+      '---',
+      '# Body',
+      '',
+    ].join('\n');
+    const { data } = parseFrontmatter(raw);
+    expect(data.name).toBe('my-skill');
+  });
+
+  it('tolerates leading blank lines before the frontmatter', () => {
+    const raw = [
+      '',
+      '',
+      '',
+      '---',
+      'name: my-skill',
+      'description: A skill.',
+      '---',
+      '# Body',
+      '',
+    ].join('\n');
+    const { data } = parseFrontmatter(raw);
+    expect(data.name).toBe('my-skill');
+  });
+
+  it('returns empty data when no frontmatter exists at all (unchanged)', () => {
+    const raw = '# Just a body\n\nNo frontmatter here.\n';
+    const { data, content } = parseFrontmatter(raw);
+    expect(data).toEqual({});
+    expect(content).toBe(raw);
+  });
+
+  it('returns empty data when leading HTML comments are present but no frontmatter follows (unchanged)', () => {
+    const raw = '<!-- Only a comment, no frontmatter -->\n\n# Body\n';
+    const { data, content } = parseFrontmatter(raw);
+    expect(data).toEqual({});
+    // content is the ORIGINAL raw (so callers can re-render), not the stripped version.
+    expect(content).toBe(raw);
+  });
+
+  it('handles CRLF line endings (Windows-authored SKILL.md)', () => {
+    const raw =
+      '<!-- comment -->\r\n---\r\nname: my-skill\r\ndescription: A skill.\r\n---\r\n# Body\r\n';
+    const { data } = parseFrontmatter(raw);
+    expect(data.name).toBe('my-skill');
+  });
+});


### PR DESCRIPTION
## Summary

`parseFrontmatter` in [`src/frontmatter.ts`](https://github.com/vercel-labs/skills/blob/main/src/frontmatter.ts) anchors the opening `---` at byte 0, so any leading character — HTML comment, blank line, whitespace — causes the regex to fail and the SKILL.md is treated as a body-only file with no frontmatter. The skill is then **silently skipped during discovery** (no `name` + `description` = not surfaced in the install picker).

## Repro

Two SKILL.md files, identical except for a single HTML comment line above the frontmatter:

```markdown
<!-- Provenance comment that breaks the parser silently. -->
---
name: repro-skill
description: A skill whose frontmatter is preceded by an HTML comment.
---

# Body
```

`npx skills add <owner>/<repo>` finds **0 skills** if every SKILL.md has a leading comment; finds N skills if you strip the comments. No warning emitted.

In our case ([mclean/icm-skills](https://github.com/mclean/icm-skills) — private), 8 of 12 SKILL.md files had `<!-- Absorbed from upstream/<name> (MIT) ... -->` provenance headers above their frontmatter. They were silently skipped on the first `npx skills add` run. Took a verify-by-install round-trip to surface; we worked around downstream by moving the comments below the closing `---`.

## Fix

Pre-strip leading whitespace + HTML-comment blocks via `stripLeadingCommentsAndWhitespace()` before the regex match. The actual match logic is unchanged; this just moves the parser's "start of frontmatter" past any obviously-not-frontmatter prefix. `content` returned is still the original `raw` (so callers can re-render including the leading comment).

Regex: `/^(?:\s+|<!--[\s\S]*?-->)+/` — matches repeated whitespace runs or HTML-comment blocks. The `+` lets the replace no-op when the file already starts with `---` (no match → original input unchanged).

## Tests (`tests/frontmatter.test.ts`)

8 new tests, all pass:

- happy path: frontmatter on line 1 (unchanged behavior)
- single-line HTML comment above frontmatter
- multi-line HTML comment above frontmatter
- stacked HTML comments + blank lines
- leading blank lines only
- no frontmatter at all (returns empty data + content = raw, unchanged)
- HTML comment but no frontmatter follows (unchanged)
- CRLF line endings (Windows-authored SKILL.md)

## Test plan

- [x] `npx vitest run tests/frontmatter.test.ts` → 8/8 pass
- [x] Verified the 5 pre-existing failures on `main` (banner tests, Windows timeouts on `list.test.ts` + `list-installed.test.ts`) are unrelated to this change — none touch the frontmatter module.
- [ ] Consider also adding a discovery-time warning when a SKILL.md is found but no frontmatter is extracted (would have made the original bug self-diagnosing). Happy to add in this PR if the maintainers want it.