### PR TITLE
feat: add Antigravity CLI support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -58,6 +58,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.gemini/antigravity'));
     },
   },
+  'antigravity-cli': {
+    name: 'antigravity-cli',
+    displayName: 'Antigravity CLI',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.gemini/antigravity-cli/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.gemini/antigravity-cli'));
+    },
+  },
   augment: {
     name: 'augment',
     displayName: 'Augment',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type AgentType =
   | 'aider-desk'
   | 'amp'
   | 'antigravity'
+  | 'antigravity-cli'
   | 'augment'
   | 'bob'
   | 'claude-code'

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -60,6 +60,19 @@ describe('XDG config paths', () => {
     });
   });
 
+  describe('Antigravity CLI', () => {
+    it('uses ~/.gemini/antigravity-cli/skills for global skills', () => {
+      const expected = join(home, '.gemini', 'antigravity-cli', 'skills');
+      expect(agents['antigravity-cli'].globalSkillsDir).toBe(expected);
+    });
+
+    it('uses a distinct global directory from the Antigravity IDE', () => {
+      expect(agents['antigravity-cli'].globalSkillsDir).not.toBe(
+        agents.antigravity.globalSkillsDir
+      );
+    });
+  });
+
   describe('skill lock file path', () => {
     function getSkillLockPath(xdgStateHome: string | undefined, homeDir: string): string {
       if (xdgStateHome) {


### PR DESCRIPTION
## Summary

Remakes #1293 with a signed commit.

Adds native support for the **Antigravity CLI** (`agy`) as a distinct agent from the existing Antigravity IDE entry.

The CLI uses a different global skills directory:

| Scope | Path |
| --- | --- |
| Workspace | `.agents/skills/` |
| Global | `~/.gemini/antigravity-cli/skills/` |

Credit to @lucasmg-dev for the original implementation and rationale in #1293.

## Tests

- `pnpm test tests/xdg-config-paths.test.ts`
- `node scripts/validate-agents.ts`
- `pnpm format:check`
