### PR TITLE
fix(add): skip agents without global support instead of failing per skill

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -90,6 +90,29 @@ Instructions here.
     expect(result.exitCode).toBe(0);
   });
 
+  it('should skip agents without global support instead of failing per skill', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+# My Skill
+`
+    );
+
+    const result = runCli(['add', testDir, '-y', '-g', '--agent', 'promptscript'], testDir);
+    const output = result.stdout + result.stderr;
+
+    expect(output).toContain('Skipping PromptScript');
+    expect(output).not.toContain('does not support global skill installation');
+    expect(output).toContain('None of the selected agents support global installation');
+    expect(result.exitCode).toBe(1);
+  });
+
   it('should filter skills by name with --skill flag', () => {
     // Create multiple test skills
     const skill1Dir = join(testDir, 'skills', 'skill-one');

--- a/src/add.ts
+++ b/src/add.ts
@@ -649,6 +649,25 @@ async function handleWellKnownSkills(
     installGlobally = scope as boolean;
   }
 
+  // Agents without a global skills directory can't be targeted with --global.
+  // Drop them (with a notice) instead of attempting and failing once per skill.
+  if (installGlobally) {
+    const unsupported = targetAgents.filter((a) => agents[a].globalSkillsDir === undefined);
+    if (unsupported.length > 0) {
+      p.log.info(
+        `Skipping ${unsupported
+          .map((a) => agents[a].displayName)
+          .join(', ')} — no global install support`
+      );
+      targetAgents = targetAgents.filter((a) => agents[a].globalSkillsDir !== undefined);
+    }
+
+    if (targetAgents.length === 0) {
+      p.log.error('None of the selected agents support global installation.');
+      process.exit(1);
+    }
+  }
+
   // Determine install mode (symlink vs copy)
   let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
@@ -1363,6 +1382,26 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       installGlobally = scope as boolean;
+    }
+
+    // Agents without a global skills directory can't be targeted with --global.
+    // Drop them (with a notice) instead of attempting and failing once per skill.
+    if (installGlobally) {
+      const unsupported = targetAgents.filter((a) => agents[a].globalSkillsDir === undefined);
+      if (unsupported.length > 0) {
+        p.log.info(
+          `Skipping ${unsupported
+            .map((a) => agents[a].displayName)
+            .join(', ')} — no global install support`
+        );
+        targetAgents = targetAgents.filter((a) => agents[a].globalSkillsDir !== undefined);
+      }
+
+      if (targetAgents.length === 0) {
+        p.log.error('None of the selected agents support global installation.');
+        await cleanup(tempDir);
+        process.exit(1);
+      }
     }
 
     // Determine install mode (symlink vs copy)


### PR DESCRIPTION
Fixes #1352

## Problem

Installing globally (`-g`/`--global`) to an agent whose config has `globalSkillsDir: undefined` produces a hard error **for every skill**:

```
✗ google-agents-cli-adk-code → PromptScript: PromptScript does not support global skill installation
✗ google-agents-cli-deploy   → PromptScript: PromptScript does not support global skill installation
... (one per skill)
```

`PromptScript` is currently the only such agent. It surfaces whenever all agents get selected — i.e. `--all` / `--agent '*'`, or `-y` with no detected agents — which is exactly the repro in #1352 (`skills add <source> --global --all`).

## Fix

Before the install loop, when installing globally, filter out agents that don't support global installs, with a one-line notice, and error clearly only if *none* of the selected agents support it:

```
ℹ Skipping PromptScript — no global install support
```

This matches the expected behavior in #1352 (skip incompatible agents instead of failing) and is future-proof for any other agent defined with `globalSkillsDir: undefined`. Applied to both global-install code paths in `add.ts` (`runAdd` and the well-known-skills flow).

## Test

Added a test in `add.test.ts` asserting that `add -g --agent promptscript` skips PromptScript (no per-skill failure) and exits with a clear message instead.