### PR TITLE
Remember add selections on rerun

### DIFF
--- a/src/add-prompt.test.ts
+++ b/src/add-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { promptForAgents } from './add.js';
+import { buildRememberedAddState, promptForAgents } from './add.js';
 import * as skillLock from './skill-lock.js';
 import * as searchMultiselectModule from './prompts/search-multiselect.js';
 
@@ -53,6 +53,19 @@ describe('promptForAgents', () => {
     );
   });
 
+  it('should prefer source-specific remembered agents over global history', async () => {
+    vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(['cursor']);
+    vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue(['opencode']);
+
+    await promptForAgents('Select agents', choices, ['opencode']);
+
+    expect(searchMultiselectModule.searchMultiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialSelected: ['opencode'],
+      })
+    );
+  });
+
   it('should filter out invalid agents from history', async () => {
     vi.mocked(skillLock.getLastSelectedAgents).mockResolvedValue(['cursor', 'invalid-agent']);
     vi.mocked(searchMultiselectModule.searchMultiselect).mockResolvedValue(['cursor']);
@@ -99,5 +112,77 @@ describe('promptForAgents', () => {
     await promptForAgents('Select agents', choices);
 
     expect(skillLock.saveSelectedAgents).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildRememberedAddState', () => {
+  it('derives remembered skills, agents, scope, and mode from project entries', () => {
+    const remembered = buildRememberedAddState(
+      {
+        alpha: {
+          source: 'org/repo',
+          sourceType: 'github',
+          computedHash: 'hash',
+          agents: ['claude-code', 'codex'],
+          installMode: 'copy',
+        },
+      },
+      {}
+    );
+
+    expect(remembered.skillNames).toEqual(['alpha']);
+    expect(remembered.agents).toEqual(['claude-code', 'codex']);
+    expect(remembered.scope).toBe(false);
+    expect(remembered.installMode).toBe('copy');
+  });
+
+  it('derives global scope only when global is the clear match', () => {
+    const remembered = buildRememberedAddState(
+      {},
+      {
+        alpha: {
+          source: 'org/repo',
+          sourceType: 'github',
+          sourceUrl: 'https://github.com/org/repo.git',
+          skillFolderHash: 'hash',
+          installedAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          agents: ['continue'],
+          installMode: 'symlink',
+        },
+      }
+    );
+
+    expect(remembered.scope).toBe(true);
+    expect(remembered.agents).toEqual(['continue']);
+    expect(remembered.installMode).toBe('symlink');
+  });
+
+  it('does not pick a scope or mode when remembered entries conflict', () => {
+    const remembered = buildRememberedAddState(
+      {
+        alpha: {
+          source: 'org/repo',
+          sourceType: 'github',
+          computedHash: 'hash',
+          installMode: 'copy',
+        },
+      },
+      {
+        beta: {
+          source: 'org/repo',
+          sourceType: 'github',
+          sourceUrl: 'https://github.com/org/repo.git',
+          skillFolderHash: 'hash',
+          installedAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          installMode: 'symlink',
+        },
+      }
+    );
+
+    expect(remembered.skillNames).toEqual(['alpha', 'beta']);
+    expect(remembered.scope).toBeUndefined();
+    expect(remembered.installMode).toBeUndefined();
   });
 });

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -90,6 +90,35 @@ Instructions here.
     expect(result.exitCode).toBe(0);
   });
 
