### PR TITLE
fix: skip reinstall of project skills whose content hash is unchanged

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -527,6 +527,7 @@ export async function updateProjectSkills(
   console.log();
 
   const bySource = new Map<string, typeof updatable>();
+  const needsUpdate = new Set<string>();
   for (const skill of updatable) {
     const source = skill.entry.source;
     const existing = bySource.get(source) || [];
@@ -571,15 +572,33 @@ export async function updateProjectSkills(
         options,
         discoveredPaths
       );
+
+      // Compare hashes to skip skills whose content hasn't changed upstream.
+      // computedHash in the local lock is a SHA-256 of the skill folder contents;
+      // compute the same hash from the cloned tempDir and skip if equal.
+      for (const skill of skillsForSource) {
+        if (deletedSkills.includes(skill.name) || !skill.entry.skillPath) continue;
+        if (!discoveredPaths.includes(skill.entry.skillPath)) continue;
+        const latestHash = await computeSkillFolderHash(
+          join(tempDir!, dirname(skill.entry.skillPath))
+        );
+        if (!latestHash || latestHash !== skill.entry.computedHash) {
+          needsUpdate.add(skill.name);
+        }
+      }
     } catch (error) {
       console.log(`${DIM}✗ Failed to check for deleted skills from ${source}${RESET}`);
+      // Can't verify hashes — conservatively mark all skills for reinstall.
+      skillsForSource.forEach((s) => needsUpdate.add(s.name));
     } finally {
       if (tempDir) {
         await cleanupTempDir(tempDir);
       }
     }
 
-    const remainingSkills = skillsForSource.filter((s) => !deletedSkills.includes(s.name));
+    const remainingSkills = skillsForSource.filter(
+      (s) => !deletedSkills.includes(s.name) && needsUpdate.has(s.name)
+    );
 
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);


### PR DESCRIPTION
## Problem

`skills update -p` reinstalls every project skill on every run, even when nothing has changed upstream.

For a project with many skills this is slow — it spawns a separate `skills add` child process per skill, each of which downloads and copies files unnecessarily.

## Root Cause

`updateProjectSkills()` clones the upstream repo to check for deleted skills, then unconditionally reinstalls every non-deleted skill:

```ts
const remainingSkills = skillsForSource.filter((s) => !deletedSkills.includes(s.name));
for (const skill of remainingSkills) {
  // always reinstalls, no hash check
  spawnSync(process.execPath, [cliEntry, 'add', installUrl, '--skill', skill.name, '-y'], ...);
}
```

The project lock file (`skills-lock.json`) already stores a `computedHash` for each skill — a SHA-256 of all files in the skill folder. The global update path (`updateGlobalSkills`) already uses an equivalent check (`skillFolderHash`) to skip unchanged skills. The project update path was never given the same treatment.

## Fix

While the tempDir from the deletion-check clone is still available, compute `computeSkillFolderHash()` for each skill's folder and compare it against `entry.computedHash` from the lock file. Only add skills to the reinstall set if the hash differs.

```ts
for (const skill of skillsForSource) {
  if (deletedSkills.includes(skill.name) || !skill.entry.skillPath) continue;
  if (!discoveredPaths.includes(skill.entry.skillPath)) continue;
  const latestHash = await computeSkillFolderHash(
    join(tempDir!, dirname(skill.entry.skillPath))
  );
  if (!latestHash || latestHash !== skill.entry.computedHash) {
    needsUpdate.add(skill.name);
  }
}
```

On clone failure, all skills are conservatively marked for reinstall — same behavior as before.

## Result

On a project with 28 skills where nothing upstream had changed, `skills update -p` went from reinstalling all 28 to reinstalling 0.

## Notes

- No new imports needed: `computeSkillFolderHash` is already imported from `./local-lock.ts` and `dirname` is already imported from `path`
- The reuse of the existing `tempDir` means no extra clone cost
- Skills without a `skillPath` (legacy entries) are excluded from the hash check and remain in the legacy reinstall path unchanged
