### PR TITLE
feat: show skill origin in list output

### DIFF
--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -126,6 +126,34 @@ description: ${description}
       expect(result.stdout).not.toMatch(/\x1b\[/);
     });
 
+    it('should report project skill provenance from skills-lock.json', () => {
+      createTestSkill(testDir, 'project-skill', 'A tracked project skill');
+      writeFileSync(
+        join(testDir, 'skills-lock.json'),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            'project-skill': {
+              source: 'owner/project-skills',
+              sourceUrl: 'https://github.com/owner/project-skills',
+              sourceType: 'github',
+              computedHash: 'project-hash',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['list', '--json'], testDir);
+      const [skill] = JSON.parse(result.stdout.trim());
+
+      expect(skill).toMatchObject({
+        source: 'owner/project-skills',
+        sourceUrl: 'https://github.com/owner/project-skills',
+        sourceType: 'github',
+      });
+      expect(skill).not.toHaveProperty('origin');
+    });
+
     it('should output multiple skills as JSON array', () => {
       createTestSkill(testDir, 'skill-alpha', 'Alpha');
       createTestSkill(testDir, 'skill-beta', 'Beta');
@@ -157,6 +185,51 @@ description: ${description}
       expect(result.exitCode).toBe(0);
     });
 
+    it('should show a tracked project skill source in human output', () => {
+      createTestSkill(testDir, 'tracked-skill', 'A tracked project skill');
+      writeFileSync(
+        join(testDir, 'skills-lock.json'),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            'tracked-skill': {
+              source: 'owner/project-skills',
+              sourceType: 'github',
+              computedHash: 'project-hash',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['list'], testDir);
+
+      expect(result.stdout).toContain('Source:');
+      expect(result.stdout).toContain('owner/project-skills');
+      expect(result.stdout).not.toContain('Origin:');
+    });
+
+    it('should keep untrusted source metadata on one output line', () => {
+      createTestSkill(testDir, 'tracked-skill', 'A tracked project skill');
+      writeFileSync(
+        join(testDir, 'skills-lock.json'),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            'tracked-skill': {
+              source: 'owner/\nFORGED',
+              sourceType: 'github',
+              computedHash: 'project-hash',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['list'], testDir);
+
+      expect(result.stdout).toContain('Source: owner/ FORGED');
+      expect(result.stdout).not.toContain('\nFORGED');
+    });
+
     it('should list multiple skills', () => {
       createTestSkill(testDir, 'skill-one', 'First skill');
       createTestSkill(testDir, 'skill-two', 'Second skill');
@@ -179,6 +252,39 @@ description: ${description}
       expect(result.stdout).not.toContain('project-skill');
       expect(result.stdout).toContain('global-skill');
       expect(result.stdout).toContain('Global Skills');
+    });
+
+    it('should report global provenance when a lock key differs from its folder name', () => {
+      const testHome = join(testDir, 'home');
+      createTestSkill(testHome, 'ce-review', 'A tracked global plugin skill');
+      const lockDir = join(testHome, '.local', 'state', 'skills');
+      mkdirSync(lockDir, { recursive: true });
+      writeFileSync(
+        join(lockDir, '.skill-lock.json'),
+        JSON.stringify({
+          version: 3,
+          skills: {
+            'ce:review': {
+              source: 'everyinc/compound-engineering-plugin',
+              sourceUrl: 'https://github.com/everyinc/compound-engineering-plugin',
+              sourceType: 'github',
+              skillFolderHash: 'global-hash',
+              installedAt: '2026-07-01T00:00:00.000Z',
+              updatedAt: '2026-07-01T00:00:00.000Z',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['list', '-g', '--json'], testDir, { HOME: testHome });
+      const [skill] = JSON.parse(result.stdout.trim());
+
+      expect(skill).toMatchObject({
+        name: 'ce-review',
+        source: 'everyinc/compound-engineering-plugin',
+        sourceUrl: 'https://github.com/everyinc/compound-engineering-plugin',
+        sourceType: 'github',
+      });
     });
 
     it('should show error for invalid agent filter', () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,9 +1,10 @@
 import { homedir } from 'os';
 import type { AgentType } from './types.ts';
 import { agents } from './agents.ts';
-import { listInstalledSkills, type InstalledSkill } from './installer.ts';
+import { listInstalledSkills, sanitizeName, type InstalledSkill } from './installer.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { getAllLockedSkills } from './skill-lock.ts';
+import { readLocalLock } from './local-lock.ts';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -16,6 +17,13 @@ interface ListOptions {
   global?: boolean;
   agent?: string[];
   json?: boolean;
+}
+
+interface ListLockEntry {
+  source: string;
+  sourceUrl?: string;
+  sourceType: string;
+  pluginName?: string;
 }
 
 /**
@@ -91,22 +99,35 @@ export async function runList(args: string[]): Promise<void> {
     agentFilter,
   });
 
+  const cwd = process.cwd();
+  // Fetch lock entries to get source and plugin grouping info for the selected scope.
+  const lockedSkills: Record<string, ListLockEntry> = scope
+    ? await getAllLockedSkills()
+    : (await readLocalLock(cwd)).skills;
+  const lockEntriesBySanitizedName = new Map(
+    Object.entries(lockedSkills).map(([name, entry]) => [sanitizeName(name), entry])
+  );
+  const getLockEntry = (skillName: string): ListLockEntry | undefined =>
+    lockedSkills[skillName] ?? lockEntriesBySanitizedName.get(sanitizeName(skillName));
+
   // JSON output mode: structured, no ANSI, untruncated agent lists
   if (options.json) {
-    const jsonOutput = installedSkills.map((skill) => ({
-      name: skill.name,
-      path: skill.canonicalPath,
-      scope: skill.scope,
-      agents: skill.agents.map((a) => agents[a].displayName),
-    }));
+    const jsonOutput = installedSkills.map((skill) => {
+      const lockEntry = getLockEntry(skill.name);
+      return {
+        name: skill.name,
+        path: skill.canonicalPath,
+        scope: skill.scope,
+        agents: skill.agents.map((a) => agents[a].displayName),
+        source: lockEntry?.source ?? null,
+        sourceUrl: lockEntry?.sourceUrl ?? null,
+        sourceType: lockEntry?.sourceType ?? null,
+      };
+    });
     console.log(JSON.stringify(jsonOutput, null, 2));
     return;
   }
 
-  // Fetch lock entries to get plugin grouping info
-  const lockedSkills = await getAllLockedSkills();
-
-  const cwd = process.cwd();
   const scopeLabel = scope ? 'Global' : 'Project';
 
   if (installedSkills.length === 0) {
@@ -139,8 +160,14 @@ export async function runList(args: string[]): Promise<void> {
     const paddedName = sanitizeMetadata(skill.name).padEnd(maxNameLength);
     const paddedPath = shortPath.padEnd(maxPathLength);
 
+    // Determine source from lock file
+    const lockEntry = getLockEntry(skill.name);
+    const source = lockEntry?.source ?? null;
+    const sourceLabel = source ? sanitizeMetadata(source) : 'local';
+
+    console.log(`${prefix}${CYAN}${paddedName}${RESET} ${DIM}${paddedPath}${RESET}`);
     console.log(
-      `${prefix}${CYAN}${paddedName}${RESET} ${DIM}${paddedPath}${RESET} ${DIM}Agents:${RESET} ${agentInfo}`
+      `${prefix}  ${DIM}Agents:${RESET} ${agentInfo}  ${DIM}Source:${RESET} ${sourceLabel}`
     );
   }
 
@@ -152,7 +179,7 @@ export async function runList(args: string[]): Promise<void> {
   const ungroupedSkills: InstalledSkill[] = [];
 
   for (const skill of installedSkills) {
-    const lockEntry = lockedSkills[skill.name];
+    const lockEntry = getLockEntry(skill.name);
     if (lockEntry?.pluginName) {
       const group = lockEntry.pluginName;
       if (!groupedSkills[group]) {


### PR DESCRIPTION
## Summary

Adds origin information to `skills list` output so users can see where each installed skill came from.

This helps distinguish GitHub-installed skills from locally created or manually copied skills.

Fixes vercel-labs/agent-skills#156

## Testing

Manually tested:

- `pnpm dev list -g`
- `pnpm dev list -g --json`