### PR TITLE
fix(source-parser): route bare domains to well-known discovery

### DIFF
--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -128,4 +128,56 @@ describe('source-parser', () => {
       });
     });
   });
+
+  describe('Bare Domain Well-Known Discovery', () => {
+    it('routes a bare domain to the well-known provider over https', () => {
+      const result = parseSource('openagreements.org');
+      expect(result).toEqual({
+        type: 'well-known',
+        url: 'https://openagreements.org',
+      });
+    });
+
+    it('routes a bare subdomain to well-known', () => {
+      const result = parseSource('skills.example.com');
+      expect(result).toEqual({
+        type: 'well-known',
+        url: 'https://skills.example.com',
+      });
+    });
+
+    it('preserves a port on a bare domain', () => {
+      const result = parseSource('skills.example.com:8443');
+      expect(result).toEqual({
+        type: 'well-known',
+        url: 'https://skills.example.com:8443',
+      });
+    });
+
+    it('routes a bare domain with a hyphenated label', () => {
+      const result = parseSource('my-skills.example-host.com');
+      expect(result).toEqual({
+        type: 'well-known',
+        url: 'https://my-skills.example-host.com',
+      });
+    });
+
+    it('still parses owner/repo shorthand as github, not a bare domain', () => {
+      const result = parseSource('vercel-labs/agent-skills');
+      expect(result.type).toBe('github');
+    });
+
+    it('leaves a scheme-less .git target to the git fallback', () => {
+      const result = parseSource('repo.git');
+      expect(result.type).toBe('git');
+    });
+
+    it('leaves a single-label host (no dot) to the git fallback', () => {
+      const result = parseSource('intranet');
+      expect(result).toEqual({
+        type: 'git',
+        url: 'intranet',
+      });
+    });
+  });
 });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -399,12 +399,44 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
+  // Bare domain (e.g. "openagreements.org" or "skills.example.com:8443"): a
+  // scheme-less, slash-less dotted hostname is neither an owner/repo shorthand
+  // (no slash) nor a clonable git target (`git clone openagreements.org` fails),
+  // so route it to the well-known provider over HTTPS. Without this, bare domains
+  // fall through to the git fallback below and fail with a confusing clone error.
+  if (isBareDomain(input)) {
+    return {
+      type: 'well-known',
+      url: `https://${input}`,
+    };
+  }
+
   // Fallback: treat as direct git URL
   return {
     type: 'git',
     url: input,
     ...(fragmentRef ? { ref: fragmentRef } : {}),
   };
+}
+
+/**
+ * Check if a string is a bare domain: a scheme-less, slash-less dotted hostname
+ * with an optional port, e.g. "openagreements.org" or "skills.example.com:8443".
+ * Such inputs are routed to the well-known provider over HTTPS rather than the
+ * git fallback, where they would fail to clone. A ".git" suffix is excluded so
+ * scheme-less git targets keep flowing to the git fallback.
+ */
+function isBareDomain(input: string): boolean {
+  if (input.endsWith('.git')) {
+    return false;
+  }
+
+  // Each label starts and ends with an alphanumeric, may contain interior
+  // hyphens; at least one dot is required (so single-label hosts like "intranet"
+  // are left to the git fallback); an optional ":port" may follow.
+  return /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)+(?::\d+)?$/.test(
+    input
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

`npx skills add openagreements.org` (bare domain, no scheme) fails — the input is routed to the git-clone provider and errors with `fatal: repository 'openagreements.org' does not exist`. The same site installs fine as `npx skills add https://openagreements.org`.

Fixes #1431.

## Root cause

In `src/source-parser.ts`, `parseSource()` rejects a scheme-less bare domain at both gates that could claim it:

- the `owner/repo` shorthand regex requires a slash, so `openagreements.org` doesn't match;
- `isWellKnownUrl()` requires an `http(s)://` prefix, so a scheme-less domain returns `false`.

With both rejecting it, the input falls through to the final `type: 'git'` fallback and fails to clone. Every scheme-less, slash-less dotted hostname hits this, and none of them is a valid `git clone` target — so the fallback can never succeed for these inputs.

## Fix

Add an `isBareDomain()` check immediately before the git fallback. A scheme-less, slash-less dotted hostname (optional `:port`, no `.git` suffix) is normalized to `https://<input>` and routed to the well-known provider — making `npx skills add openagreements.org` behave like `npx skills add https://openagreements.org`.

Because the check sits *after* `isWellKnownUrl()` and *before* the git fallback, it only captures inputs that previously fell through to the always-failing git fallback. It therefore regresses no currently-working path:

- `owner/repo` shorthand has a slash → still GitHub;
- scheme-less `.git` targets are excluded → still git (consistent with `isWellKnownUrl`'s own `.git` exclusion);
- single-label hosts like `intranet` (no dot) → still git fallback;
- any `http(s)://` URL is already handled by `isWellKnownUrl()` before this point.

The normalized URL (`https://openagreements.org`) is a valid absolute URL the well-known provider already handles — identical to a user typing the `https://` form, which works today.

## Tests

Added a `Bare Domain Well-Known Discovery` block to `src/source-parser.test.ts`: bare domain, subdomain, `:port`, hyphenated labels, plus the negative cases (owner/repo stays GitHub, scheme-less `.git` stays git, single-label host stays git).

```
✓ src/source-parser.test.ts (21 tests)
```

`pnpm build` and `pnpm format:check` pass locally. (Four unrelated CLI/banner/dist integration tests fail identically with and without this change in my environment — they're pre-existing and untouched by this PR.)

## Out of scope

A bare domain *with a path* (`openagreements.org/foo`) is still parsed as `owner/repo` GitHub shorthand. Disambiguating that from a domain+path is a larger, separate behavioral change (GitHub owners can't contain dots, which could be a signal), so I've kept this PR to the reported bare-domain case. Happy to follow up if you'd like that handled too.