### PR TITLE
fix: remove missing skills from lock files during update/uninstall

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, runCliWithInput } from './test-utils.js';
@@ -72,6 +72,30 @@ This is a test skill.
       expect(result.stdout).toContain('No skills found');
       expect(result.exitCode).toBe(0);
     });
+
+    it('should clean stale lock entry even when no skills are installed on disk', () => {
+      const lockPath = join(testDir, 'skills-lock.json');
+      const lockContent = {
+        version: 1,
+        skills: {
+          'stale-skill': {
+            source: 'some-source',
+            sourceType: 'github',
+            computedHash: 'somehash',
+          },
+        },
+      };
+      writeFileSync(lockPath, JSON.stringify(lockContent, null, 2));
+
+      // No skills exist on disk, but stale-skill lingers in the lock file
+      const result = runCli(['remove', 'stale-skill', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.exitCode).toBe(0);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['stale-skill']).toBeUndefined();
+    });
   });
 
   describe('with skills installed', () => {
@@ -132,6 +156,32 @@ This is a test skill.
 
       expect(result.stdout).toContain('No matching skills');
       expect(result.exitCode).toBe(0);
+    });
+
+    it('should remove skill that is missing from disk but exists in local lock file', () => {
+      const lockPath = join(testDir, 'skills-lock.json');
+      const lockContent = {
+        version: 1,
+        skills: {
+          'stale-skill': {
+            source: 'some-source',
+            sourceType: 'github',
+            computedHash: 'somehash',
+          },
+        },
+      };
+      writeFileSync(lockPath, JSON.stringify(lockContent, null, 2));
+
+      // stale-skill is missing from disk, but exists in lock file
+      const result = runCli(['remove', 'stale-skill', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.stdout).toContain('1 skill');
+      expect(result.exitCode).toBe(0);
+
+      // Verify lock file has been updated to remove the skill
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['stale-skill']).toBeUndefined();
     });
 
     it('should be case-insensitive when matching skill names', () => {

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -5,7 +5,8 @@ import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
-import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
+import { readLocalLock, removeSkillFromLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -73,7 +74,26 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   const installedSkills = Array.from(skillNamesSet).sort();
   spinner.stop(`Found ${installedSkills.length} unique installed skill(s)`);
 
-  if (installedSkills.length === 0) {
+  // Read lock file keys up front. These are needed both to decide whether there is
+  // anything to remove (a skill may be missing from disk but still leave a stale lock
+  // entry) and to clean up those stale entries below.
+  const lockSkillsKeys = isGlobal
+    ? Object.keys((await readSkillLock()).skills)
+    : Object.keys((await readLocalLock(cwd)).skills);
+
+  // Requested skills that are gone from disk but still have a stale lock entry.
+  // These must be cleaned up even when no skills remain installed on disk, otherwise
+  // the entry lingers forever (e.g. a skill deleted upstream during `skills update`).
+  const staleLockSkills =
+    !options.all && skillNames.length > 0
+      ? skillNames.filter(
+          (name) =>
+            !installedSkills.some((s) => s.toLowerCase() === name.toLowerCase()) &&
+            lockSkillsKeys.some((k) => k.toLowerCase() === name.toLowerCase())
+        )
+      : [];
+
+  if (installedSkills.length === 0 && staleLockSkills.length === 0) {
     p.outro(pc.yellow('No skills found to remove.'));
     return;
   }
@@ -98,6 +118,14 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     selectedSkills = installedSkills.filter((s) =>
       skillNames.some((name) => name.toLowerCase() === s.toLowerCase())
     );
+
+    // Requested skills missing from disk but still present in the lock file (computed
+    // above) are mapped back to their exact lock key so the stale entry can be cleaned up.
+    const mappedMissingSkills = staleLockSkills.map(
+      (name) => lockSkillsKeys.find((k) => k.toLowerCase() === name.toLowerCase()) || name
+    );
+
+    selectedSkills.push(...mappedMissingSkills);
 
     if (selectedSkills.length === 0) {
       p.log.error(`No matching skills found for: ${skillNames.join(', ')}`);
@@ -220,12 +248,20 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         await rm(canonicalPath, { recursive: true, force: true });
       }
 
-      const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
-      const effectiveSource = lockEntry?.source || 'local';
-      const effectiveSourceType = lockEntry?.sourceType || 'local';
+      let effectiveSource = 'local';
+      let effectiveSourceType = 'local';
 
       if (isGlobal) {
+        const lockEntry = await getSkillFromLock(skillName);
+        effectiveSource = lockEntry?.source || 'local';
+        effectiveSourceType = lockEntry?.sourceType || 'local';
         await removeSkillFromLock(skillName);
+      } else {
+        const localLock = await readLocalLock(cwd);
+        const lockEntry = localLock.skills[skillName];
+        effectiveSource = lockEntry?.source || 'local';
+        effectiveSourceType = lockEntry?.sourceType || 'local';
+        await removeSkillFromLocalLock(skillName, cwd);
       }
 
       results.push({


### PR DESCRIPTION
## Problem

Removing a skill never cleaned up the **project-scoped** lock file (`skills-lock.json`):
the cleanup only ran for the global lock (`isGlobal` branch). This left stale entries
behind on every project-scoped removal.

It also broke `skills update`: when a skill is deleted upstream and the user confirms
removal, `update` calls `removeCommand([skill], { yes: true })`. If the skill's folder
is already gone from disk, the requested name isn't in `installedSkills`, so the command
exits early with `No matching skills found for: <skill>` — **before** the lock entry is
ever removed. The stale entry survives, so the next `update` re-prompts to delete the
same skill, looping forever.

## Fix

- Clean up the **local** lock (`skills-lock.json`) on project-scoped removal, mirroring
  the existing global-lock behavior.
- When a requested skill is missing from disk but still present in a lock file, treat it
  as removable so its stale entry gets cleaned up (filesystem `rm` uses `{ force: true }`,
  so the missing folder is a no-op). Entries that exist in neither disk nor lock are still
  rejected.
- Handle the edge case where **no** skills remain on disk but a stale lock entry is
  targeted, so the early "nothing to remove" return no longer skips lock cleanup.

## Tests

Added cases in `src/remove.test.ts`:
- remove a skill missing from disk but present in the local lock
- clean a stale lock entry when no skills are installed on disk

Fixes #808
Fixes #977

## Relation to existing PRs

This supersedes the narrower lock-cleanup PRs by covering both lock files and the
missing-from-disk path in one change:
- #787 / #585 — clean the project lock only when the skill is still on disk; they don't
  fix the `update`-deleted-upstream loop.
- #416 — prunes stale skills on the `update` side (`cli.ts`); complementary, since this PR
  fixes the `remove` side that `update` delegates to.
