### PR TITLE
feat: add WorkBuddy agent support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -607,6 +607,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.codeium/windsurf'));
     },
   },
+  workbuddy: {
+    name: 'workbuddy',
+    displayName: 'WorkBuddy',
+    skillsDir: '.workbuddy/skills',
+    globalSkillsDir: join(home, '.workbuddy/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.workbuddy')) || existsSync(join(home, '.workbuddy'));
+    },
+  },
   zed: {
     name: 'zed',
     displayName: 'Zed',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -31,6 +31,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.roo/skills',
   '.trae/skills',
   '.windsurf/skills',
+  '.workbuddy/skills',
   '.zencoder/skills',
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export type AgentType =
   | 'trae-cn'
   | 'warp'
   | 'windsurf'
+  | 'workbuddy'
   | 'zed'
   | 'zencoder'
   | 'zenflow'


### PR DESCRIPTION
## Summary

Adds [WorkBuddy](https://www.codebuddy.ai/docs/workbuddy/From-Beginner-to-Expert-Guide/Function-Description/Skills-Market) as a supported agent in the skills CLI.

## Changes

- **** — Add `'workbuddy'` to `AgentType` union
- **** — Add agent config entry:
  - Project skills dir: `.workbuddy/skills`
  - Global skills dir: `~/.workbuddy/skills`
  - Detection: `.workbuddy` in cwd or home
- **** — Add `.workbuddy/skills` to `AGENT_PROJECT_SKILL_DIRS` for skill discovery

## Usage

```bash
npx skills add <package> -a workbuddy
npx skills add <package> -g -a workbuddy
```

## Test Plan

- [x] All 524 existing tests pass (`pnpm test`)
- [x] Prettier formatting applied (lint-staged)
- [ ] Manual: verify `npx skills add <pkg> -a workbuddy` installs to `.workbuddy/skills/`
- [ ] Manual: verify `npx skills add <pkg> -g -a workbuddy` installs to `~/.workbuddy/skills/`
- [ ] Manual: verify skill discovery finds skills in `.workbuddy/skills/` directories

## References

- Issue: #1353
- Skills docs: https://www.codebuddy.ai/docs/workbuddy/From-Beginner-to-Expert-Guide/Function-Description/Skills-Market
- Previous (closed) PR: #597 — resubmitted against current main as recommended by @quuu