### PR TITLE
fix: prevent copyDirectory from following ancestor symlinks (ENAMETOOLONG)

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -459,6 +459,16 @@ function stripIgnoredEveFrontmatter(raw: string): string {
   return `---\n${frontmatter}\n---\n${content.replace(/^\r?\n/u, '')}`;
 }
 
+async function symlinkTargetIsAncestor(linkPath: string): Promise<boolean> {
+  try {
+    const targetReal = await realpath(linkPath);
+    const parentReal = await realpath(dirname(linkPath));
+    return parentReal === targetReal || parentReal.startsWith(targetReal + sep);
+  } catch {
+    return false;
+  }
+}
+
 async function copyDirectory(src: string, dest: string, agentType?: AgentType): Promise<void> {
   await mkdir(dest, { recursive: true });
 
@@ -471,6 +481,12 @@ async function copyDirectory(src: string, dest: string, agentType?: AgentType): 
       .map(async (entry) => {
         const srcPath = join(src, entry.name);
         const destPath = join(dest, entry.name);
+
+        // Skip cyclic symlinks; dereferencing an ancestor-pointing link recurses to ENAMETOOLONG.
+        if (entry.isSymbolicLink() && (await symlinkTargetIsAncestor(srcPath))) {
+          console.warn(`Skipping self-referential symlink: ${srcPath}`);
+          return;
+        }
 
         if (entry.isDirectory()) {
           await copyDirectory(srcPath, destPath, agentType);

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { access, chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import {
+  access,
+  chmod,
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
@@ -70,6 +80,42 @@ describe('installer copy mode', () => {
       const sourceMode = (await stat(scriptPath)).mode & 0o777;
       const installedMode = (await stat(installedScript)).mode & 0o777;
       expect(installedMode).toBe(sourceMode);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips a self-referential AAIF symlink instead of recursing (ENAMETOOLONG regression)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-cycle-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    // .agents/skills/<name> -> ../.. : a self-symlink to the repo root that used to recurse forever.
+    const skillName = 'cycle-skill';
+    const skillDir = join(root, 'skill-root');
+    await mkdir(join(skillDir, 'scripts'), { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: test\n---\n`,
+      'utf-8'
+    );
+    await writeFile(join(skillDir, 'scripts', 'run.sh'), '#!/bin/bash\necho hi\n', 'utf-8');
+    await mkdir(join(skillDir, '.agents', 'skills'), { recursive: true });
+    await symlink('../..', join(skillDir, '.agents', 'skills', skillName));
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedDir = join(projectDir, '.agents/skills', skillName);
+      await expect(access(join(installedDir, 'SKILL.md'))).resolves.toBeUndefined();
+      await expect(access(join(installedDir, 'scripts', 'run.sh'))).resolves.toBeUndefined();
+      await expect(access(join(installedDir, '.agents', 'skills', skillName))).rejects.toThrow();
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

`npx skills add <owner/repo>` fails with `ENAMETOOLONG` and never completes (while exiting 0) when a skill repo has a root `SKILL.md` plus an AAIF self-discovery symlink `.agents/skills/<name>` pointing back at the repo root (`../..`). Full write-up and reproduction in #1396.

## Root cause

In `copyDirectory` (`src/installer.ts`), `Dirent.isDirectory()` is `false` for a symlink, so a symlink-to-directory takes the file branch and is copied with `cp(srcPath, destPath, { dereference: true, recursive: true })`. When that symlink resolves to an ancestor of its own location, `cp` dereferences and re-copies the enclosing tree — which contains the symlink again — until the path overflows the OS limit.

## Fix

Before copying an entry, if it is a symlink whose resolved target is an ancestor of (or equal to) its own directory, skip it with a warning. All other symlinks keep their existing dereference behavior, so the change is scoped to the cyclic case that currently crashes; the rest of the skill still installs.

## Test

Adds a regression test in `tests/installer-copy.test.ts` that builds a skill with a `.agents/skills/<name> → ../..` self-symlink and asserts the install succeeds, the real files copy through, and the cyclic link is skipped rather than dereferenced into a loop. `vitest run tests/installer-copy.test.ts` passes 2/2; the new case returns `success: false` (the recursion error) without this change.

Fixes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
