### PR TITLE
docs: document Windows junctions being invisible to Claude Code's slash menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ When installing interactively, you can choose:
 | **Symlink** (Recommended) | Creates symlinks from each agent to a canonical copy. Single source of truth, easy updates. |
 | **Copy**                  | Creates independent copies for each agent. Use when symlinks aren't supported.              |
 
+#### Windows and Claude Code desktop
+
+On Windows, skills are linked into agent directories with directory junctions,
+because real symlinks need admin rights or Developer Mode. Claude Code's agent
+loader follows these junctions, so the model can load and run the skills. Its
+desktop `/` command menu does not list them, because that menu scans the skills
+directory and keeps only real directories, and a junction reports as a reparse
+point rather than a plain directory.
+
+If your skills load but never appear when you type `/` in the Claude Code
+desktop app, install them with `--copy` so each skill is written as a real
+directory:
+
+```bash
+npx skills add owner/repo --copy
+```
+
+The underlying behavior is tracked in
+[anthropics/claude-code#68318](https://github.com/anthropics/claude-code/issues/68318).
+
 ## Other Commands
 
 | Command                      | Description                                   |


### PR DESCRIPTION
## What

Adds a short README note about a Windows gotcha: skills installed for Claude
Code load for the model but do not appear in the desktop app's `/` command
menu, and `--copy` is the workaround.

## Why

On Windows, `skills` links each skill into the agent directory with a directory
junction, since real symlinks need admin rights or Developer Mode. That default
is correct and keeps a single source of truth. The problem is downstream:
Claude Code's desktop `/` menu scans `~/.claude/skills` and keeps only real
directories, so junctioned skills are missing from the menu even though the
agent loader follows the junction and the model can use them. Users read this
as "skills installed but not showing up."

The tool already handles the same Node behavior correctly in its own listing
code (`isDirEntryOrSymlinkToDir` follows the link and re-checks the target).
This change documents the downstream limitation and points Windows users at the
existing `--copy` mode.

Reproduce the filesystem behavior the menu scan trips on, with a directory
holding one real subdirectory and one junction to it:

    const fs = require('fs');
    for (const e of fs.readdirSync('C:/tmp/jtest', { withFileTypes: true })) {
      console.log(e.name, e.isDirectory(), e.isSymbolicLink());
    }
    // junction -> false, true   (dropped by an isDirectory() filter)
    // real dir -> true,  false

Identical under Node 24 and Bun 1.3.

## Scope

Docs only. No behavior change. The root cause belongs in Claude Code and is
tracked at anthropics/claude-code#68318.

Found while debugging a Windows skills setup with Claude Code.
