### PR TITLE
fix: use web-design-guidelines skill for docs instead of nextjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npx skills add vercel-labs/agent-skills
 Generate a prompt for one skill, or start a supported coding agent interactively:
 
 ```bash
-npx skills use vercel-labs/agent-skills@nextjs | claude
-npx skills use vercel-labs/agent-skills --skill nextjs --agent claude-code
+npx skills use vercel-labs/agent-skills@web-design-guidelines | claude
+npx skills use vercel-labs/agent-skills --skill web-design-guidelines --agent claude-code
 ```
 
 `skills use` resolves sources the same way as `skills add`, writes the selected skill files to a temporary directory, and prints only the generated prompt to stdout unless `--agent` is provided. With `--agent`, it starts one supported agent interactively with the generated prompt.

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -39,19 +39,27 @@ describe('use command', () => {
 
   describe('parseUseOptions', () => {
     it('parses owner/repo@skill as the source', () => {
-      const result = parseUseOptions(['vercel-labs/agent-skills@nextjs']);
+      const result = parseUseOptions(['vercel-labs/agent-skills@web-design-guidelines']);
 
-      expect(result.source).toEqual(['vercel-labs/agent-skills@nextjs']);
+      expect(result.source).toEqual(['vercel-labs/agent-skills@web-design-guidelines']);
       expect(result.options.skill).toBeUndefined();
       expect(result.errors).toEqual([]);
     });
 
     it('parses --skill and -s selectors', () => {
-      const longFlag = parseUseOptions(['vercel-labs/agent-skills', '--skill', 'nextjs']);
-      const shortFlag = parseUseOptions(['vercel-labs/agent-skills', '-s', 'nextjs']);
+      const longFlag = parseUseOptions([
+        'vercel-labs/agent-skills',
+        '--skill',
+        'web-design-guidelines',
+      ]);
+      const shortFlag = parseUseOptions([
+        'vercel-labs/agent-skills',
+        '-s',
+        'web-design-guidelines',
+      ]);
 
-      expect(longFlag.options.skill).toBe('nextjs');
-      expect(shortFlag.options.skill).toBe('nextjs');
+      expect(longFlag.options.skill).toBe('web-design-guidelines');
+      expect(shortFlag.options.skill).toBe('web-design-guidelines');
       expect(longFlag.errors).toEqual([]);
       expect(shortFlag.errors).toEqual([]);
     });
@@ -82,7 +90,7 @@ describe('use command', () => {
 
     it('rejects wildcard, missing, invalid, and multiple agents', () => {
       const wildcard = parseUseOptions(['source', '--agent', '*']);
-      const missing = parseUseOptions(['source', '--agent', '--skill', 'nextjs']);
+      const missing = parseUseOptions(['source', '--agent', '--skill', 'web-design-guidelines']);
       const invalid = parseUseOptions(['source', '--agent', 'not-an-agent']);
       const multiple = parseUseOptions(['source', '--agent', 'claude-code', 'codex']);
 
@@ -282,7 +290,12 @@ describe('use command', () => {
 
     it('fails for conflicting @skill and --skill selectors before downloading', () => {
       const result = runCli(
-        ['use', 'vercel-labs/agent-skills@nextjs', '--skill', 'react-best-practices'],
+        [
+          'use',
+          'vercel-labs/agent-skills@web-design-guidelines',
+          '--skill',
+          'react-best-practices',
+        ],
         testDir
       );
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -383,9 +383,9 @@ Options:
   -h, --help            Show this help message
 
 Examples:
-  skills use vercel-labs/agent-skills@nextjs | claude
-  skills use vercel-labs/agent-skills --skill nextjs --agent claude-code
-  skills use vercel-labs/agent-skills@nextjs --agent codex`;
+  skills use vercel-labs/agent-skills@web-design-guidelines | claude
+  skills use vercel-labs/agent-skills --skill web-design-guidelines --agent claude-code
+  skills use vercel-labs/agent-skills@web-design-guidelines --agent codex`;
 }
 
 function resolveSelector(sourceSelector?: string, optionSelector?: string): string | undefined {


### PR DESCRIPTION
nextjs skill does not live in `vercel-labs/agent-skills` so the command from the docs errors out.