### PR TITLE
fix: support SSH URLs with subpaths and detect GitHub/GitLab SSH sources

### DIFF
--- a/ThirdPartyNoticeText.txt
+++ b/ThirdPartyNoticeText.txt
@@ -9,6 +9,23 @@ Third Party Code Components
 --------------------------------------------
 
 ================================================================================
+Package: @clack/core@0.5.0
+License: MIT
+Repository: https://github.com/bombshell-dev/clack
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
 Package: @clack/prompts@0.11.0
 License: MIT
 Repository: https://github.com/bombshell-dev/clack
@@ -55,6 +72,35 @@ Repository: https://github.com/steveukx/git-js
 --------------------------------------------------------------------------------
 
 MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+Package: sisteransi@1.0.5
+License: MIT
+Repository: https://github.com/terkelg/sisteransi
+--------------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2018 Terkel Gjervig Nielsen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -91,6 +91,12 @@ export function resetRepoTreeAuthState(): void {
 interface BranchFetchResult {
   tree: RepoTree | null;
   rateLimited: boolean;
+  /**
+   * The unauthenticated request returned a status that a token might resolve
+   * (404 for a private repo GitHub hides, or 401). Unlike `rateLimited`, this
+   * is per-repo rather than IP-wide, so it must not set the session-wide memo.
+   */
+  authMayHelp: boolean;
 }
 
 async function fetchTreeBranch(
@@ -121,6 +127,7 @@ async function fetchTreeBranch(
       return {
         tree: { sha: data.sha, branch, tree: data.tree },
         rateLimited: false,
+        authMayHelp: false,
       };
     }
 
@@ -128,9 +135,13 @@ async function fetchTreeBranch(
     // (A bare 403 means permission denied, which is not retryable here.)
     const rateLimited =
       response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0';
-    return { tree: null, rateLimited };
+    // A private repo returns 404 to unauthenticated callers (GitHub hides its
+    // existence); 401 means bad/absent credentials. Either may succeed once we
+    // attach a token. Only meaningful when we asked unauthenticated.
+    const authMayHelp = !token && (response.status === 404 || response.status === 401);
+    return { tree: null, rateLimited, authMayHelp };
   } catch {
-    return { tree: null, rateLimited: false };
+    return { tree: null, rateLimited: false, authMayHelp: false };
   }
 }
 
@@ -167,6 +178,7 @@ export async function fetchRepoTree(
 
   // First pass: unauthenticated.
   let rateLimited = false;
+  let authMayHelp = false;
   for (const branch of branches) {
     const result = await fetchTreeBranch(ownerRepo, branch, null);
     if (result.tree) return result.tree;
@@ -176,12 +188,16 @@ export async function fetchRepoTree(
       rateLimited = true;
       break;
     }
+    if (result.authMayHelp) authMayHelp = true;
   }
 
-  if (!rateLimited || !getToken) return null;
+  // Lazy fallback: retry with a token when one might help — either we were
+  // rate-limited (IP-wide) or the repo looks private/auth-gated (per-repo).
+  if ((!rateLimited && !authMayHelp) || !getToken) return null;
 
-  // Lazy fallback: rate limit hit and a token resolver was provided.
-  _rateLimitedThisSession = true;
+  // A rate limit is IP-wide, so memo it to skip the unauth pass next time.
+  // A 404/401 is repo-specific, so it must not poison other lookups.
+  if (rateLimited) _rateLimitedThisSession = true;
   const token = getToken();
   if (!token) return null;
 

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -25,9 +25,12 @@ import {
 } from './git.ts';
 
 function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
-  return {
+  const client = {
     clone,
+    // createGitClient() chains .env(...) onto simpleGit(); keep it chainable.
+    env: vi.fn(() => client),
   };
+  return client;
 }
 
 function mockExecFileSuccess(stdout = '', stderr = '') {

--- a/src/git.ts
+++ b/src/git.ts
@@ -101,14 +101,6 @@ function isAuthFailure(message: string): boolean {
 function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
   return simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: {
-      ...process.env,
-      GIT_TERMINAL_PROMPT: '0',
-      // When git-lfs IS installed, tell it not to download LFS content
-      // during checkout. See #952 for context and empirical impact.
-      GIT_LFS_SKIP_SMUDGE: '1',
-      ...extraEnv,
-    },
     // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect —
     // git sees `filter=lfs` in .gitattributes, tries to run
     // `git-lfs filter-process`, and aborts the checkout with:
@@ -128,6 +120,13 @@ function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
       'filter.lfs.clean=',
       'filter.lfs.process=',
     ],
+  }).env({
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+    // When git-lfs IS installed, tell it not to download LFS content
+    // during checkout. See #952 for context and empirical impact.
+    GIT_LFS_SKIP_SMUDGE: '1',
+    ...extraEnv,
   });
 }
 

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -78,10 +78,15 @@ export async function parseSkillMd(
       return null;
     }
 
