### PR TITLE
fix: fall back to gh and ssh for github clone auth

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rmSync } from 'fs';
+
+const simpleGitMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock('simple-git', () => ({
+  default: simpleGitMock,
+}));
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    execFile: execFileMock,
+  };
+});
+
+import {
+  GitCloneError,
+  cloneRepo,
+  isGitHubHttpsCloneUrl,
+  isGitHubSsoAuthError,
+  parseGitHubRepoUrl,
+} from './git.ts';
+
+function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
+  return {
+    clone,
+  };
+}
+
+function mockExecFileSuccess(stdout = '', stderr = '') {
+  execFileMock.mockImplementationOnce(
+    (_file: string, _args: string[], _options: unknown, callback: (...args: unknown[]) => void) => {
+      callback(null, stdout, stderr);
+    }
+  );
+}
+
+function mockExecFileError(message: string) {
+  execFileMock.mockImplementationOnce(
+    (_file: string, _args: string[], _options: unknown, callback: (...args: unknown[]) => void) => {
+      const error = Object.assign(new Error(message), { code: 1 });
+      callback(error, '', message);
+    }
+  );
+}
+
+describe('git clone fallbacks', () => {
+  const createdDirs: string[] = [];
+
+  beforeEach(() => {
+    simpleGitMock.mockReset();
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    for (const dir of createdDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses GitHub HTTPS and SSH clone URLs', () => {
+    expect(parseGitHubRepoUrl('https://github.com/Giphy/giphy-codex-skills.git')).toEqual({
+      owner: 'Giphy',
+      repo: 'giphy-codex-skills',
+      slug: 'Giphy/giphy-codex-skills',
+      sshUrl: 'git@github.com:Giphy/giphy-codex-skills.git',
+    });
+
+    expect(parseGitHubRepoUrl('git@github.com:Giphy/giphy-codex-skills.git')).toEqual({
+      owner: 'Giphy',
+      repo: 'giphy-codex-skills',
+      slug: 'Giphy/giphy-codex-skills',
+      sshUrl: 'git@github.com:Giphy/giphy-codex-skills.git',
+    });
+  });
+
+  it('detects GitHub SAML SSO clone failures', () => {
+    expect(
+      isGitHubSsoAuthError("remote: The 'Giphy' organization has enabled or enforced SAML SSO.")
+    ).toBe(true);
+    expect(isGitHubSsoAuthError('fatal: Authentication failed')).toBe(false);
+  });
+
+  it('only enables automatic auth fallback for GitHub HTTPS clone URLs', () => {
+    expect(isGitHubHttpsCloneUrl('https://github.com/Giphy/giphy-codex-skills.git')).toBe(true);
+    expect(isGitHubHttpsCloneUrl('http://github.com/Giphy/giphy-codex-skills.git')).toBe(false);
+    expect(isGitHubHttpsCloneUrl('git@github.com:Giphy/giphy-codex-skills.git')).toBe(false);
+    expect(isGitHubHttpsCloneUrl('https://gitlab.com/Giphy/giphy-codex-skills.git')).toBe(false);
+  });
+
+  it('falls back to gh repo clone for GitHub HTTPS auth failures', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "remote: The 'Giphy' organization has enabled or enforced SAML SSO.\n" +
+            "fatal: unable to access 'https://github.com/Giphy/giphy-codex-skills.git/': The requested URL returned error: 403"
+        )
+      );
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+    mockExecFileSuccess('Git operations protocol: https\n');
+    mockExecFileSuccess();
+
+    const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+    createdDirs.push(tempDir);
+
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      1,
+      'gh',
+      ['auth', 'status', '-h', 'github.com'],
+      expect.any(Object),
+      expect.any(Function)
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'gh',
+      ['repo', 'clone', 'Giphy/giphy-codex-skills', tempDir, '--', '--depth=1'],
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  it('falls back to SSH when gh clone is unavailable or fails', async () => {
+    const primaryClone = vi.fn().mockRejectedValue(new Error('fatal: Authentication failed'));
+    const sshClone = vi.fn().mockResolvedValue(undefined);
+
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(createGitClientMock(sshClone));
+    mockExecFileSuccess('Git operations protocol: ssh\n');
+    mockExecFileError('gh repo clone failed');
+
+    const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+    createdDirs.push(tempDir);
+
+    expect(sshClone).toHaveBeenCalledWith('git@github.com:Giphy/giphy-codex-skills.git', tempDir, [
+      '--depth',
+      '1',
+    ]);
+  });
+
+  it('surfaces a targeted SAML SSO message when all fallbacks fail', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "remote: The 'Giphy' organization has enabled or enforced SAML SSO.\n" +
+            "fatal: unable to access 'https://github.com/Giphy/giphy-codex-skills.git/': The requested URL returned error: 403"
+        )
+      );
+    const sshClone = vi.fn().mockRejectedValue(new Error('Permission denied (publickey).'));
+
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(createGitClientMock(sshClone));
+    mockExecFileError('gh auth unavailable');
+
+    try {
+      await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+      throw new Error('Expected cloneRepo to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(GitCloneError);
+      expect((error as Error).message).toMatch(/SAML SSO/);
+      expect((error as Error).message).toMatch(/git@github\.com:Giphy\/giphy-codex-skills\.git/);
+    }
+  });
+
+  it('does not try gh fallback for GitLab clone URLs', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error('fatal: unable to access repo: The requested URL returned error: 403')
+      );
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/Giphy/giphy-codex-skills.git')).rejects.toThrow(
+      GitCloneError
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('does not try gh fallback for GitHub SSH clone URLs', async () => {
+    const primaryClone = vi.fn().mockRejectedValue(new Error('Permission denied (publickey).'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('git@github.com:Giphy/giphy-codex-skills.git')).rejects.toThrow(
+      GitCloneError
+    );
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,7 +1,9 @@
 import simpleGit from 'simple-git';
 import { join, normalize, resolve, sep } from 'path';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp, mkdir, rm } from 'fs/promises';
 import { tmpdir } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 const DEFAULT_CLONE_TIMEOUT_MS = 300_000; // 5 minutes
 const CLONE_TIMEOUT_MS = (() => {
@@ -10,6 +12,14 @@ const CLONE_TIMEOUT_MS = (() => {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CLONE_TIMEOUT_MS;
 })();
+const execFileAsync = promisify(execFile);
+
+interface GitHubRepoInfo {
+  owner: string;
+  repo: string;
+  slug: string;
+  sshUrl: string;
+}
 
 export class GitCloneError extends Error {
   readonly url: string;
@@ -25,9 +35,71 @@ export class GitCloneError extends Error {
   }
 }
 
-export async function cloneRepo(url: string, ref?: string): Promise<string> {
-  const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const git = simpleGit({
+export function parseGitHubRepoUrl(url: string): GitHubRepoInfo | null {
+  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  if (sshMatch) {
+    const owner = sshMatch[1]!;
+    const repo = sshMatch[2]!;
+    return {
+      owner,
+      repo,
+      slug: `${owner}/${repo}`,
+      sshUrl: `git@github.com:${owner}/${repo}.git`,
+    };
+  }
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'github.com') return null;
+
+    const match = parsed.pathname.match(/^\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
+    if (!match) return null;
+
+    const owner = match[1]!;
+    const repo = match[2]!;
+    return {
+      owner,
+      repo,
+      slug: `${owner}/${repo}`,
+      sshUrl: `git@github.com:${owner}/${repo}.git`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isGitHubHttpsCloneUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' && parsed.hostname === 'github.com';
+  } catch {
+    return false;
+  }
+}
+
+export function isGitHubSsoAuthError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('saml sso') ||
+    lower.includes('enforced sso') ||
+    lower.includes('enabled or enforced saml') ||
+    lower.includes('re-authorize the oauth application')
+  );
+}
+
+function isAuthFailure(message: string): boolean {
+  return (
+    message.includes('Authentication failed') ||
+    message.includes('could not read Username') ||
+    message.includes('Permission denied') ||
+    message.includes('Repository not found') ||
+    message.includes('requested URL returned error: 403') ||
+    isGitHubSsoAuthError(message)
+  );
+}
+
+function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
+  return simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
     env: {
       ...process.env,
@@ -35,6 +107,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       // When git-lfs IS installed, tell it not to download LFS content
       // during checkout. See #952 for context and empirical impact.
       GIT_LFS_SKIP_SMUDGE: '1',
+      ...extraEnv,
     },
     // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect —
     // git sees `filter=lfs` in .gitattributes, tries to run
@@ -56,24 +129,80 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       'filter.lfs.process=',
     ],
   });
-  const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+}
+
+async function resetTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true }).catch(() => {});
+  await mkdir(dir, { recursive: true });
+}
+
+async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): Promise<boolean> {
+  let cloneTarget = repo.slug;
 
   try {
-    await git.clone(url, tempDir, cloneOptions);
+    const { stdout, stderr } = await execFileAsync('gh', ['auth', 'status', '-h', 'github.com'], {
+      timeout: 5000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+    const statusOutput = `${stdout}${stderr}`;
+    if (/Git operations protocol:\s+ssh/i.test(statusOutput)) {
+      cloneTarget = repo.sshUrl;
+    }
+  } catch {
+    return false;
+  }
+
+  const gitFlags = ref ? ['--depth=1', '--branch', ref] : ['--depth=1'];
+  await execFileAsync('gh', ['repo', 'clone', cloneTarget, tempDir, '--', ...gitFlags], {
+    timeout: CLONE_TIMEOUT_MS,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return true;
+}
+
+function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message: string): string {
+  if (repo && isGitHubSsoAuthError(message)) {
+    return (
+      `GitHub blocked HTTPS access to ${url} because the organization enforces SAML SSO.\n` +
+      `  skills tried your existing git credentials and available fallbacks, but none succeeded.\n` +
+      `  - Re-authorize your GitHub credentials/app for that org's SSO policy\n` +
+      `  - Or rerun with SSH: npx skills add ${repo.sshUrl}\n` +
+      `  - Verify access with: gh auth status -h github.com or ssh -T git@github.com`
+    );
+  }
+
+  if (repo) {
+    return (
+      `Authentication failed for ${url}.\n` +
+      `  - For private repos, ensure you have access\n` +
+      `  - Retry with SSH: npx skills add ${repo.sshUrl}\n` +
+      `  - Check access with: gh auth status -h github.com or ssh -T git@github.com`
+    );
+  }
+
+  return (
+    `Authentication failed for ${url}.\n` +
+    `  - For private repos, ensure you have access\n` +
+    `  - For SSH: Check your keys with 'ssh -T git@github.com'\n` +
+    `  - For HTTPS: Run 'gh auth login' or configure git credentials`
+  );
+}
+
+export async function cloneRepo(url: string, ref?: string): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
+  const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const repo = parseGitHubRepoUrl(url);
+
+  try {
+    await createGitClient().clone(url, tempDir, cloneOptions);
     return tempDir;
   } catch (error) {
-    // Clean up temp dir on failure
-    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
-
     const errorMessage = error instanceof Error ? error.message : String(error);
     const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
-    const isAuthError =
-      errorMessage.includes('Authentication failed') ||
-      errorMessage.includes('could not read Username') ||
-      errorMessage.includes('Permission denied') ||
-      errorMessage.includes('Repository not found');
+    const isAuthError = isAuthFailure(errorMessage);
 
     if (isTimeout) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
       const seconds = Math.round(CLONE_TIMEOUT_MS / 1000);
       throw new GitCloneError(
         `Clone timed out after ${seconds}s. Common causes:\n` +
@@ -88,16 +217,31 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       );
     }
 
+    if (isAuthError && repo && isGitHubHttpsCloneUrl(url)) {
+      try {
+        await resetTempDir(tempDir);
+        if (await tryGhClone(repo, tempDir, ref)) {
+          return tempDir;
+        }
+      } catch {
+        // Fall through to SSH retry.
+      }
+
+      try {
+        await resetTempDir(tempDir);
+        await createGitClient({
+          GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
+        }).clone(repo.sshUrl, tempDir, cloneOptions);
+        return tempDir;
+      } catch {
+        // Fall through to the targeted auth error below.
+      }
+    }
+
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+
     if (isAuthError) {
-      throw new GitCloneError(
-        `Authentication failed for ${url}.\n` +
-          `  - For private repos, ensure you have access\n` +
-          `  - For SSH: Check your keys with 'ssh -T git@github.com'\n` +
-          `  - For HTTPS: Run 'gh auth login' or configure git credentials`,
-        url,
-        false,
-        true
-      );
+      throw new GitCloneError(buildGitHubAuthError(url, repo, errorMessage), url, false, true);
     }
 
     throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);


### PR DESCRIPTION
## Summary

Remakes #908 as a signed maintainer PR against current `main`.

For GitHub HTTPS clone authentication failures, the clone flow now tries:

1. regular `git clone` with the existing timeout/LFS behavior,
2. `gh repo clone` when GitHub CLI auth is available,
3. the derived SSH URL (`git@github.com:owner/repo.git`),
4. targeted SAML/SSO/private-repo remediation text if all fallbacks fail.

The fallback is explicitly limited to GitHub HTTPS clone URLs. GitLab, generic Git URLs, and GitHub SSH URLs skip the `gh` fallback path.

Credit to @huntharo for the original implementation and test coverage in #908.

## Tests

- `pnpm test src/git.test.ts`
- `pnpm format:check`
