### PR TITLE
fix(update): remove shell:true to fix Windows paths with spaces

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -456,7 +456,6 @@ export async function updateGlobalSkills(
     const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
-      shell: process.platform === 'win32',
     });
 
     if (result.status === 0) {
@@ -592,7 +591,6 @@ export async function updateProjectSkills(
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
-          shell: process.platform === 'win32',
         }
       );
 


### PR DESCRIPTION
Fixes #1119

## Problem
`npx skills update` silently fails on Windows when the project path contains
spaces. When `shell: true`, Node.js concatenates the args array into a shell
string passed to `cmd.exe`, which splits on spaces and breaks the command.
This also triggers the DEP0190 deprecation warning.

## Fix
Removed `shell: process.platform === 'win32'` from both `spawnSync` calls in
`src/update.ts`. Since both calls already pass `process.execPath` as the
executable and a proper args array, Node can spawn the process directly via
`CreateProcess` without a shell — which handles spaces correctly.

## Testing
- All 5 existing tests in `tests/update.test.ts` pass
- `pnpm format` passes