+    const metadata =
+      data.metadata && typeof data.metadata === 'object'
+        ? (data.metadata as Record<string, unknown>)
+        : undefined;
+
     // Skip internal skills unless:
     // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
     // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const isInternal = data.metadata?.internal === true;
+    const isInternal = metadata?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
     }
@@ -91,7 +96,7 @@ export async function parseSkillMd(
       description: sanitizeMetadata(data.description),
       path: dirname(skillMdPath),
       rawContent: content,
-      metadata: data.metadata,
+      metadata,
     };
   } catch {
     return null;

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -120,9 +120,10 @@ describe('source-parser', () => {
     });
 
     it('parses SSH git URL with #branch', () => {
+      // GitHub SSH URLs are detected as `github` so updates can use the Trees API.
       const result = parseSource('git@github.com:owner/repo.git#feature/install');
       expect(result).toEqual({
-        type: 'git',
+        type: 'github',
         url: 'git@github.com:owner/repo.git',
         ref: 'feature/install',
       });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -389,6 +389,39 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
+  // SSH URL: git@host:owner/repo(.git), optionally with a tree path
+  // (git@host:owner/repo/tree/branch/path). Detect GitHub and GitLab SSH URLs
+  // so they get the correct sourceType for lock file tracking and update
+  // detection. For tree URLs we extract ref + subpath; otherwise the original
+  // SSH URL is preserved so cloning still works for private repos. Other hosts
+  // fall through to the generic git fallback below.
+  const SSH_HOST_TYPES: Record<string, 'github' | 'gitlab'> = {
+    'github.com': 'github',
+    'gitlab.com': 'gitlab',
+  };
+  const sshMatch = input.match(/^git@([^:]+):(.+)$/);
+  if (sshMatch) {
+    const [, hostname, path] = sshMatch;
+    const type = SSH_HOST_TYPES[hostname!];
+    if (type) {
+      const treeMatch = path!.match(/^([^/]+\/[^/]+)\/tree\/([^/]+)\/(.+)$/);
+      if (treeMatch) {
+        const [, repoPath, ref, subpath] = treeMatch;
+        return {
+          type,
+          url: `git@${hostname}:${repoPath}.git`,
+          ref: ref || fragmentRef,
+          subpath: subpath ? sanitizeSubpath(subpath) : subpath,
+        };
+      }
+      return {
+        type,
+        url: input,
+        ...(fragmentRef ? { ref: fragmentRef } : {}),
+      };
+    }
+  }
+
   // Well-known skills: arbitrary HTTP(S) URLs that aren't GitHub/GitLab
   // This is the final fallback for URLs - we'll check for /.well-known/agent-skills/index.json
   // then fall back to /.well-known/skills/index.json

--- a/src/update.ts
+++ b/src/update.ts
@@ -238,6 +238,18 @@ export async function getProjectSkillsForUpdate(
   return skills;
 }
 
+/**
+ * Extract the skill's own folder name from a SKILL.md path.
+ * e.g. `plugins/ce/skills/ce-plan/SKILL.md` -> `ce-plan`.
+ */
+function skillFolderName(skillMdPath: string): string {
+  const parts = skillMdPath.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (parts.length && parts[parts.length - 1]!.toLowerCase().endsWith('skill.md')) {
+    parts.pop();
+  }
+  return parts[parts.length - 1] ?? '';
+}
+
 export async function checkAndPromptForDeletions(
   source: string,
   allLockedForSource: string[],
@@ -246,10 +258,21 @@ export async function checkAndPromptForDeletions(
   options: UpdateCheckOptions,
   discoveredPaths: string[]
 ): Promise<string[]> {
+  // A repo can reorganize its layout (e.g. moving skills/<name> out of a
+  // plugins/<plugin>/skills/<name> tree) without deleting anything. Matching
+  // only on the exact locked path would then flag every moved skill as
+  // "deleted upstream" and offer to remove skills that still exist — data
+  // loss. Treat a skill as deleted only when no skill with the same folder
+  // name survives anywhere in the tree.
+  const discoveredFolderNames = new Set(discoveredPaths.map(skillFolderName).filter(Boolean));
+
   const deletedSkills = allLockedForSource.filter((name) => {
     const entry = lockSkills[name];
     if (!entry?.skillPath) return false;
-    return !discoveredPaths.includes(entry.skillPath);
+    if (discoveredPaths.includes(entry.skillPath)) return false;
+    const folder = skillFolderName(entry.skillPath);
+    if (folder && discoveredFolderNames.has(folder)) return false;
+    return true;
   });
 
   if (deletedSkills.length > 0) {

--- a/tests/blob-fetch-tree-auth.test.ts
+++ b/tests/blob-fetch-tree-auth.test.ts
@@ -46,6 +46,18 @@ function permissionDeniedResponse(): Response {
   });
 }
 
+function notFoundResponse(): Response {
+  // GitHub returns 404 (not 403) to unauthenticated callers for a private repo,
+  // hiding its existence. x-ratelimit-remaining is non-zero: this is NOT a rate limit.
+  return new Response(JSON.stringify({ message: 'Not Found' }), {
+    status: 404,
+    headers: {
+      'content-type': 'application/json',
+      'x-ratelimit-remaining': '44',
+    },
+  });
+}
+
 describe('fetchRepoTree lazy auth fallback', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
@@ -89,6 +101,59 @@ describe('fetchRepoTree lazy auth fallback', () => {
     expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
       'Bearer ghp_fake_token'
     );
+  });
+
+  it('retries with auth when a private repo 404s unauthenticated', async () => {
+    // A private repo returns 404 to anonymous callers. A token can unlock it,
+    // so the resolver must be invoked and the retry must carry Authorization.
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const result = await fetchRepoTree('goldsky-io/internal-skills', 'main', getToken);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer ghp_fake_token'
+    );
+  });
+
+  it('does not memo a 404 as a session-wide rate limit', async () => {
+    // A 404 is per-repo. It must not flip the session into auth-first mode and
+    // skip the unauth pass for a subsequent, unrelated public repo.
+    fetchMock
+      // First repo (private): unauth 404 -> auth 200
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE))
+      // Second repo (public): must start unauth and succeed
+      .mockResolvedValueOnce(okResponse({ ...SAMPLE_TREE, sha: 'cafef00d' }));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const first = await fetchRepoTree('goldsky-io/internal-skills', 'main', getToken);
+    const second = await fetchRepoTree('vercel/skills', 'main', getToken);
+
+    expect(first?.sha).toBe('deadbeef');
+    expect(second?.sha).toBe('cafef00d');
+    expect(getToken).toHaveBeenCalledTimes(1); // only the private repo needed it
+    const secondCallInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect((secondCallInit.headers as Record<string, string>)['Authorization']).toBeUndefined();
+  });
+
+  it('returns null when a private repo 404s and no token is available', async () => {
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse());
+    const getToken = vi.fn(() => null);
+
+    const result = await fetchRepoTree('goldsky-io/internal-skills', undefined, getToken);
+
+    expect(result).toBeNull();
+    expect(getToken).toHaveBeenCalledTimes(1);
   });
 
   it('does not invoke the token resolver on a non-rate-limit 403', async () => {

--- a/tests/deletion-detection.test.ts
+++ b/tests/deletion-detection.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for checkAndPromptForDeletions: a repo reorganization (skills moved to
+ * a new path) must NOT be reported as an upstream deletion, while genuinely
+ * removed/renamed skills still are.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkAndPromptForDeletions } from '../src/update.ts';
+
+const lockSkills: Record<string, { skillPath?: string }> = {
+  // Moved: plugins/.../skills/<name> -> skills/<name>
+  'ce-brainstorm': { skillPath: 'plugins/compound-engineering/skills/ce-brainstorm/SKILL.md' },
+  'ce:plan': { skillPath: 'plugins/compound-engineering/skills/ce-plan/SKILL.md' },
+  // Renamed upstream (ce-review -> ce-code-review): genuinely gone under this name
+  'ce:review': { skillPath: 'plugins/compound-engineering/skills/ce-review/SKILL.md' },
+  // Genuinely deleted upstream
+  changelog: { skillPath: 'plugins/compound-engineering/skills/changelog/SKILL.md' },
+  // Entry with no recorded path: never flagged
+  legacy: {},
+};
+
+// Live tree after the repo moved skills to root-level skills/
+const discoveredPaths = [
+  'skills/ce-brainstorm/SKILL.md',
+  'skills/ce-plan/SKILL.md',
+  'skills/ce-code-review/SKILL.md',
+  'skills/ce-compound/SKILL.md',
+];
+
+describe('checkAndPromptForDeletions', () => {
+  it('does not flag relocated skills, only genuinely removed ones', async () => {
+    const deleted = await checkAndPromptForDeletions(
+      'everyinc/compound-engineering-plugin',
+      Object.keys(lockSkills),
+      lockSkills,
+      true,
+      { yes: true }, // non-interactive: detect without prompting/removing
+      discoveredPaths
+    );
+
+    // ce-brainstorm and ce:plan moved -> not deleted.
+    expect(deleted).not.toContain('ce-brainstorm');
+    expect(deleted).not.toContain('ce:plan');
+    // ce:review renamed (no ce-review folder upstream) and changelog removed.
+    expect(deleted.sort()).toEqual(['ce:review', 'changelog']);
+  });
+
+  it('returns nothing when every locked path still exists', async () => {
+    const deleted = await checkAndPromptForDeletions(
+      'owner/repo',
+      ['ce-brainstorm'],
+      { 'ce-brainstorm': { skillPath: 'skills/ce-brainstorm/SKILL.md' } },
+      true,
+      { yes: true },
+      ['skills/ce-brainstorm/SKILL.md']
+    );
+    expect(deleted).toEqual([]);
+  });
+});

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -236,20 +236,56 @@ describe('parseSource', () => {
     });
   });
 
