### PR TITLE
fix(agents): give PromptScript a global skills dir

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -661,7 +661,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'promptscript',
     displayName: 'PromptScript',
     skillsDir: '.agents/skills',
-    globalSkillsDir: undefined,
+    globalSkillsDir: join(configHome, 'agents/skills'),
     showInUniversalPrompt: false,
     detectInstalled: async () => {
       return (


### PR DESCRIPTION
@
## Problem

Running `skills add <source> -y -g` inside an AI agent host prints:

```
x  Failed to install 1
   <skill> -> PromptScript: PromptScript does not support global skill installation
```

The install actually succeeds for the universal `.agents/skills` target. The noise comes from a single target: `promptscript` is the only universal agent (`skillsDir: ".agents/skills"`) whose `globalSkillsDir` is `undefined`. When an AI host is detected, `runAdd` sets `options.agent = ensureUniversalAgents([mappedAgent])`, which includes `promptscript`; with `-g`, resolving its global dir fails and the installer emits the failure line, which reads as a failed install.

## Fix

Point `promptscript.globalSkillsDir` at the shared universal global location `join(configHome, "agents/skills")` -- the same path `amp`, `replit`, and `universal` already use. PromptScript shares `skillsDir: ".agents/skills"` with them, so its global counterpart should be the same shared dir. Global install then resolves cleanly and the spurious failure line disappears. Because all universal agents resolve to the same directory, no duplicate copy or extra symlink is created.

```diff
   promptscript: {
     name: "promptscript",
     displayName: "PromptScript",
     skillsDir: ".agents/skills",
-    globalSkillsDir: undefined,
+    globalSkillsDir: join(configHome, "agents/skills"),
     showInUniversalPrompt: false,
```
@