### PR TITLE
fix(antigravity): correct global skills path for Antigravity 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Skills can be installed to any of these agents:
 |-------|-----------|--------------|-------------|
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
-| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
+| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/config/skills/` |
 | Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~/.gemini/antigravity-cli/skills/` |
 | AstrBot | `astrbot` | `data/skills/` | `~/.astrbot/data/skills/` |
 | Autohand Code CLI | `autohand-code` | `.autohand/skills/` | `~/.autohand/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -54,9 +54,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'antigravity',
     displayName: 'Antigravity',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity/skills'),
+    globalSkillsDir: join(home, '.gemini/config/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.gemini/antigravity'));
+      return existsSync(join(home, '.gemini/config'));
     },
   },
   'antigravity-cli': {


### PR DESCRIPTION
## Problem

The `antigravity` agent points its global skills directory at `~/.gemini/antigravity/skills` and detects an install by checking for `~/.gemini/antigravity`. Neither path exists on a real Antigravity 2.0 install, so `skills add -g -a antigravity` writes skills where Antigravity never looks, and auto-detection never fires.

Per the [Antigravity skills docs](https://antigravity.google/docs/skills):

| Scope | Path |
|---|---|
| Workspace | `<workspace-root>/.agents/skills/` |
| Global | `~/.gemini/config/skills/` |

Antigravity 2.0 migrated its config home to `~/.gemini/config/` (the old `~/.gemini/antigravity/` layout is gone). This is the same path mismatch reported in google/agents-cli#26.

## Fix

- `globalSkillsDir`: `~/.gemini/antigravity/skills` → `~/.gemini/config/skills`
- `detectInstalled`: check `~/.gemini/config` instead of `~/.gemini/antigravity`
- README path table updated to match

The project-level path (`.agents/skills/`) was already correct and is unchanged. The separate `antigravity-cli` agent is unaffected.