### PR TITLE
feat: add QoderWork agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [67 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -287,6 +287,7 @@ Skills can be installed to any of these agents:
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
+| QoderWork | `qoderwork` | `.qoderwork/skills/` | `~/.qoderwork/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
 | Reasonix | `reasonix` | `.reasonix/skills/` | `~/.reasonix/skills/` |
 | Rovo Dev | `rovodev` | `.rovodev/skills/` | `~/.rovodev/skills/` |
@@ -413,6 +414,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.ona/skills/`
 - `.pi/skills/`
 - `.qoder/skills/`
+- `.qoderwork/skills/`
 - `.qwen/skills/`
 - `.reasonix/skills/`
 - `.rovodev/skills/`
@@ -524,6 +526,7 @@ Telemetry is automatically disabled in CI environments.
 - [OpenHands Skills Documentation](https://docs.openhands.ai/modules/usage/how-to/using-skills)
 - [Pi Skills Documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md)
 - [Qoder Skills Documentation](https://docs.qoder.com/cli/Skills)
+- [QoderWork Skills Documentation](https://docs.qoder.com/qoderwork/skills)
 - [Replit Skills Documentation](https://docs.replit.com/replitai/skills)
 - [Roo Code Skills Documentation](https://docs.roocode.com/features/skills)
 - [Trae Skills Documentation](https://docs.trae.ai/ide/skills)

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "pi",
     "qoder",
     "qoder-cn",
+    "qoderwork",
     "qwen-code",
     "replit",
     "reasonix",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -498,6 +498,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.qoder-cn'));
     },
   },
+  qoderwork: {
+    name: 'qoderwork',
+    displayName: 'QoderWork',
+    skillsDir: '.qoderwork/skills',
+    globalSkillsDir: join(home, '.qoderwork/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.qoderwork'));
+    },
+  },
   'qwen-code': {
     name: 'qwen-code',
     displayName: 'Qwen Code',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -246,6 +246,7 @@ const PRIORITY_PREFIXES = [
   '.openhands/skills/',
   '.pi/skills/',
   '.qoder/skills/',
+  '.qoderwork/skills/',
   '.roo/skills/',
   '.trae/skills/',
   '.windsurf/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -28,6 +28,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.openhands/skills',
   '.pi/skills',
   '.qoder/skills',
+  '.qoderwork/skills',
   '.roo/skills',
   '.trae/skills',
   '.windsurf/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export type AgentType =
   | 'pi'
   | 'qoder'
   | 'qoder-cn'
+  | 'qoderwork'
   | 'qwen-code'
   | 'replit'
   | 'reasonix'


### PR DESCRIPTION
## Summary
- Add QoderWork as a supported agent with `.qoderwork/skills` project path and `~/.qoderwork/skills` global path
- Include QoderWork in local and GitHub tree skill discovery paths
- Regenerate README/package metadata and link the official QoderWork Skills documentation: https://docs.qoder.com/qoderwork/skills

## Test Plan
- `/Applications/Codex.app/Contents/Resources/node scripts/validate-agents.ts`
- `PATH=/Users/young/.local/share/fnm/node-versions/v20.20.2/installation/bin:/opt/homebrew/bin:$PATH corepack pnpm format:check`
- `git diff --check`
- `curl -I -L --max-time 20 https://docs.qoder.com/qoderwork/skills`