### PR TITLE
feat(local): track and re-sync skills installed from a local directory

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1580,8 +1580,25 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             .slice(tempDir.length + 1)
             .split(sep)
             .join('/') + '/SKILL.md';
+      } else if (parsed.type === 'local' && parsed.localPath) {
+        // Local install: record the path relative to the local source root so
+        // `skills update` can re-discover this skill in the directory. This map
+        // is never sent as telemetry for local sources (the track() call below
+        // is gated on a remote `normalizedSource`), so no local path leaks.
+        const root = parsed.localPath;
+        if (skill.path === root) {
+          skillFiles[skill.name] = 'SKILL.md';
+        } else if (skill.path.startsWith(root + sep)) {
+          skillFiles[skill.name] =
+            skill.path
+              .slice(root.length + 1)
+              .split(sep)
+              .join('/') + '/SKILL.md';
+        } else {
+          continue;
+        }
       } else {
-        // Local path - skip telemetry for local installs
+        // Unknown layout - skip
         continue;
       }
     }
@@ -1623,14 +1640,20 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    // Source identifier recorded in the global lock. Remote installs use the
+    // owner/repo (or preserved SSH URL); local installs use the resolved
+    // directory path so `skills update` can re-read it from disk later.
+    const globalLockSource =
+      lockSource || normalizedSource || (parsed.type === 'local' ? parsed.localPath! : null);
+
     // Add to skill lock file for update tracking (only for global installs)
