### PR TITLE
Create agent project dirs for symlink installs

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -305,23 +305,6 @@ export async function installSkillForAgent(
       };
     }
 
-    // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. This prevents
-    // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
-    // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir)) {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
-    }
-
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
 
     if (!symlinkCreated) {
@@ -810,21 +793,6 @@ export async function installBlobSkillForAgent(
         canonicalPath: canonicalDir,
         mode: 'symlink',
       };
-    }
-
-    // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir)) {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installSkillForAgent } from '../src/installer.ts';
+import { installBlobSkillForAgent, installSkillForAgent } from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
   const dir = join(root, 'source-skill');
@@ -142,6 +142,81 @@ describe('installer symlink regression', () => {
           expect(entryStats.isDirectory()).toBe(true);
         }
       }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates missing agent directories for project-level symlink installs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'claude-project-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalDir = join(projectDir, '.agents/skills', skillName);
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+
+      const claudeRootStats = await lstat(join(projectDir, '.claude'));
+      expect(claudeRootStats.isDirectory()).toBe(true);
+
+      const claudeSkillDir = join(projectDir, '.claude/skills', skillName);
+      const claudeStats = await lstat(claudeSkillDir);
+      expect(claudeStats.isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates missing agent directories for blob project-level symlink installs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'claude-blob-project-skill';
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            { path: 'SKILL.md', contents: `---\nname: ${skillName}\ndescription: test\n---\n` },
+          ],
+        },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalDir = join(projectDir, '.agents/skills', skillName);
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+
+      const claudeSkillDir = join(projectDir, '.claude/skills', skillName);
+      const claudeStats = await lstat(claudeSkillDir);
+      expect(claudeStats.isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- create agent-specific project skill directories during symlink installs instead of skipping when the agent root is missing
- cover both directory-based and blob-based installer paths for Claude Code project installs

## Verification
- pnpm test tests/installer-symlink.test.ts
- pnpm test (523/526 passed; existing CLI output assertions failed because this environment auto-detected codex and changed banner/interactive output)
- pnpm type-check (failed on pre-existing src/git.ts and src/skills.ts type errors unrelated to installer changes)