### PR TITLE
Fix Windows update subprocess spawning

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -456,7 +456,6 @@ export async function updateGlobalSkills(
     const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
-      shell: process.platform === 'win32',
     });
 
     if (result.status === 0) {
@@ -592,7 +591,6 @@ export async function updateProjectSkills(
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
-          shell: process.platform === 'win32',
         }
       );
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -7,6 +7,7 @@ import * as localLock from '../src/local-lock.ts';
 import * as skillLock from '../src/skill-lock.ts';
 import * as remove from '../src/remove.ts';
 import * as p from '@clack/prompts';
+import * as childProcess from 'child_process';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -120,6 +121,11 @@ describe('Update Cleanup Unit Tests', () => {
       expect(remove.removeCommand).toHaveBeenCalledWith(
         ['skill-b'],
         expect.objectContaining({ yes: true, global: false })
+      );
+      expect(childProcess.spawnSync).toHaveBeenCalledWith(
+        process.execPath,
+        expect.any(Array),
+        expect.not.objectContaining({ shell: expect.anything() })
       );
     });
 
@@ -266,6 +272,11 @@ describe('Update Cleanup Unit Tests', () => {
       expect(git.cloneRepo).toHaveBeenCalledWith('git@github.com:owner/repo.git', undefined);
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'skills/skill-a')
+      );
+      expect(childProcess.spawnSync).toHaveBeenCalledWith(
+        process.execPath,
+        expect.any(Array),
+        expect.not.objectContaining({ shell: expect.anything() })
       );
     });
   });


### PR DESCRIPTION
## What changed

I removed the Windows-only `shell: true` wrapper from the `spawnSync(process.execPath, ...)` calls used by `skills update` when it reinvokes `skills add`.

## Why

I hit a case where installing a GitHub skill worked, but updating it failed:

```text
npx skills update
...
Found 1 global update(s)
Updating git-commit-logically...
  x Failed to update git-commit-logically
```

Running the equivalent add command directly worked:

```text
npx skills add Nick2bad4u/git-commit-logically -g -y
```

The difference was the update path. It shells out with `spawnSync(process.execPath, args, { shell: true })` on Windows. On my machine, `process.execPath` is:

```text
C:\Program Files\nodejs\node.exe
```

With `shell: true`, that path was not quoted safely through `cmd.exe`, so the child process failed with:

```text
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

That also matches Node's warning about passing args with `shell: true`. Since these calls already pass an executable plus an argv array, the shell is not needed and removing it lets Node spawn the process directly.

This updates both the global and project update paths and adds regression assertions that update subprocess calls do not include a shell option.

## Validation

Passed:

```text
pnpm vitest run tests/update.test.ts src/update-source.test.ts
pnpm exec prettier --check src/update.ts tests/update.test.ts
pnpm build
```

I also smoke-tested the built CLI on Windows using a temporary project directory with spaces in its path and a stale `skills-lock.json` pointing at a local git skill source. That exercised the fixed project update path and successfully reinvoked `skills add` through `process.execPath`:

```text
node C:\Repos\skills\bin\cli.mjs update -p -y
...
Updating update-realtest...
  ✓ Updated update-realtest

✓ Updated 1 skill(s)
```

I also ran the full suite and typecheck. They currently fail on unrelated existing issues in this checkout:

```text
pnpm test
# 3 unrelated failures in banner/remove expectations

pnpm run type-check
# existing TypeScript errors in src/git.ts and src/skills.ts
```
