### PR TITLE
feat: add KogniTerm as a supported agent

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -380,6 +380,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.kiro'));
     },
   },
+  kogniterm: {
+    name: 'kogniterm',
+    displayName: 'KogniTerm',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents', 'skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.kogniterm'));
+    },
+  },
   kode: {
     name: 'kode',
     displayName: 'Kode',

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type AgentType =
   | 'kilo'
   | 'kimi-code-cli'
   | 'kiro-cli'
+  | 'kogniterm'
   | 'kode'
   | 'lingma'
   | 'loaf'


### PR DESCRIPTION
KogniTerm is an AI-powered terminal that reads skills from ~/.agents/skills. It detects installation via ~/.kogniterm directory.

- skillsDir: .agents/skills (universal)
- globalSkillsDir: ~/.agents/skills
- detectInstalled: checks for ~/.kogniterm

https://github.com/gatovillano/Gemini-Interpreter