### PR TITLE
fix(update): authenticate tree fetch for private repos

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -99,6 +99,15 @@ export function resetRepoTreeAuthState(): void {
 interface BranchFetchResult {
   tree: RepoTree | null;
   rateLimited: boolean;
+  /**
+   * The unauthenticated request 404'd. GitHub returns 404 (not 403) for a
+   * private repo accessed without credentials, to avoid leaking its existence.
+   * Flagged separately from `rateLimited` so the caller can retry with a token —
+   * which is exactly what makes a private repo resolvable. A non-rate-limit 403
+   * is genuine "forbidden" (not fixable by auth) and is intentionally NOT flagged
+   * here, preserving the behavior from issue #523.
+   */
+  maybePrivate: boolean;
 }
 
 async function fetchTreeBranch(
@@ -129,6 +138,7 @@ async function fetchTreeBranch(
       return {
         tree: { sha: data.sha, branch, tree: data.tree },
         rateLimited: false,
+        maybePrivate: false,
       };
     }
 
@@ -136,9 +146,14 @@ async function fetchTreeBranch(
     // (A bare 403 means permission denied, which is not retryable here.)
     const rateLimited =
       response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0';
-    return { tree: null, rateLimited };
+
+    // 404 on an unauthenticated request is GitHub's "private or non-existent"
+    // response — retryable with a token.
+    const maybePrivate = response.status === 404;
+
+    return { tree: null, rateLimited, maybePrivate };
   } catch {
-    return { tree: null, rateLimited: false };
+    return { tree: null, rateLimited: false, maybePrivate: false };
   }
 }
 
@@ -149,10 +164,12 @@ async function fetchTreeBranch(
  *
  * Authentication is lazy: by default the call goes out unauthenticated,
  * which is enough for the vast majority of users (60 req/hr per IP).
- * Only if GitHub responds with a rate-limit 403 do we ask the optional
- * `getToken` callback for a token and retry. This avoids invoking
- * `gh auth token` on every install, which corporate endpoint security
- * tools flag as suspicious credential extraction. See issue #523.
+ * We ask the optional `getToken` callback for a token and retry only if the
+ * unauthenticated request hits a rate-limit 403 OR a 404 (a private repo,
+ * which 404s without credentials). Public repos — the common case — succeed on
+ * the first unauthenticated request and never invoke the token resolver, which
+ * avoids spawning `gh auth token` on every install (corporate endpoint security
+ * tools flag that as suspicious credential extraction; see issue #523).
  */
 export async function fetchRepoTree(
   ownerRepo: string,
@@ -175,6 +192,7 @@ export async function fetchRepoTree(
 
   // First pass: unauthenticated.
   let rateLimited = false;
+  let maybePrivate = false;
   for (const branch of branches) {
     const result = await fetchTreeBranch(ownerRepo, branch, null);
     if (result.tree) return result.tree;
@@ -184,12 +202,17 @@ export async function fetchRepoTree(
       rateLimited = true;
       break;
     }
+    // A private repo 404s on every branch; remember it but keep probing the
+    // other candidate branches in case the default branch is named differently.
+    if (result.maybePrivate) maybePrivate = true;
   }
 
-  if (!rateLimited || !getToken) return null;
+  if ((!rateLimited && !maybePrivate) || !getToken) return null;
 
-  // Lazy fallback: rate limit hit and a token resolver was provided.
-  _rateLimitedThisSession = true;
+  // Lazy fallback: rate limit, or a possibly-private repo, plus a token
+  // resolver. Only memoize the rate-limit fast path — a 404 is repo-specific,
+  // not a process-wide condition, so other repos shouldn't skip their unauth pass.
+  if (rateLimited) _rateLimitedThisSession = true;
   const token = getToken();
   if (!token) return null;
 

--- a/tests/blob-fetch-tree-auth.test.ts
+++ b/tests/blob-fetch-tree-auth.test.ts
@@ -46,6 +46,17 @@ function permissionDeniedResponse(): Response {
   });
 }
 
+function notFoundResponse(): Response {
+  // GitHub returns 404 for a private repo accessed without credentials.
+  return new Response(JSON.stringify({ message: 'Not Found' }), {
+    status: 404,
+    headers: {
+      'content-type': 'application/json',
+      'x-ratelimit-remaining': '59',
+    },
+  });
+}
+
 describe('fetchRepoTree lazy auth fallback', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
@@ -104,6 +115,56 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
     expect(result).toBeNull();
     expect(getToken).not.toHaveBeenCalled();
+  });
+
+  it('invokes the token resolver and retries with auth on a 404 (private repo)', async () => {
+    // Private repos 404 unauthenticated, then resolve once a token is sent.
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const result = await fetchRepoTree('owner/private-repo', 'main', getToken);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer ghp_fake_token'
+    );
+  });
+
+  it('does not memoize the auth fast path after a 404 (404 is repo-specific)', async () => {
+    // A 404-driven auth retry must not flip the process-wide rate-limit memo,
+    // so an unrelated public repo still gets its unauthenticated first pass.
+    fetchMock
+      // First repo: private — unauth 404, then auth 200.
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE))
+      // Second repo: public — must be attempted unauthenticated first.
+      .mockResolvedValueOnce(okResponse({ ...SAMPLE_TREE, sha: 'cafef00d' }));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const first = await fetchRepoTree('owner/private-repo', 'main', getToken);
+    const second = await fetchRepoTree('owner/public-repo', 'main', getToken);
+
+    expect(first?.sha).toBe('deadbeef');
+    expect(second?.sha).toBe('cafef00d');
+    expect(getToken).toHaveBeenCalledTimes(1); // only the private repo needed it
+    const secondCallInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect((secondCallInit.headers as Record<string, string>)['Authorization']).toBeUndefined();
+  });
+
+  it('returns null on a 404 when no token resolver is provided', async () => {
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse());
+
+    const result = await fetchRepoTree('owner/private-repo');
+
+    expect(result).toBeNull();
   });
 
   it('returns null gracefully when rate-limited and no token resolver is provided', async () => {


### PR DESCRIPTION
## Summary

Fixes `skills update` failing on private GitHub repos with `✗ Failed to fetch tree`.

`fetchRepoTree` (`src/blob.ts`) only retried with a token after a rate-limit `403`. A private repo returns `404` unauthenticated, so the token was never sent and the version-check failed — even though `skills add` already installs private repos fine via the clone fallback.

## Change

- Flag a `404` on the unauthenticated tree fetch as `maybePrivate` and retry once with the token resolver.
- A non-rate-limit `403` (genuine "forbidden") is **not** retried, preserving the `gh auth token` minimization from #523.
- Public repos succeed on the first unauthenticated request and never invoke the resolver.
- The `404` retry is not memoized to the rate-limit fast path (it is repo-specific), so unrelated repos still get their unauthenticated first pass.

## Tests

Extended `tests/blob-fetch-tree-auth.test.ts`:
- retries with auth on a `404` (private repo) and succeeds
- a `404`-driven retry does not flip the process-wide rate-limit memo (a later public repo is still tried unauthenticated)
- returns `null` on `404` when no token resolver is provided

Full suite: no new failures (the 3 pre-existing CLI-banner failures on `main` are unrelated).

Closes #1441
