### PR TITLE
fix(list): attribute canonical global skills to universal agents

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1009,7 +1009,7 @@ export async function listInstalledSkills(
             continue;
           }
 
-          const agentBase = scope.global ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+          const agentBase = getAgentBaseDir(agentType, scope.global, cwd);
           let found = false;
 
           // Try exact directory name matches

--- a/tests/list-installed.test.ts
+++ b/tests/list-installed.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdir, writeFile, rm, symlink } from 'fs/promises';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { listInstalledSkills } from '../src/installer.ts';
 import * as agentsModule from '../src/agents.ts';
 
@@ -123,6 +123,37 @@ ${skillData.description}
       cwd: testDir,
     });
     expect(Array.isArray(skills)).toBe(true);
+  });
+
+  it('attributes global canonical skills to universal agents with native global dirs', async () => {
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['opencode']);
+
+    const skillDir = join(homedir(), '.agents', 'skills', 'opencode-global-attribution-test');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: opencode-global-attribution-test
+description: Test OpenCode global attribution
+---
+
+# opencode-global-attribution-test
+`
+    );
+
+    try {
+      const skills = await listInstalledSkills({
+        global: true,
+        agentFilter: ['opencode'],
+      });
+
+      const skill = skills.find((s) => s.name === 'opencode-global-attribution-test');
+      expect(skill).toBeDefined();
+      expect(skill!.agents).toContain('opencode');
+    } finally {
+      vi.restoreAllMocks();
+      await rm(skillDir, { recursive: true, force: true });
+    }
   });
 
   it('should apply agent filter', async () => {


### PR DESCRIPTION
## Summary

Fixes the `skills list -g` attribution inconsistency discussed in #770 without changing OpenCode away from the universal `.agents/skills` path.

OpenCode is currently configured as universal for project installs (`skillsDir: '.agents/skills'`) but also has a native `globalSkillsDir` (`~/.config/opencode/skills`). Installation uses universal-agent semantics and writes global OpenCode installs to the canonical `~/.agents/skills` directory, while `listInstalledSkills()` attributed canonical skills by checking `agent.globalSkillsDir` directly.

This changes canonical-skill attribution to use `getAgentBaseDir()`, matching the installer semantics. Universal agents such as OpenCode are therefore checked against the canonical global skills directory and no longer show as `Agents: not linked` when installed globally.

## Tests

- `pnpm exec vitest run tests/list-installed.test.ts -t "attributes global canonical skills"`
- `pnpm format:check`
