### PR TITLE
fix: support update checking for non-GitHub git sources

### DIFF
--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -202,6 +202,41 @@ export async function fetchSkillFolderHash(
 }
 
 /**
+ * Fetch the skill folder hash for a non-GitHub git source (Bitbucket, GitLab,
+ * Azure DevOps, self-hosted, etc.) by performing a shallow clone and computing
+ * a SHA-256 hash of the skill folder contents.
+ *
+ * Uses the same hashing algorithm as the install path in add.ts so stored and
+ * fetched hashes are directly comparable.
+ *
+ * @param sourceUrl - Git clone URL (e.g., "git@bitbucket.org:owner/repo.git")
+ * @param skillPath - Path to skill folder or SKILL.md within the repo
+ * @param ref - Optional branch/tag ref
+ * @returns SHA-256 hash of the skill folder contents, or null on failure
+ */
+export async function fetchGitSkillFolderHash(
+  sourceUrl: string,
+  skillPath: string,
+  ref?: string
+): Promise<string | null> {
+  const { cloneRepo, cleanupTempDir } = await import('./git.ts');
+  const { computeSkillFolderHash } = await import('./local-lock.ts');
+
+  let tempDir: string | null = null;
+  try {
+    tempDir = await cloneRepo(sourceUrl, ref);
+    const skillDir = join(tempDir, dirname(skillPath));
+    return await computeSkillFolderHash(skillDir);
+  } catch {
+    return null;
+  } finally {
+    if (tempDir) {
+      await cleanupTempDir(tempDir).catch(() => {});
+    }
+  }
+}
+
+/**
  * Add or update a skill entry in the lock file.
  */
 export async function addSkillToLock(

--- a/src/update.ts
+++ b/src/update.ts
@@ -8,6 +8,7 @@ import pc from 'picocolors';
 import {
   readSkillLock,
   fetchSkillFolderHash,
+  fetchGitSkillFolderHash,
   getGitHubToken,
   type SkillLockEntry,
 } from './skill-lock.ts';
@@ -172,9 +173,6 @@ export function getSkipReason(entry: SkillLockEntry): string {
   if (entry.sourceType === 'local') {
     return 'Local path';
   }
-  if (entry.sourceType === 'git') {
-    return 'Git URL';
-  }
   if (entry.sourceType === 'well-known') {
     return 'Well-known skill';
   }
@@ -312,6 +310,18 @@ export async function updateGlobalSkills(
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
+    // Local paths and well-known skills cannot be re-fetched for hash comparison.
+    if (entry.sourceType === 'local' || entry.sourceType === 'well-known') {
+      skipped.push({
+        name: skillName,
+        reason: getSkipReason(entry),
+        sourceUrl: entry.sourceUrl,
+        sourceType: entry.sourceType,
+        ref: entry.ref,
+      });
+      continue;
+    }
+
     if (!entry.skillFolderHash || !entry.skillPath) {
       skipped.push({
         name: skillName,
@@ -326,8 +336,14 @@ export async function updateGlobalSkills(
     checkable.push({ name: skillName, entry });
   }
 
-  const bySource = new Map<string, typeof checkable>();
-  for (const item of checkable) {
+  // Separate github sources (which can use the GitHub Trees API for efficient
+  // bulk checking) from non-github git sources (which need per-skill cloning).
+  const githubCheckable = checkable.filter((item) => item.entry.sourceType === 'github');
+  const nonGithubCheckable = checkable.filter((item) => item.entry.sourceType !== 'github');
+
+  // Handle github sources: group by source and use the GitHub Trees API.
+  const bySource = new Map<string, typeof githubCheckable>();
+  for (const item of githubCheckable) {
     const source = item.entry.source;
     const existing = bySource.get(source) || [];
     existing.push(item);
@@ -369,6 +385,24 @@ export async function updateGlobalSkills(
       }
     } catch (error) {
       console.log(`  ${DIM}✗ Error checking skills from ${source}${RESET}`);
+    }
+  }
+
+  // Handle non-github sources: use shallow clone + folder hash for each skill.
+  for (const { name: skillName, entry } of nonGithubCheckable) {
+    process.stdout.write(`\r${DIM}Checking skills from source: ${entry.source}${RESET}\x1b[K\n`);
+
+    try {
+      const latestHash = await fetchGitSkillFolderHash(
+        entry.sourceUrl,
+        entry.skillPath!,
+        entry.ref
+      );
+      if (latestHash && latestHash !== entry.skillFolderHash) {
+        updates.push({ name: skillName, source: entry.source, entry });
+      }
+    } catch (error) {
+      // Silently skip — the skill stays at its current version.
     }
   }
 


### PR DESCRIPTION
Skills installed from non-GitHub git sources (Bitbucket, GitLab self-hosted, Azure DevOps, etc.) were never checkable for updates because the update flow exclusively used the GitHub Trees API, which returns null for non-GitHub URLs.

This adds fetchGitSkillFolderHash() for git/gitlab source types using a shallow clone + SHA-256 hash of the skill folder contents — the same mechanism already used at install time, so stored and fetched hashes are comparable.

In updateGlobalSkills:
- Removes the unconditional skip of sourceType=git in getSkipReason()
- Adds early skip for local/well-known sources before the hash check
- Splits checkable items: GitHub sources keep the efficient bySource grouping, non-GitHub sources use per-skill fetchGitSkillFolderHash()

Rebased from #1047 by @cjamesrohan onto upstream/main (v1.5.9).