### PR TITLE
fix: allow update from private repositories by retrying with token on 404

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -167,7 +167,7 @@ export async function fetchRepoTree(
 
   // First pass: unauthenticated.
   let rateLimited = false;
-  let anyFailed = false;
+  let unauthenticatedFetchFailed = false;
   for (const branch of branches) {
     const result = await fetchTreeBranch(ownerRepo, branch, null);
     if (result.tree) return result.tree;
@@ -177,12 +177,13 @@ export async function fetchRepoTree(
       rateLimited = true;
       break;
     }
-    anyFailed = true;
+    unauthenticatedFetchFailed = true;
   }
 
-  if ((!rateLimited && !anyFailed) || !getToken) return null;
+  if ((!rateLimited && !unauthenticatedFetchFailed) || !getToken) return null;
 
-  // Lazy fallback: rate limit hit or potential private repo, and a token resolver was provided.
+  // Lazy fallback: rate limit hit or unauthenticated fetch failed (e.g. private repo),
+  // and a token resolver was provided.
   if (rateLimited) {
     _rateLimitedThisSession = true;
   }

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -167,6 +167,7 @@ export async function fetchRepoTree(
 
   // First pass: unauthenticated.
   let rateLimited = false;
+  let anyFailed = false;
   for (const branch of branches) {
     const result = await fetchTreeBranch(ownerRepo, branch, null);
     if (result.tree) return result.tree;
@@ -176,12 +177,15 @@ export async function fetchRepoTree(
       rateLimited = true;
       break;
     }
+    anyFailed = true;
   }
 
-  if (!rateLimited || !getToken) return null;
+  if ((!rateLimited && !anyFailed) || !getToken) return null;
 
-  // Lazy fallback: rate limit hit and a token resolver was provided.
-  _rateLimitedThisSession = true;
+  // Lazy fallback: rate limit hit or potential private repo, and a token resolver was provided.
+  if (rateLimited) {
+    _rateLimitedThisSession = true;
+  }
   const token = getToken();
   if (!token) return null;
 


### PR DESCRIPTION
Fixes #1331.

This PR ensures that the `skills update` (and `add`) command correctly attempts to use a GitHub token if the initial anonymous fetch of the repository tree fails with a 404. 

GitHub returns a 404 for private repositories when accessed anonymously. The previous logic only retried with a token if a 403 (rate limit) was detected. This change expands the retry logic to also include cases where the initial fetch failed (which includes the 404 case for private repos).