### PR TITLE
feat: support per-repo self-hosted blob download URLs (zapier/connectors first)

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -70,6 +70,7 @@ import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import {
   tryBlobInstall,
+  BLOB_ALLOWED_REPOS,
   getSkillFolderHashFromTree,
   fetchRepoTree,
   type BlobSkill,
@@ -1047,12 +1048,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         fullDepth: options.fullDepth,
       });
     } else if (parsed.type === 'github' && !options.fullDepth) {
-      // Try blob-based fast install for GitHub sources
-      // Only enabled for allowlisted orgs; skip for --full-depth
+      // Try the blob-based fast install for GitHub sources; skip for --full-depth.
+      // Eligible per repo (a BLOB_ALLOWED_REPOS entry = self-hosted download URL) or
+      // per owner (BLOB_ALLOWED_OWNERS = all their repos, skills.sh-hosted).
       const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com'];
       const ownerRepo = getOwnerRepo(parsed);
       const owner = ownerRepo?.split('/')[0]?.toLowerCase();
-      if (ownerRepo && owner && BLOB_ALLOWED_OWNERS.includes(owner)) {
+      const isSelfHostedRepo =
+        !!ownerRepo && Object.hasOwn(BLOB_ALLOWED_REPOS, ownerRepo.toLowerCase());
+      if (ownerRepo && owner && (isSelfHostedRepo || BLOB_ALLOWED_OWNERS.includes(owner))) {
         spinner.start('Fetching skills...');
         blobResult = await tryBlobInstall(ownerRepo, {
           subpath: parsed.subpath,

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -43,6 +43,14 @@ export interface BlobSkill extends Skill {
 
 const DOWNLOAD_BASE_URL = process.env.SKILLS_DOWNLOAD_URL || 'https://skills.sh';
 
+// Repos that self-host their downloads on the blob fast-path
+export const BLOB_ALLOWED_REPOS: Record<string, { downloadUrl: (slug: string) => string }> = {
+  'zapier/connectors': {
+    downloadUrl: (slug) =>
+      `https://connectors-skills.zapier.com/download/${encodeURIComponent(slug)}/snapshot.json`,
+  },
+};
+
 /** Timeout for individual HTTP fetches (ms) */
 const FETCH_TIMEOUT = 10_000;
 
@@ -372,7 +380,10 @@ async function fetchSkillDownload(
 ): Promise<SkillDownloadResponse | null> {
   try {
     const [owner, repo] = source.split('/');
-    const url = `${DOWNLOAD_BASE_URL}/api/download/${encodeURIComponent(owner!)}/${encodeURIComponent(repo!)}/${encodeURIComponent(slug)}`;
+    const defaultUrl = `${DOWNLOAD_BASE_URL}/api/download/${encodeURIComponent(owner!)}/${encodeURIComponent(repo!)}/${encodeURIComponent(slug)}`;
+    // Self-hosted repos build their own URL; otherwise fall back to the default.
+    const selfHosted = BLOB_ALLOWED_REPOS[source.toLowerCase()]?.downloadUrl(slug);
+    const url = selfHosted ?? defaultUrl;
     const response = await fetch(url, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT),
     });


### PR DESCRIPTION
Add `BLOB_ALLOWED_REPOS` — a per-repo table (keyed by `owner/repo`) whose value builds
the download URL for a skill slug. An entry both opts the repo into the blob fast-path
and resolves its snapshot to that repo's own host. With no entry, resolution falls back
to the existing `${DOWNLOAD_BASE_URL}/api/download/...` shape, and eligibility becomes an
allowlisted owner (`BLOB_ALLOWED_OWNERS`, unchanged) **or** a repo with an entry.

This lets a repo that self-hosts its download API opt into the fast path. `zapier/connectors`
is the first — a large monorepo serving its own snapshots — so `npx skills add zapier/connectors`
can skip the clone.

**Non-breaking:** repos without an entry (including the current allowlisted owners) resolve to
the default skills.sh URL, and `SKILLS_DOWNLOAD_URL` still works.

**Verified:** installed `zapier/connectors@slack` from the live host via the fast path.
