### PR TITLE
fix: install skills once per directory instead of once per agent

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -38,6 +38,7 @@ import {
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
+  dedupeAgentsByDir,
   type InstallMode,
 } from './installer.ts';
 import {
@@ -754,8 +755,13 @@ async function handleWellKnownSkills(
     error?: string;
   }[] = [];
 
+  // Agents sharing a resolved skills directory (e.g. all universal agents
+  // share `.agents/skills`) would otherwise install the same skill to the same
+  // path repeatedly. Install once per distinct directory.
+  const installAgents = dedupeAgentsByDir(targetAgents, { global: installGlobally, cwd });
+
   for (const skill of selectedSkills) {
-    for (const agent of targetAgents) {
+    for (const agent of installAgents) {
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
@@ -1526,8 +1532,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       pluginName?: string;
     }[] = [];
 
+    // Agents sharing a resolved skills directory (e.g. all universal agents
+    // share `.agents/skills`) would otherwise install the same skill to the
+    // same path repeatedly. Install once per distinct directory.
+    const installAgents = dedupeAgentsByDir(targetAgents, { global: installGlobally, cwd });
+
     for (const skill of selectedSkills) {
-      for (const agent of targetAgents) {
+      for (const agent of installAgents) {
         let result;
         if (blobResult && 'files' in skill) {
           // Blob-based install: write files from snapshot

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -111,6 +111,34 @@ export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: str
   return join(baseDir, agent.skillsDir);
 }
 
+/**
+ * Deduplicate agents by their resolved skills directory.
+ *
+ * Many agents — every "universal" agent — share the same canonical
+ * `.agents/skills` directory. Installing a skill once per agent would copy
+ * identical files to that same directory repeatedly (and re-run existence
+ * checks for each), producing redundant filesystem work and duplicated output.
+ *
+ * This keeps only the first agent encountered for each distinct resolved
+ * directory, preserving input order.
+ */
+export function dedupeAgentsByDir(
+  agentTypes: AgentType[],
+  options: { global: boolean; cwd?: string }
+): AgentType[] {
+  const seen = new Set<string>();
+  const deduped: AgentType[] = [];
+
+  for (const agentType of agentTypes) {
+    const baseDir = getAgentBaseDir(agentType, options.global, options.cwd);
+    if (seen.has(baseDir)) continue;
+    seen.add(baseDir);
+    deduped.push(agentType);
+  }
+
+  return deduped;
+}
+
 function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
   return resolve(dirname(linkPath), linkTarget);
 }

--- a/tests/dedupe-agents-by-dir.test.ts
+++ b/tests/dedupe-agents-by-dir.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { dedupeAgentsByDir } from '../src/installer.ts';
+import { getUniversalAgents } from '../src/agents.ts';
+
+describe('dedupeAgentsByDir', () => {
+  it('collapses universal agents that share the canonical skills dir into one', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'dedupe-'));
+    const universal = getUniversalAgents();
+    // Sanity: the regression only matters when several agents share one directory
+    expect(universal.length).toBeGreaterThan(1);
+
+    const result = dedupeAgentsByDir(universal, { global: false, cwd });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(universal[0]);
+  });
+
+  it('keeps agents that resolve to distinct directories', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'dedupe-'));
+    const universal = getUniversalAgents();
+
+    const result = dedupeAgentsByDir([universal[0]!, universal[1]!, 'claude-code'], {
+      global: false,
+      cwd,
+    });
+
+    // The two universal agents collapse to one; claude-code has its own dir and stays.
+    expect(result).toHaveLength(2);
+    expect(result).toContain(universal[0]);
+    expect(result).toContain('claude-code');
+    expect(result).not.toContain(universal[1]);
+  });
+
+  it('preserves input order, keeping the first occurrence of each directory', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'dedupe-'));
+    const universal = getUniversalAgents();
+
+    const result = dedupeAgentsByDir(['claude-code', universal[0]!, universal[1]!], {
+      global: false,
+      cwd,
+    });
+
+    expect(result).toEqual(['claude-code', universal[0]]);
+  });
+});

--- a/tests/install-dedupe.test.ts
+++ b/tests/install-dedupe.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runCli } from '../src/test-utils.ts';
+
+/**
+ * Regression test for duplicated destination paths in the copy-mode install
+ * summary (vercel-labs/skills#1368).
+ *
+ * When several universal agents are targeted, they all resolve to the same
+ * `.agents/skills` directory. The install must not copy the skill there once
+ * per agent — the success summary should list the destination path exactly
+ * once.
+ */
+describe('install deduplicates agents sharing one directory', () => {
+  let sourceDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    sourceDir = await mkdtemp(join(tmpdir(), 'dedupe-src-'));
+    projectDir = await mkdtemp(join(tmpdir(), 'dedupe-proj-'));
+    const skillDir = join(sourceDir, 'demo-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: demo-skill\ndescription: demo\n---\n# Demo\n',
+      'utf-8'
+    );
+  });
+
+  afterEach(async () => {
+    await rm(sourceDir, { recursive: true, force: true });
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('lists the destination path once when targeting multiple universal agents', () => {
+    // codex, amp and antigravity are all universal agents → one shared dir → copy mode.
+    const result = runCli(
+      ['add', sourceDir, '-y', '-a', 'codex', '-a', 'amp', '-a', 'antigravity'],
+      projectDir
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const destinationLines = result.stdout
+      .split('\n')
+      .filter((line) => line.includes('→') && line.includes('demo-skill'));
+
+    expect(destinationLines).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1368.

All "universal" agents share the same `.agents/skills` directory. The install
routine looped over every target agent and installed the skill once per agent,
so when multiple universal agents were targeted the same skill was copied to the
**same directory repeatedly**.

In copy mode this is what produced the duplicated destination paths reported in
#1368 (the path printed once per agent), and it also meant redundant filesystem
writes for any directory shared by more than one agent.

## What changed

- Add `dedupeAgentsByDir(agentTypes, { global, cwd })` in `src/installer.ts`,
  which collapses agents that resolve to the same skills directory (via the
  existing `getAgentBaseDir`) while preserving input order.
- Use it in both install loops in `src/add.ts` (the well-known path and the
  remote/blob path) so each distinct directory is written exactly once.

This addresses the root cause rather than only de-duplicating the printed
output, so the redundant copies disappear too — and the duplicated summary
lines from #1368 go away as a result.

The informational agent listings in the summary (`universal: …`,
`symlinked: …`) are intentionally left untouched: they should still enumerate
every targeted agent.

## Tests

- `tests/dedupe-agents-by-dir.test.ts` — unit tests for the helper (collapses
  agents sharing a directory, keeps distinct directories, preserves order).
- `tests/install-dedupe.test.ts` — regression test that installing a skill to
  several universal agents lists the destination path exactly once.

Both were written test-first (red → green). The full suite was run locally; the
only failures are pre-existing and unrelated to this change (Windows
symlink-permission and banner tests on this machine).
