### PR TITLE
fix: expand source shorthand to full URL before cloneRepo in project update

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -12,6 +12,7 @@ import {
   buildUpdateInstallSource,
   buildLocalUpdateSource,
 } from './update-source.ts';
+import { parseSource } from './source-parser.ts';
 import { cloneRepo, cleanupTempDir } from './git.ts';
 import { discoverSkills } from './skills.ts';
 import { fetchRepoTree, findSkillMdPaths, getSkillFolderHashFromTree } from './blob.ts';
@@ -544,7 +545,7 @@ export async function updateProjectSkills(
 
   for (const [source, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
-    const sourceUrl = firstEntry.source;
+    const sourceUrl = parseSource(firstEntry.source).url || firstEntry.source;
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)


### PR DESCRIPTION
## Problem

`skills update -p` (project-level update) prints:

```
✗ Failed to check for deleted skills from github/awesome-copilot
```

This happens when skills were installed from a GitHub shorthand source (e.g. `github/awesome-copilot`).

## Root Cause

`updateProjectSkills()` iterates over skills grouped by source and calls `cloneRepo(sourceUrl)` to detect deleted skills. It was passing `firstEntry.source` verbatim:

```ts
const sourceUrl = firstEntry.source;  // "github/awesome-copilot" — not a valid git remote
```

`cloneRepo()` runs `git clone <url>` directly. A bare shorthand like `github/awesome-copilot` is not a valid git URL, so the clone fails.

The `LocalSkillLockEntry` type (used by project-level locks) stores only the shorthand in `source`, unlike the global `SkillLockEntry` which also has a `sourceUrl` field containing the full HTTPS URL.

## Fix

Use the already-available `parseSource()` helper (from `source-parser.ts`) to expand the shorthand to a full HTTPS URL before passing it to `cloneRepo()`:

```ts
// Before
const sourceUrl = firstEntry.source;

// After
const sourceUrl = parseSource(firstEntry.source).url || firstEntry.source;
```

`parseSource('github/awesome-copilot').url` returns `https://github.com/github/awesome-copilot.git`.

The fallback `|| firstEntry.source` preserves behavior for non-shorthand sources (e.g. full HTTPS URLs already stored directly in the lock file).

## Notes

- `parseSource` is already used elsewhere in the codebase and is exported from `source-parser.ts`
- `updateGlobalSkills()` avoids this code path for GitHub-type sources by using the GitHub Tree API instead; project updates lack that branch and fall through to `cloneRepo()`
