### PR TITLE
fix: remove shell:true on Windows for spawnSync calls

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -456,7 +456,7 @@ export async function updateGlobalSkills(
     const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
-      shell: process.platform === 'win32',
+      shell: false,
     });
 
     if (result.status === 0) {
@@ -592,7 +592,7 @@ export async function updateProjectSkills(
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
-          shell: process.platform === 'win32',
+          shell: false,
         }
       );
 


### PR DESCRIPTION
## Problem

When Node.js is installed to a path containing spaces (e.g. `C:\Program Files\nodejs\node.exe`), using `shell: process.platform === 'win32'` in `spawnSync` causes the spawned process to fail. On Windows, `shell: true` routes execution through `cmd.exe`, which does not properly handle unquoted paths with spaces.

This affects both `updateGlobalSkills()` and `updateProjectSkills()` in `update.ts`.

## Root Cause

```ts
const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, ...], {
  shell: process.platform === 'win32',  // broken when Node path has spaces
});
```

`process.execPath` is always a fully-qualified path to the Node binary. Wrapping it with `shell: true` on Windows passes it to `cmd.exe` unquoted, which breaks when the path contains spaces.

## Fix

Set `shell: false` (the Node.js default). Since the binary path is explicit and fully-qualified, `shell` is unnecessary on all platforms.

## Affected locations

- `updateGlobalSkills()` (~line 459)
- `updateProjectSkills()` (~line 595)