### PR TITLE
fix(update): fall back to clone when tree fetch fails for private repos

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -149,10 +149,13 @@ async function fetchTreeBranch(
  *
  * Authentication is lazy: by default the call goes out unauthenticated,
  * which is enough for the vast majority of users (60 req/hr per IP).
- * Only if GitHub responds with a rate-limit 403 do we ask the optional
- * `getToken` callback for a token and retry. This avoids invoking
- * `gh auth token` on every install, which corporate endpoint security
- * tools flag as suspicious credential extraction. See issue #523.
+ * If the unauthenticated pass fails for any reason (rate-limit 403,
+ * private-repo 404, etc.) and a `getToken` callback was provided, we
+ * retry once with a token. Public repos — the common case — succeed on
+ * the first unauthenticated request and never invoke the resolver, which
+ * avoids spawning `gh auth token` on every install (corporate endpoint
+ * security tools flag that as suspicious credential extraction;
+ * see issue #523).
  */
 export async function fetchRepoTree(
   ownerRepo: string,
@@ -186,10 +189,12 @@ export async function fetchRepoTree(
     }
   }
 
-  if (!rateLimited || !getToken) return null;
+  if (!getToken) return null;
 
-  // Lazy fallback: rate limit hit and a token resolver was provided.
-  _rateLimitedThisSession = true;
+  // Lazy fallback: unauthenticated pass failed and a token resolver was
+  // provided. Memoize only the rate-limit signal — it is process-wide,
+  // whereas a 404 is repo-specific.
+  if (rateLimited) _rateLimitedThisSession = true;
   const token = getToken();
   if (!token) return null;
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -339,41 +339,42 @@ export async function updateGlobalSkills(
     try {
       const isGitHubSource = firstEntry.sourceType === 'github';
 
+      // GitHub API fast path: compare tree hashes without cloning.
+      // Falls through to the clone-based check on failure (e.g. private
+      // repo without a token, SSH-only auth, rate limit with no resolver).
       if (isGitHubSource) {
         const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);
 
-        if (!tree) {
-          console.log(`  ${DIM}✗ Failed to fetch tree for ${source}${RESET}`);
+        if (tree) {
+          const discoveredPaths = findSkillMdPaths(tree);
+
+          const allLockedForSource = Object.entries(lock.skills)
+            .filter(([_, entry]) => entry.source === source)
+            .map(([name, _]) => name);
+
+          const deletedSkills = await checkAndPromptForDeletions(
+            source,
+            allLockedForSource,
+            lock.skills,
+            true,
+            options,
+            discoveredPaths
+          );
+
+          const deletedSkillSet = new Set(deletedSkills);
+
+          for (const { name: skillName, entry } of itemsForSource) {
+            if (deletedSkillSet.has(skillName)) continue;
+
+            const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
+            if (latestHash && latestHash !== entry.skillFolderHash) {
+              updates.push({ name: skillName, source, entry });
+            }
+          }
+
           continue;
         }
-
-        const discoveredPaths = findSkillMdPaths(tree);
-
-        const allLockedForSource = Object.entries(lock.skills)
-          .filter(([_, entry]) => entry.source === source)
-          .map(([name, _]) => name);
-
-        const deletedSkills = await checkAndPromptForDeletions(
-          source,
-          allLockedForSource,
-          lock.skills,
-          true,
-          options,
-          discoveredPaths
-        );
-
-        const deletedSkillSet = new Set(deletedSkills);
-
-        for (const { name: skillName, entry } of itemsForSource) {
-          if (deletedSkillSet.has(skillName)) continue;
-
-          const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
-          if (latestHash && latestHash !== entry.skillFolderHash) {
-            updates.push({ name: skillName, source, entry });
-          }
-        }
-
-        continue;
+        // tree fetch failed — fall through to clone-based check
       }
 
       tempDir = await cloneRepo(sourceUrl, firstEntry.ref);

--- a/tests/blob-fetch-tree-auth.test.ts
+++ b/tests/blob-fetch-tree-auth.test.ts
@@ -36,6 +36,17 @@ function rateLimitResponse(): Response {
   });
 }
 
+function notFoundResponse(): Response {
+  // GitHub returns 404 for a private repo accessed without credentials.
+  return new Response(JSON.stringify({ message: 'Not Found' }), {
+    status: 404,
+    headers: {
+      'content-type': 'application/json',
+      'x-ratelimit-remaining': '59',
+    },
+  });
+}
+
 function permissionDeniedResponse(): Response {
   return new Response(JSON.stringify({ message: 'Not Found' }), {
     status: 403,
@@ -91,19 +102,77 @@ describe('fetchRepoTree lazy auth fallback', () => {
     );
   });
 
-  it('does not invoke the token resolver on a non-rate-limit 403', async () => {
-    // A 403 for a private repo (permission denied) is not retryable.
-    // The fallback should NOT trigger and should NOT spawn `gh auth token`.
+  it('invokes the token resolver and retries with auth on a 404 (private repo)', async () => {
+    // Private repos 404 unauthenticated, then resolve once a token is sent.
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const result = await fetchRepoTree('private/repo', undefined, getToken);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(getToken).toHaveBeenCalledTimes(1);
+    // 3 unauth attempts (HEAD, main, master) + 1 auth attempt = 4
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const retryInit = fetchMock.mock.calls[3]?.[1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer ghp_fake_token'
+    );
+  });
+
+  it('returns null for a 404 when no token resolver is provided', async () => {
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(notFoundResponse());
+
+    const result = await fetchRepoTree('private/repo', undefined);
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not memoize 404 fallback to subsequent calls (repo-specific, not process-wide)', async () => {
+    // First call: private repo 404 → auth fallback (ref='main' → 1 branch)
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE))
+      // Second call: different repo, should still try unauth first
+      .mockResolvedValueOnce(okResponse({ ...SAMPLE_TREE, sha: 'cafef00d' }));
+
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const first = await fetchRepoTree('private/repo', 'main', getToken);
+    const second = await fetchRepoTree('public/repo', 'main', getToken);
+
+    expect(first?.sha).toBe('deadbeef');
+    expect(second?.sha).toBe('cafef00d');
+    // The second call should NOT have used Authorization (unauth succeeded)
+    const secondCallInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect((secondCallInit.headers as Record<string, string>)['Authorization']).toBeUndefined();
+  });
+
+  it('invokes the token resolver on a non-rate-limit 403 but still returns null when auth fails', async () => {
+    // A bare 403 is unlikely to be fixed by auth, but the lazy fallback
+    // tries once anyway — the cost is one extra getToken() call and one
+    // extra API round-trip, both on an already-failed path.
     fetchMock
       .mockResolvedValueOnce(permissionDeniedResponse())
       .mockResolvedValueOnce(permissionDeniedResponse())
+      .mockResolvedValueOnce(permissionDeniedResponse())
+      // Auth retry also 403s
+      .mockResolvedValueOnce(permissionDeniedResponse())
+      .mockResolvedValueOnce(permissionDeniedResponse())
       .mockResolvedValueOnce(permissionDeniedResponse());
-    const getToken = vi.fn(() => 'should-not-be-called');
+    const getToken = vi.fn(() => 'ghp_fake_token');
 
     const result = await fetchRepoTree('private/repo', undefined, getToken);
 
     expect(result).toBeNull();
-    expect(getToken).not.toHaveBeenCalled();
+    expect(getToken).toHaveBeenCalledTimes(1);
   });
 
   it('returns null gracefully when rate-limited and no token resolver is provided', async () => {


### PR DESCRIPTION
## Problem

`skills update` fails on private GitHub repos with `✗ Failed to fetch tree` while `skills add` works fine for the same repo.

### Root cause

There are two issues, at different layers:

**1. `blob.ts` — the API fast path never authenticates for private repos**

`fetchRepoTree` only retried with a token after a rate-limit 403 (`X-RateLimit-Remaining: 0`). A private repo returns 404 when accessed without credentials (GitHub does this to avoid leaking repo existence). Since 404 ≠ rate-limit 403, the token resolver was never invoked.

**2. `update.ts` — no fallback when the fast path fails**

When `fetchRepoTree` returned null, `updateGlobalSkills` printed an error and moved on (`continue`). It never fell through to the clone-based check path — which already exists for non-GitHub sources and has full auth support via `cloneRepo` in `git.ts` (HTTPS → `gh repo clone` → SSH fallback).

Meanwhile, `skills add` always uses the `cloneRepo` path with the full auth cascade, which is why it works for private repos.

## Fix

Two complementary changes:

### 1. `blob.ts` — retry with a token when the unauthenticated pass fails

```diff
- if (!rateLimited || !getToken) return null;
+ if (!getToken) return null;
```

If the unauthenticated pass fails for any reason and a `getToken` callback is available, retry once with a token. Public repos succeed on the first unauthenticated request and never invoke the resolver — the [#523](https://github.com/vercel-labs/skills/issues/523) guarantee (avoiding unnecessary `gh auth token` spawns) is preserved.

The `_rateLimitedThisSession` memoization is kept only for rate-limits (process-wide), not for other failures (repo-specific).

### 2. `update.ts` — fall through to clone when the tree fetch fails

```diff
  if (isGitHubSource) {
    const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);
-   if (!tree) {
-     console.log(`  ✗ Failed to fetch tree for ${source}`);
-     continue;
-   }
-   // ... hash comparison ...
-   continue;
+   if (tree) {
+     // ... hash comparison ...
+     continue;
+   }
+   // tree fetch failed — fall through to clone-based check
  }
+ // Clone-based check (all sources, full auth cascade)
  tempDir = await cloneRepo(sourceUrl, firstEntry.ref);
```

The API tree fetch becomes an optimization, not a gate. When it fails — private repo without a token, SSH-only auth, rate limit — it silently degrades to the clone path, which already handles all auth flows via `git.ts`.

### Why this matters

| Scenario | Before | After |
|---|---|---|
| Private repo + `gh auth` configured | ❌ `Failed to fetch tree` | ✅ Fast path (API with token) |
| Private repo + SSH keys only (no `gh auth`) | ❌ `Failed to fetch tree` | ✅ Clone fallback (SSH) |
| Private repo + no auth at all | ❌ `Failed to fetch tree` | ❌ Auth error (same as `add`) |
| Public repo | ✅ Fast path (unauthenticated API) | ✅ Same (no behavior change) |
| Rate-limited | ✅ Retries with token | ✅ Same (no behavior change) |

## Tests

- 3 new tests: private repo 404 → auth retry, 404 without token resolver, 404 fallback not memoized process-wide
- 1 updated test: bare 403 behavior (auth retry attempted, still returns null)
- All 531 tests pass