### PR TITLE
fix(add): exclude project-only agents (e.g. PromptScript) from global installs

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,7 +4,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import { parseAddOptions, getLockSource } from './add.ts';
+import { parseAddOptions, getLockSource, filterAgentsForGlobalScope } from './add.ts';
+import type { AgentType } from './types.ts';
 
 describe('add command', () => {
   let testDir: string;
@@ -406,6 +407,19 @@ describe('parseAddOptions', () => {
     expect(result.options.fullDepth).toBe(true);
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
+  });
+});
+
+describe('filterAgentsForGlobalScope', () => {
+  it('drops agents without a global skills dir for global installs', () => {
+    const result = filterAgentsForGlobalScope(['claude-code', 'promptscript'] as AgentType[], true);
+    expect(result).toContain('claude-code');
+    expect(result).not.toContain('promptscript');
+  });
+
+  it('keeps every agent for project (non-global) installs', () => {
+    const agents = ['claude-code', 'promptscript'] as AgentType[];
+    expect(filterAgentsForGlobalScope(agents, false)).toEqual(agents);
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -257,6 +257,22 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
 }
 
 /**
+ * When agents are auto-selected (`--agent '*'`, `--yes`, or detection) for a
+ * global install, drop the ones that only support project-scoped skills (no
+ * `globalSkillsDir`, e.g. PromptScript). Without this, a blanket
+ * `--global`/`--yes` install reports a spurious "does not support global skill
+ * installation" failure for them. Explicit `--agent <name>` selections bypass
+ * this so the per-agent error still surfaces for a deliberately-named agent.
+ */
+export function filterAgentsForGlobalScope(
+  targetAgents: AgentType[],
+  global: boolean
+): AgentType[] {
+  if (!global) return targetAgents;
+  return targetAgents.filter((a) => agents[a].globalSkillsDir !== undefined);
+}
+
+/**
  * Builds result lines from installation results, splitting by universal vs symlinked
  */
 function buildResultLines(
@@ -648,6 +664,13 @@ async function handleWellKnownSkills(
     }
 
     installGlobally = scope as boolean;
+  }
+
+  // Drop auto-selected agents that can't satisfy a global install (e.g.
+  // PromptScript). Skip when the user named agents explicitly so the
+  // per-agent error still surfaces for a deliberately-named agent.
+  if (!(options.agent?.length && !options.agent.includes('*'))) {
+    targetAgents = filterAgentsForGlobalScope(targetAgents, installGlobally);
   }
 
   // Determine install mode (symlink vs copy)
@@ -1367,6 +1390,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       installGlobally = scope as boolean;
+    }
+
+    // Drop auto-selected agents that can't satisfy a global install (e.g.
+    // PromptScript). Skip when the user named agents explicitly so the
+    // per-agent error still surfaces for a deliberately-named agent.
+    if (!(options.agent?.length && !options.agent.includes('*'))) {
+      targetAgents = filterAgentsForGlobalScope(targetAgents, installGlobally);
     }
 
     // Determine install mode (symlink vs copy)


### PR DESCRIPTION
`skills add <repo> -g -y` (and any global install where agents are auto-selected) always ends with a spurious failure:

```
■  Failed to install 1
   ✗ <skill> → PromptScript: PromptScript does not support global skill installation
```

PromptScript has `skillsDir: '.agents/skills'` but `globalSkillsDir: undefined`. When no `--agent` is passed, `targetAgents` expands to **all** agents (via `--agent '*'`, `--yes`, or detection) without filtering for global capability, so a `--global` install always trips over PromptScript. The skill installs everywhere else and the exit code is 0, but the red line reads as broken.

Fix: when agents are auto-selected for a global install, drop the ones without a `globalSkillsDir`. Explicit `--agent <name>` is left untouched, so deliberately naming a project-only agent still surfaces the informative per-agent error. The filter is a small exported helper (`filterAgentsForGlobalScope`) applied at both selection sites (`handleWellKnownSkills` and `runAdd`), with unit tests.

Repro (before this change prints the failure; after, it's clean):

```
npx skills add vercel-labs/agent-skills -g -y
```