### PR TITLE
feat: support installing skills pinned to a commit SHA

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -20,8 +20,10 @@ import {
   GitCloneError,
   cloneRepo,
   getGitTreeHash,
+  isCommitSha,
   isGitHubHttpsCloneUrl,
   isGitHubSsoAuthError,
+  isMissingRefError,
   parseGitHubRepoUrl,
 } from './git.ts';
 
@@ -33,6 +35,24 @@ function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
   client.env.mockReturnValue(client);
   return client;
 }
+
+// A client mock for the commit-SHA fetch path (cloneAtSha):
+// cwd().init().addRemote().fetch().checkout().
+function createShaClientMock(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}) {
+  const env = vi.fn();
+  const client = {
+    cwd: overrides.cwd ?? vi.fn().mockResolvedValue(undefined),
+    init: overrides.init ?? vi.fn().mockResolvedValue(undefined),
+    addRemote: overrides.addRemote ?? vi.fn().mockResolvedValue(undefined),
+    fetch: overrides.fetch ?? vi.fn().mockResolvedValue(undefined),
+    checkout: overrides.checkout ?? vi.fn().mockResolvedValue(undefined),
+    env,
+  };
+  env.mockReturnValue(client);
+  return client;
+}
+
+const FULL_SHA = '6c6076a293e7ffeb108bad2a231cbd855890d3b5';
 
 function mockExecFileSuccess(stdout = '', stderr = '') {
   execFileMock.mockImplementationOnce(
@@ -325,5 +345,102 @@ describe('git clone fallbacks', () => {
 
     expect(simpleGitMock).not.toHaveBeenCalled();
     expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a commit-SHA fetch when --branch reports a missing ref', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(`fatal: Remote branch ${FULL_SHA} not found in upstream origin`)
+      );
+    const shaClient = createShaClientMock();
+
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(shaClient);
+
+    const tempDir = await cloneRepo('https://gitlab.com/group/repo.git', FULL_SHA);
+    createdDirs.push(tempDir);
+
+    expect(primaryClone).toHaveBeenCalledWith('https://gitlab.com/group/repo.git', tempDir, [
+      '--depth',
+      '1',
+      '--branch',
+      FULL_SHA,
+    ]);
+    expect(shaClient.fetch).toHaveBeenCalledWith(['--depth', '1', 'origin', FULL_SHA]);
+    expect(shaClient.checkout).toHaveBeenCalledWith('FETCH_HEAD');
+  });
+
+  it('does not attempt the SHA fetch for a non-SHA ref', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(new Error('fatal: Remote branch deadbeef not found in upstream origin'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/group/repo.git', 'deadbeef')).rejects.toThrow(
+      GitCloneError
+    );
+    // Only the primary --branch client is constructed; no SHA-fetch client.
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt the SHA fetch when the failure is not a missing ref', async () => {
+    const primaryClone = vi.fn().mockRejectedValue(new Error('fatal: Authentication failed'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/group/repo.git', FULL_SHA)).rejects.toThrow(
+      GitCloneError
+    );
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isCommitSha', () => {
+  it('matches a full 40-character hex SHA', () => {
+    expect(isCommitSha(FULL_SHA)).toBe(true);
+    expect(isCommitSha('abcdef0123456789abcdef0123456789abcdef01')).toBe(true);
+  });
+
+  it('rejects a 40-character string containing non-hex characters', () => {
+    expect(isCommitSha('z'.repeat(40))).toBe(false);
+    expect(isCommitSha('g0000000000000000000000000000000000000000'.slice(0, 40))).toBe(false);
+  });
+
+  it('rejects abbreviated SHAs (not fetchable by the protocol)', () => {
+    expect(isCommitSha('6c6076a')).toBe(false);
+    expect(isCommitSha('6c6076a293')).toBe(false);
+  });
+
+  it('rejects branch and tag names', () => {
+    expect(isCommitSha('main')).toBe(false);
+    expect(isCommitSha('v1.2.3')).toBe(false);
+    expect(isCommitSha('deadbeef')).toBe(false); // hex but only 8 chars
+    expect(isCommitSha('release/2.0')).toBe(false);
+  });
+});
+
+describe('isMissingRefError', () => {
+  it('matches the clone --branch missing-ref message', () => {
+    expect(isMissingRefError(`fatal: Remote branch ${FULL_SHA} not found in upstream origin`)).toBe(
+      true
+    );
+  });
+
+  it('matches the fetch shorthand missing-ref message', () => {
+    expect(isMissingRefError("fatal: couldn't find remote ref deadbeef")).toBe(true);
+  });
+
+  it('matches the server-side fetch-by-SHA rejection', () => {
+    expect(isMissingRefError(`fatal: remote error: upload-pack: not our ref ${FULL_SHA}`)).toBe(
+      true
+    );
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isMissingRefError('fatal: Authentication failed')).toBe(false);
+    expect(isMissingRefError('fatal: unable to access: timed out')).toBe(false);
   });
 });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -19,8 +19,10 @@ vi.mock('child_process', async () => {
 import {
   GitCloneError,
   cloneRepo,
+  isCommitSha,
   isGitHubHttpsCloneUrl,
   isGitHubSsoAuthError,
+  isMissingRefError,
   parseGitHubRepoUrl,
 } from './git.ts';
 
@@ -29,6 +31,20 @@ function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
     clone,
   };
 }
+
+// A client mock for the commit-SHA fetch path (cloneAtSha):
+// cwd().init().addRemote().fetch().checkout().
+function createShaClientMock(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}) {
+  return {
+    cwd: overrides.cwd ?? vi.fn().mockResolvedValue(undefined),
+    init: overrides.init ?? vi.fn().mockResolvedValue(undefined),
+    addRemote: overrides.addRemote ?? vi.fn().mockResolvedValue(undefined),
+    fetch: overrides.fetch ?? vi.fn().mockResolvedValue(undefined),
+    checkout: overrides.checkout ?? vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const FULL_SHA = '6c6076a293e7ffeb108bad2a231cbd855890d3b5';
 
 function mockExecFileSuccess(stdout = '', stderr = '') {
   execFileMock.mockImplementationOnce(
@@ -193,5 +209,102 @@ describe('git clone fallbacks', () => {
       GitCloneError
     );
     expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a commit-SHA fetch when --branch reports a missing ref', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(`fatal: Remote branch ${FULL_SHA} not found in upstream origin`)
+      );
+    const shaClient = createShaClientMock();
+
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(shaClient);
+
+    const tempDir = await cloneRepo('https://gitlab.com/group/repo.git', FULL_SHA);
+    createdDirs.push(tempDir);
+
+    expect(primaryClone).toHaveBeenCalledWith('https://gitlab.com/group/repo.git', tempDir, [
+      '--depth',
+      '1',
+      '--branch',
+      FULL_SHA,
+    ]);
+    expect(shaClient.fetch).toHaveBeenCalledWith(['--depth', '1', 'origin', FULL_SHA]);
+    expect(shaClient.checkout).toHaveBeenCalledWith('FETCH_HEAD');
+  });
+
+  it('does not attempt the SHA fetch for a non-SHA ref', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(new Error('fatal: Remote branch deadbeef not found in upstream origin'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/group/repo.git', 'deadbeef')).rejects.toThrow(
+      GitCloneError
+    );
+    // Only the primary --branch client is constructed; no SHA-fetch client.
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt the SHA fetch when the failure is not a missing ref', async () => {
+    const primaryClone = vi.fn().mockRejectedValue(new Error('fatal: Authentication failed'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/group/repo.git', FULL_SHA)).rejects.toThrow(
+      GitCloneError
+    );
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isCommitSha', () => {
+  it('matches a full 40-character hex SHA', () => {
+    expect(isCommitSha(FULL_SHA)).toBe(true);
+    expect(isCommitSha('abcdef0123456789abcdef0123456789abcdef01')).toBe(true);
+  });
+
+  it('rejects a 40-character string containing non-hex characters', () => {
+    expect(isCommitSha('z'.repeat(40))).toBe(false);
+    expect(isCommitSha('g0000000000000000000000000000000000000000'.slice(0, 40))).toBe(false);
+  });
+
+  it('rejects abbreviated SHAs (not fetchable by the protocol)', () => {
+    expect(isCommitSha('6c6076a')).toBe(false);
+    expect(isCommitSha('6c6076a293')).toBe(false);
+  });
+
+  it('rejects branch and tag names', () => {
+    expect(isCommitSha('main')).toBe(false);
+    expect(isCommitSha('v1.2.3')).toBe(false);
+    expect(isCommitSha('deadbeef')).toBe(false); // hex but only 8 chars
+    expect(isCommitSha('release/2.0')).toBe(false);
+  });
+});
+
+describe('isMissingRefError', () => {
+  it('matches the clone --branch missing-ref message', () => {
+    expect(isMissingRefError(`fatal: Remote branch ${FULL_SHA} not found in upstream origin`)).toBe(
+      true
+    );
+  });
+
+  it('matches the fetch shorthand missing-ref message', () => {
+    expect(isMissingRefError("fatal: couldn't find remote ref deadbeef")).toBe(true);
+  });
+
+  it('matches the server-side fetch-by-SHA rejection', () => {
+    expect(isMissingRefError(`fatal: remote error: upload-pack: not our ref ${FULL_SHA}`)).toBe(
+      true
+    );
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isMissingRefError('fatal: Authentication failed')).toBe(false);
+    expect(isMissingRefError('fatal: unable to access: timed out')).toBe(false);
   });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -16,6 +16,66 @@ const CLONE_TIMEOUT_MS = (() => {
 })();
 const execFileAsync = promisify(execFile);
 
+/**
+ * Whether a ref is a full 40-character Git commit SHA.
+ *
+ * Used only to decide whether the commit-SHA fetch fallback is worth attempting
+ * after a `--branch` clone fails. The fetch-by-SHA protocol requires the full
+ * 40-char SHA; abbreviated SHAs are rejected by the server, so they are not
+ * matched here. Branch and tag detection is never inferred from the string:
+ * `--branch` is always tried first, so any real branch or tag (including a
+ * hex-looking name like "deadbeef" or a 40-char-hex name) resolves correctly
+ * before the SHA fallback is ever considered.
+ */
+export function isCommitSha(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+/**
+ * Whether a clone or fetch error means the requested ref does not exist as a
+ * branch or tag. `git clone --branch <sha>` fails this way because `--branch`
+ * only accepts branch or tag names, never a bare commit SHA.
+ *
+ * These messages come from the git client and the server `upload-pack`, not from
+ * the host, so they are identical across GitHub, GitLab, self-hosted git, and
+ * `gh` (which wraps git). Verified on git 2.53. The variants cover the different
+ * code paths a missing ref can surface through:
+ *   - `clone --branch <ref>`            -> "Remote branch <ref> not found in upstream origin"
+ *   - GitHub shorthand fetch path       -> "couldn't find remote ref <ref>"
+ *   - server-side fetch by SHA rejected -> "upload-pack: not our ref <ref>"
+ */
+export function isMissingRefError(message: string): boolean {
+  return (
+    /Remote branch .* not found in upstream origin/i.test(message) ||
+    /couldn't find remote ref/i.test(message) ||
+    /upload-pack: not our ref/i.test(message)
+  );
+}
+
+/**
+ * Clone a repository pinned to a specific commit SHA.
+ *
+ * `git clone --branch` cannot target a bare SHA, and a `--depth 1` clone does
+ * not contain arbitrary commits. Instead, init an empty repo and fetch only the
+ * requested commit, then check it out. This requires the server to allow
+ * fetching reachable commits by SHA (`uploadpack.allowReachableSHA1InWant`),
+ * which GitHub and GitLab.com both enable. If the server rejects it, the caller
+ * falls back to the standard error handling.
+ */
+async function cloneAtSha(
+  url: string,
+  sha: string,
+  tempDir: string,
+  extraEnv?: NodeJS.ProcessEnv
+): Promise<void> {
+  const git = createGitClient(extraEnv);
+  await git.cwd(tempDir);
+  await git.init();
+  await git.addRemote('origin', url);
+  await git.fetch(['--depth', '1', 'origin', sha]);
+  await git.checkout('FETCH_HEAD');
+}
+
 interface GitHubRepoInfo {
   owner: string;
   repo: string;
@@ -101,7 +161,7 @@ function isAuthFailure(message: string): boolean {
   );
 }
 
-function createGitClient(sshCommand?: string) {
+function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
   const git = simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
     // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect —
@@ -163,7 +223,7 @@ function createGitClient(sshCommand?: string) {
     // When git-lfs IS installed, tell it not to download LFS content
     // during checkout. See #952 for context and empirical impact.
     GIT_LFS_SKIP_SMUDGE: '1',
-    ...(sshCommand ? { GIT_SSH_COMMAND: sshCommand } : {}),
+    ...extraEnv,
   });
 
   return git;
@@ -239,6 +299,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const refCanBeSha = !!ref && isCommitSha(ref);
   const repo = parseGitHubRepoUrl(url);
 
   try {
@@ -246,6 +307,21 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     return tempDir;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // `--branch` cannot target a bare commit SHA. If the ref is a full SHA and
+    // the clone failed because the ref was not a branch or tag, retry by
+    // fetching the commit directly. This runs only after `--branch` fails, so a
+    // real branch or tag (any name) is always resolved first.
+    if (refCanBeSha && isMissingRefError(errorMessage)) {
+      try {
+        await resetTempDir(tempDir);
+        await cloneAtSha(url, ref!, tempDir);
+        return tempDir;
+      } catch {
+        // Fall through to the standard error handling below.
+      }
+    }
+
     const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
     const isAuthError = isAuthFailure(errorMessage);
 
@@ -277,11 +353,20 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
       try {
         await resetTempDir(tempDir);
-        await createGitClient(process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes').clone(
-          repo.sshUrl,
-          tempDir,
-          cloneOptions
-        );
+        const sshEnv = {
+          GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
+        };
+        try {
+          await createGitClient(sshEnv).clone(repo.sshUrl, tempDir, cloneOptions);
+        } catch (sshError) {
+          const sshMessage = sshError instanceof Error ? sshError.message : String(sshError);
+          if (refCanBeSha && isMissingRefError(sshMessage)) {
+            await resetTempDir(tempDir);
+            await cloneAtSha(repo.sshUrl, ref!, tempDir, sshEnv);
+          } else {
+            throw sshError;
+          }
+        }
         return tempDir;
       } catch {
         // Fall through to the targeted auth error below.

--- a/src/git.ts
+++ b/src/git.ts
@@ -14,6 +14,66 @@ const CLONE_TIMEOUT_MS = (() => {
 })();
 const execFileAsync = promisify(execFile);
 
+/**
+ * Whether a ref is a full 40-character Git commit SHA.
+ *
+ * Used only to decide whether the commit-SHA fetch fallback is worth attempting
+ * after a `--branch` clone fails. The fetch-by-SHA protocol requires the full
+ * 40-char SHA; abbreviated SHAs are rejected by the server, so they are not
+ * matched here. Branch and tag detection is never inferred from the string:
+ * `--branch` is always tried first, so any real branch or tag (including a
+ * hex-looking name like "deadbeef" or a 40-char-hex name) resolves correctly
+ * before the SHA fallback is ever considered.
+ */
+export function isCommitSha(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+/**
+ * Whether a clone or fetch error means the requested ref does not exist as a
+ * branch or tag. `git clone --branch <sha>` fails this way because `--branch`
+ * only accepts branch or tag names, never a bare commit SHA.
+ *
+ * These messages come from the git client and the server `upload-pack`, not from
+ * the host, so they are identical across GitHub, GitLab, self-hosted git, and
+ * `gh` (which wraps git). Verified on git 2.53. The variants cover the different
+ * code paths a missing ref can surface through:
+ *   - `clone --branch <ref>`            -> "Remote branch <ref> not found in upstream origin"
+ *   - GitHub shorthand fetch path       -> "couldn't find remote ref <ref>"
+ *   - server-side fetch by SHA rejected -> "upload-pack: not our ref <ref>"
+ */
+export function isMissingRefError(message: string): boolean {
+  return (
+    /Remote branch .* not found in upstream origin/i.test(message) ||
+    /couldn't find remote ref/i.test(message) ||
+    /upload-pack: not our ref/i.test(message)
+  );
+}
+
+/**
+ * Clone a repository pinned to a specific commit SHA.
+ *
+ * `git clone --branch` cannot target a bare SHA, and a `--depth 1` clone does
+ * not contain arbitrary commits. Instead, init an empty repo and fetch only the
+ * requested commit, then check it out. This requires the server to allow
+ * fetching reachable commits by SHA (`uploadpack.allowReachableSHA1InWant`),
+ * which GitHub and GitLab.com both enable. If the server rejects it, the caller
+ * falls back to the standard error handling.
+ */
+async function cloneAtSha(
+  url: string,
+  sha: string,
+  tempDir: string,
+  extraEnv?: NodeJS.ProcessEnv
+): Promise<void> {
+  const git = createGitClient(extraEnv);
+  await git.cwd(tempDir);
+  await git.init();
+  await git.addRemote('origin', url);
+  await git.fetch(['--depth', '1', 'origin', sha]);
+  await git.checkout('FETCH_HEAD');
+}
+
 interface GitHubRepoInfo {
   owner: string;
   repo: string;
@@ -191,6 +251,7 @@ function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message:
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const refCanBeSha = !!ref && isCommitSha(ref);
   const repo = parseGitHubRepoUrl(url);
 
   try {
@@ -198,6 +259,21 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     return tempDir;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // `--branch` cannot target a bare commit SHA. If the ref is a full SHA and
+    // the clone failed because the ref was not a branch or tag, retry by
+    // fetching the commit directly. This runs only after `--branch` fails, so a
+    // real branch or tag (any name) is always resolved first.
+    if (refCanBeSha && isMissingRefError(errorMessage)) {
+      try {
+        await resetTempDir(tempDir);
+        await cloneAtSha(url, ref!, tempDir);
+        return tempDir;
+      } catch {
+        // Fall through to the standard error handling below.
+      }
+    }
+
     const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
     const isAuthError = isAuthFailure(errorMessage);
 
@@ -229,9 +305,20 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
       try {
         await resetTempDir(tempDir);
-        await createGitClient({
+        const sshEnv = {
           GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
-        }).clone(repo.sshUrl, tempDir, cloneOptions);
+        };
+        try {
+          await createGitClient(sshEnv).clone(repo.sshUrl, tempDir, cloneOptions);
+        } catch (sshError) {
+          const sshMessage = sshError instanceof Error ? sshError.message : String(sshError);
+          if (refCanBeSha && isMissingRefError(sshMessage)) {
+            await resetTempDir(tempDir);
+            await cloneAtSha(repo.sshUrl, ref!, tempDir, sshEnv);
+          } else {
+            throw sshError;
+          }
+        }
         return tempDir;
       } catch {
         // Fall through to the targeted auth error below.


### PR DESCRIPTION
## Problem

`skills add <url>` accepts a ref from `/-/tree/<ref>/` and `/tree/<ref>/` URLs, but a full commit SHA fails:

```
fatal: Remote branch <sha> not found in upstream origin
```

`cloneRepo` passes the ref to `git clone --depth 1 --branch <ref>`. `--branch` only accepts branch or tag names, never a bare commit SHA. So tag and branch pins work, but commit pins do not. This blocks reproducible installs from repos that do not cut tags, where a SHA is the only stable pin.

## Change

`cloneRepo` now tries `--branch` first, exactly as before. If that fails because the ref is not a branch or tag, and the ref is a full 40-character SHA, it retries by fetching that commit directly:

```
git init
git remote add origin <url>
git fetch --depth 1 origin <sha>
git checkout FETCH_HEAD
```

This runs on both the primary clone and the SSH retry path. Branch and tag installs are unchanged: they resolve on the first `--branch` attempt.

## Approaches considered

I assessed three ways to route a SHA to the fetch path and chose the third.

1. **Classify the ref by shape before cloning.** Treat any hex-looking ref as a SHA and skip `--branch`. Rejected: a branch or tag whose name is hex (`deadbeef`, `abc1234`, or a 40-char-hex name) would be misrouted and fail, even though `git` resolves it fine as a ref.

2. **Resolve the ref type up front with `git ls-remote`.** Robust, but adds a network round trip and more code for a case that the existing flow can detect naturally.

3. **Try `--branch` first, fall back to SHA fetch on a missing-ref error (chosen).** No ref is classified by shape. Any real branch or tag, including hex-looking names, resolves on the first attempt. Only a real SHA reaches the fallback. The SHA check (`isCommitSha`, full 40-char only) gates only whether the fallback is worth attempting.

## On the error-text detection

The fallback triggers on a missing-ref error string. This matches the existing convention in `src/git.ts` (`isAuthFailure`, `isGitHubSsoAuthError`, the timeout check all branch on git error text).

These messages come from the git client and the server `upload-pack`, not from the host. I verified on git 2.53 that GitHub, GitLab, and a generic `file://` remote produce identical text for the same operation, so the detection is host-independent. `isMissingRefError` covers the three paths a missing ref surfaces through:

- `clone --branch <ref>`: `Remote branch <ref> not found in upstream origin`
- GitHub shorthand fetch path: `couldn't find remote ref <ref>`
- server-side fetch by SHA rejected: `upload-pack: not our ref <ref>`

## Scope

GitHub SHA pins already work through the blob/tree API path, so the default GitHub flow is unaffected. The fix matters for every install that goes through `cloneRepo`: GitLab, generic git URLs, and the GitHub clone fallback (`--full-depth`, non-allowlisted owners, or blob unavailable).

## Validation

Tested with the real registries:

- GitLab, full SHA pin: installs (previously failed at `--branch`).
- GitHub via clone path (`--full-depth`), full SHA pin: installs (previously failed at `--branch`).
- GitHub default path (blob API), full SHA pin: installs (unchanged).
- Tag pin and branch pin: install (unchanged).
- Hex-looking branch name: resolves via `--branch`, no misroute.
