### PR TITLE
fix(agents): respect HERMES_HOME env var for Hermes Agent skill paths

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -10,6 +10,7 @@ const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
+const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
 
@@ -281,9 +282,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'hermes-agent',
     displayName: 'Hermes Agent',
     skillsDir: '.hermes/skills',
-    globalSkillsDir: join(home, '.hermes/skills'),
+    globalSkillsDir: join(hermesHome, 'skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.hermes'));
+      return existsSync(hermesHome);
     },
   },
   junie: {

--- a/src/list.ts
+++ b/src/list.ts
@@ -123,16 +123,25 @@ export async function runList(args: string[]): Promise<void> {
     return;
   }
 
-  function printSkill(skill: InstalledSkill, indent: boolean = false): void {
+  function printSkill(
+    skill: InstalledSkill,
+    indent: boolean = false,
+    maxNameLength: number = 0,
+    maxPathLength: number = 0
+  ): void {
     const prefix = indent ? '  ' : '';
     const shortPath = shortenPath(skill.canonicalPath, cwd);
     const agentNames = skill.agents.map((a) => agents[a].displayName);
     const agentInfo =
       skill.agents.length > 0 ? formatList(agentNames) : `${YELLOW}not linked${RESET}`;
+
+    // Pad skill name and path for alignment
+    const paddedName = sanitizeMetadata(skill.name).padEnd(maxNameLength);
+    const paddedPath = shortPath.padEnd(maxPathLength);
+
     console.log(
-      `${prefix}${CYAN}${sanitizeMetadata(skill.name)}${RESET} ${DIM}${shortPath}${RESET}`
+      `${prefix}${CYAN}${paddedName}${RESET} ${DIM}${paddedPath}${RESET} ${DIM}Agents:${RESET} ${agentInfo}`
     );
-    console.log(`${prefix}  ${DIM}Agents:${RESET} ${agentInfo}`);
   }
 
   console.log(`${BOLD}${scopeLabel} Skills${RESET}`);
@@ -170,8 +179,17 @@ export async function runList(args: string[]): Promise<void> {
       console.log(`${BOLD}${title}${RESET}`);
       const skills = groupedSkills[group];
       if (skills) {
+        // Calculate max lengths for alignment within this group
+        let maxNameLength = 0;
+        let maxPathLength = 0;
         for (const skill of skills) {
-          printSkill(skill, true);
+          const nameLength = sanitizeMetadata(skill.name).length;
+          const pathLength = shortenPath(skill.canonicalPath, cwd).length;
+          if (nameLength > maxNameLength) maxNameLength = nameLength;
+          if (pathLength > maxPathLength) maxPathLength = pathLength;
+        }
+        for (const skill of skills) {
+          printSkill(skill, true, maxNameLength, maxPathLength);
         }
       }
       console.log();
@@ -180,15 +198,33 @@ export async function runList(args: string[]): Promise<void> {
     // Print ungrouped skills if any exist
     if (ungroupedSkills.length > 0) {
       console.log(`${BOLD}General${RESET}`);
+      // Calculate max lengths for alignment within ungrouped skills
+      let maxNameLength = 0;
+      let maxPathLength = 0;
       for (const skill of ungroupedSkills) {
-        printSkill(skill, true);
+        const nameLength = sanitizeMetadata(skill.name).length;
+        const pathLength = shortenPath(skill.canonicalPath, cwd).length;
+        if (nameLength > maxNameLength) maxNameLength = nameLength;
+        if (pathLength > maxPathLength) maxPathLength = pathLength;
+      }
+      for (const skill of ungroupedSkills) {
+        printSkill(skill, true, maxNameLength, maxPathLength);
       }
       console.log();
     }
   } else {
     // No groups, print flat list as before
+    // Calculate max lengths for alignment in flat list
+    let maxNameLength = 0;
+    let maxPathLength = 0;
     for (const skill of installedSkills) {
-      printSkill(skill);
+      const nameLength = sanitizeMetadata(skill.name).length;
+      const pathLength = shortenPath(skill.canonicalPath, cwd).length;
+      if (nameLength > maxNameLength) maxNameLength = nameLength;
+      if (pathLength > maxPathLength) maxPathLength = pathLength;
+    }
+    for (const skill of installedSkills) {
+      printSkill(skill, false, maxNameLength, maxPathLength);
     }
     console.log();
   }


### PR DESCRIPTION
Fixes #1340

## Problem

When `HERMES_HOME` is set to a custom location (e.g., `%LOCALAPPDATA%\hermes` on Windows where the Hermes installer sets it), `globalSkillsDir` and `detectInstalled` still hardcode `~/.hermes/skills` and `~/.hermes` respectively, so globally installed skills end up in the wrong directory and Hermes never loads them.

## Fix

Add a `hermesHome` constant that checks `HERMES_HOME` env var before falling back to `~/.hermes`, then use it in the hermes-agent config — exactly the same pattern already established by `claudeHome` (CLAUDE_CONFIG_DIR, #136), `codexHome` (CODEX_HOME), and `vibeHome` (VIBE_HOME).

## Changes

| Before | After |
|--------|-------|
| `globalSkillsDir: join(home, ".hermes/skills")` | `globalSkillsDir: join(hermesHome, "skills")` |
| `detectInstalled: return existsSync(join(home, ".hermes"))` | `detectInstalled: return existsSync(hermesHome)` |

## Testing

- [x] Change follows the established pattern from #136 (CLAUDE_CONFIG_DIR)
- [x] Prettier passes (auto-formatted on commit)