### PR TITLE
Improve `skills list -g` performance for linked global agent skill directories

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,7 +1,6 @@
 import {
   mkdir,
   cp,
-  access,
   readdir,
   symlink,
   lstat,
@@ -882,6 +881,65 @@ export async function listInstalledSkills(
   // Use a Map to deduplicate skills by scope:name
   const skillsMap: Map<string, InstalledSkill> = new Map();
   const scopes: Array<{ global: boolean; path: string; agentType?: AgentType }> = [];
+  const parsedSkillCache = new Map<string, Skill | null>();
+  const agentSkillIndexCache = new Map<
+    string,
+    {
+      dirNames: Set<string>;
+      skillNames: Set<string>;
+    }
+  >();
+
+  async function parseSkillMdForList(skillMdPath: string): Promise<Skill | null> {
+    let cacheKey = skillMdPath;
+    try {
+      cacheKey = await realpath(skillMdPath);
+    } catch {
+      // Fall back to the requested path for dangling links or inaccessible files.
+    }
+
+    if (!parsedSkillCache.has(cacheKey)) {
+      parsedSkillCache.set(cacheKey, await parseSkillMd(skillMdPath));
+    }
+
+    return parsedSkillCache.get(cacheKey)!;
+  }
+
+  async function getAgentSkillIndex(agentBase: string): Promise<{
+    dirNames: Set<string>;
+    skillNames: Set<string>;
+  }> {
+    if (agentSkillIndexCache.has(agentBase)) {
+      return agentSkillIndexCache.get(agentBase)!;
+    }
+
+    const index = {
+      dirNames: new Set<string>(),
+      skillNames: new Set<string>(),
+    };
+
+    try {
+      const agentEntries = await readdir(agentBase, { withFileTypes: true });
+      for (const agentEntry of agentEntries) {
+        const candidateDir = join(agentBase, agentEntry.name);
+        if (!(await isDirEntryOrSymlinkToDir(agentEntry, candidateDir))) continue;
+        if (!isPathSafe(agentBase, candidateDir)) continue;
+
+        index.dirNames.add(agentEntry.name);
+        index.dirNames.add(agentEntry.name.toLowerCase());
+
+        const candidateSkill = await parseSkillMdForList(join(candidateDir, 'SKILL.md'));
+        if (candidateSkill) {
+          index.skillNames.add(candidateSkill.name);
+        }
+      }
+    } catch {
+      // Agent base directory doesn't exist or cannot be scanned.
+    }
+
+    agentSkillIndexCache.set(agentBase, index);
+    return index;
+  }
 
   // Detect which agents are actually installed
   const detectedAgents = await detectInstalledAgents();
@@ -938,15 +996,17 @@ export async function listInstalledSkills(
     // skills were installed with `--agent <name>` but the agent is no longer
     // detected (e.g. ~/.openclaw was removed).  Only add dirs that actually
     // exist on disk to avoid unnecessary readdir errors.
-    const allAgentTypes = Object.keys(agents) as AgentType[];
-    for (const agentType of allAgentTypes) {
-      if (agentsToCheck.includes(agentType)) continue;
-      const agent = agents[agentType];
-      if (isGlobal && agent.globalSkillsDir === undefined) continue;
-      const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
-      if (scopes.some((s) => s.path === agentDir && s.global === isGlobal)) continue;
-      if (existsSync(agentDir)) {
-        scopes.push({ global: isGlobal, path: agentDir, agentType });
+    if (!agentFilter) {
+      const allAgentTypes = Object.keys(agents) as AgentType[];
+      for (const agentType of allAgentTypes) {
+        if (agentsToCheck.includes(agentType)) continue;
+        const agent = agents[agentType];
+        if (isGlobal && agent.globalSkillsDir === undefined) continue;
+        const agentDir = isGlobal ? agent.globalSkillsDir! : join(cwd, agent.skillsDir);
+        if (scopes.some((s) => s.path === agentDir && s.global === isGlobal)) continue;
+        if (existsSync(agentDir)) {
+          scopes.push({ global: isGlobal, path: agentDir, agentType });
+        }
       }
     }
   }
@@ -970,7 +1030,7 @@ export async function listInstalledSkills(
         }
 
         // Parse the skill
-        const skill = await parseSkillMd(skillMdPath);
+        const skill = await parseSkillMdForList(skillMdPath);
         if (!skill) {
           continue;
         }
@@ -1024,44 +1084,19 @@ export async function listInstalledSkills(
             ])
           );
 
+          const agentIndex = await getAgentSkillIndex(agentBase);
           for (const possibleName of possibleNames) {
-            const agentSkillDir = join(agentBase, possibleName);
-            if (!isPathSafe(agentBase, agentSkillDir)) continue;
-
-            try {
-              await access(agentSkillDir);
+            if (
+              agentIndex.dirNames.has(possibleName) ||
+              agentIndex.dirNames.has(possibleName.toLowerCase())
+            ) {
               found = true;
               break;
-            } catch {
-              // Try next name
             }
           }
 
-          // Fallback: scan all directories and check SKILL.md files
-          // Handles cases where directory names don't match (e.g., "git-review" vs "Git Review Before Commit")
-          if (!found) {
-            try {
-              const agentEntries = await readdir(agentBase, { withFileTypes: true });
-              for (const agentEntry of agentEntries) {
-                const candidateDir = join(agentBase, agentEntry.name);
-                if (!(await isDirEntryOrSymlinkToDir(agentEntry, candidateDir))) continue;
-                if (!isPathSafe(agentBase, candidateDir)) continue;
-
-                try {
-                  const candidateSkillMd = join(candidateDir, 'SKILL.md');
-                  await stat(candidateSkillMd);
-                  const candidateSkill = await parseSkillMd(candidateSkillMd);
-                  if (candidateSkill && candidateSkill.name === skill.name) {
-                    found = true;
-                    break;
-                  }
-                } catch {
-                  // Not a valid skill directory
-                }
-              }
-            } catch {
-              // Agent base directory doesn't exist
-            }
+          if (!found && agentIndex.skillNames.has(skill.name)) {
+            found = true;
           }
 
           if (found) {

--- a/tests/list-installed.test.ts
+++ b/tests/list-installed.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, writeFile, rm, symlink } from 'fs/promises';
+import { mkdir, writeFile, rm, symlink, realpath } from 'fs/promises';
 import { join } from 'path';
-import { homedir, tmpdir } from 'os';
+import { homedir, tmpdir, platform } from 'os';
 import { listInstalledSkills } from '../src/installer.ts';
 import * as agentsModule from '../src/agents.ts';
 
@@ -116,13 +116,19 @@ ${skillData.description}
   });
 
   it('should handle global scope option', async () => {
-    // Test with global: true - verifies the function doesn't crash
-    // Note: This checks ~/.agents/skills, results depend on system state
-    const skills = await listInstalledSkills({
-      global: true,
-      cwd: testDir,
-    });
-    expect(Array.isArray(skills)).toBe(true);
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue([]);
+
+    try {
+      // Test with global: true while avoiding environment-dependent scans of every installed agent.
+      const skills = await listInstalledSkills({
+        global: true,
+        cwd: testDir,
+        agentFilter: [],
+      });
+      expect(Array.isArray(skills)).toBe(true);
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 
   it('attributes global canonical skills to universal agents with native global dirs', async () => {
@@ -209,32 +215,142 @@ description: Skill reached through a directory symlink
 
     const agentSkillsDir = join(testDir, '.agents', 'skills');
     await mkdir(agentSkillsDir, { recursive: true });
-    await symlink(realSkillDir, join(agentSkillsDir, 'linked-skill'), 'dir');
+    await symlink(
+      realSkillDir,
+      join(agentSkillsDir, 'linked-skill'),
+      platform() === 'win32' ? 'junction' : 'dir'
+    );
 
     const skills = await listInstalledSkills({ global: false, cwd: testDir });
     expect(skills).toHaveLength(1);
     expect(skills[0]!.name).toBe('linked-skill');
   });
 
-  it('should ignore dangling symlinks without a reachable SKILL.md', async () => {
-    const agentSkillsDir = join(testDir, '.agents', 'skills');
-    await mkdir(agentSkillsDir, { recursive: true });
-    await symlink(join(testDir, 'does-not-exist'), join(agentSkillsDir, 'broken'), 'dir');
+  it.skipIf(platform() === 'win32')(
+    'should ignore dangling symlinks without a reachable SKILL.md',
+    async () => {
+      const agentSkillsDir = join(testDir, '.agents', 'skills');
+      await mkdir(agentSkillsDir, { recursive: true });
+      await symlink(join(testDir, 'does-not-exist'), join(agentSkillsDir, 'broken'), 'dir');
 
-    const skills = await listInstalledSkills({ global: false, cwd: testDir });
-    expect(skills).toEqual([]);
+      const skills = await listInstalledSkills({ global: false, cwd: testDir });
+      expect(skills).toEqual([]);
+    }
+  );
+
+  it.skipIf(platform() === 'win32')(
+    'should ignore symlinks that point to a regular file',
+    async () => {
+      const filePath = join(testDir, 'not-a-skill.md');
+      await writeFile(filePath, '# not a skill');
+
+      const agentSkillsDir = join(testDir, '.agents', 'skills');
+      await mkdir(agentSkillsDir, { recursive: true });
+      await symlink(filePath, join(agentSkillsDir, 'file-link'));
+
+      const skills = await listInstalledSkills({ global: false, cwd: testDir });
+      expect(skills).toEqual([]);
+    }
+  );
+
+  it('does not repeatedly parse the same real SKILL.md reached through multiple agent links', async () => {
+    const skillName = 'linked-canonical-skill';
+    const canonicalSkillDir = join(testDir, '.agents', 'skills', skillName);
+    const canonicalSkillMdPath = join(canonicalSkillDir, 'SKILL.md');
+    await mkdir(canonicalSkillDir, { recursive: true });
+    await writeFile(
+      canonicalSkillMdPath,
+      `---
+name: ${skillName}
+description: Skill shared through multiple agent links
+---
+
+# ${skillName}
+`
+    );
+
+    const linkType = platform() === 'win32' ? 'junction' : 'dir';
+    const claudeSkillsDir = join(testDir, '.claude', 'skills');
+    const windsurfSkillsDir = join(testDir, '.windsurf', 'skills');
+    await mkdir(claudeSkillsDir, { recursive: true });
+    await mkdir(windsurfSkillsDir, { recursive: true });
+    await symlink(canonicalSkillDir, join(claudeSkillsDir, skillName), linkType);
+    await symlink(canonicalSkillDir, join(windsurfSkillsDir, skillName), linkType);
+
+    const realCanonicalSkillMdPath = await realpath(canonicalSkillMdPath);
+    const parsedSkillMdRealPaths: string[] = [];
+
+    vi.resetModules();
+    vi.doMock('../src/agents.ts', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../src/agents.ts')>();
+      return {
+        ...actual,
+        detectInstalledAgents: vi.fn().mockResolvedValue(['claude-code', 'windsurf']),
+      };
+    });
+    vi.doMock('../src/skills.ts', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../src/skills.ts')>();
+      return {
+        ...actual,
+        parseSkillMd: vi.fn(async (...args: Parameters<typeof actual.parseSkillMd>) => {
+          const [skillMdPath, options] = args;
+          parsedSkillMdRealPaths.push(await realpath(skillMdPath).catch(() => skillMdPath));
+          return actual.parseSkillMd(skillMdPath, options);
+        }),
+      };
+    });
+
+    try {
+      const { listInstalledSkills: listInstalledSkillsWithMock } =
+        await import('../src/installer.ts');
+
+      const skills = await listInstalledSkillsWithMock({ global: false, cwd: testDir });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.name).toBe(skillName);
+      expect(skills[0]!.agents).toEqual(expect.arrayContaining(['claude-code', 'windsurf']));
+      expect(
+        parsedSkillMdRealPaths.filter((path) => path === realCanonicalSkillMdPath)
+      ).toHaveLength(1);
+    } finally {
+      vi.doUnmock('../src/agents.ts');
+      vi.doUnmock('../src/skills.ts');
+      vi.resetModules();
+    }
   });
 
-  it('should ignore symlinks that point to a regular file', async () => {
-    const filePath = join(testDir, 'not-a-skill.md');
-    await writeFile(filePath, '# not a skill');
+  it('does not scan unrelated agent directories when an agent filter is provided', async () => {
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['codex']);
 
-    const agentSkillsDir = join(testDir, '.agents', 'skills');
-    await mkdir(agentSkillsDir, { recursive: true });
-    await symlink(filePath, join(agentSkillsDir, 'file-link'));
+    await createSkillDir(testDir, 'codex-only-skill', {
+      name: 'codex-only-skill',
+      description: 'Codex skill',
+    });
 
-    const skills = await listInstalledSkills({ global: false, cwd: testDir });
-    expect(skills).toEqual([]);
+    const unrelatedAgentSkillsDir = join(testDir, '.claude', 'skills');
+    await mkdir(join(unrelatedAgentSkillsDir, 'unrelated-skill'), { recursive: true });
+    await writeFile(
+      join(unrelatedAgentSkillsDir, 'unrelated-skill', 'SKILL.md'),
+      `---
+name: unrelated-skill
+description: Unrelated Claude skill
+---
+
+# unrelated-skill
+`
+    );
+
+    try {
+      const skills = await listInstalledSkills({
+        global: false,
+        cwd: testDir,
+        agentFilter: ['codex'],
+      });
+
+      expect(skills.map((skill) => skill.name)).toEqual(['codex-only-skill']);
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 
   // Issue #225 part 2: Skills in agent-specific directories should be found


### PR DESCRIPTION
## Problem

`skills list -g` can become very slow when the same global skills are exposed through many agent-specific skill directories. This is especially visible on Windows, where those agent directories are often Junctions pointing back to the same canonical skills folder.

In my local AI-agent workflow, this command is on the critical path because I run it frequently to let the agent discover the full set of global skills before planning or resuming work. In the reported real-world setup, a single `skills list -g` run commonly took about 20 to 25 seconds and made the machine feel noticeably sluggish.

## Root Cause

`listInstalledSkills()` already deduplicates the final output by skill name and scope, but the global listing path still repeats a lot of filesystem work before that output is produced.

For each canonical skill, the previous implementation checked each detected agent directory with repeated `access()` calls. If directory-name matching did not find the skill, it then fell back to `readdir()` and `parseSkillMd()` for the agent directory. When multiple agent directories point to the same real `SKILL.md`, the same file can be parsed repeatedly in one list operation.

The previous scope discovery also added existing agent directories outside the requested `--agent` filter, so `skills list -g --agent codex` could still scan unrelated agent skill directories.

## Solution

This PR keeps the existing output semantics but reduces repeated small filesystem I/O inside one `listInstalledSkills()` call:

- Cache parsed `SKILL.md` results for the duration of a single list operation.
- Prefer `realpath(SKILL.md)` as the cache key, with a safe fallback to the requested path.
- Build one in-memory index per agent skills directory.
- Store both directory names and frontmatter skill names in the index.
- Replace repeated `access()` / fallback `readdir()` / repeated `parseSkillMd()` work with Set lookups.
- Respect `agentFilter` when adding existing agent directories, so unrelated agents are not scanned when a filter is present.

## Compatibility

The cache is local to a single `listInstalledSkills()` call, so it does not introduce persistent stale state across CLI runs.

The output shape is unchanged. Skills are still deduplicated by scope and name, and the `agents` list is still preserved when the same skill is found through multiple agent directories.

## Tests

Added and updated tests in `tests/list-installed.test.ts`:

- Multiple linked agent directories pointing to the same real `SKILL.md` are merged into one output skill.
- The merged output still preserves the expected agents list.
- The same real `SKILL.md` is parsed once in the linked-directory scenario.
- `agentFilter: ['codex']` does not include skills from unrelated agent directories.
- Windows uses Junctions for linked directory coverage; non-Windows keeps directory symlink coverage.

Local verification:

```text
pnpm test tests/list-installed.test.ts --run
pnpm run format:check
```

Local notes:

```text
pnpm run type-check
pnpm run build
```

These two commands did not complete successfully in my local Windows environment for issues outside the edited files. I will use the GitHub PR checks as the authoritative CI signal and follow up if they fail.

## Before / After

Real-world local case from the linked issue:

Before:

- `skills list -g`: about 20 to 25 seconds
- 60 global skills
- 39 global skill scopes
- 1305 top-level entries
- 1241 Windows Junctions

After applying the same optimization locally:

- `skills list -g`: about 2.2 seconds
- `skills list -g --agent codex`: typically about 0.4 to 0.7 seconds

## Related Issue

Closes https://github.com/vercel-labs/skills/issues/1389