### PR TITLE
Fix local skills overwrite during all-agent installs

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -68,6 +68,10 @@ function isPathSafe(basePath: string, targetPath: string): boolean {
   return normalizedTarget.startsWith(normalizedBase + sep) || normalizedTarget === normalizedBase;
 }
 
+function pathsOverlap(pathA: string, pathB: string): boolean {
+  return isPathSafe(pathA, pathB) || isPathSafe(pathB, pathA);
+}
+
 // Dirent.isDirectory() is false for symlinks; follow and verify the target is a directory.
 async function isDirEntryOrSymlinkToDir(
   entry: { isDirectory(): boolean; isSymbolicLink(): boolean },
@@ -216,8 +220,9 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
     const realLinkDir = await resolveParentSymlinks(linkDir);
     const relativePath = relative(realLinkDir, target);
     const symlinkType = platform() === 'win32' ? 'junction' : undefined;
+    const symlinkTarget = symlinkType === 'junction' ? resolvedTarget : relativePath;
 
-    await symlink(relativePath, linkPath, symlinkType);
+    await symlink(symlinkTarget, linkPath, symlinkType);
     return true;
   } catch {
     return false;
@@ -277,6 +282,20 @@ export async function installSkillForAgent(
   }
 
   try {
+    // Never install onto (or inside) the source directory. This can happen with
+    // agent-specific project directories like OpenClaw's "skills" when users run
+    // `skills add ./skills --all`: the source `./skills/<name>` and destination
+    // `./skills/<name>` are the same path. Cleaning the destination would delete
+    // the user's source skill before we can link or copy it.
+    if (pathsOverlap(skill.path, agentDir)) {
+      return {
+        success: true,
+        path: agentDir,
+        mode: installMode,
+        skipped: true,
+      };
+    }
+
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
@@ -286,6 +305,16 @@ export async function installSkillForAgent(
         success: true,
         path: agentDir,
         mode: 'copy',
+      };
+    }
+
+    if (pathsOverlap(skill.path, canonicalDir)) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
       };
     }
 

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -57,6 +57,43 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('skips agent installs that would overwrite the source directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'source-overlap-skill';
+    const skillDir = join(projectDir, 'skills', skillName);
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: test\n---\n`,
+      'utf-8'
+    );
+    await writeFile(join(skillDir, 'extra.txt'), 'preserve me\n', 'utf-8');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'openclaw',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+
+      const stats = await lstat(skillDir);
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
+      await expect(readFile(join(skillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+      await expect(readFile(join(skillDir, 'extra.txt'), 'utf-8')).resolves.toBe('preserve me\n');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('cleans pre-existing self-loop symlink in canonical dir', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
     const projectDir = join(root, 'project');


### PR DESCRIPTION
## Summary
- prevent installer destinations from overlapping the source skill directory
- skip agent-specific installs that would clean/delete the source, such as OpenClaw `skills/` when running `skills add ./skills --all`
- use absolute targets for Windows junctions to avoid wrong relative target resolution
- add regression coverage for preserving `./skills/<name>` during OpenClaw installs

## Tests
- `pnpm test tests/installer-symlink.test.ts tests/installer-copy.test.ts`

## Notes
- `pnpm type-check` currently fails on pre-existing unrelated errors in `src/git.ts` and `src/skills.ts`.