### PR TITLE
fix: project install silently skips Claude Code when its config dir is absent, yet the prompt promises a symlink

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -38,6 +38,7 @@ import {
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
+  willSkipAgentSymlink,
   type InstallMode,
 } from './installer.ts';
 import {
@@ -216,18 +217,45 @@ function splitAgentsByType(agentTypes: AgentType[]): {
 }
 
 /**
- * Builds summary lines showing universal vs symlinked agents
+ * Builds the hint shown next to skipped agents, naming the missing config
+ * directories and the remedies.
  */
-function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallMode): string[] {
+function formatSkipHint(skippedAgents: AgentType[]): string {
+  const dirs = [...new Set(skippedAgents.map((a) => agents[a].skillsDir.split('/')[0]))];
+  return `(no ${dirs.join(' or ')} in project — use -g, --copy, or create the directory first)`;
+}
+
+/**
+ * Builds summary lines showing universal vs symlinked agents.
+ * Agents whose project-level symlink will be skipped (config dir missing,
+ * see willSkipAgentSymlink) are listed as skipped instead of promised.
+ */
+function buildAgentSummaryLines(
+  targetAgents: AgentType[],
+  installMode: InstallMode,
+  isGlobal: boolean,
+  cwd: string
+): string[] {
   const lines: string[] = [];
-  const { universal, symlinked } = splitAgentsByType(targetAgents);
+  const { universal } = splitAgentsByType(targetAgents);
 
   if (installMode === 'symlink') {
+    const willSkip = targetAgents.filter((a) => willSkipAgentSymlink(a, isGlobal, cwd));
+    const skippedNames = willSkip.map((a) => agents[a].displayName);
+    const symlinked = targetAgents
+      .filter((a) => !isUniversalAgent(a) && !willSkip.includes(a))
+      .map((a) => agents[a].displayName);
+
     if (universal.length > 0) {
       lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
     }
     if (symlinked.length > 0) {
       lines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
+    }
+    if (skippedNames.length > 0) {
+      lines.push(
+        `  ${pc.yellow('skipped:')} ${formatList(skippedNames)} ${pc.dim(formatSkipHint(willSkip))}`
+      );
     }
   } else {
     // Copy mode - all agents get copies
@@ -278,6 +306,8 @@ function buildResultLines(
     .map((r) => r.agent);
   const failedSymlinks = results.filter((r) => r.symlinkFailed && !r.skipped).map((r) => r.agent);
 
+  const skippedNames = [...new Set(results.filter((r) => r.skipped).map((r) => r.agent))];
+
   if (universal.length > 0) {
     lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
   }
@@ -286,6 +316,12 @@ function buildResultLines(
   }
   if (failedSymlinks.length > 0) {
     lines.push(`  ${pc.yellow('copied:')} ${formatList(failedSymlinks)}`);
+  }
+  if (skippedNames.length > 0) {
+    const skippedTypes = targetAgents.filter((a) => skippedNames.includes(agents[a].displayName));
+    lines.push(
+      `  ${pc.yellow('skipped:')} ${formatList(skippedNames)} ${pc.dim(formatSkipHint(skippedTypes))}`
+    );
   }
 
   return lines;
@@ -710,7 +746,7 @@ async function handleWellKnownSkills(
     const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
     const shortCanonical = shortenPath(canonicalPath, cwd);
     summaryLines.push(`${pc.cyan(shortCanonical)}`);
-    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode, installGlobally, cwd));
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
     }
@@ -1443,7 +1479,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const canonicalPath = getCanonicalPath(skill.name, { global: installGlobally });
         const shortCanonical = shortenPath(canonicalPath, cwd);
         summaryLines.push(`${pc.cyan(shortCanonical)}`);
-        summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+        summaryLines.push(
+          ...buildAgentSummaryLines(targetAgents, installMode, installGlobally, cwd)
+        );
 
         const skillOverwrites = overwriteStatus.get(skill.name);
         const overwriteAgents = targetAgents

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -111,6 +111,25 @@ export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: str
   return join(baseDir, agent.skillsDir);
 }
 
+/**
+ * True when a project-level symlink install for this agent will be skipped
+ * because the agent's config directory (e.g. .claude/, .windsurf/) doesn't
+ * already exist in the project. The skill still lands in .agents/skills/,
+ * but agents that don't read that path (like Claude Code) won't see it.
+ * Remedies: install globally (-g), use --copy, or create the directory first.
+ */
+export function willSkipAgentSymlink(
+  agentType: AgentType,
+  isGlobal: boolean,
+  cwd: string
+): boolean {
+  if (isGlobal || isUniversalAgent(agentType)) {
+    return false;
+  }
+  const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
+  return !existsSync(agentRootDir);
+}
+
 function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
   return resolve(dirname(linkPath), linkTarget);
 }
