### PR TITLE
fix(update): preserve sourceUrl for custom GitLab installs

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -7,6 +7,77 @@ import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './sour
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
+/**
+ * Sanitize a source URL for safe storage in lock files.
+ * Removes credentials (username/password), query strings, and fragments.
+ * Preserves the scheme, host, port, and path.
+ *
+ * For SSH URLs (ssh://...), keeps username/host/path but removes query/hash.
+ * For scp-like SSH (git@host:org/repo.git), leaves as-is.
+ * For non-URL strings (owner/repo shorthand), returns as-is.
+ */
+export function sanitizeSourceUrl(url: string): string {
+  const scheme = url.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
+
+  // scp-like SSH: git@host:org/repo.git — leave as-is
+  if (url.startsWith('git@')) {
+    return url;
+  }
+
+  // ssh:// URLs: keep username/host/path, remove query/hash
+  if (scheme === 'ssh') {
+    try {
+      const parsed = new URL(url);
+      // Rebuild without credentials, query, or hash
+      // For SSH, we need to keep the username (typically 'git')
+      const userInfo = parsed.username ? `${parsed.username}@` : '';
+      return `ssh://${userInfo}${parsed.host}${parsed.pathname}`;
+    } catch {
+      return stripUrlSecretsBestEffort(url);
+    }
+  }
+
+  // HTTP(S) URLs: remove credentials, query, hash
+  if (scheme === 'http' || scheme === 'https') {
+    try {
+      const parsed = new URL(url);
+      parsed.username = '';
+      parsed.password = '';
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString();
+    } catch {
+      return stripUrlSecretsBestEffort(url);
+    }
+  }
+
+  // Non-URL strings (owner/repo, local paths): return as-is
+  return url;
+}
+
+function stripUrlSecretsBestEffort(url: string): string {
+  return url.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/@\s]+@/i, '$1').replace(/[?#].*$/, '');
+}
+
+export function getLocalLockSourceUrl(
+  parsedUrl: string,
+  lockSourceValue: string,
+  sourceType: string
+): string | undefined {
+  // GitHub shorthand/full URL project updates already work with the normalized source.
+  // Only persist a full clone URL when the normalized source would be lossy.
+  if (sourceType === 'github' || sourceType === 'local') {
+    return undefined;
+  }
+
+  if (parsedUrl === lockSourceValue) {
+    return undefined;
+  }
+
+  const sanitizedSourceUrl = sanitizeSourceUrl(parsedUrl);
+  return sanitizedSourceUrl === lockSourceValue ? undefined : sanitizedSourceUrl;
+}
+
 // Helper to check if a value is a cancel symbol (works with both clack and our custom prompts)
 const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
 
@@ -1668,6 +1739,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Add to local lock file for project-scoped installs
     if (successful.length > 0 && !installGlobally) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
+      const lockSourceValue = lockSource || parsed.url;
+      const sourceUrl = getLocalLockSourceUrl(parsed.url, lockSourceValue, parsed.type);
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
@@ -1681,9 +1754,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             await addSkillToLocalLock(
               skill.name,
               {
-                source: lockSource || parsed.url,
+                source: lockSourceValue,
                 ref: parsed.ref,
                 sourceType: parsed.type,
+                ...(sourceUrl && { sourceUrl }),
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
               },

--- a/src/install.ts
+++ b/src/install.ts
@@ -40,7 +40,8 @@ export async function runInstallFromLock(args: string[]): Promise<void> {
       continue;
     }
 
-    const installSource = entry.ref ? `${entry.source}#${entry.ref}` : entry.source;
+    const effectiveSource = entry.sourceUrl || entry.source;
+    const installSource = entry.ref ? `${effectiveSource}#${entry.ref}` : effectiveSource;
     const existing = bySource.get(installSource);
     if (existing) {
       existing.skills.push(skillName);

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -20,6 +20,13 @@ export interface LocalSkillLockEntry {
   /** The provider/source type (e.g., "github", "node_modules", "local") */
   sourceType: string;
   /**
+   * Sanitized clone URL for restoring/updating when `source` is normalized/hostless.
+   * Stored for self-hosted GitLab or other non-GitHub sources where `source` may
+   * be normalized to `owner/repo` but the full URL is needed for cloning.
+   * Credentials, query strings, and fragments are stripped for security.
+   */
+  sourceUrl?: string;
+  /**
    * Path to the skill's SKILL.md within the source repo (e.g., "skills/pdf/SKILL.md").
    * Required to re-install only this skill on update — without it, an update would
    * refetch every skill in the source repo. Optional for backward compatibility with

--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -21,24 +21,47 @@ describe('update-source', () => {
   });
 
   describe('buildUpdateInstallSource', () => {
-    it('builds root-level install source without trailing slash', () => {
+    it('builds root-level GitHub install source without trailing slash', () => {
       const result = buildUpdateInstallSource({
         source: 'owner/repo',
         sourceUrl: 'https://github.com/owner/repo.git',
+        sourceType: 'github',
         ref: 'feature/install',
         skillPath: 'SKILL.md',
       });
       expect(result).toBe('owner/repo#feature/install');
     });
 
-    it('builds nested skill install source with ref', () => {
+    it('builds nested GitHub skill install source with ref', () => {
       const result = buildUpdateInstallSource({
         source: 'owner/repo',
         sourceUrl: 'https://github.com/owner/repo.git',
+        sourceType: 'github',
         ref: 'feature/install',
         skillPath: 'skills/my-skill/SKILL.md',
       });
       expect(result).toBe('owner/repo/skills/my-skill#feature/install');
+    });
+
+    it('uses sourceUrl for GitLab skillPath updates', () => {
+      const result = buildUpdateInstallSource({
+        source: 'owner/repo',
+        sourceUrl: 'https://gitlab.com/owner/repo.git',
+        sourceType: 'gitlab',
+        ref: 'feature/install',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://gitlab.com/owner/repo.git#feature/install');
+    });
+
+    it('uses sourceUrl for generic git skillPath updates', () => {
+      const result = buildUpdateInstallSource({
+        source: 'owner/repo',
+        sourceUrl: 'https://git.example.com/owner/repo.git',
+        sourceType: 'git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://git.example.com/owner/repo.git');
     });
 
     it('falls back to sourceUrl when skillPath is missing', () => {

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -1,6 +1,7 @@
 export interface UpdateSourceEntry {
   source: string;
   sourceUrl: string;
+  sourceType?: string;
   ref?: string;
   skillPath?: string;
 }
@@ -66,6 +67,16 @@ function appendFolderAndRef(source: string, skillPath: string, ref?: string): st
   return ref ? `${withFolder}#${ref}` : withFolder;
 }
 
+function getPathTargetedUpdateSource(entry: UpdateSourceEntry): string {
+  // GitHub shorthand supports path-targeted update sources like owner/repo/path#ref.
+  if (entry.sourceType === 'github') {
+    return entry.source;
+  }
+
+  // Generic/custom Git sources can have hostless normalized `source`, so prefer sourceUrl.
+  return entry.sourceUrl || entry.source;
+}
+
 /**
  * Build the source argument for `skills add` during update.
  * Uses shorthand form for path-targeted updates to avoid branch/path ambiguity.
@@ -74,7 +85,7 @@ export function buildUpdateInstallSource(entry: UpdateSourceEntry): string {
   if (!entry.skillPath) {
     return formatSourceInput(entry.sourceUrl, entry.ref);
   }
-  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
+  return appendFolderAndRef(getPathTargetedUpdateSource(entry), entry.skillPath, entry.ref);
 }
 
 /**

--- a/src/update.ts
+++ b/src/update.ts
@@ -189,6 +189,11 @@ export function getInstallSource(skill: SkippedSkill): string {
   return formatSourceInput(url, skill.ref);
 }
 
+function getGlobalUpdateGroupKey(entry: SkillLockEntry): string {
+  const source = entry.sourceType === 'github' ? entry.source : entry.sourceUrl || entry.source;
+  return JSON.stringify([entry.sourceType, entry.ref || '', source]);
+}
+
 export function printSkippedSkills(skipped: SkippedSkill[]): void {
   if (skipped.length === 0) return;
   console.log();
@@ -319,14 +324,15 @@ export async function updateGlobalSkills(
 
   const bySource = new Map<string, typeof checkable>();
   for (const item of checkable) {
-    const source = item.entry.source;
-    const existing = bySource.get(source) || [];
+    const groupKey = getGlobalUpdateGroupKey(item.entry);
+    const existing = bySource.get(groupKey) || [];
     existing.push(item);
-    bySource.set(source, existing);
+    bySource.set(groupKey, existing);
   }
 
-  for (const [source, itemsForSource] of bySource) {
+  for (const [groupKey, itemsForSource] of bySource) {
     const firstEntry = itemsForSource[0]!.entry;
+    const source = firstEntry.source;
     const sourceUrl = firstEntry.sourceUrl || firstEntry.source;
     let tempDir: string | null = null;
 
@@ -346,7 +352,7 @@ export async function updateGlobalSkills(
         const discoveredPaths = findSkillMdPaths(tree);
 
         const allLockedForSource = Object.entries(lock.skills)
-          .filter(([_, entry]) => entry.source === source)
+          .filter(([_, entry]) => getGlobalUpdateGroupKey(entry) === groupKey)
           .map(([name, _]) => name);
 
         const deletedSkills = await checkAndPromptForDeletions(
@@ -378,7 +384,7 @@ export async function updateGlobalSkills(
       });
 
       const allLockedForSource = Object.entries(lock.skills)
-        .filter(([_, entry]) => entry.source === source)
+        .filter(([_, entry]) => getGlobalUpdateGroupKey(entry) === groupKey)
         .map(([name, _]) => name);
 
       const deletedSkills = await checkAndPromptForDeletions(
@@ -628,7 +634,10 @@ export function printLegacyProjectSkills(
     `${DIM}${legacy.length} project skill(s) cannot be updated automatically (installed before skillPath tracking):${RESET}`
   );
   for (const skill of legacy) {
-    const reinstall = formatSourceInput(skill.entry.source, skill.entry.ref);
+    const reinstall = formatSourceInput(
+      skill.entry.sourceUrl || skill.entry.source,
+      skill.entry.ref
+    );
     console.log(`  ${TEXT}•${RESET} ${sanitizeMetadata(skill.name)}`);
     console.log(`    ${DIM}To refresh: ${TEXT}npx skills add ${reinstall} -y${RESET}`);
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -449,11 +449,15 @@ export async function updateGlobalSkills(
       );
       continue;
     }
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-      shell: process.platform === 'win32',
-    });
+    const result = spawnSync(
+      process.execPath,
+      [cliEntry, 'add', installUrl, '--skill', update.name, '-g', '-y'],
+      {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+        shell: process.platform === 'win32',
+      }
+    );
 
     if (result.status === 0) {
       successCount++;

--- a/src/update.ts
+++ b/src/update.ts
@@ -7,11 +7,7 @@ import pc from 'picocolors';
 
 import { readSkillLock, getGitHubToken, type SkillLockEntry } from './skill-lock.ts';
 import { computeSkillFolderHash, readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
-import {
-  formatSourceInput,
-  buildUpdateInstallSource,
-  buildLocalUpdateSource,
-} from './update-source.ts';
+import { formatSourceInput, buildUpdateInstallSource } from './update-source.ts';
 import { cloneRepo, cleanupTempDir } from './git.ts';
 import { discoverSkills } from './skills.ts';
 import { fetchRepoTree, findSkillMdPaths, getSkillFolderHashFromTree } from './blob.ts';
@@ -526,12 +522,15 @@ export async function updateProjectSkills(
   console.log(`${TEXT}Refreshing ${updatable.length} skill(s)...${RESET}`);
   console.log();
 
+  // Group by effective source (sourceUrl || source).
+  // Different hosts must not mix — e.g. same owner/repo on github.com
+  // vs a self-hosted GitLab are separate clone groups.
   const bySource = new Map<string, typeof updatable>();
   for (const skill of updatable) {
-    const source = skill.entry.source;
-    const existing = bySource.get(source) || [];
+    const effectiveSource = skill.entry.sourceUrl || skill.entry.source;
+    const existing = bySource.get(effectiveSource) || [];
     existing.push(skill);
-    bySource.set(source, existing);
+    bySource.set(effectiveSource, existing);
   }
 
   const localLock = await readLocalLock();
@@ -542,20 +541,25 @@ export async function updateProjectSkills(
     return { successCount, failCount: updatable.length, foundCount: projectSkills.length };
   }
 
-  for (const [source, skillsForSource] of bySource) {
+  for (const [, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
-    const sourceUrl = firstEntry.source;
+    const cloneSource = firstEntry.sourceUrl || firstEntry.source;
     const ref = firstEntry.ref;
 
+    // For deletion checks, filter lock entries with the same effective source.
+    const firstEffectiveSource = firstEntry.sourceUrl || firstEntry.source;
     const allLockedForSource = Object.entries(localLock.skills)
-      .filter(([_, entry]) => entry.source === source)
-      .map(([name, _]) => name);
+      .filter(([, entry]) => {
+        const entryEffectiveSource = entry.sourceUrl || entry.source;
+        return entryEffectiveSource === firstEffectiveSource;
+      })
+      .map(([name]) => name);
 
     let tempDir: string | null = null;
     let deletedSkills: string[] = [];
 
     try {
-      tempDir = await cloneRepo(sourceUrl, ref);
+      tempDir = await cloneRepo(cloneSource, ref);
       const discovered = await discoverSkills(tempDir);
 
       const discoveredPaths = discovered.map((s) => {
@@ -564,7 +568,7 @@ export async function updateProjectSkills(
       });
 
       deletedSkills = await checkAndPromptForDeletions(
-        source,
+        cloneSource,
         allLockedForSource,
         localLock.skills,
         false,
@@ -572,7 +576,7 @@ export async function updateProjectSkills(
         discoveredPaths
       );
     } catch (error) {
-      console.log(`${DIM}✗ Failed to check for deleted skills from ${source}${RESET}`);
+      console.log(`${DIM}✗ Failed to check for deleted skills from ${cloneSource}${RESET}`);
     } finally {
       if (tempDir) {
         await cleanupTempDir(tempDir);
@@ -584,7 +588,8 @@ export async function updateProjectSkills(
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);
       console.log(`${TEXT}Updating ${safeName}...${RESET}`);
-      const installUrl = formatSourceInput(skill.entry.source, skill.entry.ref);
+      const installSource = skill.entry.sourceUrl || skill.entry.source;
+      const installUrl = formatSourceInput(installSource, skill.entry.ref);
 
       const result = spawnSync(
         process.execPath,

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runInstallFromLock } from '../src/install.ts';
+import * as add from '../src/add.ts';
+import * as agents from '../src/agents.ts';
+import * as localLock from '../src/local-lock.ts';
+
+vi.mock('../src/add.ts');
+vi.mock('../src/agents.ts');
+vi.mock('../src/local-lock.ts');
+vi.mock('../src/sync.ts');
+vi.mock('@clack/prompts', () => ({
+  log: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('runInstallFromLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(agents.getUniversalAgents).mockReturnValue(['claude-code']);
+  });
+
+  it('restores project skills using sourceUrl and ref when available', async () => {
+    vi.mocked(localLock.readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {
+        'gitlab-skill': {
+          source: 'org/repo',
+          sourceUrl: 'https://gitlab.example.com/org/repo.git',
+          ref: 'main',
+          sourceType: 'gitlab',
+          computedHash: 'abc',
+        },
+      },
+    });
+
+    await runInstallFromLock([]);
+
+    expect(add.runAdd).toHaveBeenCalledWith(['https://gitlab.example.com/org/repo.git#main'], {
+      skill: ['gitlab-skill'],
+      agent: ['claude-code'],
+      yes: true,
+    });
+  });
+
+  it('falls back to source when sourceUrl is not available', async () => {
+    vi.mocked(localLock.readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {
+        'github-skill': {
+          source: 'owner/repo',
+          ref: 'v1',
+          sourceType: 'github',
+          computedHash: 'abc',
+        },
+      },
+    });
+
+    await runInstallFromLock([]);
+
+    expect(add.runAdd).toHaveBeenCalledWith(['owner/repo#v1'], {
+      skill: ['github-skill'],
+      agent: ['claude-code'],
+      yes: true,
+    });
+  });
+});

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -226,6 +226,106 @@ describe('local-lock', () => {
         await rm(dir, { recursive: true, force: true });
       }
     });
+
+    it('stores and preserves sourceUrl when present', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'gitlab-skill',
+          {
+            source: 'gradiant-organization/skill-inventory',
+            sourceUrl: 'https://gitlab.gradiant.co.kr/gradiant-organization/skill-inventory.git',
+            sourceType: 'gitlab',
+            computedHash: 'hash456',
+          },
+          dir
+        );
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['gitlab-skill']).toEqual({
+          source: 'gradiant-organization/skill-inventory',
+          sourceUrl: 'https://gitlab.gradiant.co.kr/gradiant-organization/skill-inventory.git',
+          sourceType: 'gitlab',
+          computedHash: 'hash456',
+        });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves sourceUrl across read/write cycle', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'skill-with-url',
+          {
+            source: 'org/repo',
+            sourceUrl: 'https://custom-git.example.com/org/repo.git',
+            ref: 'develop',
+            sourceType: 'gitlab',
+            computedHash: 'hash789',
+          },
+          dir
+        );
+
+        // Read back and verify sourceUrl is preserved
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['skill-with-url']!.sourceUrl).toBe(
+          'https://custom-git.example.com/org/repo.git'
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('reads a lock file with sourceUrl field', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const content = {
+          version: 1,
+          skills: {
+            'my-skill': {
+              source: 'owner/repo',
+              sourceUrl: 'https://gitlab.example.com/owner/repo.git',
+              sourceType: 'gitlab',
+              computedHash: 'abc123',
+            },
+          },
+        };
+        await writeFile(join(dir, 'skills-lock.json'), JSON.stringify(content), 'utf-8');
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['my-skill']!.sourceUrl).toBe(
+          'https://gitlab.example.com/owner/repo.git'
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('reads lock files without sourceUrl (backward compatibility)', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        // Old format without sourceUrl
+        const content = {
+          version: 1,
+          skills: {
+            'old-skill': {
+              source: 'org/repo',
+              sourceType: 'github',
+              computedHash: 'abc123',
+            },
+          },
+        };
+        await writeFile(join(dir, 'skills-lock.json'), JSON.stringify(content), 'utf-8');
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['old-skill']!.sourceUrl).toBeUndefined();
+        expect(lock.skills['old-skill']!.source).toBe('org/repo');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('removeSkillFromLocalLock', () => {

--- a/tests/source-url.test.ts
+++ b/tests/source-url.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { getLocalLockSourceUrl, sanitizeSourceUrl } from '../src/add.ts';
+
+describe('sanitizeSourceUrl', () => {
+  describe('HTTP(S) URLs', () => {
+    it('strips username and password from HTTPS URL', () => {
+      const result = sanitizeSourceUrl('https://user:pass@gitlab.example.com/org/repo.git');
+      expect(result).toBe('https://gitlab.example.com/org/repo.git');
+    });
+
+    it('strips username only from HTTPS URL', () => {
+      const result = sanitizeSourceUrl('https://user@gitlab.example.com/org/repo.git');
+      expect(result).toBe('https://gitlab.example.com/org/repo.git');
+    });
+
+    it('strips query string from HTTPS URL', () => {
+      const result = sanitizeSourceUrl('https://gitlab.example.com/org/repo.git?token=abc123');
+      expect(result).toBe('https://gitlab.example.com/org/repo.git');
+    });
+
+    it('strips hash/fragment from HTTPS URL', () => {
+      const result = sanitizeSourceUrl('https://gitlab.example.com/org/repo.git#main');
+      expect(result).toBe('https://gitlab.example.com/org/repo.git');
+    });
+
+    it('strips credentials, query, and hash together', () => {
+      const result = sanitizeSourceUrl(
+        'https://user:pass@gitlab.example.com/org/repo.git?token=abc#frag'
+      );
+      expect(result).toBe('https://gitlab.example.com/org/repo.git');
+    });
+
+    it('preserves port in HTTPS URL', () => {
+      const result = sanitizeSourceUrl('https://user:pass@gitlab.example.com:8443/org/repo.git');
+      expect(result).toBe('https://gitlab.example.com:8443/org/repo.git');
+    });
+
+    it('preserves clean HTTPS URL unchanged', () => {
+      const result = sanitizeSourceUrl('https://gitlab.example.com/org/repo.git');
+      expect(result).toBe('https://gitlab.example.com/org/repo.git');
+    });
+
+    it('handles http:// URLs', () => {
+      const result = sanitizeSourceUrl('http://user:pass@gitlab.example.com/org/repo.git');
+      expect(result).toBe('http://gitlab.example.com/org/repo.git');
+    });
+
+    it('handles uppercase HTTPS schemes', () => {
+      const result = sanitizeSourceUrl(
+        'HTTPS://user:pass@gitlab.example.com/org/repo.git?token=abc'
+      );
+      expect(result).toBe('https://gitlab.example.com/org/repo.git');
+    });
+  });
+
+  describe('ssh:// URLs', () => {
+    it('strips query and hash from ssh:// URL', () => {
+      const result = sanitizeSourceUrl('ssh://git@gitlab.example.com/org/repo.git?query#hash');
+      expect(result).toBe('ssh://git@gitlab.example.com/org/repo.git');
+    });
+
+    it('preserves username in ssh:// URL', () => {
+      const result = sanitizeSourceUrl('ssh://git@gitlab.example.com:7999/org/repo.git');
+      expect(result).toBe('ssh://git@gitlab.example.com:7999/org/repo.git');
+    });
+
+    it('preserves clean ssh:// URL unchanged', () => {
+      const result = sanitizeSourceUrl('ssh://git@gitlab.example.com/org/repo.git');
+      expect(result).toBe('ssh://git@gitlab.example.com/org/repo.git');
+    });
+
+    it('handles uppercase SSH schemes', () => {
+      const result = sanitizeSourceUrl('SSH://git@gitlab.example.com/org/repo.git?query#hash');
+      expect(result).toBe('ssh://git@gitlab.example.com/org/repo.git');
+    });
+  });
+
+  describe('scp-like SSH (git@host:...)', () => {
+    it('leaves scp-like SSH URL as-is', () => {
+      const result = sanitizeSourceUrl('git@gitlab.example.com:org/repo.git');
+      expect(result).toBe('git@gitlab.example.com:org/repo.git');
+    });
+
+    it('leaves GitHub SSH URL as-is', () => {
+      const result = sanitizeSourceUrl('git@github.com:owner/repo.git');
+      expect(result).toBe('git@github.com:owner/repo.git');
+    });
+  });
+
+  describe('non-URL strings', () => {
+    it('returns owner/repo shorthand as-is', () => {
+      expect(sanitizeSourceUrl('owner/repo')).toBe('owner/repo');
+    });
+
+    it('returns local path as-is', () => {
+      expect(sanitizeSourceUrl('/some/local/path')).toBe('/some/local/path');
+    });
+  });
+});
+
+describe('getLocalLockSourceUrl', () => {
+  it('stores sourceUrl for self-hosted GitLab when normalized source loses host', () => {
+    expect(
+      getLocalLockSourceUrl('https://gitlab.example.com/org/repo.git', 'org/repo', 'git')
+    ).toBe('https://gitlab.example.com/org/repo.git');
+  });
+
+  it('does not store sourceUrl for GitHub sources to preserve existing behavior', () => {
+    expect(
+      getLocalLockSourceUrl('https://github.com/owner/repo.git', 'owner/repo', 'github')
+    ).toBeUndefined();
+  });
+
+  it('does not store sourceUrl when source already contains the clone URL', () => {
+    expect(
+      getLocalLockSourceUrl(
+        'git@gitlab.example.com:org/repo.git',
+        'git@gitlab.example.com:org/repo.git',
+        'git'
+      )
+    ).toBeUndefined();
+  });
+
+  it('sanitizes sourceUrl before storing', () => {
+    expect(
+      getLocalLockSourceUrl(
+        'https://user:pass@gitlab.example.com/org/repo.git?token=abc#frag',
+        'org/repo',
+        'git'
+      )
+    ).toBe('https://gitlab.example.com/org/repo.git');
+  });
+
+  it('does not store sourceUrl when source already contains the original URL', () => {
+    expect(
+      getLocalLockSourceUrl(
+        'https://user:pass@gitlab.example.com/repo.git',
+        'https://user:pass@gitlab.example.com/repo.git',
+        'git'
+      )
+    ).toBeUndefined();
+  });
+});

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -359,6 +359,56 @@ describe('Update Cleanup Unit Tests', () => {
         expect.anything()
       );
     });
+
+    it('keeps same normalized global sources isolated by sourceUrl during clone and deletion checks', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'github-skill': {
+            source: 'org/repo',
+            sourceUrl: 'https://github.com/org/repo.git',
+            skillPath: 'skills/github-skill/SKILL.md',
+            sourceType: 'git',
+            skillFolderHash: 'old-a',
+            installedAt: '',
+            updatedAt: '',
+          },
+          'gitlab-skill': {
+            source: 'org/repo',
+            sourceUrl: 'https://gitlab.example.com/org/repo.git',
+            skillPath: 'skills/gitlab-skill/SKILL.md',
+            sourceType: 'git',
+            skillFolderHash: 'old-b',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockImplementation(async (source) =>
+        source === 'https://github.com/org/repo.git' ? '/tmp/github' : '/tmp/gitlab'
+      );
+      vi.mocked(skills.discoverSkills).mockImplementation(async (root) => [
+        {
+          name: root === '/tmp/github' ? 'github-skill' : 'gitlab-skill',
+          path: `${root}/skills/${root === '/tmp/github' ? 'github-skill' : 'gitlab-skill'}`,
+          description: 'A',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(p.confirm).mockResolvedValue(true);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('old-a');
+
+      await updateGlobalSkills();
+
+      expect(git.cloneRepo).toHaveBeenCalledTimes(2);
+      expect(git.cloneRepo).toHaveBeenCalledWith('https://github.com/org/repo.git', undefined);
+      expect(git.cloneRepo).toHaveBeenCalledWith(
+        'https://gitlab.example.com/org/repo.git',
+        undefined
+      );
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateProjectSkills with sourceUrl', () => {
@@ -630,6 +680,29 @@ describe('Update Cleanup Unit Tests', () => {
       const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
       expect(output).toContain('owner/repo#v1');
       expect(output).not.toContain('owner/repo/skills/github-skill#v1');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('uses sourceUrl with ref when sourceUrl exists', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      printLegacyProjectSkills([
+        {
+          name: 'gitlab-skill',
+          source: 'org/repo',
+          entry: {
+            source: 'org/repo',
+            sourceUrl: 'https://gitlab.example.com/org/repo.git',
+            ref: 'v1',
+            sourceType: 'git',
+            computedHash: 'abc',
+          },
+        },
+      ]);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('https://gitlab.example.com/org/repo.git#v1');
 
       consoleSpy.mockRestore();
     });

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { updateProjectSkills, updateGlobalSkills } from '../src/update.ts';
+import { spawnSync } from 'child_process';
+import {
+  updateProjectSkills,
+  updateGlobalSkills,
+  printLegacyProjectSkills,
+} from '../src/update.ts';
 import * as git from '../src/git.ts';
 import * as skills from '../src/skills.ts';
 import * as blob from '../src/blob.ts';
@@ -267,6 +272,280 @@ describe('Update Cleanup Unit Tests', () => {
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'skills/skill-a')
       );
+    });
+  });
+
+  describe('updateProjectSkills with sourceUrl', () => {
+    it('should use sourceUrl for clone when available', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'gradiant-organization/skill-inventory',
+            sourceUrl: 'https://gitlab.gradiant.co.kr/gradiant-organization/skill-inventory.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'gitlab',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateProjectSkills({ yes: true });
+
+      // Should clone using sourceUrl, not the hostless source
+      expect(git.cloneRepo).toHaveBeenCalledWith(
+        'https://gitlab.gradiant.co.kr/gradiant-organization/skill-inventory.git',
+        undefined
+      );
+    });
+
+    it('should use sourceUrl in spawned add command', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'gradiant-organization/skill-inventory',
+            sourceUrl: 'https://gitlab.gradiant.co.kr/gradiant-organization/skill-inventory.git',
+            ref: 'main',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'gitlab',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateProjectSkills({ yes: true });
+
+      // The spawned add command should use sourceUrl with ref
+      expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining([
+          'add',
+          'https://gitlab.gradiant.co.kr/gradiant-organization/skill-inventory.git#main',
+          '--skill',
+          'skill-a',
+          '-y',
+        ]),
+        expect.anything()
+      );
+    });
+
+    it('should fall back to source when sourceUrl is not set', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateProjectSkills({ yes: true });
+
+      // Should clone using source (owner/repo) when no sourceUrl
+      expect(git.cloneRepo).toHaveBeenCalledWith('owner/repo', undefined);
+    });
+
+    it('should keep GitHub project update spawned source at repo root', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            ref: 'main',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateProjectSkills({ yes: true });
+
+      expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining(['add', 'owner/repo#main', '--skill', 'skill-a', '-y']),
+        expect.anything()
+      );
+      expect(vi.mocked(spawnSync).mock.calls[0]![1]).not.toContain(
+        'owner/repo/skills/skill-a#main'
+      );
+    });
+
+    it('should group by effective source, separating different hosts', async () => {
+      // Two skills with same hostless "source" but different sourceUrl (different hosts)
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'github-skill': {
+            source: 'org/repo',
+            skillPath: 'skills/github-skill/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'aaa',
+          },
+          'gitlab-skill': {
+            source: 'org/repo',
+            sourceUrl: 'https://gitlab.example.com/org/repo.git',
+            skillPath: 'skills/gitlab-skill/SKILL.md',
+            sourceType: 'gitlab',
+            computedHash: 'bbb',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'github-skill',
+          path: '/tmp/repo/skills/github-skill',
+          description: 'A',
+          rawContent: '',
+        },
+        {
+          name: 'gitlab-skill',
+          path: '/tmp/repo/skills/gitlab-skill',
+          description: 'B',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateProjectSkills({ yes: true });
+
+      // Should clone twice — once for each host
+      expect(git.cloneRepo).toHaveBeenCalledTimes(2);
+      expect(git.cloneRepo).toHaveBeenCalledWith('org/repo', undefined);
+      expect(git.cloneRepo).toHaveBeenCalledWith(
+        'https://gitlab.example.com/org/repo.git',
+        undefined
+      );
+    });
+
+    it('should not consider other sourceUrl entries deleted during deletion checks', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'github-skill': {
+            source: 'org/repo',
+            skillPath: 'skills/github-skill/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'aaa',
+          },
+          'gitlab-skill': {
+            source: 'org/repo',
+            sourceUrl: 'https://gitlab.example.com/org/repo.git',
+            skillPath: 'skills/gitlab-skill/SKILL.md',
+            sourceType: 'gitlab',
+            computedHash: 'bbb',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockImplementation(async (source) => {
+        return source === 'org/repo' ? '/tmp/github' : '/tmp/gitlab';
+      });
+      vi.mocked(skills.discoverSkills).mockImplementation(async (root) => {
+        if (root === '/tmp/github') {
+          return [
+            {
+              name: 'github-skill',
+              path: '/tmp/github/skills/github-skill',
+              description: 'A',
+              rawContent: '',
+            },
+          ];
+        }
+        return [
+          {
+            name: 'gitlab-skill',
+            path: '/tmp/gitlab/skills/gitlab-skill',
+            description: 'B',
+            rawContent: '',
+          },
+        ];
+      });
+      vi.mocked(p.confirm).mockResolvedValue(true);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateProjectSkills();
+
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('printLegacyProjectSkills', () => {
+    it('falls back to source when sourceUrl is not set', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      printLegacyProjectSkills([
+        {
+          name: 'github-skill',
+          source: 'owner/repo',
+          entry: {
+            source: 'owner/repo',
+            ref: 'v1',
+            sourceType: 'github',
+            computedHash: 'abc',
+          },
+        },
+      ]);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('owner/repo#v1');
+      expect(output).not.toContain('undefined');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('does not append legacy skillPath to GitHub reinstall command', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      printLegacyProjectSkills([
+        {
+          name: 'github-skill',
+          source: 'owner/repo',
+          entry: {
+            source: 'owner/repo',
+            ref: 'v1',
+            sourceType: 'github',
+            skillPath: 'skills/github-skill/SKILL.md',
+            computedHash: 'abc',
+          },
+        },
+      ]);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('owner/repo#v1');
+      expect(output).not.toContain('owner/repo/skills/github-skill#v1');
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -273,6 +273,78 @@ describe('Update Cleanup Unit Tests', () => {
         join('/tmp/repo', 'skills/skill-a')
       );
     });
+
+    it('should keep GitHub global update source path-targeted', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            ref: 'main',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          { path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'sha1' },
+          { path: 'skills/skill-a', type: 'tree', sha: 'abc' },
+        ],
+      });
+      vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining(['add', 'owner/repo/skills/skill-a#main', '-g', '-y']),
+        expect.anything()
+      );
+      expect(vi.mocked(spawnSync).mock.calls[0]![1]).not.toContain(
+        'https://github.com/owner/repo.git#main'
+      );
+    });
+
+    it('should use sourceUrl when applying global non-GitHub git updates', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://gitlab.com/owner/repo.git',
+            ref: 'main',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'git',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining(['add', 'https://gitlab.com/owner/repo.git#main', '-g', '-y']),
+        expect.anything()
+      );
+    });
   });
 
   describe('updateProjectSkills with sourceUrl', () => {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -306,7 +306,14 @@ describe('Update Cleanup Unit Tests', () => {
 
       expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
         expect.anything(),
-        expect.arrayContaining(['add', 'owner/repo/skills/skill-a#main', '-g', '-y']),
+        expect.arrayContaining([
+          'add',
+          'owner/repo/skills/skill-a#main',
+          '--skill',
+          'skill-a',
+          '-g',
+          '-y',
+        ]),
         expect.anything()
       );
       expect(vi.mocked(spawnSync).mock.calls[0]![1]).not.toContain(
@@ -341,7 +348,14 @@ describe('Update Cleanup Unit Tests', () => {
 
       expect(vi.mocked(spawnSync)).toHaveBeenCalledWith(
         expect.anything(),
-        expect.arrayContaining(['add', 'https://gitlab.com/owner/repo.git#main', '-g', '-y']),
+        expect.arrayContaining([
+          'add',
+          'https://gitlab.com/owner/repo.git#main',
+          '--skill',
+          'skill-a',
+          '-g',
+          '-y',
+        ]),
         expect.anything()
       );
     });


### PR DESCRIPTION
Fixes #997

## Summary

`npx skills update -p` currently fails for project skills installed from self-hosted or custom GitLab instances because `skills-lock.json` only stores the normalized, hostless `source` value:

```json
{
  "source": "it-operations/marketplace-ops",
  "sourceType": "git"
}
```

That normalized value is not enough to reconstruct the original clone URL during update.

This change stores an optional, sanitized `sourceUrl` when the normalized `source` would otherwise be lossy, then prefers the preserved URL in project update, global update, and install-from-lock paths when needed.

Global update grouping and deletion checks now use the effective source and `ref`, so entries with the same normalized `source` but different preserved URLs are kept isolated.

GitHub and local sources are unchanged because their normalized source values remain sufficient. Existing lock files stay backward compatible, but self-hosted GitLab entries written before this change need a one-time `npx skills add <full URL>` to populate `sourceUrl`.

## Related PRs

Related to #1019 and #1401, but this PR specifically fixes the HTTPS self-hosted/custom GitLab case from #997 where the lock file loses the original clone URL.

## Tests

- `pnpm test`
- `pnpm build`
- `pnpm format:check`