### PR TITLE
fix: create agent dir for explicitly-selected non-universal agents

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync, lstatSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
@@ -129,10 +129,11 @@ description: Detected agent dir creation
 
     expect(result.exitCode).toBe(0);
 
-    // The skill must be symlinked into the project's .claude/skills.
+    // The skill must be materialized into the project's .claude/skills so the
+    // detected agent can read it (symlink on POSIX, junction/copy on Windows).
     const linked = join(projectDir, '.claude', 'skills', 'detected-skill');
     expect(existsSync(linked)).toBe(true);
-    expect(lstatSync(linked).isSymbolicLink()).toBe(true);
+    expect(readFileSync(join(linked, 'SKILL.md'), 'utf-8')).toContain('detected-skill');
   });
 
   it('should filter skills by name with --skill flag', () => {

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -90,6 +90,43 @@ Instructions here.
     expect(result.exitCode).toBe(0);
   });
 
+  // Coverage for the global non-universal-agent install (#851 / #744): a global
+  // `-g -a claude-code` install must place the skill where claude-code reads it
+  // (~/.claude/skills), not only in the canonical ~/.agents/skills. The current
+  // behavior is correct; this locks it in. HOME and CLAUDE_CONFIG_DIR are isolated
+  // into testDir so the test never touches the real home directory.
+  it('installs a global skill into the claude-code global dir (~/.claude/skills)', () => {
+    const sourceRoot = join(testDir, 'source');
+    const skillDir = join(sourceRoot, 'skills', 'global-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: global-skill
+description: Global install for a non-universal agent
+---
+
+# Global Skill
+`
+    );
+
+    const fakeHome = join(testDir, 'home');
+    const claudeConfig = join(fakeHome, '.claude');
+    mkdirSync(claudeConfig, { recursive: true });
+
+    const result = runCli(['add', sourceRoot, '-y', '-g', '-a', 'claude-code'], testDir, {
+      HOME: fakeHome,
+      CLAUDE_CONFIG_DIR: claudeConfig,
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    // The skill must be readable from claude-code's global skills dir.
+    const installed = join(claudeConfig, 'skills', 'global-skill');
+    expect(existsSync(installed)).toBe(true);
+    expect(readFileSync(join(installed, 'SKILL.md'), 'utf-8')).toContain('global-skill');
+  });
+
   // Regression: a non-universal agent that is auto-detected (NOT passed via -a) must
   // still get its config dir created when missing. claude-code reads from .claude/skills,
   // so skipping would silently install nothing for it. This covers the detected-agent

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, lstatSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
@@ -88,6 +88,51 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  // Regression: a non-universal agent that is auto-detected (NOT passed via -a) must
+  // still get its config dir created when missing. claude-code reads from .claude/skills,
+  // so skipping would silently install nothing for it. This covers the detected-agent
+  // path, not just the explicit `-a` flag.
+  it('creates missing .claude/skills for an auto-detected (non -a) agent', () => {
+    // Skill to install from a local source directory.
+    const sourceRoot = join(testDir, 'source');
+    const skillDir = join(sourceRoot, 'skills', 'detected-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: detected-skill
+description: Detected agent dir creation
+---
+
+# Detected Skill
+`
+    );
+
+    // Project to install into — no .claude/ present.
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    // Isolate detection: an empty HOME means no agents are detected via the home dir,
+    // while CLAUDE_CONFIG_DIR pointing at an existing dir makes claude-code the single
+    // detected agent — so it is selected without `-a`.
+    const fakeHome = join(testDir, 'home');
+    const claudeConfig = join(testDir, 'claude-config');
+    mkdirSync(fakeHome, { recursive: true });
+    mkdirSync(claudeConfig, { recursive: true });
+
+    const result = runCli(['add', sourceRoot, '-y'], projectDir, {
+      HOME: fakeHome,
+      CLAUDE_CONFIG_DIR: claudeConfig,
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    // The skill must be symlinked into the project's .claude/skills.
+    const linked = join(projectDir, '.claude', 'skills', 'detected-skill');
+    expect(existsSync(linked)).toBe(true);
+    expect(lstatSync(linked).isSymbolicLink()).toBe(true);
   });
 
   it('should filter skills by name with --skill flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1261,11 +1261,16 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       : Promise.resolve(null);
 
     let targetAgents: AgentType[];
+    // Blanket install to every known agent (e.g. `--agent '*'`). In this mode we
+    // skip non-universal agents whose config dir doesn't exist; when agents are
+    // explicitly selected we honor the choice and create their directories.
+    let installToAllAgents = false;
     const validAgents = Object.keys(agents);
 
     if (options.agent?.includes('*')) {
       // --agent '*' selects all agents
       targetAgents = validAgents as AgentType[];
+      installToAllAgents = true;
       p.log.info(`Installing to all ${targetAgents.length} agents`);
     } else if (options.agent && options.agent.length > 0) {
       const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -1287,6 +1292,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       if (installedAgents.length === 0) {
         if (options.yes) {
           targetAgents = validAgents as AgentType[];
+          installToAllAgents = true;
           p.log.info('Installing to all agents');
         } else {
           p.log.info('Select agents to install skills to');
@@ -1535,13 +1541,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode }
+            { global: installGlobally, mode: installMode, explicitAgents: !installToAllAgents }
           );
         } else {
           // Disk-based install: copy from cloned/local directory
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
+            explicitAgents: !installToAllAgents,
           });
         }
         results.push({

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -227,7 +227,7 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; explicitAgents?: boolean } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -309,7 +309,12 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    //
+    // Only applies to blanket installs (e.g. `--agent '*'`). When the user
+    // explicitly selects an agent, honor that choice and create its directory —
+    // non-universal agents like Claude Code (.claude/skills) cannot read from
+    // .agents/skills, so skipping would silently fail to install the skill for them.
+    if (!isGlobal && !isUniversalAgent(agentType) && !options.explicitAgents) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir)) {
         return {
@@ -738,7 +743,7 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; explicitAgents?: boolean } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -813,8 +818,10 @@ export async function installBlobSkillForAgent(
     }
 
     // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    // whose config directory doesn't already exist in the project. Only applies to
+    // blanket installs — when the user explicitly selects an agent, honor that choice
+    // and create its directory (see installSkillForAgent for the full rationale).
+    if (!isGlobal && !isUniversalAgent(agentType) && !options.explicitAgents) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir)) {
         return {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -226,12 +226,17 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
 
   // 3. Select agents
   let targetAgents: AgentType[];
+  // Blanket install to every known agent (e.g. `--agent '*'`). In this mode we skip
+  // non-universal agents whose config dir doesn't exist; when agents are explicitly
+  // selected we honor the choice and create their directories.
+  let installToAllAgents = false;
   const validAgents = Object.keys(agents);
   const universalAgents = getUniversalAgents();
   const visibleUniversalAgents = getVisibleUniversalAgents();
 
   if (options.agent?.includes('*')) {
     targetAgents = validAgents as AgentType[];
+    installToAllAgents = true;
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -361,6 +366,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         global: false,
         cwd,
         mode: 'symlink',
+        explicitAgents: !installToAllAgents,
       });
       results.push({
         skill: skill.name,

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -242,17 +242,15 @@ describe('installer symlink regression', () => {
 
       expect(result.success).toBe(true);
       expect(result.skipped).toBeUndefined();
-      expect(result.symlinkFailed).toBeUndefined();
 
       // Skill exists in the canonical location.
       const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
       expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
 
-      // And it is symlinked into .claude/skills so Claude Code can actually read it.
+      // And it is materialized into .claude/skills so Claude Code can actually read it.
+      // (Symlink on POSIX, junction/copy fallback on Windows — assert the skill is
+      // readable rather than the link type, to stay platform-agnostic like the tests above.)
       const claudeSkillDir = join(projectDir, '.claude/skills', skillName);
-      const linkStats = await lstat(claudeSkillDir);
-      expect(linkStats.isSymbolicLink()).toBe(true);
-
       const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
       expect(contents).toContain(`name: ${skillName}`);
     } finally {

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -187,4 +187,76 @@ describe('installer symlink regression', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  // Regression: a non-universal agent whose config dir doesn't exist in the project
+  // is skipped on a blanket install (default behavior), so we don't create directories
+  // like .claude/ for agents that aren't actually used in the project.
+  it('skips non-universal agent when its config dir is missing (blanket install)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'blanket-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      // No .claude/ dir exists; explicitAgents defaults to false (blanket install).
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+
+      // Skill exists in the canonical location...
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+
+      // ...but no .claude/ directory was created for the unused agent.
+      await expect(lstat(join(projectDir, '.claude'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: when a non-universal agent is explicitly selected, its directory and
+  // symlink must be created even if the dir doesn't exist yet. Claude Code reads from
+  // .claude/skills (not .agents/skills), so skipping would silently install nothing.
+  it('creates symlink for explicitly selected non-universal agent with missing dir', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'explicit-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      // No .claude/ dir exists, but the user explicitly chose claude-code.
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false, explicitAgents: true }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      // Skill exists in the canonical location.
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+
+      // And it is symlinked into .claude/skills so Claude Code can actually read it.
+      const claudeSkillDir = join(projectDir, '.claude/skills', skillName);
+      const linkStats = await lstat(claudeSkillDir);
+      expect(linkStats.isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, lstatSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from '../src/test-utils.ts';
@@ -238,10 +238,11 @@ description: Test explicit agent dir creation
 
       runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
 
-      // The skill must be symlinked into .claude/skills so claude-code can read it.
+      // The skill must be materialized into .claude/skills so claude-code can read it
+      // (symlink on POSIX, junction/copy fallback on Windows — assert readability).
       const linked = join(testDir, '.claude', 'skills', 'sync-explicit-skill');
       expect(existsSync(linked)).toBe(true);
-      expect(lstatSync(linked).isSymbolicLink()).toBe(true);
+      expect(readFileSync(join(linked, 'SKILL.md'), 'utf-8')).toContain('sync-explicit-skill');
     });
   });
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, lstatSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from '../src/test-utils.ts';
@@ -211,6 +211,37 @@ description: Test force
       const result = runCli(['experimental_sync', '-y', '-a', 'claude-code', '--force'], testDir);
       expect(result.stdout).toContain('force-skill');
       expect(result.stdout).not.toContain('All skills are up to date');
+    });
+  });
+
+  // Regression: sync into a non-universal agent (claude-code) whose config dir
+  // doesn't exist yet must still create it when that agent is explicitly selected.
+  // claude-code reads from .claude/skills (not .agents/skills), so skipping would
+  // silently sync nothing usable for it.
+  describe('agent directory creation', () => {
+    it('creates a missing .claude/skills symlink for explicitly selected claude-code', () => {
+      const pkgDir = join(testDir, 'node_modules', 'my-pkg');
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'SKILL.md'),
+        `---
+name: sync-explicit-skill
+description: Test explicit agent dir creation
+---
+
+# Sync Explicit
+`
+      );
+
+      // No .claude/ dir exists in the project before sync.
+      expect(existsSync(join(testDir, '.claude'))).toBe(false);
+
+      runCli(['experimental_sync', '-y', '-a', 'claude-code'], testDir);
+
+      // The skill must be symlinked into .claude/skills so claude-code can read it.
+      const linked = join(testDir, '.claude', 'skills', 'sync-explicit-skill');
+      expect(existsSync(linked)).toBe(true);
+      expect(lstatSync(linked).isSymbolicLink()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Problem

In **symlink mode**, a project-local install silently skips creating the agent
symlink for any non-universal agent whose config directory doesn't already exist
in the project (e.g. `.claude/`, `.windsurf/`, `.kiro/`).

The guard's justifying comment — *"the skill is already available in
`.agents/skills/`"* — only holds for **universal** agents. Agents like Claude
Code read from `.claude/skills`, **not** `.agents/skills`, so skipping the
symlink means the skill is written to `.agents/skills/` and then silently never
reaches the agent the user explicitly asked for. The install summary reports
success with no warning.

This skip is only appropriate for **blanket** installs (e.g. `--agent '*'`),
where avoiding dozens of unused agent directories is the goal. When the user
**explicitly selects** an agent — by flag, by the interactive prompt, or by
auto-detection — that choice should be honored and the directory created.

## Fix

Add an `explicitAgents` option to `installSkillForAgent` and
`installBlobSkillForAgent` that gates the existing "don't auto-create unused
agent dirs" guard. It's threaded through the `add` and `sync` flows and set to
`true` for every selection path **except** the blanket "install to all agents"
case. Blanket-install behavior is unchanged.

```
if (!isGlobal && !isUniversalAgent(agentType) && !options.explicitAgents) {
  // ...skip only on blanket installs
}
```

## Issues

- **Fixes #1355** — `add -a claude-code` (project scope) not creating
  `.claude/skills` (no other open PR covers this one).
- **Fixes #1138** — project-local install silently skipping Claude Code symlinks
  when `.claude/` doesn't pre-exist.
- Related umbrella: #1045.
- **#851 / #744 (global scope)** — these already work in current code; this PR
  adds the **missing regression test** confirming `add -g -a claude-code` lands
  in `~/.claude/skills`.

There are a few in-flight PRs in this area (#1186, #1159, #1150). This one tries
to cover the cases they don't — the interactive / auto-detected selection path
and the `sync` command — and adds tests. Happy to have it folded into one of
those or closed in favor of whichever you prefer.

## Coverage compared with the in-flight PRs

| Case | This PR | #1186 | #1150 |
| --- | :---: | :---: | :---: |
| Explicit `-a` non-universal agent | ✅ | ✅ | ✅ |
| **Interactive / auto-detected** selection | ✅ | ❌ (flag only) | ❌ |
| **`sync` command** path | ✅ | ❌ | ❌ |
| Blanket `--agent '*'` still skips unused dirs | ✅ | ✅ | ✅ |
| Tests | ✅ | ✅ | ❌ |

## Tests

All new tests fail on pre-fix code and pass with the fix (except the global
lock-in test, which documents already-correct behavior):

- `installer-symlink.test.ts` — explicit selection creates the dir; blanket
  install still skips it.
- `add.test.ts` — auto-detected (non-`-a`) agent gets its dir; global
  `-g -a claude-code` lands in `~/.claude/skills` (HOME/`CLAUDE_CONFIG_DIR`
  isolated into the test dir).
- `sync.test.ts` — `sync -a claude-code` creates `.claude/skills` when missing.

Assertions check that the skill is **readable** at the agent path rather than
asserting the link *type*, to stay correct on the Windows CI matrix (junctions /
copy fallback).

Verified locally: `pnpm build`, `pnpm format:check`, and the affected suites all
pass.
