### PR TITLE
feat: expose programmatic API for library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,168 @@ npx skills rm my-skill
 | `-y, --yes`    | Skip confirmation prompts                        |
 | `--all`        | Shorthand for `--skill '*' --agent '*' -y`       |
 
+## Programmatic Usage
+
+In addition to the CLI, this package exports a programmatic API for managing skills from Node.js applications, CI pipelines, and other tools.
+
+```bash
+npm install skills
+```
+
+### Quick Start
+
+```ts
+import {
+  parseSource,
+  getOwnerRepo,
+  tryBlobInstall,
+  installBlobSkillForAgent,
+  addSkillToLocalLock,
+} from 'skills';
+
+// Parse a source string (same formats as the CLI)
+const parsed = parseSource('vercel-labs/agent-skills');
+const ownerRepo = getOwnerRepo(parsed)!;
+
+// Fetch skills via the GitHub blob fast path (no git clone needed)
+const result = await tryBlobInstall(ownerRepo, {
+  skillFilter: 'web-design-guidelines',
+});
+
+if (result) {
+  for (const skill of result.skills) {
+    // Install to the cursor agent directory
+    await installBlobSkillForAgent(skill, 'cursor', {
+      mode: 'copy',
+    });
+
+    // Record in the project lock file
+    await addSkillToLocalLock(skill.name, {
+      source: ownerRepo,
+      sourceType: parsed.type,
+      skillPath: skill.repoPath,
+      computedHash: skill.snapshotHash,
+    });
+  }
+}
+```
+
+### API Overview
+
+The library organizes exports into several areas:
+
+#### Source Parsing
+
+Parse the same source formats accepted by the CLI — GitHub shorthand, URLs, GitLab, local paths, and well-known endpoints.
+
+```ts
+import { parseSource, getOwnerRepo, parseOwnerRepo } from 'skills';
+
+parseSource('vercel-labs/agent-skills');
+// → { type: 'github', url: 'https://github.com/vercel-labs/agent-skills.git' }
+
+parseSource('https://gitlab.com/org/repo/-/tree/main/skills/my-skill');
+// → { type: 'gitlab', url: '...', ref: 'main', subpath: 'skills/my-skill' }
+
+getOwnerRepo(parseSource('vercel-labs/agent-skills'));
+// → 'vercel-labs/agent-skills'
+```
+
+#### Lock Files
+
+Read and write both project-scoped (`skills-lock.json`) and global (`~/.agents/.skill-lock.json`) lock files.
+
+```ts
+import { readLocalLock, readSkillLock } from 'skills';
+
+// Project lock
+const projectLock = await readLocalLock();
+// → { version: 1, skills: { 'find-skills': { source: '...', computedHash: '...' } } }
+
+// Global lock
+const globalLock = await readSkillLock();
+```
+
+#### Skill Discovery
+
+Discover `SKILL.md` files on disk or from a GitHub repo tree.
+
+```ts
+import {
+  discoverSkills,
+  fetchRepoTree,
+  findSkillMdPaths,
+  getSkillFolderHashFromTree,
+} from 'skills';
+
+// On-disk discovery
+const skills = await discoverSkills('/path/to/cloned/repo');
+
+// Remote discovery via GitHub Trees API (single API call)
+const tree = await fetchRepoTree('vercel-labs/agent-skills');
+if (tree) {
+  const paths = findSkillMdPaths(tree);
+  // → ['skills/web-design-guidelines/SKILL.md', ...]
+
+  const hash = getSkillFolderHashFromTree(tree, 'skills/web-design-guidelines/SKILL.md');
+  // → 'abc123...' (tree SHA, changes when any file in the folder changes)
+}
+```
+
+#### Installation
+
+Install skills to agent directories, check installation status, and list installed skills.
+
+```ts
+import { installBlobSkillForAgent, listInstalledSkills, isSkillInstalled } from 'skills';
+
+const installed = await listInstalledSkills({ global: false });
+const exists = await isSkillInstalled('web-design-guidelines', 'cursor');
+```
+
+#### Agent Registry
+
+Access the full registry of supported agents with their paths and detection logic.
+
+```ts
+import { agents, getAgentConfig, detectInstalledAgents } from 'skills';
+
+const cursorConfig = getAgentConfig('cursor');
+// → { name: 'cursor', displayName: 'Cursor', skillsDir: '.agents/skills/', ... }
+
+const installed = await detectInstalledAgents();
+// → ['cursor', 'claude-code', ...]
+```
+
+#### Search
+
+Search the [skills.sh](https://skills.sh) directory programmatically.
+
+```ts
+import { searchSkillsAPI } from 'skills';
+
+const results = await searchSkillsAPI('typescript');
+// → [{ name: 'TypeScript Best Practices', slug: '...', source: '...', installs: 42 }, ...]
+```
+
+#### Frontmatter Parsing
+
+Parse `SKILL.md` YAML frontmatter.
+
+```ts
+import { parseFrontmatter } from 'skills';
+
+const { data, content } = parseFrontmatter(rawMarkdown);
+// data → { name: 'my-skill', description: '...' }
+// content → '# My Skill\n...'
+```
+
+### Notes
+
+- **Side effects**: Lock file functions perform filesystem I/O. Blob and tree functions make HTTP requests to GitHub APIs and `skills.sh`. Installation functions create directories, write files, and create symlinks.
+- **`getGitHubToken()`** falls back to `gh auth token` via subprocess when environment variables (`GITHUB_TOKEN`, `GH_TOKEN`) are not set. Set one of these environment variables for fully silent programmatic usage.
+- **Telemetry**: The library exports `fetchAuditData` for checking skill security data but does not send CLI telemetry when used programmatically. The `track()` function is intentionally not exported.
+
 ## What are Agent Skills?
 
 Agent skills are reusable instruction sets that extend your coding agent's capabilities. They're defined in `SKILL.md`

--- a/build.config.mjs
+++ b/build.config.mjs
@@ -2,5 +2,10 @@ import { defineBuildConfig } from 'obuild/config';
 
 // https://github.com/unjs/obuild
 export default defineBuildConfig({
-  entries: [{ type: 'bundle', input: './src/cli.ts' }],
+  entries: [
+    {
+      type: 'bundle',
+      input: ['./src/cli.ts', './src/index.ts'],
+    },
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "1.5.11",
   "description": "The open agent skills ecosystem",
   "type": "module",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
   "bin": {
     "skills": "./bin/cli.mjs",
     "add-skill": "./bin/cli.mjs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,193 @@
+/**
+ * Programmatic API for the skills ecosystem.
+ *
+ * This module exposes the core building blocks of the `skills` CLI as a
+ * library so that other tools, CI pipelines, and applications can manage
+ * agent skills without shelling out to the CLI.
+ *
+ * @example
+ * ```ts
+ * import { parseSource, getOwnerRepo, tryBlobInstall } from 'skills';
+ *
+ * const parsed = parseSource('vercel-labs/agent-skills');
+ * const ownerRepo = getOwnerRepo(parsed)!;
+ * const result = await tryBlobInstall(ownerRepo, { skillFilter: 'web-design-guidelines' });
+ *
+ * if (result) {
+ *   for (const skill of result.skills) {
+ *     console.log(skill.name, skill.repoPath);
+ *   }
+ * }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type { AgentType, Skill, AgentConfig, ParsedSource, RemoteSkill } from './types.ts';
+
+export type { SkillLockEntry, DismissedPrompts, SkillLockFile } from './skill-lock.ts';
+
+export type { LocalSkillLockEntry, LocalSkillLockFile } from './local-lock.ts';
+
+export type {
+  SkillSnapshotFile,
+  SkillDownloadResponse,
+  BlobSkill,
+  TreeEntry,
+  RepoTree,
+  BlobInstallResult,
+} from './blob.ts';
+
+export type { UpdateSourceEntry, LocalUpdateSourceEntry } from './update-source.ts';
+
+export type { DiscoverSkillsOptions } from './skills.ts';
+
+export type { InstallMode, InstalledSkill } from './installer.ts';
+
+export type { SearchSkill } from './find.ts';
+
+// ── Source Parsing ───────────────────────────────────────────────────
+
+export {
+  parseSource,
+  getOwnerRepo,
+  parseOwnerRepo,
+  isRepoPrivate,
+  sanitizeSubpath,
+} from './source-parser.ts';
+
+// ── Frontmatter & Sanitization ──────────────────────────────────────
+
+export { parseFrontmatter } from './frontmatter.ts';
+export { sanitizeMetadata, stripTerminalEscapes } from './sanitize.ts';
+
+// ── Lock Files (project-scoped) ─────────────────────────────────────
+
+export {
+  getLocalLockPath,
+  readLocalLock,
+  writeLocalLock,
+  computeSkillFolderHash,
+  addSkillToLocalLock,
+  removeSkillFromLocalLock,
+} from './local-lock.ts';
+
+// ── Lock Files (global) ─────────────────────────────────────────────
+
+export {
+  getSkillLockPath,
+  readSkillLock,
+  writeSkillLock,
+  computeContentHash,
+  getGitHubToken,
+  fetchSkillFolderHash,
+  addSkillToLock,
+  removeSkillFromLock,
+  getSkillFromLock,
+  getAllLockedSkills,
+  getSkillsBySource,
+} from './skill-lock.ts';
+
+// ── GitHub Blob Fast Path ───────────────────────────────────────────
+
+export {
+  toSkillSlug,
+  fetchRepoTree,
+  getSkillFolderHashFromTree,
+  findSkillMdPaths,
+  tryBlobInstall,
+  BLOB_ALLOWED_REPOS,
+} from './blob.ts';
+
+// ── Skill Discovery (on-disk) ───────────────────────────────────────
+
+export {
+  discoverSkills,
+  parseSkillMd,
+  filterSkills,
+  getSkillDisplayName,
+  shouldInstallInternalSkills,
+} from './skills.ts';
+
+// ── Update Source URL Builders ───────────────────────────────────────
+
+export {
+  formatSourceInput,
+  buildUpdateInstallSource,
+  buildLocalUpdateSource,
+} from './update-source.ts';
+
+// ── Agent Registry ──────────────────────────────────────────────────
+
+export {
+  agents,
+  getAgentConfig,
+  detectInstalledAgents,
+  getUniversalAgents,
+  getVisibleUniversalAgents,
+  getNonUniversalAgents,
+  isUniversalAgent,
+} from './agents.ts';
+
+// ── Installer ───────────────────────────────────────────────────────
+
+export {
+  sanitizeName,
+  getCanonicalSkillsDir,
+  getAgentBaseDir,
+  getInstallPath,
+  getCanonicalPath,
+  installSkillForAgent,
+  installRemoteSkillForAgent,
+  installBlobSkillForAgent,
+  isSkillInstalled,
+  listInstalledSkills,
+} from './installer.ts';
+
+// ── Git Clone Fallback ──────────────────────────────────────────────
+
+export {
+  GitCloneError,
+  cloneRepo,
+  cleanupTempDir,
+  isGitHubHttpsCloneUrl,
+  isGitHubSsoAuthError,
+} from './git.ts';
+
+// ── Constants ───────────────────────────────────────────────────────
+
+export { AGENTS_DIR, SKILLS_SUBDIR, UNIVERSAL_SKILLS_DIR } from './constants.ts';
+
+// ── Plugin Manifest ─────────────────────────────────────────────────
+
+export { getPluginSkillPaths, getPluginGroupings } from './plugin-manifest.ts';
+
+// ── Providers ───────────────────────────────────────────────────────
+
+export type { HostProvider, ProviderMatch, ProviderRegistry } from './providers/types.ts';
+
+export { registry, registerProvider, findProvider, getProviders } from './providers/registry.ts';
+
+export type {
+  WellKnownIndex,
+  WellKnownIndexV1,
+  WellKnownIndexV2,
+  WellKnownSkillEntry,
+  WellKnownSkillEntryV1,
+  WellKnownSkillEntryV2,
+  WellKnownSkill,
+  WellKnownFileContent,
+} from './providers/wellknown.ts';
+
+export { WellKnownProvider, wellKnownProvider } from './providers/wellknown.ts';
+
+// ── Search ──────────────────────────────────────────────────────────
+
+export { searchSkillsAPI } from './find.ts';
+
+// ── Telemetry ───────────────────────────────────────────────────────
+
+export type { PartnerAudit, SkillAuditData, AuditResponse } from './telemetry.ts';
+export { fetchAuditData } from './telemetry.ts';


### PR DESCRIPTION
## Summary

The `skills` package is currently CLI-only — all internal modules are bundled into a single `dist/cli.mjs` with `export {}`, making it impossible for Node.js applications, CI pipelines, and other tools to use the well-structured internals programmatically.

This PR adds a library entry point (`src/index.ts`) that re-exports the pure and mostly-pure modules while intentionally excluding CLI-only code (interactive prompts, `process.exit`, ANSI banner output).

### Changes

- **`src/index.ts`** — New barrel file with organized exports across 14 categories: source parsing, frontmatter, lock files (project + global), GitHub blob fast path, skill discovery, agent registry, installer, git clone, providers (well-known), search API, telemetry (audit only — `track()` intentionally excluded), constants, and plugin manifest
- **`build.config.mjs`** — Updated to bundle both `cli.ts` and `index.ts` as co-entries in a single bundle (shared chunks via rolldown)
- **`package.json`** — Added `exports`, `main`, and `types` fields for proper ESM resolution
- **`README.md`** — Added "Programmatic Usage" section with quick start example, API overview organized by category, and notes on side effects / telemetry behavior

### What's exported (71 named exports)

| Category | Key exports |
|----------|-------------|
| Source Parsing | `parseSource`, `getOwnerRepo`, `parseOwnerRepo`, `isRepoPrivate`, `sanitizeSubpath` |
| Frontmatter | `parseFrontmatter`, `sanitizeMetadata`, `stripTerminalEscapes` |
| Lock Files (project) | `readLocalLock`, `writeLocalLock`, `computeSkillFolderHash`, `addSkillToLocalLock`, `removeSkillFromLocalLock` |
| Lock Files (global) | `readSkillLock`, `writeSkillLock`, `getAllLockedSkills`, `getSkillsBySource`, `fetchSkillFolderHash` |
| GitHub Blob Fast Path | `tryBlobInstall`, `fetchRepoTree`, `getSkillFolderHashFromTree`, `findSkillMdPaths`, `toSkillSlug` |
| Skill Discovery | `discoverSkills`, `parseSkillMd`, `filterSkills`, `getSkillDisplayName` |
| Agent Registry | `agents`, `getAgentConfig`, `detectInstalledAgents`, `isUniversalAgent` |
| Installer | `installBlobSkillForAgent`, `installSkillForAgent`, `listInstalledSkills`, `isSkillInstalled` |
| Git | `cloneRepo`, `cleanupTempDir`, `GitCloneError` |
| Providers | `WellKnownProvider`, `wellKnownProvider`, `registry` |
| Search | `searchSkillsAPI` |
| Telemetry | `fetchAuditData` |

### What's intentionally NOT exported

CLI command modules (`add`, `remove`, `update`, `list`, `find`, `sync`, `install`, `use`) and the interactive prompt (`search-multiselect`) — these depend on `@clack/prompts`, `process.exit`, and subprocess spawning which are unsuitable for library use.

### Build output

```
[bundle] ./dist/cli.mjs
Size: 428 kB, 288 kB minified, 78.3 kB min+gzipped

[bundle] ./dist/index.mjs
Size: 298 kB, 181 kB minified, 51.4 kB min+gzipped
Exports: 71 named exports

dist/index.d.mts — 901 lines of type declarations
```

### Backward compatibility

- The CLI (`npx skills`) continues to work exactly as before
- No changes to any existing source modules
- The `bin` field in `package.json` is unchanged
- All 521 existing tests pass (3 pre-existing failures unrelated to this change)

## Test plan

- [x] `pnpm run build` succeeds with both `cli.mjs` and `index.mjs` outputs
- [x] `pnpm run format:check` passes
- [x] All 521 existing tests pass (3 pre-existing failures in banner/remove tests)
- [x] CLI still works: `node dist/cli.mjs --version` → `1.5.11`
- [x] Runtime verification: all 71 exports import and execute correctly
- [x] Type declarations generated: `dist/index.d.mts` (901 lines)