### PR TITLE
feat: add Theia IDE support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -562,6 +562,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.terramind'));
     },
   },
+  'theia-ide': {
+    name: 'theia-ide',
+    displayName: 'Theia IDE',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.theia-ide'));
+    },
+  },
   tinycloud: {
     name: 'tinycloud',
     displayName: 'Tinycloud',

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export type AgentType =
   | 'rovodev'
   | 'tabnine-cli'
   | 'terramind'
+  | 'theia-ide'
   | 'tinycloud'
   | 'trae'
   | 'trae-cn'


### PR DESCRIPTION
[Theia IDE](https://theia-ide.org/) reads skills from `.agents/skills/` in the workspace and `~/.agents/skills/` globally. Detection checks for `~/.theia-ide`, the config folder used by the official Theia IDE distribution.

Theia IDE uses the same `.agents/skills` location as other universal agents (cline, dexto, warp, zed), so no install-path changes are needed.