+  it('should persist explicit copy mode and agents for project installs', () => {
+    const skillDir = join(testDir, 'skills', 'copy-mode-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: copy-mode-skill
+description: Copy mode test skill
+---
+
+# Copy Mode Skill
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(['add', testDir, '-y', '--agent', 'claude-code', '--copy'], targetDir);
+
+    expect(result.exitCode).toBe(0);
+    const lock = JSON.parse(
+      require('fs').readFileSync(join(targetDir, 'skills-lock.json'), 'utf-8')
+    );
+    expect(lock.skills['copy-mode-skill']).toMatchObject({
+      agents: ['claude-code'],
+      installMode: 'copy',
+    });
+  });
+
   it('should filter skills by name with --skill flag', () => {
     // Create multiple test skills
     const skill1Dir = join(testDir, 'skills', 'skill-one');

--- a/src/add.ts
+++ b/src/add.ts
@@ -38,6 +38,7 @@ import {
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
+  inferInstallModeForSkill,
   type InstallMode,
 } from './installer.ts';
 import {
@@ -65,8 +66,15 @@ import {
   dismissPrompt,
   getLastSelectedAgents,
   saveSelectedAgents,
+  getSkillsFromLockBySource,
+  type SkillLockEntry,
 } from './skill-lock.ts';
-import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
+import {
+  addSkillToLocalLock,
+  computeSkillFolderHash,
+  getLocalSkillsBySource,
+  type LocalSkillLockEntry,
+} from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import {
   tryBlobInstall,
@@ -256,6 +264,151 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
   return result;
 }
 
+interface RememberedAddState {
+  projectSkills: Record<string, LocalSkillLockEntry>;
+  globalSkills: Record<string, SkillLockEntry>;
+  skillNames: string[];
+  agents: AgentType[];
+  installMode?: InstallMode;
+  scope?: boolean;
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => !!value))];
+}
+
+function getRememberedSkillNames(
+  projectSkills: Record<string, LocalSkillLockEntry>,
+  globalSkills: Record<string, SkillLockEntry>
+): string[] {
+  return uniqueStrings([...Object.keys(projectSkills), ...Object.keys(globalSkills)]);
+}
+
+function getRememberedAgentsFromEntries(
+  entries: Array<LocalSkillLockEntry | SkillLockEntry>
+): AgentType[] {
+  const validAgents = new Set(Object.keys(agents));
+  const remembered: AgentType[] = [];
+
+  for (const entry of entries) {
+    for (const agent of entry.agents ?? []) {
+      if (validAgents.has(agent) && !remembered.includes(agent as AgentType)) {
+        remembered.push(agent as AgentType);
+      }
+    }
+  }
+
+  return remembered;
+}
+
+function getCommonInstallMode(
+  entries: Array<LocalSkillLockEntry | SkillLockEntry>
+): InstallMode | undefined {
+  const modes = uniqueStrings(entries.map((entry) => entry.installMode));
+  return modes.length === 1 ? (modes[0] as InstallMode) : undefined;
+}
+
+export function buildRememberedAddState(
+  projectSkills: Record<string, LocalSkillLockEntry>,
+  globalSkills: Record<string, SkillLockEntry>
+): RememberedAddState {
+  const projectEntries = Object.values(projectSkills);
+  const globalEntries = Object.values(globalSkills);
+  const allEntries = [...projectEntries, ...globalEntries];
+  const hasProjectMatches = projectEntries.length > 0;
+  const hasGlobalMatches = globalEntries.length > 0;
+
+  return {
+    projectSkills,
+    globalSkills,
+    skillNames: getRememberedSkillNames(projectSkills, globalSkills),
+    agents: getRememberedAgentsFromEntries(allEntries),
+    installMode: getCommonInstallMode(allEntries),
+    scope: hasProjectMatches !== hasGlobalMatches ? hasGlobalMatches : undefined,
+  };
+}
+
+function filterRememberedSkills<T extends { name?: string; installName?: string }>(
+  skills: T[],
+  rememberedSkillNames: string[]
+): T[] {
+  const remembered = new Set(rememberedSkillNames);
+  return skills.filter((skill) => {
+    const name = 'installName' in skill ? skill.installName : skill.name;
+    return name ? remembered.has(name) : false;
+  });
+}
+
+function getRememberedSkillScope(
+  skillName: string,
+  remembered: RememberedAddState
+): 'project' | 'global' | 'project + global' | undefined {
+  const hasProject = skillName in remembered.projectSkills;
+  const hasGlobal = skillName in remembered.globalSkills;
+
+  if (hasProject && hasGlobal) return 'project + global';
+  if (hasProject) return 'project';
+  if (hasGlobal) return 'global';
+  return undefined;
+}
+
+function buildSkillChoiceHint(
+  skillName: string,
+  description: string,
+  remembered: RememberedAddState
+): string {
+  const scope = getRememberedSkillScope(skillName, remembered);
+  const rememberedEntry = remembered.projectSkills[skillName] ?? remembered.globalSkills[skillName];
+  const parts: string[] = [];
+
+  if (scope) {
+    const agentCount = rememberedEntry?.agents?.length;
+    const mode = rememberedEntry?.installMode;
+    parts.push(
+      `installed: ${scope}${agentCount ? `, ${agentCount} agent${agentCount !== 1 ? 's' : ''}` : ''}${mode ? `, ${mode}` : ''}`
+    );
+  }
+
+  if (description) {
+    parts.push(description.length > 60 ? description.slice(0, 57) + '...' : description);
+  }
+
+  return parts.join(' • ');
+}
+
+async function loadRememberedAddState(
+  sourceCandidates: string[],
+  cwd: string
+): Promise<RememberedAddState> {
+  const [projectSkills, globalSkills] = await Promise.all([
+    getLocalSkillsBySource(sourceCandidates, cwd).catch(() => ({})),
+    getSkillsFromLockBySource(sourceCandidates).catch(() => ({})),
+  ]);
+
+  return buildRememberedAddState(projectSkills, globalSkills);
+}
+
+async function inferRememberedInstallMode(options: {
+  remembered: RememberedAddState;
+  selectedSkillNames: string[];
+  targetAgents: AgentType[];
+  global: boolean;
+  cwd: string;
+}): Promise<InstallMode | undefined> {
+  if (options.remembered.installMode) return options.remembered.installMode;
+
+  const modes = new Set<InstallMode>();
+  for (const skillName of options.selectedSkillNames) {
+    const inferred = await inferInstallModeForSkill(skillName, options.targetAgents, {
+      global: options.global,
+      cwd: options.cwd,
+    });
+    if (inferred) modes.add(inferred);
+  }
+
+  return modes.size === 1 ? [...modes][0] : undefined;
+}
+
 /**
  * Builds result lines from installation results, splitting by universal vs symlinked
  */
@@ -317,7 +470,8 @@ function multiselect<Value>(opts: {
  */
 export async function promptForAgents(
   message: string,
-  choices: Array<{ value: AgentType; label: string; hint?: string }>
+  choices: Array<{ value: AgentType; label: string; hint?: string }>,
+  rememberedAgents?: AgentType[]
 ): Promise<AgentType[] | symbol> {
   // Get last selected agents to pre-select
   let lastSelected: string[] | undefined;
@@ -335,7 +489,11 @@ export async function promptForAgents(
 
   let initialValues: AgentType[] = [];
 
-  if (lastSelected && lastSelected.length > 0) {
+  if (rememberedAgents && rememberedAgents.length > 0) {
+    initialValues = rememberedAgents.filter((a) => validAgents.includes(a));
+  }
+
+  if (initialValues.length === 0 && lastSelected && lastSelected.length > 0) {
     // Filter stored agents against currently valid agents
     initialValues = lastSelected.filter((a) => validAgents.includes(a as AgentType)) as AgentType[];
   }
@@ -370,6 +528,8 @@ export async function promptForAgents(
  */
 async function selectAgentsInteractive(options: {
   global?: boolean;
+  rememberedAgents?: AgentType[];
+  fallbackAgents?: AgentType[];
 }): Promise<AgentType[] | symbol> {
   // Filter out agents that don't support global installation when --global is used
   const supportsGlobalFilter = (a: AgentType) => !options.global || agents[a].globalSkillsDir;
@@ -403,11 +563,23 @@ async function selectAgentsInteractive(options: {
     // Silently ignore errors
   }
 
-  const initialSelected = lastSelected
-    ? (lastSelected.filter(
-        (a) => otherAgents.includes(a as AgentType) && !universalAgents.includes(a as AgentType)
-      ) as AgentType[])
+  let initialSelected = options.rememberedAgents
+    ? options.rememberedAgents.filter(
+        (a) => otherAgents.includes(a) && !universalAgents.includes(a)
+      )
     : [];
+
+  if (initialSelected.length === 0 && lastSelected) {
+    initialSelected = lastSelected.filter(
+      (a) => otherAgents.includes(a as AgentType) && !universalAgents.includes(a as AgentType)
+    ) as AgentType[];
+  }
+
+  if (initialSelected.length === 0 && options.fallbackAgents) {
+    initialSelected = options.fallbackAgents.filter(
+      (a) => otherAgents.includes(a) && !universalAgents.includes(a)
+    );
+  }
 
   const selected = await searchMultiselect({
     message: 'Which agents do you want to install to?',
@@ -495,6 +667,10 @@ async function handleWellKnownSkills(
     process.exit(0);
   }
 
+  const cwd = process.cwd();
+  const sourceIdentifier = wellKnownProvider.getSourceIdentifier(url);
+  const remembered = await loadRememberedAddState([sourceIdentifier, url], cwd);
+
   // Filter skills if --skill option is provided
   let selectedSkills: WellKnownSkill[];
 
@@ -527,16 +703,18 @@ async function handleWellKnownSkills(
     selectedSkills = skills;
     p.log.info(`Installing all ${skills.length} skills`);
   } else {
+    const rememberedSkills = filterRememberedSkills(skills, remembered.skillNames);
     // Prompt user to select skills
     const skillChoices = skills.map((s) => ({
       value: s,
       label: s.installName,
-      hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
+      hint: buildSkillChoiceHint(s.installName, s.description, remembered),
     }));
 
     const selected = await multiselect({
       message: 'Select skills to install',
       options: skillChoices,
+      initialValues: rememberedSkills,
       required: true,
     });
 
@@ -572,7 +750,42 @@ async function handleWellKnownSkills(
     const totalAgents = Object.keys(agents).length;
     spinner.stop(`${totalAgents} agents`);
 
-    if (installedAgents.length === 0) {
+    if (!options.yes && remembered.agents.length > 0) {
+      if (installedAgents.length === 0) {
+        p.log.info('Select agents to install skills to');
+
+        const allAgentChoices = Object.entries(agents).map(([key, config]) => ({
+          value: key as AgentType,
+          label: config.displayName,
+        }));
+
+        const selected = await promptForAgents(
+          'Which agents do you want to install to?',
+          allAgentChoices,
+          remembered.agents
+        );
+
+        if (p.isCancel(selected)) {
+          p.cancel('Installation cancelled');
+          process.exit(0);
+        }
+
+        targetAgents = selected as AgentType[];
+      } else {
+        const selected = await selectAgentsInteractive({
+          global: options.global,
+          rememberedAgents: remembered.agents,
+          fallbackAgents: installedAgents,
+        });
+
+        if (p.isCancel(selected)) {
+          p.cancel('Installation cancelled');
+          process.exit(0);
+        }
+
+        targetAgents = selected as AgentType[];
+      }
+    } else if (installedAgents.length === 0) {
       if (options.yes) {
         targetAgents = validAgents as AgentType[];
         p.log.info('Installing to all agents');
@@ -587,7 +800,8 @@ async function handleWellKnownSkills(
         // Use helper to prompt with search
         const selected = await promptForAgents(
           'Which agents do you want to install to?',
-          allAgentChoices
+          allAgentChoices,
+          remembered.agents
         );
 
         if (p.isCancel(selected)) {
@@ -609,7 +823,11 @@ async function handleWellKnownSkills(
         );
       }
     } else {
-      const selected = await selectAgentsInteractive({ global: options.global });
+      const selected = await selectAgentsInteractive({
+        global: options.global,
+        rememberedAgents: remembered.agents,
+        fallbackAgents: installedAgents,
+      });
 
       if (p.isCancel(selected)) {
         p.cancel('Installation cancelled');
@@ -628,6 +846,7 @@ async function handleWellKnownSkills(
   if (options.global === undefined && !options.yes && supportsGlobal) {
     const scope = await p.select({
       message: 'Installation scope',
+      initialValue: remembered.scope,
       options: [
         {
           value: false,
@@ -656,10 +875,19 @@ async function handleWellKnownSkills(
   // Only prompt for install mode when there are multiple unique target directories.
   // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
   const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+  const selectedSkillNames = selectedSkills.map((skill) => skill.installName);
+  const rememberedInstallMode = await inferRememberedInstallMode({
+    remembered,
+    selectedSkillNames,
+    targetAgents,
+    global: installGlobally,
+    cwd,
+  });
 
   if (!options.copy && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
       message: 'Installation method',
+      initialValue: rememberedInstallMode ?? 'symlink',
       options: [
         {
           value: 'symlink',
@@ -680,8 +908,6 @@ async function handleWellKnownSkills(
     // Single target directory — default to copy (no symlink needed)
     installMode = 'copy';
   }
-
-  const cwd = process.cwd();
 
   // Build installation summary
   const summaryLines: string[] = [];
@@ -739,7 +965,6 @@ async function handleWellKnownSkills(
   }
 
   // Kick off privacy check early so it runs in parallel with installation
-  const sourceIdentifier = wellKnownProvider.getSourceIdentifier(url);
   const wellKnownPrivacyPromise = isSourcePrivate(sourceIdentifier).catch(() => null);
 
   spinner.start('Installing skills...');
@@ -806,6 +1031,8 @@ async function handleWellKnownSkills(
             sourceType: 'well-known',
             sourceUrl: skill.sourceUrl,
             skillFolderHash: '', // Well-known skills don't have a folder hash
+            agents: targetAgents,
+            installMode,
           });
         } catch {
           // Don't fail installation if lock file update fails
@@ -830,6 +1057,8 @@ async function handleWellKnownSkills(
                 source: sourceIdentifier,
                 sourceType: 'well-known',
                 computedHash,
+                agents: targetAgents,
+                installMode,
               },
               cwd
             );
@@ -970,6 +1199,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   }
 
   let tempDir: string | null = null;
+  const cwd = process.cwd();
 
   try {
     const spinner = p.spinner();
@@ -1024,6 +1254,16 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         options.skill.push(parsed.skillFilter);
       }
     }
+
+    const normalizedSourceForMemory = getOwnerRepo(parsed);
+    const lockSourceForMemory = getLockSource(parsed.url, normalizedSourceForMemory);
+    const sourceCandidates = uniqueStrings([
+      lockSourceForMemory,
+      normalizedSourceForMemory,
+      parsed.url,
+      parsed.localPath,
+    ]);
+    const remembered = await loadRememberedAddState(sourceCandidates, cwd);
 
     // Include internal skills when a specific skill is explicitly requested
     // (via --skill or @skill syntax)
@@ -1204,6 +1444,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       // Check if any skills have plugin grouping
       const hasGroups = sortedSkills.some((s) => s.pluginName);
+      const rememberedSkills = filterRememberedSkills(sortedSkills, remembered.skillNames);
 
       let selected: Skill[] | symbol;
 
@@ -1222,25 +1463,27 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           grouped[groupName]!.push({
             value: s,
             label: getSkillDisplayName(s),
-            hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
+            hint: buildSkillChoiceHint(getSkillDisplayName(s), s.description, remembered),
           });
         }
 
         selected = await p.groupMultiselect({
           message: `Select skills to install ${pc.dim('(space to toggle)')}`,
           options: grouped,
+          initialValues: rememberedSkills,
           required: true,
-        });
+        } as Parameters<typeof p.groupMultiselect<Skill>>[0]);
       } else {
         const skillChoices = sortedSkills.map((s) => ({
           value: s,
           label: getSkillDisplayName(s),
-          hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
+          hint: buildSkillChoiceHint(getSkillDisplayName(s), s.description, remembered),
         }));
 
         selected = await multiselect({
           message: 'Select skills to install',
           options: skillChoices,
+          initialValues: rememberedSkills,
           required: true,
         });
       }
@@ -1288,7 +1531,44 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const totalAgents = Object.keys(agents).length;
       spinner.stop(`${totalAgents} agents`);
 
-      if (installedAgents.length === 0) {
+      if (!options.yes && remembered.agents.length > 0) {
+        if (installedAgents.length === 0) {
+          p.log.info('Select agents to install skills to');
+
+          const allAgentChoices = Object.entries(agents).map(([key, config]) => ({
+            value: key as AgentType,
+            label: config.displayName,
+          }));
+
+          const selected = await promptForAgents(
+            'Which agents do you want to install to?',
+            allAgentChoices,
+            remembered.agents
+          );
+
+          if (p.isCancel(selected)) {
+            p.cancel('Installation cancelled');
+            await cleanup(tempDir);
+            process.exit(0);
+          }
+
+          targetAgents = selected as AgentType[];
+        } else {
+          const selected = await selectAgentsInteractive({
+            global: options.global,
+            rememberedAgents: remembered.agents,
+            fallbackAgents: installedAgents,
+          });
+
+          if (p.isCancel(selected)) {
+            p.cancel('Installation cancelled');
+            await cleanup(tempDir);
+            process.exit(0);
+          }
+
+          targetAgents = selected as AgentType[];
+        }
+      } else if (installedAgents.length === 0) {
         if (options.yes) {
           targetAgents = validAgents as AgentType[];
           p.log.info('Installing to all agents');
@@ -1303,7 +1583,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           // Use helper to prompt with search
           const selected = await promptForAgents(
             'Which agents do you want to install to?',
-            allAgentChoices
+            allAgentChoices,
+            remembered.agents
           );
 
           if (p.isCancel(selected)) {
@@ -1326,7 +1607,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           );
         }
       } else {
-        const selected = await selectAgentsInteractive({ global: options.global });
+        const selected = await selectAgentsInteractive({
+          global: options.global,
+          rememberedAgents: remembered.agents,
+          fallbackAgents: installedAgents,
+        });
 
         if (p.isCancel(selected)) {
           p.cancel('Installation cancelled');
@@ -1346,6 +1631,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     if (options.global === undefined && !options.yes && supportsGlobal) {
       const scope = await p.select({
         message: 'Installation scope',
+        initialValue: remembered.scope,
         options: [
           {
             value: false,
@@ -1375,10 +1661,19 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Only prompt for install mode when there are multiple unique target directories.
     // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
     const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+    const selectedSkillNames = selectedSkills.map((skill) => getSkillDisplayName(skill));
+    const rememberedInstallMode = await inferRememberedInstallMode({
+      remembered,
+      selectedSkillNames,
+      targetAgents,
+      global: installGlobally,
+      cwd,
+    });
 
     if (!options.copy && !options.yes && uniqueDirs.size > 1) {
       const modeChoice = await p.select({
         message: 'Installation method',
+        initialValue: rememberedInstallMode ?? 'symlink',
         options: [
           {
             value: 'symlink',
@@ -1400,8 +1695,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Single target directory — default to copy (no symlink needed)
       installMode = 'copy';
     }
-
-    const cwd = process.cwd();
 
     // Build installation summary
     const summaryLines: string[] = [];
@@ -1661,6 +1954,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
+              agents: targetAgents,
+              installMode,
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -1690,6 +1985,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
+                agents: targetAgents,
+                installMode,
               },
               cwd
             );

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -224,6 +224,15 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
   }
 }
 
+async function pathsReferToSameLocation(a: string, b: string): Promise<boolean> {
+  const [realA, realB] = await Promise.all([
+    realpath(a).catch(() => resolve(a)),
+    realpath(b).catch(() => resolve(b)),
+  ]);
+
+  return realA === realB;
+}
+
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
@@ -277,8 +286,18 @@ export async function installSkillForAgent(
   }
 
   try {
+    const sourceIsAgentDir = await pathsReferToSameLocation(skill.path, agentDir);
+
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
+      if (sourceIsAgentDir) {
+        return {
+          success: true,
+          path: agentDir,
+          mode: 'copy',
+        };
+      }
+
       await cleanAndCreateDirectory(agentDir);
       await copyDirectory(skill.path, agentDir);
 
@@ -290,8 +309,11 @@ export async function installSkillForAgent(
     }
 
     // Symlink mode: copy to canonical location and symlink to agent location
-    await cleanAndCreateDirectory(canonicalDir);
-    await copyDirectory(skill.path, canonicalDir);
+    const sourceIsCanonicalDir = await pathsReferToSameLocation(skill.path, canonicalDir);
+    if (!sourceIsCanonicalDir) {
+      await cleanAndCreateDirectory(canonicalDir);
+      await copyDirectory(skill.path, canonicalDir);
+    }
 
     // For universal agents with global install, the skill is already in the canonical
     // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
@@ -302,6 +324,16 @@ export async function installSkillForAgent(
         path: canonicalDir,
         canonicalPath: canonicalDir,
         mode: 'symlink',
+      };
+    }
+
+    if (sourceIsAgentDir) {
+      return {
+        success: true,
+        path: agentDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
       };
     }
 
@@ -473,6 +505,86 @@ export function getCanonicalPath(
   }
 
   return canonicalPath;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isSymlinkToTarget(linkPath: string, targetPath: string): Promise<boolean> {
+  try {
+    const stats = await lstat(linkPath);
+    if (!stats.isSymbolicLink()) return false;
+
+    const linkTarget = await readlink(linkPath);
+    const resolvedLinkTarget = resolveSymlinkTarget(linkPath, linkTarget);
+    const [realLinkTarget, realTarget] = await Promise.all([
+      realpath(resolvedLinkTarget).catch(() => resolve(resolvedLinkTarget)),
+      realpath(targetPath).catch(() => resolve(targetPath)),
+    ]);
+
+    return realLinkTarget === realTarget;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Infer the install mode for legacy lock entries that predate persisted mode.
+ *
+ * Symlink mode is represented by a canonical .agents/skills/<skill> directory
+ * plus agent-specific symlinks pointing to it. Copy mode is represented by
+ * independent agent skill directories. If every selected agent resolves to the
+ * same target directory, copy remains the least surprising default.
+ */
+export async function inferInstallModeForSkill(
+  skillName: string,
+  agentTypes: AgentType[],
+  options: { global?: boolean; cwd?: string } = {}
+): Promise<InstallMode | undefined> {
+  if (agentTypes.length === 0) return undefined;
+
+  const isGlobal = options.global ?? false;
+  const cwd = options.cwd || process.cwd();
+  const uniqueDirs = new Set(agentTypes.map((a) => getAgentBaseDir(a, isGlobal, cwd)));
+  if (uniqueDirs.size <= 1) return 'copy';
+
+  const canonicalPath = getCanonicalPath(skillName, { global: isGlobal, cwd });
+  const canonicalExists = await pathExists(canonicalPath);
+
+  let sawAgentInstall = false;
+  let sawCanonicalSymlink = false;
+  let sawIndependentAgentDir = false;
+
+  for (const agentType of agentTypes) {
+    if (isGlobal && agents[agentType].globalSkillsDir === undefined) continue;
+
+    const agentPath = getInstallPath(skillName, agentType, { global: isGlobal, cwd });
+    if (resolve(agentPath) === resolve(canonicalPath)) {
+      if (canonicalExists) sawAgentInstall = true;
+      continue;
+    }
+
+    if (!(await pathExists(agentPath))) continue;
+    sawAgentInstall = true;
+
+    if (canonicalExists && (await isSymlinkToTarget(agentPath, canonicalPath))) {
+      sawCanonicalSymlink = true;
+    } else {
+      sawIndependentAgentDir = true;
+    }
+  }
+
+  if (canonicalExists && sawCanonicalSymlink && !sawIndependentAgentDir) return 'symlink';
+  if (sawIndependentAgentDir) return 'copy';
+  if (sawAgentInstall && !canonicalExists) return 'copy';
+
+  return undefined;
 }
 
 /**

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, readdir, stat } from 'fs/promises';
 import { join, relative } from 'path';
 import { createHash } from 'crypto';
+import type { InstallMode } from './installer.ts';
 
 const LOCAL_LOCK_FILE = 'skills-lock.json';
 const CURRENT_VERSION = 1;
@@ -33,6 +34,10 @@ export interface LocalSkillLockEntry {
    * computes the hash from actual file contents on disk.
    */
   computedHash: string;
+  /** Agents selected when this skill was installed. Used to seed rerun prompts. */
+  agents?: string[];
+  /** Install mode selected when this skill was installed. */
+  installMode?: InstallMode;
 }
 
 /**
@@ -157,6 +162,28 @@ export async function addSkillToLocalLock(
   const lock = await readLocalLock(cwd);
   lock.skills[skillName] = entry;
   await writeLocalLock(lock, cwd);
+}
+
+/**
+ * Get project skills whose source matches one of the provided source identifiers.
+ */
+export async function getLocalSkillsBySource(
+  sources: string[],
+  cwd?: string
+): Promise<Record<string, LocalSkillLockEntry>> {
+  const sourceSet = new Set(sources.filter(Boolean));
+  if (sourceSet.size === 0) return {};
+
+  const lock = await readLocalLock(cwd);
+  const matches: Record<string, LocalSkillLockEntry> = {};
+
+  for (const [skillName, entry] of Object.entries(lock.skills)) {
+    if (sourceSet.has(entry.source)) {
+      matches[skillName] = entry;
+    }
+  }
+
+  return matches;
 }
 
 /**

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -104,6 +104,36 @@ This is a test skill.
       expect(existsSync(join(skillsDir, 'skill-three'))).toBe(true);
     });
 
+    it('should remove project skill from local lock file', () => {
+      writeFileSync(
+        join(testDir, 'skills-lock.json'),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            'skill-one': {
+              source: 'org/repo',
+              sourceType: 'github',
+              computedHash: 'hash-one',
+            },
+            'skill-two': {
+              source: 'org/repo',
+              sourceType: 'github',
+              computedHash: 'hash-two',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['remove', 'skill-one', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      const lock = JSON.parse(
+        require('fs').readFileSync(join(testDir, 'skills-lock.json'), 'utf-8')
+      );
+      expect(lock.skills['skill-one']).toBeUndefined();
+      expect(lock.skills['skill-two']).toBeDefined();
+    });
+
     it('should remove multiple skills by name', () => {
       const result = runCli(['remove', 'skill-one', 'skill-two', '-y'], testDir);
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -6,6 +6,7 @@ import { agents, detectInstalledAgents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -226,6 +227,8 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);
+      } else {
+        await removeSkillFromLocalLock(skillName, cwd);
       }
 
       results.push({

--- a/src/skill-lock.test.ts
+++ b/src/skill-lock.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  addSkillToLock,
+  getSkillsFromLockBySource,
+  readSkillLock,
+  writeSkillLock,
+} from './skill-lock.ts';
+
+describe('skill-lock install preferences', () => {
+  let stateDir: string | undefined;
+
+  async function useTempStateDir(): Promise<string> {
+    stateDir = await mkdtemp(join(tmpdir(), 'skill-lock-state-'));
+    vi.stubEnv('XDG_STATE_HOME', stateDir);
+    return stateDir;
+  }
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+
+    if (stateDir) {
+      await rm(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+  });
+
+  it('reads v3 lock entries without install preference fields', async () => {
+    const dir = await useTempStateDir();
+    await mkdir(join(dir, 'skills'), { recursive: true });
+    await writeFile(
+      join(dir, 'skills', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          legacy: {
+            source: 'org/repo',
+            sourceType: 'github',
+            sourceUrl: 'https://github.com/org/repo.git',
+            skillFolderHash: 'abc',
+            installedAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        },
+      }),
+      'utf-8'
+    );
+
+    const lock = await readSkillLock();
+    expect(lock.skills.legacy?.installMode).toBeUndefined();
+    expect(lock.skills.legacy?.agents).toBeUndefined();
+  });
+
+  it('writes and matches remembered install preferences by source', async () => {
+    await useTempStateDir();
+
+    await addSkillToLock('remembered', {
+      source: 'org/repo',
+      sourceType: 'github',
+      sourceUrl: 'https://github.com/org/repo.git',
+      skillFolderHash: 'abc',
+      agents: ['claude-code', 'continue'],
+      installMode: 'copy',
+    });
+
+    const matches = await getSkillsFromLockBySource(['org/repo']);
+    expect(matches.remembered?.agents).toEqual(['claude-code', 'continue']);
+    expect(matches.remembered?.installMode).toBe('copy');
+  });
+
+  it('keeps optional preference fields when writing the full lock', async () => {
+    const dir = await useTempStateDir();
+
+    await writeSkillLock({
+      version: 3,
+      skills: {
+        alpha: {
+          source: 'org/repo',
+          sourceType: 'github',
+          sourceUrl: 'https://github.com/org/repo.git',
+          skillFolderHash: 'abc',
+          installedAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          agents: ['codex'],
+          installMode: 'symlink',
+        },
+      },
+    });
+
+    const raw = await readFile(join(dir, 'skills', '.skill-lock.json'), 'utf-8');
+    expect(JSON.parse(raw).skills.alpha).toMatchObject({
+      agents: ['codex'],
+      installMode: 'symlink',
+    });
+  });
+});

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import pc from 'picocolors';
+import type { InstallMode } from './installer.ts';
 
 const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
@@ -35,6 +36,10 @@ export interface SkillLockEntry {
   updatedAt: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  /** Agents selected when this skill was installed. Used to seed rerun prompts. */
+  agents?: string[];
+  /** Install mode selected when this skill was installed. */
+  installMode?: InstallMode;
 }
 
 /**
@@ -251,6 +256,27 @@ export async function getSkillFromLock(skillName: string): Promise<SkillLockEntr
 export async function getAllLockedSkills(): Promise<Record<string, SkillLockEntry>> {
   const lock = await readSkillLock();
   return lock.skills;
+}
+
+/**
+ * Get locked global skills whose source matches one of the provided source identifiers.
+ */
+export async function getSkillsFromLockBySource(
+  sources: string[]
+): Promise<Record<string, SkillLockEntry>> {
+  const sourceSet = new Set(sources.filter(Boolean));
+  if (sourceSet.size === 0) return {};
+
+  const lock = await readSkillLock();
+  const matches: Record<string, SkillLockEntry> = {};
+
+  for (const [skillName, entry] of Object.entries(lock.skills)) {
+    if (sourceSet.has(entry.source) || sourceSet.has(entry.sourceUrl)) {
+      matches[skillName] = entry;
+    }
+  }
+
+  return matches;
 }
 
 /**

--- a/tests/install-mode-inference.test.ts
+++ b/tests/install-mode-inference.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile, symlink } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+import { inferInstallModeForSkill } from '../src/installer.ts';
+
+describe('install mode inference', () => {
+  async function createSkillDir(path: string) {
+    await mkdir(path, { recursive: true });
+    await writeFile(join(path, 'SKILL.md'), '---\nname: legacy-skill\ndescription: Test\n---\n');
+  }
+
+  it('infers symlink mode from canonical storage and agent symlinks', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'install-mode-'));
+    try {
+      const canonical = join(dir, '.agents', 'skills', 'legacy-skill');
+      const claude = join(dir, '.claude', 'skills', 'legacy-skill');
+      const continuePath = join(dir, '.continue', 'skills', 'legacy-skill');
+      await createSkillDir(canonical);
+      await mkdir(join(dir, '.claude', 'skills'), { recursive: true });
+      await mkdir(join(dir, '.continue', 'skills'), { recursive: true });
+      await symlink(relative(join(dir, '.claude', 'skills'), canonical), claude, 'dir');
+      await symlink(relative(join(dir, '.continue', 'skills'), canonical), continuePath, 'dir');
+
+      await expect(
+        inferInstallModeForSkill('legacy-skill', ['claude-code', 'continue'], { cwd: dir })
+      ).resolves.toBe('symlink');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('infers copy mode from independent agent skill directories', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'install-mode-'));
+    try {
+      await createSkillDir(join(dir, '.claude', 'skills', 'legacy-skill'));
+      await createSkillDir(join(dir, '.continue', 'skills', 'legacy-skill'));
+
+      await expect(
+        inferInstallModeForSkill('legacy-skill', ['claude-code', 'continue'], { cwd: dir })
+      ).resolves.toBe('copy');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps single target directory installs in copy mode', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'install-mode-'));
+    try {
+      await createSkillDir(join(dir, '.agents', 'skills', 'legacy-skill'));
+
+      await expect(
+        inferInstallModeForSkill('legacy-skill', ['codex', 'amp'], { cwd: dir })
+      ).resolves.toBe('copy');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -88,6 +88,60 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('does not replace a local source that is also an agent skill destination', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    const skillName = 'demo-skill';
+    const skillDir = join(projectDir, 'skills', skillName);
+
+    try {
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${skillName}\ndescription: test\n---\n`,
+        'utf-8'
+      );
+
+      const openClawResult = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'openclaw',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(openClawResult.success).toBe(true);
+      expect(openClawResult.skipped).toBe(true);
+
+      const sourceStats = await lstat(skillDir);
+      expect(sourceStats.isDirectory()).toBe(true);
+      expect(sourceStats.isSymbolicLink()).toBe(false);
+      await expect(readFile(join(skillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+
+      const canonicalDir = join(projectDir, '.agents', 'skills', skillName);
+      await expect(readFile(join(canonicalDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+
+      await mkdir(join(projectDir, '.claude'), { recursive: true });
+      const claudeResult = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(claudeResult.success).toBe(true);
+      await expect(readFile(join(canonicalDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+      await expect(readFile(join(skillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Regression test for #293: when agent skills dir is a symlink to canonical dir
   it('handles agent skills dir being a symlink to canonical dir', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -9,6 +9,7 @@ import {
   removeSkillFromLocalLock,
   computeSkillFolderHash,
   getLocalLockPath,
+  getLocalSkillsBySource,
 } from '../src/local-lock.ts';
 
 describe('local-lock', () => {
@@ -222,6 +223,52 @@ describe('local-lock', () => {
           sourceType: 'github',
           computedHash: 'hash123',
         });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('stores install preferences when present', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'preferred-skill',
+          {
+            source: 'org/repo',
+            sourceType: 'github',
+            computedHash: 'hash123',
+            agents: ['claude-code', 'codex'],
+            installMode: 'symlink',
+          },
+          dir
+        );
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['preferred-skill']).toMatchObject({
+          agents: ['claude-code', 'codex'],
+          installMode: 'symlink',
+        });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('finds skills by source for rerun defaults', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'matching-skill',
+          { source: 'org/repo', sourceType: 'github', computedHash: 'hash123' },
+          dir
+        );
+        await addSkillToLocalLock(
+          'other-skill',
+          { source: 'other/repo', sourceType: 'github', computedHash: 'hash456' },
+          dir
+        );
+
+        const matches = await getLocalSkillsBySource(['org/repo'], dir);
+        expect(Object.keys(matches)).toEqual(['matching-skill']);
       } finally {
         await rm(dir, { recursive: true, force: true });
       }


### PR DESCRIPTION
just wanted to say... I love this project and other projects that use this package (namely https://github.com/mattpocock/skills ) but I always hate updating his skills whenever I ran npx skills@latest add mattpocock/skills ) this PR slightly changes the add command to have a better persistent state and show previously selected values to make rerunning the same npx skills add commands to be a little bit more graceful.


## Summary


- Remember source-specific `skills add` choices from project/global lock files so rerunning `skills add <same-source>` preselects previously installed skills.
- Persist selected agents and install mode (`symlink` / `copy`) in both global and project lock entries, while keeping the new fields optional for existing lock files.
- Seed agent, scope, and install-method prompts from prior installs, falling back to existing `lastSelectedAgents` and detected agents when no source-specific state exists.
- Show installed state in the skill picker hints, e.g. `installed: project, 2 agents, copy`, so reruns make it clear what is already installed.
- Infer legacy install mode from filesystem shape when old lock entries do not have persisted mode.
- Remove project lock entries when `skills remove` removes project-scoped skills, preventing stale local lock state from being preselected later.
- Protect local source directories that overlap agent install destinations, such as `./skills/<skill>` for OpenClaw, from being replaced during install.

## Why

Users often rerun `npx skills add <source>` to add one more skill or refresh a prior install, but the current interactive flow makes them remember every previous skill, agent, scope, and symlink/copy choice. The existing `skills update` command remains the canonical update path; this change focuses only on making rerun-add ergonomic and non-destructive by seeding prompt defaults from prior install state.

## Notes

- Explicit CLI flags still win: `--yes`, `--skill`, `--agent`, `--global`, and `--copy` continue to bypass or override remembered defaults.
- Deselecting a preselected skill in `skills add` does not uninstall it. Uninstall remains the responsibility of `skills remove`.
- The install mode inference is best-effort for legacy installs:
  - canonical `.agents/skills/<skill>` plus agent symlinks pointing to it => `symlink`
  - independent agent skill directories => `copy`
  - one unique target directory remains `copy`

## Testing

- `pnpm format`
- `pnpm test src/skill-lock.test.ts tests/local-lock.test.ts tests/install-mode-inference.test.ts tests/installer-symlink.test.ts src/add-prompt.test.ts src/add.test.ts`
- `pnpm test src/remove.test.ts -t "remove project skill from local lock file"`
- Full `pnpm test` was also run locally: 532 tests passed, with 5 environment-related failures unrelated to this change:
  - `tests/dist.test.ts` attempted to fetch `license-checker` from npm and failed due network/DNS.
  - `tests/list-installed.test.ts` attempted to write to real `~/.agents`.
  - two banner tests returned empty output in this Codex-detected environment.
  - an existing remove confirmation test ran non-interactively because Codex auto-detection forces `--yes`.
- `pnpm type-check` currently fails on pre-existing typing issues in `src/git.ts` and `src/skills.ts`.


## Manual Testing

I created some dummy local skills (not included in the PR but I can assure you they exist on my local machine)
ran
`    pnpm dev add ./fixtures/rerun-demo-package`
 installed them with various settings, then 
`    pnpm dev add ./fixtures/rerun-demo-package`
 to verify that it preselected the settings I previously had installed that package with.
