### PR TITLE
fix(update): drop subpath append for non-shorthand sources

### DIFF
--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -84,5 +84,38 @@ describe('update-source', () => {
       });
       expect(result).toBe('owner/repo#main');
     });
+
+    it('does not append skill folder for SSH sources (would produce unclonable URL)', () => {
+      const result = buildLocalUpdateSource({
+        source: 'git@gitea.example.com:owner/repo.git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('git@gitea.example.com:owner/repo.git');
+    });
+
+    it('keeps ref on SSH sources even when skill folder is dropped', () => {
+      const result = buildLocalUpdateSource({
+        source: 'git@gitea.example.com:owner/repo.git',
+        ref: 'main',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('git@gitea.example.com:owner/repo.git#main');
+    });
+
+    it('does not append skill folder for self-hosted HTTPS .git URLs', () => {
+      const result = buildLocalUpdateSource({
+        source: 'https://gitea.example.com/owner/repo.git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://gitea.example.com/owner/repo.git');
+    });
+
+    it('appends skill folder for github.com HTTPS URLs', () => {
+      const result = buildLocalUpdateSource({
+        source: 'https://github.com/owner/repo',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://github.com/owner/repo/skills/my-skill');
+    });
   });
 });

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -35,7 +35,32 @@ function deriveSkillFolder(skillPath: string): string {
   return folder;
 }
 
+/**
+ * Whether a skill folder can be safely appended to the given source as a
+ * subpath. Only true for sources the source-parser can resolve as a
+ * GitHub/GitLab tree URL — owner/repo shorthand or an HTTPS URL on those
+ * hosts. Full SSH URLs (`git@host:owner/repo.git`) and generic Git URLs
+ * (anything ending in `.git`, or hosts other than github.com/gitlab.com)
+ * cannot have a subpath appended without producing an unclonable URL.
+ */
+function supportsAppendedSubpath(source: string): boolean {
+  if (source.startsWith('git@')) return false;
+  if (source.endsWith('.git')) return false;
+  if (source.startsWith('http://') || source.startsWith('https://')) {
+    try {
+      const host = new URL(source).hostname;
+      return host === 'github.com' || host === 'gitlab.com';
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
 function appendFolderAndRef(source: string, skillPath: string, ref?: string): string {
+  if (!supportsAppendedSubpath(source)) {
+    return formatSourceInput(source, ref);
+  }
   const folder = deriveSkillFolder(skillPath);
   const withFolder = folder ? `${source}/${folder}` : source;
   return ref ? `${withFolder}#${ref}` : withFolder;


### PR DESCRIPTION
## Summary

Remakes #1096 with a signed commit.

Fixes project-scoped updates for non-shorthand Git sources by avoiding invalid source strings like:

```sh
git@gitea.example.com:owner/repo.git/skills/foo
```

For SSH URLs, `.git` URLs, and non-GitHub/GitLab HTTPS Git hosts, we now keep the bare source URL and rely on the existing `--skill <name>` scoping used by the update path.

Credit to @tkaufmann for the original implementation and detailed reproduction in #1096.

## Tests

- `pnpm test src/update-source.test.ts`
- `pnpm format:check`
