### PR TITLE
test: global lock stale cleanup regression (complements #1357)

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, runCliWithInput } from './test-utils.js';
@@ -72,6 +72,30 @@ This is a test skill.
       expect(result.stdout).toContain('No skills found');
       expect(result.exitCode).toBe(0);
     });
+
+    it('should clean stale lock entry even when no skills are installed on disk', () => {
+      const lockPath = join(testDir, 'skills-lock.json');
+      const lockContent = {
+        version: 1,
+        skills: {
+          'stale-skill': {
+            source: 'some-source',
+            sourceType: 'github',
+            computedHash: 'somehash',
+          },
+        },
+      };
+      writeFileSync(lockPath, JSON.stringify(lockContent, null, 2));
+
+      // No skills exist on disk, but stale-skill lingers in the lock file
+      const result = runCli(['remove', 'stale-skill', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.exitCode).toBe(0);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['stale-skill']).toBeUndefined();
+    });
   });
 
   describe('with skills installed', () => {
@@ -132,6 +156,32 @@ This is a test skill.
 
       expect(result.stdout).toContain('No matching skills');
       expect(result.exitCode).toBe(0);
+    });
+
+    it('should remove skill that is missing from disk but exists in local lock file', () => {
+      const lockPath = join(testDir, 'skills-lock.json');
+      const lockContent = {
+        version: 1,
+        skills: {
+          'stale-skill': {
+            source: 'some-source',
+            sourceType: 'github',
+            computedHash: 'somehash',
+          },
+        },
+      };
+      writeFileSync(lockPath, JSON.stringify(lockContent, null, 2));
+
+      // stale-skill is missing from disk, but exists in lock file
+      const result = runCli(['remove', 'stale-skill', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.stdout).toContain('1 skill');
+      expect(result.exitCode).toBe(0);
+
+      // Verify lock file has been updated to remove the skill
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['stale-skill']).toBeUndefined();
     });
 
     it('should be case-insensitive when matching skill names', () => {

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, runCliWithInput } from './test-utils.js';
@@ -258,6 +258,67 @@ This is a test skill.
       const result = runCli(['remove', 'global-skill', '--global', '-y'], testDir);
       // Command should run without error (skill may not be found in global scope from test dir)
       expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('global lock stale cleanup', () => {
+    let fakeHome: string;
+
+    beforeEach(() => {
+      fakeHome = join(tmpdir(), `skills-global-lock-test-${Date.now()}`);
+      mkdirSync(join(fakeHome, '.agents'), { recursive: true });
+      mkdirSync(join(fakeHome, '.claude', 'skills'), { recursive: true });
+
+      const lockPath = join(fakeHome, '.agents', '.skill-lock.json');
+      writeFileSync(
+        lockPath,
+        JSON.stringify(
+          {
+            version: 3,
+            skills: {
+              'ollama-review': {
+                source: 'pizzayap/pza-skills',
+                sourceType: 'github',
+                sourceUrl: 'https://github.com/pizzayap/pza-skills.git',
+                skillPath: 'skills/ollama-review/SKILL.md',
+                skillFolderHash: 'fffc535918d3cdc76702eb0d93ef8b8a9b310379',
+                installedAt: '2026-05-01T08:41:34.050Z',
+                updatedAt: '2026-05-21T07:14:46.367Z',
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      // Canonical dir intentionally missing; dangling harness symlink only.
+      symlinkSync(
+        join('..', '..', '.agents', 'skills', 'ollama-review'),
+        join(fakeHome, '.claude', 'skills', 'ollama-review')
+      );
+    });
+
+    afterEach(() => {
+      if (existsSync(fakeHome)) {
+        rmSync(fakeHome, { recursive: true, force: true });
+      }
+    });
+
+    it('should remove stale global lock entry and dangling symlink when canonical dir is gone', () => {
+      const result = runCli(['remove', 'ollama-review', '-g', '-y'], testDir, {
+        HOME: fakeHome,
+      });
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.exitCode).toBe(0);
+
+      const updatedLock = JSON.parse(
+        readFileSync(join(fakeHome, '.agents', '.skill-lock.json'), 'utf-8')
+      );
+      expect(updatedLock.skills['ollama-review']).toBeUndefined();
+      expect(existsSync(join(fakeHome, '.claude', 'skills', 'ollama-review'))).toBe(false);
+      expect(existsSync(join(fakeHome, '.agents', 'skills', 'ollama-review'))).toBe(false);
     });
   });
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -5,7 +5,8 @@ import { join } from 'path';
 import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
-import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
+import { readLocalLock, removeSkillFromLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -73,7 +74,26 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   const installedSkills = Array.from(skillNamesSet).sort();
   spinner.stop(`Found ${installedSkills.length} unique installed skill(s)`);
 
-  if (installedSkills.length === 0) {
+  // Read lock file keys up front. These are needed both to decide whether there is
+  // anything to remove (a skill may be missing from disk but still leave a stale lock
+  // entry) and to clean up those stale entries below.
+  const lockSkillsKeys = isGlobal
+    ? Object.keys((await readSkillLock()).skills)
+    : Object.keys((await readLocalLock(cwd)).skills);
+
+  // Requested skills that are gone from disk but still have a stale lock entry.
+  // These must be cleaned up even when no skills remain installed on disk, otherwise
+  // the entry lingers forever (e.g. a skill deleted upstream during `skills update`).
+  const staleLockSkills =
+    !options.all && skillNames.length > 0
+      ? skillNames.filter(
+          (name) =>
+            !installedSkills.some((s) => s.toLowerCase() === name.toLowerCase()) &&
+            lockSkillsKeys.some((k) => k.toLowerCase() === name.toLowerCase())
+        )
+      : [];
+
+  if (installedSkills.length === 0 && staleLockSkills.length === 0) {
     p.outro(pc.yellow('No skills found to remove.'));
     return;
   }
@@ -98,6 +118,14 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     selectedSkills = installedSkills.filter((s) =>
       skillNames.some((name) => name.toLowerCase() === s.toLowerCase())
     );
+
+    // Requested skills missing from disk but still present in the lock file (computed
+    // above) are mapped back to their exact lock key so the stale entry can be cleaned up.
+    const mappedMissingSkills = staleLockSkills.map(
+      (name) => lockSkillsKeys.find((k) => k.toLowerCase() === name.toLowerCase()) || name
+    );
+
+    selectedSkills.push(...mappedMissingSkills);
 
     if (selectedSkills.length === 0) {
       p.log.error(`No matching skills found for: ${skillNames.join(', ')}`);
@@ -220,12 +248,20 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         await rm(canonicalPath, { recursive: true, force: true });
       }
 
-      const lockEntry = isGlobal ? await getSkillFromLock(skillName) : null;
-      const effectiveSource = lockEntry?.source || 'local';
-      const effectiveSourceType = lockEntry?.sourceType || 'local';
+      let effectiveSource = 'local';
+      let effectiveSourceType = 'local';
 
       if (isGlobal) {
+        const lockEntry = await getSkillFromLock(skillName);
+        effectiveSource = lockEntry?.source || 'local';
+        effectiveSourceType = lockEntry?.sourceType || 'local';
         await removeSkillFromLock(skillName);
+      } else {
+        const localLock = await readLocalLock(cwd);
+        const lockEntry = localLock.skills[skillName];
+        effectiveSource = lockEntry?.source || 'local';
+        effectiveSourceType = lockEntry?.sourceType || 'local';
+        await removeSkillFromLocalLock(skillName, cwd);
       }
 
       results.push({


### PR DESCRIPTION
## Summary

Adds a **global-lock** regression test for the deleted-upstream cleanup loop reported from `pizzayap/pza-skills` retirements (`ollama-review`, `ollama-setup`).

This branch is based on #1357 (`fix/skills-update-missing-upstream`) and adds one commit with the test only.

### Scenario covered
- Stale entry in `~/.agents/.skill-lock.json`
- Missing canonical `~/.agents/skills/<skill>/` directory
- Dangling `~/.claude/skills/<skill>` symlink

`remove <skill> -g -y` should prune the lock entry and remove the dangling symlink.

### Manual verification
Repro confirmed on a real machine with global PZA skills install; built #1357 locally and verified `remove ollama-review ollama-setup -g -y` cleans lockfile + symlinks.

## Relation to #1357
- #1357 fixes the behavior
- This PR adds the missing global-lock test case (#1357 tests currently focus on project `skills-lock.json`)

Recommend landing together, or merging #1357 first then cherry-picking the test commit.

## Test plan
- [x] `npm test -- src/remove.test.ts -t "global lock stale cleanup"`

Made with [Cursor](https://cursor.com)