@@ -309,17 +328,14 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir)) {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
+    if (willSkipAgentSymlink(agentType, isGlobal, cwd)) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
+      };
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
@@ -814,17 +830,14 @@ export async function installBlobSkillForAgent(
 
     // For project-level installs, skip creating symlinks for non-universal agents
     // whose config directory doesn't already exist in the project.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir)) {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
+    if (willSkipAgentSymlink(agentType, isGlobal, cwd)) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
+      };
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -15,8 +15,9 @@ import {
   readdir,
 } from 'node:fs/promises';
 import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { installSkillForAgent } from '../src/installer.ts';
+import { installSkillForAgent, willSkipAgentSymlink } from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
   const dir = join(root, 'source-skill');
@@ -183,6 +184,85 @@ describe('installer symlink regression', () => {
       const stats = await lstat(installedPath);
       expect(stats.isDirectory()).toBe(true);
       expect(stats.isSymbolicLink()).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('project-level symlink skip (config dir missing)', () => {
+  it('predicts the skip via willSkipAgentSymlink', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    try {
+      // Project install, non-universal agent, no .claude/ in project → skip
+      expect(willSkipAgentSymlink('claude-code', false, projectDir)).toBe(true);
+
+      // Global installs never skip
+      expect(willSkipAgentSymlink('claude-code', true, projectDir)).toBe(false);
+
+      // Universal agents never skip
+      expect(willSkipAgentSymlink('github-copilot', false, projectDir)).toBe(false);
+
+      // Existing config dir disarms the skip
+      await mkdir(join(projectDir, '.claude'), { recursive: true });
+      expect(willSkipAgentSymlink('claude-code', false, projectDir)).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('returns skipped: true and creates no .claude/ when the config dir is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'skip-report-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+
+      // The skill lands in the canonical dir, but no .claude/ is created
+      const canonicalPath = join(projectDir, '.agents/skills', skillName);
+      const stats = await lstat(canonicalPath);
+      expect(stats.isDirectory()).toBe(true);
+      expect(existsSync(join(projectDir, '.claude'))).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('symlinks into .claude/skills/ when .claude/ pre-exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, '.claude'), { recursive: true });
+
+    const skillName = 'no-skip-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+
+      const agentPath = join(projectDir, '.claude/skills', skillName);
+      const stats = await lstat(agentPath);
+      expect(stats.isSymbolicLink()).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes #1138. Also addresses #1355 and #1045 (and the symptom in #1385).

## Problem

When `claude-code` (or any non-universal agent) is selected for a **project** install in a repo that has no `.claude/` directory, `installer.ts` skips the symlink by design — to avoid creating config dirs for agents not used in that project. The skill lands in `.agents/skills/`, which Claude Code does not read. Two reporting gaps turn that design decision into a silent failure:

- The confirmation summary (`buildAgentSummaryLines`) unconditionally lists the agent under `symlink →`, promising an install that will be skipped.
- The result summary (`buildResultLines`) filters skipped agents out entirely — no mention, no remedy.

So the user is told Claude Code will get the skills, the install quietly skips it, and the summary says nothing. Multiple users have hit this (#1138, #1355, #1045, #1385).

## Repro (v1.5.10)

```bash
mkdir -p /tmp/repro && cd /tmp/repro   # note: no .claude/ here
npx -y skills add stonegiantstudio/skills --agent claude-code cursor -y
ls .claude/skills/   # → No such file or directory
```

## Fix (reporting only — the skip behavior is unchanged)

- Extract the skip condition into an exported `willSkipAgentSymlink()` in `installer.ts`, used by both symlink install paths (single source of truth).
- **Summary**: predict the skip and list affected agents as skipped instead of promising a symlink:

  ```
  ./.agents/skills/park
    universal: Cursor
    skipped: Claude Code (no .claude in project — use -g, --copy, or create the directory first)
  ```

- **Result**: print the same `skipped:` line instead of silently dropping the agent.
- Regression tests: the predicate (project/global/universal/dir-exists cases), the skipped install result, and the happy path with a pre-existing `.claude/`.

When `.claude/` exists (or with `-g` / `--copy`), output is unchanged: `symlink → Claude Code` / `symlinked: Claude Code`.

Whether project installs should *create* the config dir for selected agents (or prompt) is a separate design question for the maintainers — this PR only makes the current behavior visible.

## Testing

- `pnpm vitest run tests/installer-symlink.test.ts` — 7/7 pass (3 new)
- Full suite: failure set identical to `main` before/after (pre-existing env-dependent failures only)
- Manual end-to-end via `src/cli.ts` in fresh temp dirs: skip case shows the new `skipped:` lines and still creates no `.claude/`; pre-existing `.claude/` case unchanged