-    if (successful.length > 0 && installGlobally && normalizedSource) {
+    if (successful.length > 0 && installGlobally && globalLockSource) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
 
       // For GitHub clone installs, fetch the repo tree once and reuse it
       // for all skills — avoids N sequential API calls that take ~400ms each.
       let cachedTree: Awaited<ReturnType<typeof fetchRepoTree>> | undefined;
-      if (parsed.type === 'github' && !blobResult) {
+      if (parsed.type === 'github' && !blobResult && normalizedSource) {
         cachedTree = await fetchRepoTree(normalizedSource, parsed.ref, getGitHubToken);
       }
 
@@ -1651,10 +1674,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               const skillDir = join(tempDir, dirname(skillPathValue));
               const hash = await computeSkillFolderHash(skillDir);
               if (hash) skillFolderHash = hash;
+            } else if (parsed.type === 'local' && skillPathValue) {
+              // Local install: hash the skill folder on disk (no clone). This
+              // is what a later `skills update` recomputes to detect changes.
+              const hash = await computeSkillFolderHash(skill.path);
+              if (hash) skillFolderHash = hash;
             }
 
             await addSkillToLock(skill.name, {
-              source: lockSource || normalizedSource,
+              source: globalLockSource,
               sourceType: parsed.type,
               sourceUrl: parsed.url,
               ref: parsed.ref,

--- a/src/update.ts
+++ b/src/update.ts
@@ -337,6 +337,49 @@ export async function updateGlobalSkills(
     process.stdout.write(`\r${DIM}Checking skills from source: ${source}${RESET}\x1b[K\n`);
 
     try {
+      // Local sources: re-read the directory from disk (no clone, no network)
+      // and re-sync any skill whose folder hash changed since install.
+      if (firstEntry.sourceType === 'local') {
+        const localRoot = firstEntry.sourceUrl || source;
+        if (!existsSync(localRoot)) {
+          console.log(`  ${DIM}✗ Local source no longer exists: ${localRoot}${RESET}`);
+          continue;
+        }
+
+        const discoveredPaths = (await discoverSkills(localRoot)).map((skill) =>
+          join(relative(localRoot, skill.path), 'SKILL.md').split(sep).join('/')
+        );
+
+        const allLockedForSource = Object.entries(lock.skills)
+          .filter(([_, entry]) => entry.source === source)
+          .map(([name, _]) => name);
+
+        const deletedSkills = await checkAndPromptForDeletions(
+          source,
+          allLockedForSource,
+          lock.skills,
+          true,
+          options,
+          discoveredPaths
+        );
+
+        const deletedSkillSet = new Set(deletedSkills);
+
+        for (const { name: skillName, entry } of itemsForSource) {
+          if (deletedSkillSet.has(skillName)) continue;
+
+          const skillPath = entry.skillPath!;
+          if (!discoveredPaths.includes(skillPath)) continue;
+
+          const latestHash = await computeSkillFolderHash(join(localRoot, dirname(skillPath)));
+          if (latestHash && latestHash !== entry.skillFolderHash) {
+            updates.push({ name: skillName, source, entry });
+          }
+        }
+
+        continue;
+      }
+
       const isGitHubSource = firstEntry.sourceType === 'github';
 
       if (isGitHubSource) {
@@ -443,7 +486,6 @@ export async function updateGlobalSkills(
   for (const update of updates) {
     const safeName = sanitizeMetadata(update.name);
     console.log(`${TEXT}Updating ${safeName}...${RESET}`);
-    const installUrl = buildUpdateInstallSource(update.entry);
 
     const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
     if (!existsSync(cliEntry)) {
@@ -453,7 +495,24 @@ export async function updateGlobalSkills(
       );
       continue;
     }
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
+
+    // Local sources: re-install from the directory root, filtered to this skill
+    // by name. This keeps the lock entry's source/skillPath stable (re-deriving
+    // them from the root) instead of collapsing to the skill's subfolder.
+    const isLocal = update.entry.sourceType === 'local';
+    const addArgs = isLocal
+      ? [
+          cliEntry,
+          'add',
+          update.entry.sourceUrl || update.entry.source,
+          '-g',
+          '-y',
+          '-s',
+          update.name,
+        ]
+      : [cliEntry, 'add', buildUpdateInstallSource(update.entry), '-g', '-y'];
+
+    const result = spawnSync(process.execPath, addArgs, {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
       shell: process.platform === 'win32',

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -8,6 +8,7 @@ import * as skillLock from '../src/skill-lock.ts';
 import * as remove from '../src/remove.ts';
 import * as p from '@clack/prompts';
 import { readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
 import { join } from 'path';
 
 // Mock dependencies
@@ -267,6 +268,81 @@ describe('Update Cleanup Unit Tests', () => {
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'skills/skill-a')
       );
+    });
+
+    it('re-syncs a local-source skill from disk when its folder hash changed', async () => {
+      const localRoot = '/tmp/local-src';
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: localRoot,
+            sourceUrl: localRoot,
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'local',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      // Local sources are read from disk directly — never cloned.
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'skill-a',
+          path: join(localRoot, 'skills/skill-a'),
+          description: 'A',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(git.cloneRepo).not.toHaveBeenCalled();
+      expect(blob.fetchRepoTree).not.toHaveBeenCalled();
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
+        join(localRoot, 'skills/skill-a')
+      );
+      // Re-installs from the directory root, filtered to the skill by name.
+      expect(spawnSync).toHaveBeenCalledWith(
+        process.execPath,
+        expect.arrayContaining(['add', localRoot, '-g', '-y', '-s', 'skill-a']),
+        expect.anything()
+      );
+    });
+
+    it('does not re-sync a local-source skill when its folder hash is unchanged', async () => {
+      const localRoot = '/tmp/local-src';
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: localRoot,
+            sourceUrl: localRoot,
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'local',
+            skillFolderHash: 'same-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'skill-a',
+          path: join(localRoot, 'skills/skill-a'),
+          description: 'A',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('same-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(spawnSync).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Makes skills installed from a **local directory** trackable and updatable, so `skills update` re-syncs them when the source changes. Today `skills add ./dir -g` copies the files but writes no global lock entry, so `skills update -g` silently ignores them.

## Root cause

In `src/add.ts`, the global lock-write block was gated on `normalizedSource` (`getOwnerRepo(parsed)`), which is `null` for local paths — so local installs were never recorded. `SkillLockEntry.sourceType` already documents `"local"` and `getSkipReason` already handles it, so the schema anticipated this; it just wasn't wired up.

## Change

- **add**: record a global lock entry for local installs — `sourceType: 'local'`, `source`/`sourceUrl` = resolved directory path, `skillPath` relative to the source root, and `skillFolderHash` computed from the folder on disk.
- **update**: re-read local sources directly from disk (no clone, no network), recompute the folder hash, and re-install changed skills from the directory root filtered to the skill name (`add <root> -g -y -s <name>`) — which keeps `source`/`skillPath` stable across updates and preserves deletion detection. A source directory that no longer exists is reported and skipped instead of crashing.

## Verified end-to-end

```
add ./myskills -g        → lock entry written (sourceType local, hash recorded)
update -g (no change)     → "All global skills are up to date"
edit source SKILL.md
update -g                 → "Updating demo… ✓"; installed copy updated; hash + updatedAt bumped
rm -rf ./myskills
update -g                 → "✗ Local source no longer exists: …" (graceful, exit 0)
```

## Tests

Added to `tests/update.test.ts`:
- re-syncs a local-source skill from disk when its folder hash changed (re-installs from root with `-s <name>`; never clones)
- does not re-sync when the folder hash is unchanged

Full suite: no new failures (the 3 pre-existing CLI-banner failures on `main` are unrelated).

Closes #1440