-  describe('Git URL fallback tests', () => {
-    it('Git URL - SSH format', () => {
+  describe('SSH URL tests', () => {
+    it('SSH URL - GitHub', () => {
       const result = parseSource('git@github.com:owner/repo.git');
-      expect(result.type).toBe('git');
+      expect(result.type).toBe('github');
       expect(result.url).toBe('git@github.com:owner/repo.git');
     });
 
-    it('Git URL - SSH format with #branch', () => {
+    it('SSH URL - GitHub without .git suffix', () => {
+      const result = parseSource('git@github.com:owner/repo');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('git@github.com:owner/repo');
+    });
+
+    it('SSH URL - GitHub with #branch', () => {
       const result = parseSource('git@github.com:owner/repo.git#feature/install');
-      expect(result.type).toBe('git');
+      expect(result.type).toBe('github');
       expect(result.url).toBe('git@github.com:owner/repo.git');
       expect(result.ref).toBe('feature/install');
     });
 
+    it('SSH URL - GitLab', () => {
+      const result = parseSource('git@gitlab.com:owner/repo.git');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('git@gitlab.com:owner/repo.git');
+    });
+
+    it('SSH URL - GitHub with tree path', () => {
+      const result = parseSource('git@github.com:owner/repo/tree/main/path/to/skill');
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('git@github.com:owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('path/to/skill');
+    });
+
+    it('SSH URL - GitLab with tree path', () => {
+      const result = parseSource('git@gitlab.com:owner/repo/tree/develop/my-skill');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('git@gitlab.com:owner/repo.git');
+      expect(result.ref).toBe('develop');
+      expect(result.subpath).toBe('my-skill');
+    });
+
+    it('SSH URL - custom host falls back to git type', () => {
+      const result = parseSource('git@git.company.com:org/repo.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git@git.company.com:org/repo.git');
+    });
+  });
+
+  describe('Git URL fallback tests', () => {
     it('Git URL - custom host', () => {
       const result = parseSource('https://git.example.com/owner/repo.git');
       expect(result.type).toBe('git');
@@ -420,6 +456,39 @@ describe('getOwnerRepo', () => {
   it('getOwnerRepo - SSH URL without path (returns null)', () => {
     const parsed = { type: 'git', url: 'git@github.com:repo.git' } as const;
     expect(getOwnerRepo(parsed)).toBeNull();
+  });
+});
+
+describe('SSH URL lock file integration', () => {
+  it('GitHub SSH URL produces correct lock entry fields', () => {
+    const parsed = parseSource('git@github.com:my-org/my-skills.git');
+    const normalizedSource = getOwnerRepo(parsed);
+
+    // Lock entry requires normalizedSource to be truthy
+    expect(normalizedSource).toBe('my-org/my-skills');
+    // sourceType must be 'github' for fetchSkillFolderHash to run
+    expect(parsed.type).toBe('github');
+    // SSH URL preserved for cloning (private repos need SSH auth)
+    expect(parsed.url).toBe('git@github.com:my-org/my-skills.git');
+  });
+
+  it('GitLab SSH URL produces correct lock entry fields', () => {
+    const parsed = parseSource('git@gitlab.com:group/project.git');
+    const normalizedSource = getOwnerRepo(parsed);
+
+    expect(normalizedSource).toBe('group/project');
+    expect(parsed.type).toBe('gitlab');
+    expect(parsed.url).toBe('git@gitlab.com:group/project.git');
+  });
+
+  it('custom host SSH URL still creates lock entry via getOwnerRepo', () => {
+    const parsed = parseSource('git@git.company.com:org/repo.git');
+    const normalizedSource = getOwnerRepo(parsed);
+
+    // Should still extract owner/repo for lock tracking
+    expect(normalizedSource).toBe('org/repo');
+    // Falls back to generic git type (no special handling)
+    expect(parsed.type).toBe('git');
   });
 });
 


### PR DESCRIPTION
## Problem

`parseSource` does not recognize SSH URLs as GitHub/GitLab sources:

- SSH tree URLs with a subpath (`git@github.com:owner/repo/tree/branch/path`) aren't parsed at all — no `ref`/`subpath` is extracted.
- Plain SSH URLs (`git@github.com:owner/repo.git`) fall through to the generic `git` type, so the lock file never records a `github`/`gitlab` `sourceType`. As a result `fetchSkillFolderHash` is skipped and `skills update` can't detect updates for skills installed over SSH.

Separately, **private GitHub repos could never be update-checked at all.** GitHub returns `404` (not a rate-limit `403`) to unauthenticated Trees-API calls for private repos, but `fetchRepoTree` only fell back to the auth token on a rate-limit `403`. So `skills update` printed `✗ Failed to fetch tree` for any private source (e.g. an internal skills repo) even with a valid `gh` token available.

## Change

**SSH source detection** in `parseSource`:

1. `git@host:owner/repo/tree/branch/path` → `github`/`gitlab` type with `ref` and a sanitized `subpath` (via `sanitizeSubpath`, respecting `fragmentRef`).
2. `git@host:owner/repo(.git)` → `github`/`gitlab` type with the original SSH URL preserved, so cloning still works for private repos and update detection runs.

Other hosts continue to fall through to the generic `git` type. `getOwnerRepo` already normalizes SSH URLs for any host, so lock entries are still created.

**Private-repo update checks** (`src/blob.ts`):

- `fetchTreeBranch` now reports an `authMayHelp` signal when an *unauthenticated* request returns `404`/`401` (the canonical response GitHub gives for a private repo it hides).
- `fetchRepoTree` does its lazy auth retry on that signal in addition to rate-limit `403`, **without** setting the session-wide rate-limit memo — a `404` is per-repo, not IP-wide, so it must not flip subsequent public-repo lookups into auth-first mode. This preserves the issue #523 design: `gh auth token` still never runs on a successful public install.

## Incidental fixes

This branch did not compile or fully pass tests; fixed alongside:

- `src/source-parser.test.ts`: stale assertion still expected `type: 'git'` for SSH GitHub URLs — updated to `type: 'github'` to match the feature.
- `src/git.ts`: `env` is not a valid `simpleGit()` constructor option (type error) — moved to the chained `.env()` method; `git.test.ts` mock updated to keep `.env()` chainable.
- `src/skills.ts`: narrowed `data.metadata` (`unknown`) to fix two type errors.

## Tests

- `SSH URL tests` + `SSH URL lock file integration` suites in `tests/source-parser.test.ts` (GitHub/GitLab SSH URLs, tree-path subpaths, `#branch` refs, no-`.git` suffix, custom-host fallback).
- New cases in `tests/blob-fetch-tree-auth.test.ts`: private repo `404` → auth retry, `404` not memoized as a session rate limit, and graceful `null` when no token is available.
- `pnpm type-check` clean; full suite **535/535 passing**. Verified live: `fetchRepoTree` now resolves a private internal skills repo (16 skills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also: relocated skills no longer reported as deleted

The `update` deletion check matched only on the exact locked `skillPath`. When a repo reorganizes its layout (e.g. `everyinc/compound-engineering-plugin` moving `plugins/compound-engineering/skills/<name>/SKILL.md` → `skills/<name>/SKILL.md`), every moved skill was reported as "deleted upstream" and the prompt offered to remove skills that still exist — data loss on confirm. Now a skill is flagged deleted only when no skill with the same folder name survives anywhere in the tree; genuine deletions/renames are still caught. Covered by `tests/deletion-detection.test.ts`.
