### PR TITLE
Add Codex as a dedicated skills target

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Skills can be installed to any of these agents:
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codemaker | `codemaker` | `.codemaker/skills/` | `~/.codemaker/skills/` |
 | Code Studio | `codestudio` | `.codestudio/skills/` | `~/.codestudio/skills/` |
-| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
+| Codex | `codex` | `.codex/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
 | Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
@@ -388,6 +388,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.codebuddy/skills/`
 - `.codemaker/skills/`
 - `.codestudio/skills/`
+- `.codex/skills/`
 - `.commandcode/skills/`
 - `.continue/skills/`
 - `.cortex/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -174,7 +174,7 @@ export const agents: Record<AgentType, AgentConfig> = {
   codex: {
     name: 'codex',
     displayName: 'Codex',
-    skillsDir: '.agents/skills',
+    skillsDir: '.codex/skills',
     globalSkillsDir: join(codexHome, 'skills'),
     detectInstalled: async () => {
       return existsSync(codexHome) || existsSync('/etc/codex');

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -59,6 +59,13 @@ describe('XDG config paths', () => {
     });
   });
 
+  describe('Codex', () => {
+    it('uses ~/.codex/skills for global skills', () => {
+      const expected = join(home, '.codex', 'skills');
+      expect(agents.codex.globalSkillsDir).toBe(expected);
+    });
+  });
+
   describe('Goose', () => {
     it('uses ~/.config/goose/skills for global skills', () => {
       const expected = join(home, '.config', 'goose', 'skills');


### PR DESCRIPTION
## Summary
- make Codex use its dedicated `.codex/skills` project path so it appears as a selectable agent target instead of being grouped under universal `.agents/skills`
- keep Codex global installs under `CODEX_HOME/skills` (default `~/.codex/skills`)
- update the supported agents table and skill discovery paths
- add path coverage for Codex

## Verification
- `pnpm test tests/xdg-config-paths.test.ts`
- `pnpm format:check`
- `git diff --check`
- E2E: `HOME=<tmp>/home CODEX_HOME=<tmp>/codex pnpm dev add https://github.com/cloudflare/skills --skill cloudflare --agent codex --global --yes` installed to `<tmp>/codex/skills/cloudflare/SKILL.md`

## Notes
- `pnpm type-check` currently fails on existing unrelated errors in `src/git.ts` and `src/skills.ts`.
- Full `pnpm test` has 3 failures in this Codex-hosted environment because `@vercel/detect-agent` sees `CODEX_*` variables and switches banner/remove tests into non-interactive Codex mode.