### PR TITLE
feat: add ai-assist agent registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [67 more](#supported-agents).
+
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -239,6 +241,7 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:start -->
 | Agent | `--agent` | Project Path | Global Path |
 |-------|-----------|--------------|-------------|
+| [AI Assist](https://github.com/fredericlepied/ai-assist) | `ai-assist` | `.agents/skills/` | `~/.agents/skills/` |
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
 | Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -9,6 +9,7 @@ const home = homedir();
 const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
+const aiAssistHome = process.env.AI_ASSIST_CONFIG_DIR?.trim() || join(home, '.ai-assist');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
@@ -32,6 +33,15 @@ export function getOpenClawGlobalSkillsDir(
 }
 
 export const agents: Record<AgentType, AgentConfig> = {
+  'ai-assist': {
+    name: 'ai-assist',
+    displayName: 'AI Assist',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
+    detectInstalled: async () => {
+      return existsSync(aiAssistHome);
+    },
+  },
   'aider-desk': {
     name: 'aider-desk',
     displayName: 'AiderDesk',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type AgentType =
+  | 'ai-assist'
   | 'aider-desk'
   | 'amp'
   | 'antigravity'


### PR DESCRIPTION
## Summary

- Register [AI Assist](https://github.com/fredericlepied/ai-assist) as a supported agent
- Uses the universal `.agents/skills` directory (no agent-specific directory needed)
- Respects `AI_ASSIST_CONFIG_DIR` environment variable for detection
- Add AI Assist to the supported agents table in README

## Files changed

- `src/types.ts` — add `'ai-assist'` to `AgentType` union
- `src/agents.ts` — add agent config with `aiAssistHome` variable and detection
- `README.md` — add AI Assist to supported agents table

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 478 passing (4 pre-existing failures unrelated to this change)
- [x] `skills add ./path --agent ai-assist -g -y` installs to `~/.agents/skills/`
- [x] `skills list` shows skill under "AI Assist"
- [x] Auto-detection works when `~/.ai-assist` exists
