### PR TITLE
fix: retry GitHub tree fetch with auth on 404 so private repos update

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -91,6 +91,8 @@ export function resetRepoTreeAuthState(): void {
 interface BranchFetchResult {
   tree: RepoTree | null;
   rateLimited: boolean;
+  /** 404 from an unauthenticated request — the signature of a private repo. */
+  notFound: boolean;
 }
 
 async function fetchTreeBranch(
@@ -121,6 +123,7 @@ async function fetchTreeBranch(
       return {
         tree: { sha: data.sha, branch, tree: data.tree },
         rateLimited: false,
+        notFound: false,
       };
     }
 
@@ -128,9 +131,13 @@ async function fetchTreeBranch(
     // (A bare 403 means permission denied, which is not retryable here.)
     const rateLimited =
       response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0';
-    return { tree: null, rateLimited };
+    // GitHub returns 404 (not 403) to unauthenticated requests for private
+    // repos, to avoid disclosing their existence. An authenticated retry may
+    // succeed for a user who has access.
+    const notFound = response.status === 404;
+    return { tree: null, rateLimited, notFound };
   } catch {
-    return { tree: null, rateLimited: false };
+    return { tree: null, rateLimited: false, notFound: false };
   }
 }
 
@@ -141,10 +148,14 @@ async function fetchTreeBranch(
  *
  * Authentication is lazy: by default the call goes out unauthenticated,
  * which is enough for the vast majority of users (60 req/hr per IP).
- * Only if GitHub responds with a rate-limit 403 do we ask the optional
- * `getToken` callback for a token and retry. This avoids invoking
- * `gh auth token` on every install, which corporate endpoint security
- * tools flag as suspicious credential extraction. See issue #523.
+ * We only ask the optional `getToken` callback for a token and retry when the
+ * unauthenticated call cannot possibly succeed without one:
+ *   - a rate-limit 403 (X-RateLimit-Remaining: 0), or
+ *   - a 404, which is what GitHub returns to unauthenticated requests for a
+ *     private repo (so `update` can refresh private skills, like `add` does).
+ * The happy path (public repo, 200) never reaches for a token, so this keeps
+ * `gh auth token` from running on ordinary installs — which corporate endpoint
+ * security tools flag as suspicious credential extraction. See issue #523.
  */
 export async function fetchRepoTree(
   ownerRepo: string,
@@ -167,6 +178,7 @@ export async function fetchRepoTree(
 
   // First pass: unauthenticated.
   let rateLimited = false;
+  let notFound = false;
   for (const branch of branches) {
     const result = await fetchTreeBranch(ownerRepo, branch, null);
     if (result.tree) return result.tree;
@@ -176,12 +188,20 @@ export async function fetchRepoTree(
       rateLimited = true;
       break;
     }
+    if (result.notFound) {
+      // Likely a private repo (unauth 404). An auth retry covers all branches,
+      // so stop the unauth pass here.
+      notFound = true;
+      break;
+    }
   }
 
-  if (!rateLimited || !getToken) return null;
+  if ((!rateLimited && !notFound) || !getToken) return null;
 
-  // Lazy fallback: rate limit hit and a token resolver was provided.
-  _rateLimitedThisSession = true;
+  // Lazy fallback: the unauth pass hit a rate limit or a private-repo 404, and
+  // a token resolver was provided. Only memoize the rate-limit case — a private
+  // 404 is repo-specific, so later public repos should still try unauth first.
+  if (rateLimited) _rateLimitedThisSession = true;
   const token = getToken();
   if (!token) return null;
 

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -140,8 +140,8 @@ export function resetGhAuthWarning(): void {
  *    stderr before invoking `gh auth token`, because that subprocess call
  *    is flagged by some corporate endpoint security tooling (Defender, etc.)
  *    as credential extraction. Callers should invoke this function lazily
- *    (e.g. only after an unauthenticated request hits a rate limit) so the
- *    fallback rarely runs in practice.
+ *    (e.g. only after an unauthenticated request hits a rate limit or a
+ *    private-repo 404) so the fallback rarely runs in practice.
  *
  * @returns The token string or null if not available
  */
@@ -157,8 +157,8 @@ export function getGitHubToken(): string | null {
   // Last resort: spawn gh CLI. Warn the user once per process before doing so.
   if (!_ghWarningShown) {
     process.stderr.write(
-      `${pc.yellow('│')}  ${pc.yellow('GitHub rate limit reached')} — using your ${pc.cyan('gh')} login to continue.\n` +
-        `${pc.yellow('│')}  ${pc.dim(`Tip: set ${pc.cyan('GITHUB_TOKEN')} to avoid this prompt, or use ${pc.cyan('--full-depth')} to clone instead.\n`)}`
+      `${pc.yellow('│')}  Using your ${pc.cyan('gh')} login to authenticate with GitHub (rate limit or private repo).\n` +
+        `${pc.yellow('│')}  ${pc.dim(`Tip: set ${pc.cyan('GITHUB_TOKEN')} to avoid this, or use ${pc.cyan('--full-depth')} to clone instead.\n`)}`
     );
     _ghWarningShown = true;
   }

--- a/tests/blob-fetch-tree-auth.test.ts
+++ b/tests/blob-fetch-tree-auth.test.ts
@@ -46,6 +46,14 @@ function permissionDeniedResponse(): Response {
   });
 }
 
+function notFoundResponse(): Response {
+  // GitHub returns 404 to unauthenticated requests for private repos.
+  return new Response(JSON.stringify({ message: 'Not Found' }), {
+    status: 404,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
 describe('fetchRepoTree lazy auth fallback', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
@@ -104,6 +112,64 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
     expect(result).toBeNull();
     expect(getToken).not.toHaveBeenCalled();
+  });
+
+  it('invokes the token resolver and retries with auth on a 404 (private repo)', async () => {
+    // Private repos return 404 to unauthenticated requests; an authenticated
+    // retry can succeed for a user who has access (e.g. `skills update`).
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const result = await fetchRepoTree('private/repo', 'main', getToken);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer ghp_fake_token'
+    );
+  });
+
+  it('returns null on a 404 when no token resolver is provided', async () => {
+    fetchMock.mockResolvedValueOnce(notFoundResponse());
+
+    const result = await fetchRepoTree('private/repo', 'main');
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null on a 404 when the resolver returns null', async () => {
+    fetchMock.mockResolvedValueOnce(notFoundResponse());
+    const getToken = vi.fn(() => null);
+
+    const result = await fetchRepoTree('private/repo', 'main', getToken);
+
+    expect(result).toBeNull();
+    expect(getToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('a private-repo 404 does not make later public repos skip the unauth pass', async () => {
+    // A 404 is repo-specific, not a global rate limit, so it must not poison
+    // the session memo — the next (public) repo should still try unauth first.
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse()) // repo1 unauth → 404
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE)) // repo1 authed → 200
+      .mockResolvedValueOnce(okResponse({ ...SAMPLE_TREE, sha: 'cafef00d' })); // repo2 unauth → 200
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const first = await fetchRepoTree('private/repo', 'main', getToken);
+    const second = await fetchRepoTree('public/repo', 'main', getToken);
+
+    expect(first?.sha).toBe('deadbeef');
+    expect(second?.sha).toBe('cafef00d');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(getToken).toHaveBeenCalledTimes(1); // only the private repo needed a token
+    const repo2FirstInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect((repo2FirstInit.headers as Record<string, string>)['Authorization']).toBeUndefined();
   });
 
   it('returns null gracefully when rate-limited and no token resolver is provided', async () => {


### PR DESCRIPTION
## Summary

`skills update` fails for **private** GitHub repos with `✗ Failed to fetch tree`, even though `skills add` installs/updates them fine. This makes private skills un-updatable via `update`.

## Root cause

`fetchRepoTree` (`src/blob.ts`) probes the GitHub trees API unauthenticated first and only escalates to the `getToken` resolver on a **rate-limit 403**. A private repo returns **404** to unauthenticated requests (GitHub hides its existence), which isn't treated as "auth might help", so it returns `null` without ever trying the user's token.

`add` works on the same repo because it detects private repos (`isRepoPrivate`) and clones with git auth.

Repro:
```sh
skills add --global <owner>/<private-repo>   # works (clones with git auth)
skills update -g                              # ✗ Failed to fetch tree for <owner>/<private-repo>
```
Setting `GITHUB_TOKEN` doesn't help, because the token path is only reachable on a 403 — the 404 short-circuits to `return null` first.

## Fix

Treat a **404** from the unauthenticated pass the same as a rate-limit: escalate once to the `getToken` resolver and retry. This mirrors the existing lazy-auth policy and preserves the intent of #523:

- The happy path (public repo → 200) still **never** reaches for a token, so `gh auth token` stays off ordinary installs.
- A non-rate-limit **403** is still not retried (unchanged; existing test stays green).
- A private-repo 404 does **not** set the rate-limit session memo, so later public repos still try unauthenticated first.

## Tests

Added to `tests/blob-fetch-tree-auth.test.ts`:
- 404 → authenticated retry succeeds, with `Authorization` header on the retry
- 404 with no token resolver → `null`
- 404 with resolver returning `null` → `null`
- a private-repo 404 does not make a subsequent public repo skip the unauth pass (memo isolation)

`pnpm prettier --check` is clean on the touched files. The new + existing `blob-fetch-tree-auth` and `update` suites pass.