### PR TITLE
Fix global update for git skill sources

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -5,13 +5,8 @@ import { fileURLToPath } from 'url';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 
-import {
-  readSkillLock,
-  fetchSkillFolderHash,
-  getGitHubToken,
-  type SkillLockEntry,
-} from './skill-lock.ts';
-import { readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
+import { readSkillLock, getGitHubToken, type SkillLockEntry } from './skill-lock.ts';
+import { computeSkillFolderHash, readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
 import {
   formatSourceInput,
   buildUpdateInstallSource,
@@ -336,13 +331,22 @@ export async function updateGlobalSkills(
 
   for (const [source, itemsForSource] of bySource) {
     const firstEntry = itemsForSource[0]!.entry;
+    const sourceUrl = firstEntry.sourceUrl || firstEntry.source;
+    let tempDir: string | null = null;
 
     process.stdout.write(`\r${DIM}Checking skills from source: ${source}${RESET}\x1b[K\n`);
 
     try {
-      const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);
+      const isGitHubSource = firstEntry.sourceType === 'github';
 
-      if (tree) {
+      if (isGitHubSource) {
+        const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);
+
+        if (!tree) {
+          console.log(`  ${DIM}✗ Failed to fetch tree for ${source}${RESET}`);
+          continue;
+        }
+
         const discoveredPaths = findSkillMdPaths(tree);
 
         const allLockedForSource = Object.entries(lock.skills)
@@ -358,17 +362,55 @@ export async function updateGlobalSkills(
           discoveredPaths
         );
 
+        const deletedSkillSet = new Set(deletedSkills);
+
         for (const { name: skillName, entry } of itemsForSource) {
+          if (deletedSkillSet.has(skillName)) continue;
+
           const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
           if (latestHash && latestHash !== entry.skillFolderHash) {
             updates.push({ name: skillName, source, entry });
           }
         }
-      } else {
-        console.log(`  ${DIM}✗ Failed to fetch tree for ${source}${RESET}`);
+
+        continue;
+      }
+
+      tempDir = await cloneRepo(sourceUrl, firstEntry.ref);
+      const discoveredPaths = (await discoverSkills(tempDir)).map((skill) => {
+        return join(relative(tempDir!, skill.path), 'SKILL.md').split(sep).join('/');
+      });
+
+      const allLockedForSource = Object.entries(lock.skills)
+        .filter(([_, entry]) => entry.source === source)
+        .map(([name, _]) => name);
+
+      const deletedSkills = await checkAndPromptForDeletions(
+        source,
+        allLockedForSource,
+        lock.skills,
+        true,
+        options,
+        discoveredPaths
+      );
+
+      const deletedSkillSet = new Set(deletedSkills);
+
+      for (const { name: skillName, entry } of itemsForSource) {
+        if (deletedSkillSet.has(skillName)) continue;
+
+        const skillPath = entry.skillPath!;
+        if (!discoveredPaths.includes(skillPath)) continue;
+
+        const latestHash = await computeSkillFolderHash(join(tempDir, dirname(skillPath)));
+        if (latestHash && latestHash !== entry.skillFolderHash) {
+          updates.push({ name: skillName, source, entry });
+        }
       }
     } catch (error) {
-      console.log(`  ${DIM}✗ Error checking skills from ${source}${RESET}`);
+      console.log(`  ${DIM}✗ Failed to check skills from ${source}${RESET}`);
+    } finally {
+      if (tempDir) await cleanupTempDir(tempDir);
     }
   }
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -8,6 +8,7 @@ import * as skillLock from '../src/skill-lock.ts';
 import * as remove from '../src/remove.ts';
 import * as p from '@clack/prompts';
 import { readFileSync } from 'fs';
+import { join } from 'path';
 
 // Mock dependencies
 vi.mock('../src/git.ts');
@@ -213,17 +214,14 @@ describe('Update Cleanup Unit Tests', () => {
         },
       });
 
-      // Mock fetchRepoTree
       vi.mocked(blob.fetchRepoTree).mockResolvedValue({
         sha: 'rootsha',
         branch: 'main',
         tree: [
           { path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'sha1' },
-          { path: 'skills/skill-a', type: 'tree', sha: 'sha2' },
+          { path: 'skills/skill-a', type: 'tree', sha: 'abc' },
         ],
       });
-
-      // Mock findSkillMdPaths
       vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
 
       vi.mocked(p.confirm).mockResolvedValue(true);
@@ -234,6 +232,36 @@ describe('Update Cleanup Unit Tests', () => {
       expect(remove.removeCommand).toHaveBeenCalledWith(
         ['skill-b'],
         expect.objectContaining({ yes: true, global: true })
+      );
+    });
+
+    it('should check global non-GitHub git sources by cloning', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'git@github.com:owner/repo.git',
+            sourceUrl: 'git@github.com:owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'git',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(git.cloneRepo).toHaveBeenCalledWith('git@github.com:owner/repo.git', undefined);
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
+        join('/tmp/repo', 'skills/skill-a')
       );
     });
   });


### PR DESCRIPTION
## Summary

Fixes global skill updates for non-GitHub git sources such as SSH URLs.

The existing global update path always used GitHub tree lookup semantics. That works for GitHub-backed lock entries, but fails for sources like [git@github.com:owner/repo.git](git@github.com:owner/repo.git).

This keeps the existing GitHub update behavior unchanged and adds a non-GitHub path that mirrors add: clone the source, discover skill paths, and compare the filesystem hash stored by current lock semantics.

## Tests

- npm test -- tests/update.test.ts
- npx prettier --check src/update.ts tests/update.test.ts
- npm run build