### PR TITLE
fix(source-parser): resolve tree-URL refs containing slashes against the remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ npx skills add git@github.com:vercel-labs/agent-skills.git
 npx skills add ./my-local-skills
 ```
 
+Tree URLs (GitHub `/tree/...`, GitLab `/-/tree/...`) can be pasted straight from the browser — branch names containing slashes are resolved against the repository's refs.
+
 ### Options
 
 | Option                    | Description                                                                                                                                        |

--- a/src/add.ts
+++ b/src/add.ts
@@ -3,7 +3,13 @@ import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { sep, join, dirname } from 'path';
-import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
+import {
+  parseSource,
+  resolveAmbiguousTreeRef,
+  getOwnerRepo,
+  parseOwnerRepo,
+  isRepoPrivate,
+} from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
@@ -975,7 +981,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const spinner = p.spinner();
 
     spinner.start('Parsing source...');
-    const parsed = parseSource(source);
+    const parsed = await resolveAmbiguousTreeRef(source, parseSource(source));
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );

--- a/src/git.ts
+++ b/src/git.ts
@@ -248,6 +248,36 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   }
 }
 
+export interface RemoteRefs {
+  heads: Set<string>;
+  tags: Set<string>;
+}
+
+/**
+ * List branch and tag names on a remote without cloning (one ls-remote
+ * round-trip). Authentication is delegated entirely to local git.
+ */
+export async function listRemoteRefs(url: string): Promise<RemoteRefs> {
+  const output = await createGitClient().listRemote(['--heads', '--tags', url]);
+  const heads = new Set<string>();
+  const tags = new Set<string>();
+
+  for (const line of output.split('\n')) {
+    const refName = line.split('\t')[1];
+    // Skip peeled tag entries (refs/tags/v1^{}) — the plain entry is enough.
+    if (!refName || refName.endsWith('^{}')) {
+      continue;
+    }
+    if (refName.startsWith('refs/heads/')) {
+      heads.add(refName.slice('refs/heads/'.length));
+    } else if (refName.startsWith('refs/tags/')) {
+      tags.add(refName.slice('refs/tags/'.length));
+    }
+  }
+
+  return { heads, tags };
+}
+
 export async function cleanupTempDir(dir: string): Promise<void> {
   // Validate that the directory path is within tmpdir to prevent deletion of arbitrary paths
   const normalizedDir = normalize(resolve(dir));

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, resolve } from 'path';
+import { listRemoteRefs, type RemoteRefs } from './git.ts';
 import type { ParsedSource } from './types.ts';
 
 /**
@@ -281,6 +282,12 @@ export function parseSource(input: string): ParsedSource {
     );
   }
 
+  // Tree URLs copied from the GitHub/GitLab web UI may carry a query string
+  // (GitLab appends ?ref_type=heads); it is never part of the ref or subpath.
+  if (/^https?:\/\/[^?#]*\/tree\/[^?#]*\?/.test(input)) {
+    input = input.slice(0, input.indexOf('?'));
+  }
+
   // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
   const githubTreeWithPathMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/);
   if (githubTreeWithPathMatch) {
@@ -405,6 +412,69 @@ export function parseSource(input: string): ParsedSource {
     url: input,
     ...(fragmentRef ? { ref: fragmentRef } : {}),
   };
+}
+
+/**
+ * A tree URL whose portion after /tree/ spans multiple segments is ambiguous:
+ * the string alone cannot tell where a branch name containing "/" ends and
+ * the subpath begins (e.g. /-/tree/bugfix/ABC-123/libs/skills). Resolve it
+ * the same way GitLab's own router does — ask the remote for its refs and
+ * take the longest prefix that names an existing branch or tag (branches win
+ * over tags on an exact tie).
+ *
+ * Lazy by design: returns `parsed` untouched, with zero network calls, unless
+ * the source is an http(s) tree URL with a multi-segment tail. If ls-remote
+ * fails (offline, no access) or no ref matches, the current single-segment
+ * behavior is preserved.
+ */
+export async function resolveAmbiguousTreeRef(
+  source: string,
+  parsed: ParsedSource
+): Promise<ParsedSource> {
+  if (parsed.type !== 'github' && parsed.type !== 'gitlab') {
+    return parsed;
+  }
+  if (!source.startsWith('http://') && !source.startsWith('https://')) {
+    return parsed;
+  }
+
+  // Neither the fragment nor the query string is part of the ref or subpath.
+  const sourceUrl = source.split('#')[0]!.split('?')[0]!;
+  const treeMatch =
+    parsed.type === 'gitlab'
+      ? sourceUrl.match(/^https?:\/\/[^/]+\/.+?\/-\/tree\/(.+)$/)
+      : sourceUrl.match(/github\.com\/[^/]+\/[^/]+\/tree\/(.+)$/);
+  if (!treeMatch) {
+    return parsed;
+  }
+
+  // The GitLab UI sometimes encodes "/" within branch names as %2F.
+  const rest = treeMatch[1]!.replace(/%2F/gi, '/').replace(/\/+$/, '');
+  const segments = rest.split('/').filter(Boolean);
+  if (segments.length <= 1) {
+    return parsed;
+  }
+
+  let refs: RemoteRefs;
+  try {
+    refs = await listRemoteRefs(parsed.url);
+  } catch {
+    return parsed;
+  }
+
+  for (let i = segments.length; i >= 1; i--) {
+    const candidate = segments.slice(0, i).join('/');
+    if (refs.heads.has(candidate) || refs.tags.has(candidate)) {
+      const subpath = segments.slice(i).join('/');
+      return {
+        ...parsed,
+        ref: candidate,
+        subpath: subpath ? sanitizeSubpath(subpath) : undefined,
+      };
+    }
+  }
+
+  return parsed;
 }
 
 /**

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -6,9 +6,14 @@
  * correctly extracts type, url, ref (branch), and subpath.
  */
 
-import { describe, it, expect } from 'vitest';
-import { platform } from 'os';
-import { parseSource, getOwnerRepo } from '../src/source-parser.ts';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { platform, tmpdir } from 'os';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import { parseSource, resolveAmbiguousTreeRef, getOwnerRepo } from '../src/source-parser.ts';
+import type { ParsedSource } from '../src/types.ts';
 
 const isWindows = platform() === 'win32';
 
@@ -480,5 +485,169 @@ describe('Prefix shorthand tests', () => {
       expect(result.type).toBe('gitlab');
       expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
     });
+  });
+});
+
+describe('tree URL query strings', () => {
+  it('strips ?ref_type=heads from a GitLab tree URL with branch only', () => {
+    const result = parseSource('https://gitlab.com/owner/repo/-/tree/main?ref_type=heads');
+    expect(result.type).toBe('gitlab');
+    expect(result.url).toBe('https://gitlab.com/owner/repo.git');
+    expect(result.ref).toBe('main');
+    expect(result.subpath).toBeUndefined();
+  });
+
+  it('strips ?ref_type=heads from a GitLab tree URL with subpath', () => {
+    const result = parseSource('https://gitlab.com/owner/repo/-/tree/main/skills?ref_type=heads');
+    expect(result.type).toBe('gitlab');
+    expect(result.ref).toBe('main');
+    expect(result.subpath).toBe('skills');
+  });
+
+  it('strips query strings from GitHub tree URLs', () => {
+    const result = parseSource('https://github.com/owner/repo/tree/main/skills?foo=bar');
+    expect(result.type).toBe('github');
+    expect(result.ref).toBe('main');
+    expect(result.subpath).toBe('skills');
+  });
+});
+
+describe('resolveAmbiguousTreeRef', () => {
+  let fixtureDir: string;
+  let fixtureUrl: string;
+
+  function git(cwd: string, ...args: string[]): void {
+    execFileSync('git', args, { cwd, stdio: 'pipe' });
+  }
+
+  // Build the parsed source for a tree URL, but point its repo URL at the
+  // local fixture so ls-remote runs against file:// (zero network).
+  function parsedForFixture(source: string): ParsedSource {
+    return { ...parseSource(source), url: fixtureUrl };
+  }
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'skills-tree-ref-fixture-'));
+    fixtureUrl = pathToFileURL(fixtureDir).href;
+
+    git(fixtureDir, 'init', '-b', 'main');
+    git(
+      fixtureDir,
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'user.name=test',
+      'commit',
+      '--allow-empty',
+      '-m',
+      'init'
+    );
+    // Branch names containing slashes. Note git itself forbids a branch named
+    // "bugfix" alongside "bugfix/x" (ref namespace conflict), so the ambiguous
+    // shorter ref is a tag.
+    git(fixtureDir, 'branch', 'bugfix/ABC-123-some-fix');
+    git(fixtureDir, 'branch', 'bugfix/x');
+    git(fixtureDir, 'tag', 'bugfix');
+    git(fixtureDir, 'tag', 'release/1.0');
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('resolves a GitLab branch containing slashes plus a subpath', async () => {
+    const source =
+      'https://gitlab.example.com/group/repo/-/tree/bugfix/ABC-123-some-fix/libs/skills';
+    const parsed = parsedForFixture(source);
+    // Without resolution, the parser can only guess a single-segment ref.
+    expect(parsed.ref).toBe('bugfix');
+
+    const resolved = await resolveAmbiguousTreeRef(source, parsed);
+    expect(resolved.ref).toBe('bugfix/ABC-123-some-fix');
+    expect(resolved.subpath).toBe('libs/skills');
+  });
+
+  it('prefers the longest matching ref when both bugfix and bugfix/x exist', async () => {
+    const source = 'https://gitlab.example.com/group/repo/-/tree/bugfix/x';
+    const resolved = await resolveAmbiguousTreeRef(source, parsedForFixture(source));
+    expect(resolved.ref).toBe('bugfix/x');
+    expect(resolved.subpath).toBeUndefined();
+  });
+
+  it('falls back to the shorter ref when the longer prefix is not a ref', async () => {
+    const source = 'https://gitlab.example.com/group/repo/-/tree/bugfix/docs';
+    const resolved = await resolveAmbiguousTreeRef(source, parsedForFixture(source));
+    expect(resolved.ref).toBe('bugfix');
+    expect(resolved.subpath).toBe('docs');
+  });
+
+  it('resolves tag refs containing slashes', async () => {
+    const source = 'https://gitlab.example.com/group/repo/-/tree/release/1.0/skills';
+    const resolved = await resolveAmbiguousTreeRef(source, parsedForFixture(source));
+    expect(resolved.ref).toBe('release/1.0');
+    expect(resolved.subpath).toBe('skills');
+  });
+
+  it('resolves GitHub-style tree URLs', async () => {
+    const source = 'https://github.com/owner/repo/tree/bugfix/ABC-123-some-fix/libs/skills';
+    const resolved = await resolveAmbiguousTreeRef(source, parsedForFixture(source));
+    expect(resolved.ref).toBe('bugfix/ABC-123-some-fix');
+    expect(resolved.subpath).toBe('libs/skills');
+  });
+
+  it('decodes %2F in the tree portion before matching', async () => {
+    const source =
+      'https://gitlab.example.com/group/repo/-/tree/bugfix%2FABC-123-some-fix/libs/skills';
+    const resolved = await resolveAmbiguousTreeRef(source, parsedForFixture(source));
+    expect(resolved.ref).toBe('bugfix/ABC-123-some-fix');
+    expect(resolved.subpath).toBe('libs/skills');
+  });
+
+  it('ignores query strings appended by the GitLab UI', async () => {
+    const source =
+      'https://gitlab.example.com/group/repo/-/tree/bugfix/ABC-123-some-fix/libs/skills?ref_type=heads';
+    const resolved = await resolveAmbiguousTreeRef(source, parsedForFixture(source));
+    expect(resolved.ref).toBe('bugfix/ABC-123-some-fix');
+    expect(resolved.subpath).toBe('libs/skills');
+  });
+
+  it('keeps the single-segment parse when no ref matches', async () => {
+    const source = 'https://gitlab.example.com/group/repo/-/tree/nope/nothing';
+    const parsed = parsedForFixture(source);
+    const resolved = await resolveAmbiguousTreeRef(source, parsed);
+    expect(resolved).toBe(parsed);
+    expect(resolved.ref).toBe('nope');
+    expect(resolved.subpath).toBe('nothing');
+  });
+
+  it('keeps the single-segment parse when ls-remote fails', async () => {
+    const source =
+      'https://gitlab.example.com/group/repo/-/tree/bugfix/ABC-123-some-fix/libs/skills';
+    const parsed: ParsedSource = {
+      ...parseSource(source),
+      url: pathToFileURL(join(tmpdir(), 'skills-no-such-repo')).href,
+    };
+    const resolved = await resolveAmbiguousTreeRef(source, parsed);
+    expect(resolved).toBe(parsed);
+    expect(resolved.ref).toBe('bugfix');
+    expect(resolved.subpath).toBe('ABC-123-some-fix/libs/skills');
+  });
+
+  it('returns single-segment tree URLs unchanged without resolving', async () => {
+    const source = 'https://gitlab.example.com/group/repo/-/tree/main';
+    // The repo URL is intentionally unreachable: a single-segment tree URL
+    // must short-circuit before any ls-remote happens.
+    const parsed = parseSource(source);
+    const resolved = await resolveAmbiguousTreeRef(source, parsed);
+    expect(resolved).toBe(parsed);
+    expect(resolved.ref).toBe('main');
+  });
+
+  it('returns non-tree sources unchanged without resolving', async () => {
+    const source = 'owner/repo/skills/my-skill';
+    const parsed = parseSource(source);
+    const resolved = await resolveAmbiguousTreeRef(source, parsed);
+    expect(resolved).toBe(parsed);
+    expect(resolved.subpath).toBe('skills/my-skill');
   });
 });


### PR DESCRIPTION
Related (independent, either merge order works): #1419 adds sparse checkout for subpath installs.

Closes #1417

## Repro

```bash
npx skills add "https://gitlab.example.com/group/repo/-/tree/bugfix/ABC-123-some-fix/libs/skills"
# => Failed to clone ...: Remote branch bugfix not found
```

Any tree URL copied from the GitLab/GitHub UI fails this way when the branch
name contains `/`.

## Root cause

A tree URL is ambiguous by construction: in `/-/tree/bugfix/ABC-123/libs/skills`
nothing marks where the ref ends and the subpath begins — `bugfix`,
`bugfix/ABC-123`, and `bugfix/ABC-123/libs` are all valid branch names. The
parser's `/-/tree/([^/]+)/(.+)` regex can only guess one segment, which is wrong
for every slash-containing branch.

The ambiguity is unresolvable from the string alone. #215 tried the greedy
opposite (everything after `/tree/` is the branch) and broke subpath installs.
GitLab's own router resolves these URLs by matching against the project's actual
branch/tag list — this PR does the same.

## Fix

New `resolveAmbiguousTreeRef` (invoked from `add` right before cloning): when an
http(s) source is a tree URL whose tail spans multiple segments, run **one**
`git ls-remote --heads --tags` round-trip and take the longest prefix naming an
existing branch or tag as the ref (branches win ties); the remainder is the
subpath. Also strips `?ref_type=heads` query strings and decodes `%2F`.

- **Lazy**: zero network calls unless the source is a multi-segment http(s) tree
  URL; `parseSource` stays synchronous; single-segment tree URLs are untouched.
- **Safe**: if ls-remote fails (offline, no access) or nothing matches, the
  current single-segment behavior is kept — previously-working inputs cannot
  regress.
- **No new flag**: the stalled `-b`/`--ref` PRs (#228, #467, #590) push the
  ambiguity onto the user, who has no reason to know their pasted URL is
  ambiguous. Resolving against the remote handles it transparently.
- **Auth** stays fully delegated to local git; no credential handling anywhere.

## Tests

Zero-network: `git ls-remote` runs against `file://` fixture repos created in
temp dirs (no git mocking). Covers: slash-branch + subpath; ambiguous prefix
(`bugfix` tag vs `bugfix/x` branch → longest wins; git forbids both as sibling
branches, hence the tag); slashed tag refs; GitHub-style `/tree/`; query-string
stripping; `%2F` decoding; ls-remote failure → fallback; single-segment and
non-tree sources returned unchanged with no network.

`pnpm build`, `pnpm test`, `pnpm format:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
