### PR TITLE
fix: prevent Windows libuv assertion on CLI exit (UV_HANDLE_CLOSING)

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -854,11 +854,19 @@ async function handleWellKnownSkills(
       const firstResult = skillResults[0]!;
 
       if (firstResult.mode === 'copy') {
-        // Copy mode: show skill name and list all agent paths
+        // Copy mode: group by unique path (global installs share one dir across agents)
         resultLines.push(`${pc.green('✓')} ${skillName} ${pc.dim('(copied)')}`);
+        const byPath = new Map<string, string[]>();
         for (const r of skillResults) {
           const shortPath = shortenPath(r.path, cwd);
-          resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
+          const names = byPath.get(shortPath) ?? [];
+          names.push(r.agent);
+          byPath.set(shortPath, names);
+        }
+        for (const [shortPath, agentNames] of byPath) {
+          resultLines.push(
+            `  ${pc.dim('→')} ${shortPath} ${pc.dim('(' + formatList(agentNames) + ')')}`
+          );
         }
       } else {
         // Symlink mode: show canonical path and universal/symlinked agents
@@ -1729,11 +1737,19 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           const firstResult = skillResults[0]!;
 
           if (firstResult.mode === 'copy') {
-            // Copy mode: show skill name and list all agent paths
+            // Copy mode: group by unique path (global installs share one dir across agents)
             resultLines.push(`${pc.green('✓')} ${entry.skill} ${pc.dim('(copied)')}`);
+            const byPath = new Map<string, string[]>();
             for (const r of skillResults) {
               const shortPath = shortenPath(r.path, cwd);
-              resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
+              const names = byPath.get(shortPath) ?? [];
+              names.push(r.agent);
+              byPath.set(shortPath, names);
+            }
+            for (const [shortPath, agentNames] of byPath) {
+              resultLines.push(
+                `  ${pc.dim('→')} ${shortPath} ${pc.dim('(' + formatList(agentNames) + ')')}`
+              );
             }
           } else {
             // Symlink mode: show canonical path and universal/symlinked agents

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -360,4 +360,7 @@ async function main(): Promise<void> {
   }
 }
 
-main().finally(() => flushTelemetry().then(() => process.exit(0)));
+// No explicit process.exit(0) — let Node drain naturally after flush.
+// Calling process.exit() while undici connection-pool handles are still
+// live triggers a libuv assertion on Windows (UV_HANDLE_CLOSING, async.c:76).
+main().finally(() => flushTelemetry());

--- a/src/find.ts
+++ b/src/find.ts
@@ -69,6 +69,11 @@ const MOVE_TO_COL = (n: number) => `\x1b[${n}G`;
 
 // Custom fzf-style search prompt using raw readline
 async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
+  // VT escape codes only work when the terminal has ANSI/VT processing enabled.
+  // On Windows without VT mode, escape sequences print as literal text, causing
+  // each render to append new lines instead of overwriting the previous frame.
+  const vtSupported = process.stdout.isTTY && (process.stdout.getColorDepth?.() ?? 1) > 1;
+
   let results: SearchSkill[] = [];
   let selectedIndex = 0;
   let query = initialQuery;
@@ -87,17 +92,21 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
   // Resume stdin to start receiving events
   process.stdin.resume();
 
-  // Hide cursor during selection
-  process.stdout.write(HIDE_CURSOR);
+  // Hide cursor during selection (only when VT is supported)
+  if (vtSupported) {
+    process.stdout.write(HIDE_CURSOR);
+  }
 
   function render(): void {
-    // Move cursor up to overwrite previous render
-    if (lastRenderedLines > 0) {
+    // Move cursor up to overwrite previous render (only when VT is supported)
+    if (vtSupported && lastRenderedLines > 0) {
       process.stdout.write(MOVE_UP(lastRenderedLines) + MOVE_TO_COL(1));
     }
 
-    // Clear from cursor to end of screen (removes ghost trails)
-    process.stdout.write(CLEAR_DOWN);
+    // Clear from cursor to end of screen (only when VT is supported)
+    if (vtSupported) {
+      process.stdout.write(CLEAR_DOWN);
+    }
 
     const lines: string[] = [];
 
@@ -139,7 +148,8 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
       process.stdout.write(line + '\n');
     }
 
-    lastRenderedLines = lines.length;
+    // Only track height for overwriting when VT is supported
+    lastRenderedLines = vtSupported ? lines.length : 0;
   }
 
   function triggerSearch(q: string): void {
@@ -193,7 +203,9 @@ async function runSearchPrompt(initialQuery = ''): Promise<SearchSkill | null> {
       if (process.stdin.isTTY) {
         process.stdin.setRawMode(false);
       }
-      process.stdout.write(SHOW_CURSOR);
+      if (vtSupported) {
+        process.stdout.write(SHOW_CURSOR);
+      }
       // Pause stdin to fully release it for child processes
       process.stdin.pause();
     }

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -143,6 +143,13 @@ export async function searchMultiselect<T>(
     lockedSection,
   } = options;
 
+  // VT escape codes (cursor movement, line erase) only work when the terminal
+  // has ANSI/VT processing enabled. On Windows cmd/PowerShell without VT mode,
+  // escape sequences print as literal text, causing each render to append a new
+  // frame instead of overwriting the previous one. Use color depth as a proxy:
+  // depth > 1 means the terminal processes ANSI escapes.
+  const vtSupported = process.stdout.isTTY && (process.stdout.getColorDepth?.() ?? 1) > 1;
+
   return new Promise((resolve) => {
     const rl = readline.createInterface({
       input: process.stdin,
@@ -178,14 +185,13 @@ export async function searchMultiselect<T>(
     };
 
     const clearRender = (): void => {
-      if (lastRenderHeight > 0) {
-        // Move up and clear each line
-        process.stdout.write(`\x1b[${lastRenderHeight}A`);
-        for (let i = 0; i < lastRenderHeight; i++) {
-          process.stdout.write('\x1b[2K\x1b[1B');
-        }
-        process.stdout.write(`\x1b[${lastRenderHeight}A`);
+      if (!vtSupported || lastRenderHeight === 0) return;
+      // Move up and clear each line
+      process.stdout.write(`\x1b[${lastRenderHeight}A`);
+      for (let i = 0; i < lastRenderHeight; i++) {
+        process.stdout.write('\x1b[2K\x1b[1B');
       }
+      process.stdout.write(`\x1b[${lastRenderHeight}A`);
     };
 
     const render = (state: 'active' | 'submit' | 'cancel' = 'active'): void => {
@@ -290,7 +296,8 @@ export async function searchMultiselect<T>(
       // Use wrapped row count: logical lines can span multiple terminal rows when hints
       // or labels exceed column width. Using lines.length alone under-counts and breaks
       // clearRender(), causing the prompt to re-print hundreds of times on each redraw.
-      lastRenderHeight = countVisualRowsForLines(lines, process.stdout.columns);
+      // Only track height for overwriting when VT is supported
+      lastRenderHeight = vtSupported ? countVisualRowsForLines(lines, process.stdout.columns) : 0;
     };
 
     const cleanup = (): void => {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -119,13 +119,15 @@ export async function fetchAuditData(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-    const response = await fetch(`${AUDIT_URL}?${params.toString()}`, {
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-
-    if (!response.ok) return null;
-    return (await response.json()) as AuditResponse;
+    try {
+      const response = await fetch(`${AUDIT_URL}?${params.toString()}`, {
+        signal: controller.signal,
+      });
+      if (!response.ok) return null;
+      return (await response.json()) as AuditResponse;
+    } finally {
+      clearTimeout(timeout);
+    }
   } catch {
     return null;
   }
@@ -181,6 +183,17 @@ export function track(data: TelemetryData): void {
  */
 export async function flushTelemetry(timeoutMs = 5000): Promise<void> {
   if (pendingTelemetry.length === 0) return;
-  const timeout = new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
-  await Promise.race([Promise.all(pendingTelemetry), timeout]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+    // Unref so this timer doesn't prevent natural process exit if everything
+    // else has already drained — avoids hanging when telemetry is the last
+    // active handle.
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([Promise.all(pendingTelemetry), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
 }


### PR DESCRIPTION
## Problem

On Windows, any command that fires telemetry (`search`, `install`, `remove`, `update`) crashes with:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
error: exit status 0xc0000409
```

Root cause: `main().finally(() => flushTelemetry().then(() => process.exit(0)))` calls `process.exit()` while Node's undici connection-pool still has live handles (TLSSocket/Socket). On Windows, libuv asserts in `uv_async_send` when a handle is in `UV_HANDLE_CLOSING` state. This is a Windows-only assert — Linux/macOS silently tolerate it.

Additionally, two UX bugs on Windows terminals without VT processing (cmd.exe, PowerShell without VT mode):

1. The interactive `searchMultiselect` and `runSearchPrompt` prompts produce ~30 duplicate frames because ANSI cursor-movement sequences (`MOVE_UP`, `CLEAR_DOWN`, `clearRender`) print as literal text instead of moving the cursor.

2. The post-install summary prints one `→ <path>` line per agent even when multiple agents share the same install directory (e.g. all global installs go to `~/.agents/skills`), producing 13 identical lines.

## Fix

**`src/cli.ts`** — Remove the explicit `process.exit(0)`. Node now exits naturally after all handles drain.

**`src/telemetry.ts`** — Two changes:
- `flushTelemetry`: store the timer ref, call `timer.unref()` so the timeout alone doesn't prevent natural exit, and clear it in a `finally` block to avoid leaking the handle on early resolution.
- `fetchAuditData`: move `clearTimeout(timeout)` into a `finally` block so the AbortController timer is cleared on `!response.ok` and error paths, not just the happy path.

**`src/find.ts`, `src/prompts/search-multiselect.ts`** — Add a `vtSupported` flag (`process.stdout.getColorDepth() > 1`) and guard all cursor-movement ANSI sequences behind it. On non-VT terminals, renders append (readable, not spammy) instead of overwriting.

**`src/add.ts`** — Group copy-mode result paths by unique path and show agent names inline using the existing `formatList()`, matching the style of the pre-install Installation Summary.

Before:
```
✓ my-skill (copied)
  → ~/.agents/skills/my-skill
  → ~/.agents/skills/my-skill
  → ~/.agents/skills/my-skill  (×13)
```
After:
```
✓ my-skill (copied)
  → ~/.agents/skills/my-skill (Amp, Antigravity, Cline, Codex, Cursor +8 more)
```

## Test

```
# Before fix — crashes on Windows
npx skills find typescript

# After fix
npx skills find typescript   # exits cleanly, exit code 0
npx skills install owner/repo@skill  # single prompt frame, clean summary
```

Confirmed on Windows 11 / Node 24. Natural exit also works on macOS/Linux (no hanging).