### PR TITLE
fix: retry with auth token for private repos, not only rate limits

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -178,10 +178,15 @@ export async function fetchRepoTree(
     }
   }
 
-  if (!rateLimited || !getToken) return null;
+  if (!getToken) return null;
 
-  // Lazy fallback: rate limit hit and a token resolver was provided.
-  _rateLimitedThisSession = true;
+  // Lazy fallback: retry with auth. Covers two cases:
+  //   1. Rate-limited (403 + x-ratelimit-remaining: 0) — same as before.
+  //   2. Private repo (401/404 without auth) — unauthenticated pass returns
+  //      rateLimited: false, so the old guard `!rateLimited || !getToken`
+  //      would bail here without ever trying a token. Now we always retry
+  //      with auth when a token resolver is available.
+  if (rateLimited) _rateLimitedThisSession = true;
   const token = getToken();
   if (!token) return null;
 


### PR DESCRIPTION
Closes #1331

## Problem

`skills update` silently fails for private GitHub repos installed via SSH URL (e.g. `git@github.com:user/my-skills.git`).

`fetchRepoTree` only retries with a GitHub token when the unauthenticated request hits a rate limit (403 + `x-ratelimit-remaining: 0`). Private repos return 401/404 without auth — `fetchTreeBranch` sets `rateLimited: false` for these — so the guard on line 181:

\`\`\`ts
if (!rateLimited || !getToken) return null;
\`\`\`

bails immediately without ever trying an authenticated request. The CLI prints `✗ Failed to fetch tree for <source>` and moves on, even when a valid `gh` token is available with `repo` scope.

## Fix

Drop `!rateLimited` from the guard so we always retry with a token when `getToken` is provided and the unauthenticated pass returned no tree. `_rateLimitedThisSession` is still only set when a true rate limit is detected, preserving the fast-path optimisation for subsequent calls in the same process.

\`\`\`ts
// Before
if (!rateLimited || !getToken) return null;
_rateLimitedThisSession = true;

// After
if (!getToken) return null;
if (rateLimited) _rateLimitedThisSession = true;
\`\`\`

## Behaviour after fix

- Public repos: unchanged — unauthenticated pass succeeds, token never invoked.
- Rate-limited: unchanged — `_rateLimitedThisSession` still set, fast path still used.
- Private repos: unauthenticated pass returns `null` with `rateLimited: false` → now falls through to authenticated retry → succeeds.

## Reproduction

\`\`\`bash
# Install a skill from a private GitHub repo via SSH URL
npx skills add git@github.com:<you>/<private-repo>.git

# Run update — currently fails silently
npx skills update
# ✗ Failed to fetch tree for git@github.com:<you>/<private-repo>.git
\`\`\`