### PR TITLE
fix: pre-select detected installed agents in interactive picker

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -370,6 +370,7 @@ export async function promptForAgents(
  */
 async function selectAgentsInteractive(options: {
   global?: boolean;
+  installedAgents?: AgentType[];
 }): Promise<AgentType[] | symbol> {
   // Filter out agents that don't support global installation when --global is used
   const supportsGlobalFilter = (a: AgentType) => !options.global || agents[a].globalSkillsDir;
@@ -403,11 +404,15 @@ async function selectAgentsInteractive(options: {
     // Silently ignore errors
   }
 
+  const detectedNonUniversal = (options.installedAgents ?? []).filter(
+    (a) => otherAgents.includes(a) && !universalAgents.includes(a)
+  );
+
   const initialSelected = lastSelected
     ? (lastSelected.filter(
         (a) => otherAgents.includes(a as AgentType) && !universalAgents.includes(a as AgentType)
       ) as AgentType[])
-    : [];
+    : detectedNonUniversal;
 
   const selected = await searchMultiselect({
     message: 'Which agents do you want to install to?',
@@ -609,7 +614,10 @@ async function handleWellKnownSkills(
         );
       }
     } else {
-      const selected = await selectAgentsInteractive({ global: options.global });
+      const selected = await selectAgentsInteractive({
+        global: options.global,
+        installedAgents,
+      });
 
       if (p.isCancel(selected)) {
         p.cancel('Installation cancelled');
@@ -1326,7 +1334,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           );
         }
       } else {
-        const selected = await selectAgentsInteractive({ global: options.global });
+        const selected = await selectAgentsInteractive({
+          global: options.global,
+          installedAgents,
+        });
 
         if (p.isCancel(selected)) {
           p.cancel('Installation cancelled');


### PR DESCRIPTION
## Summary

- When multiple agents are detected and no saved selection history exists, non-universal agents (e.g. Claude Code) started **unchecked** in the interactive agent picker
- Pressing Enter without manually toggling them excluded them from `targetAgents`, so no `~/.claude/skills/` symlink was created for global installs
- Fix pre-selects detected installed non-universal agents as the fallback `initialSelected` when no history exists — consistent with the single-agent path which auto-selects without prompting

Closes #1412

## Root cause

In `selectAgentsInteractive` (`src/add.ts`), the `initialSelected` fallback was an empty array:

```ts
const initialSelected = lastSelected ? lastSelected.filter(...) : [];
//                                                                ^^ first-run: nothing pre-checked
```

## Fix

Fall back to detected installed non-universal agents instead of `[]`:

```ts
const detectedNonUniversal = (options.installedAgents ?? []).filter(
  (a) => otherAgents.includes(a) && !universalAgents.includes(a)
);

const initialSelected = lastSelected ? lastSelected.filter(...) : detectedNonUniversal;
```

`installedAgents` was already available at both call sites (`handleWellKnownSkills` and `runAdd`) and is now threaded into the function.

## Test plan

- [ ] Run `npx skills add <source> -g` with multiple agents detected and no prior selection history — Claude Code should be pre-checked in the picker
- [ ] Confirm `~/.claude/skills/<skill>` symlink is created after accepting defaults
- [ ] Confirm saved history still takes precedence on subsequent runs
- [ ] Confirm single-agent path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)