### PR TITLE
add --prefix for namespaced skill installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npx skills add ./my-local-skills
 | `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                                                                                                                                                                      |
 | `-l, --list`              | List available skills without installing                                                                                                                                                                                                                                                        |
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                                                                                                                                                                           |
-| `--prefix[=<value>]`      | Namespace installed skills (e.g. `marketing-skills-seo-audit`) so a repo's skills group together and don't collide across sources. Bare `--prefix` derives the prefix from the repo name; `--prefix=<value>` sets a custom one. Recorded in the lock file so `update` keeps the skill prefixed. |
+| `--prefix[=<value>]`      | Namespace installed skills so a repo's skills group together and don't collide across sources. Bare `--prefix` derives the prefix from the repo name; `--prefix=<value>` sets a custom one. Recorded in the lock file so `update` keeps the skill prefixed. |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                                                                                                                                                                   |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                                                                                                                                                                |
 
@@ -87,11 +87,11 @@ npx skills add vercel-labs/agent-skills --skill '*' -a claude-code
 # Install specific skills to all agents
 npx skills add vercel-labs/agent-skills --agent '*' --skill frontend-design
 
-# Group a repo's skills under its name (e.g. marketing-skills-seo-audit)
-npx skills add vercel-labs/marketing-skills --prefix
+# Group a repo's skills under its repo name
+npx skills add owner/repo --prefix
 
 # Use a custom prefix instead of the repo name
-npx skills add vercel-labs/marketing-skills --prefix=mktg
+npx skills add owner/repo --prefix=team
 ```
 
 ### Installation Scope

--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ npx skills add ./my-local-skills
 
 ### Options
 
-| Option                    | Description                                                                                                                                        |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-g, --global`            | Install to user directory instead of project                                                                                                       |
-| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Supported Agents](#supported-agents)<!-- agent-names:end --> |
-| `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                         |
-| `-l, --list`              | List available skills without installing                                                                                                           |
-| `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
-| `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
-| `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+| Option                    | Description                                                                                                                                                                                                                                                                                     |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-g, --global`            | Install to user directory instead of project                                                                                                                                                                                                                                                    |
+| `-a, --agent <agents...>` | <!-- agent-names:start -->Target specific agents (e.g., `claude-code`, `codex`). See [Supported Agents](#supported-agents)<!-- agent-names:end -->                                                                                                                                              |
+| `-s, --skill <skills...>` | Install specific skills by name (use `'*'` for all skills)                                                                                                                                                                                                                                      |
+| `-l, --list`              | List available skills without installing                                                                                                                                                                                                                                                        |
+| `--copy`                  | Copy files instead of symlinking to agent directories                                                                                                                                                                                                                                           |
+| `--prefix[=<value>]`      | Namespace installed skills (e.g. `marketing-skills-seo-audit`) so a repo's skills group together and don't collide across sources. Bare `--prefix` derives the prefix from the repo name; `--prefix=<value>` sets a custom one. Recorded in the lock file so `update` keeps the skill prefixed. |
+| `-y, --yes`               | Skip all confirmation prompts                                                                                                                                                                                                                                                                   |
+| `--all`                   | Install all skills to all agents without prompts                                                                                                                                                                                                                                                |
 
 ### Examples
 
@@ -85,6 +86,12 @@ npx skills add vercel-labs/agent-skills --skill '*' -a claude-code
 
 # Install specific skills to all agents
 npx skills add vercel-labs/agent-skills --agent '*' --skill frontend-design
+
+# Group a repo's skills under its name (e.g. marketing-skills-seo-audit)
+npx skills add vercel-labs/marketing-skills --prefix
+
+# Use a custom prefix instead of the repo name
+npx skills add vercel-labs/marketing-skills --prefix=mktg
 ```
 
 ### Installation Scope

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
@@ -88,6 +88,39 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('should preserve Eve frontmatter rules when installing with --prefix', () => {
+    const skillDir = join(testDir, 'skills', 'eve-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: eve-skill
+description: Eve skill
+---
+
+# Eve Skill
+`
+    );
+
+    const targetDir = join(testDir, 'eve-project');
+    mkdirSync(join(targetDir, 'agent'), { recursive: true });
+    writeFileSync(
+      join(targetDir, 'package.json'),
+      JSON.stringify({ dependencies: { eve: '^0.11.5' } }),
+      'utf-8'
+    );
+
+    const result = runCli(['add', testDir, '-y', '--agent', 'eve', '--prefix=repo'], targetDir);
+
+    expect(result.exitCode).toBe(0);
+    const installed = readFileSync(
+      join(targetDir, 'agent/skills/repo-eve-skill/SKILL.md'),
+      'utf-8'
+    );
+    expect(installed).toContain('description: "Eve skill"');
+    expect(installed).not.toContain('name:');
   });
 
   it('should filter skills by name with --skill flag', () => {

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -415,9 +415,9 @@ describe('parseAddOptions', () => {
   });
 
   it('should parse --prefix=<value> as a custom string', () => {
-    const result = parseAddOptions(['owner/repo', '--prefix=mktg']);
+    const result = parseAddOptions(['owner/repo', '--prefix=team']);
     expect(result.source).toEqual(['owner/repo']);
-    expect(result.options.prefix).toBe('mktg');
+    expect(result.options.prefix).toBe('team');
   });
 
   it('should not consume the positional source as a prefix value', () => {
@@ -438,7 +438,7 @@ describe('resolvePrefix', () => {
   });
 
   it('derives the repo name from the source for bare --prefix', () => {
-    expect(resolvePrefix(true, 'vercel-labs/marketing-skills')).toBe('marketing-skills');
+    expect(resolvePrefix(true, 'owner/bundle')).toBe('bundle');
   });
 
   it('returns undefined for bare --prefix when the source has no repo', () => {
@@ -447,8 +447,8 @@ describe('resolvePrefix', () => {
   });
 
   it('uses a custom prefix string as-is, even without a repo source', () => {
-    expect(resolvePrefix('mktg', null)).toBe('mktg');
-    expect(resolvePrefix('mktg', 'owner/repo')).toBe('mktg');
+    expect(resolvePrefix('team', null)).toBe('team');
+    expect(resolvePrefix('team', 'owner/repo')).toBe('team');
   });
 });
 

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import { parseAddOptions, getLockSource } from './add.ts';
+import { parseAddOptions, getLockSource, resolvePrefix } from './add.ts';
 
 describe('add command', () => {
   let testDir: string;
@@ -406,6 +406,49 @@ describe('parseAddOptions', () => {
     expect(result.options.fullDepth).toBe(true);
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
+  });
+
+  it('should parse bare --prefix as true (derive from repo)', () => {
+    const result = parseAddOptions(['owner/repo', '--prefix']);
+    expect(result.source).toEqual(['owner/repo']);
+    expect(result.options.prefix).toBe(true);
+  });
+
+  it('should parse --prefix=<value> as a custom string', () => {
+    const result = parseAddOptions(['owner/repo', '--prefix=mktg']);
+    expect(result.source).toEqual(['owner/repo']);
+    expect(result.options.prefix).toBe('mktg');
+  });
+
+  it('should not consume the positional source as a prefix value', () => {
+    const result = parseAddOptions(['--prefix', 'owner/repo']);
+    expect(result.source).toEqual(['owner/repo']);
+    expect(result.options.prefix).toBe(true);
+  });
+
+  it('should treat an empty --prefix= as auto-derive', () => {
+    const result = parseAddOptions(['owner/repo', '--prefix=']);
+    expect(result.options.prefix).toBe(true);
+  });
+});
+
+describe('resolvePrefix', () => {
+  it('returns undefined when no prefix requested', () => {
+    expect(resolvePrefix(undefined, 'owner/repo')).toBeUndefined();
+  });
+
+  it('derives the repo name from the source for bare --prefix', () => {
+    expect(resolvePrefix(true, 'vercel-labs/marketing-skills')).toBe('marketing-skills');
+  });
+
+  it('returns undefined for bare --prefix when the source has no repo', () => {
+    expect(resolvePrefix(true, null)).toBeUndefined();
+    expect(resolvePrefix(true, 'not-a-repo-source')).toBeUndefined();
+  });
+
+  it('uses a custom prefix string as-is, even without a repo source', () => {
+    expect(resolvePrefix('mktg', null)).toBe('mktg');
+    expect(resolvePrefix('mktg', 'owner/repo')).toBe('mktg');
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -463,8 +463,8 @@ export interface AddOptions {
   fullDepth?: boolean;
   copy?: boolean;
   /**
-   * Namespace installed skills under a prefix (e.g. `marketing-skills-seo-audit`)
-   * so a repo's skills group together and don't collide across sources.
+   * Namespace installed skills under a prefix so a repo's skills group
+   * together and don't collide across sources.
    * `true` (bare `--prefix`) derives the prefix from the source repo name;
    * a string (`--prefix=<value>`) uses a custom prefix. Recorded in the lock
    * file so `update` keeps the skill prefixed.
@@ -1647,9 +1647,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     spinner.stop('Installation complete');
 
     // When a prefix was applied, rewrite each installed SKILL.md's `name:` to
-    // the prefixed name so the agent actually invokes it as e.g.
-    // `marketing-skills-seo-audit`. Symlink mode shares one canonical copy, so
-    // dedupe paths; copy mode rewrites each agent's copy.
+    // the prefixed name so the agent invokes the namespaced skill. Symlink mode
+    // shares one canonical copy, so dedupe paths; copy mode rewrites each
+    // agent's copy.
     if (resolvedPrefix) {
       const renamed = new Set<string>();
       for (const skill of selectedSkills) {

--- a/src/add.ts
+++ b/src/add.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { sep, join, dirname } from 'path';
+import { sep, join, dirname, basename } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
@@ -30,6 +30,24 @@ export function getLockSource(parsedUrl: string, normalizedSource: string | null
   const isSSH = parsedUrl.startsWith('git@') || parsedUrl.startsWith('ssh://');
   return isSSH ? parsedUrl : normalizedSource;
 }
+
+/**
+ * Resolve the effective prefix string for an install from the `--prefix`
+ * option. `true` (bare `--prefix`) derives it from the source repo name; a
+ * string is used as-is. Returns undefined when no prefix was requested or when
+ * the repo name can't be determined (e.g. a non owner/repo source).
+ */
+export function resolvePrefix(
+  prefixOption: string | true | undefined,
+  normalizedSource: string | null
+): string | undefined {
+  if (!prefixOption) return undefined;
+  if (typeof prefixOption === 'string') return prefixOption;
+  // Bare `--prefix`: derive from the source repo name (e.g. owner/repo -> repo).
+  if (!normalizedSource) return undefined;
+  const ownerRepo = parseOwnerRepo(normalizedSource);
+  return ownerRepo?.repo;
+}
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
@@ -38,6 +56,8 @@ import {
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
+  buildInstallName,
+  renameInstalledSkill,
   type InstallMode,
 } from './installer.ts';
 import {
@@ -442,6 +462,14 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  /**
+   * Namespace installed skills under a prefix (e.g. `marketing-skills-seo-audit`)
+   * so a repo's skills group together and don't collide across sources.
+   * `true` (bare `--prefix`) derives the prefix from the source repo name;
+   * a string (`--prefix=<value>`) uses a custom prefix. Recorded in the lock
+   * file so `update` keeps the skill prefixed.
+   */
+  prefix?: string | true;
   dangerouslyAcceptOpenclawRisks?: boolean;
 }
 
@@ -472,6 +500,12 @@ async function handleWellKnownSkills(
   }
 
   spinner.stop(`Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
+
+  if (options.prefix) {
+    p.log.warn(
+      '--prefix is not supported for well-known skill sources; installing without a prefix.'
+    );
+  }
 
   // Log discovered skills
   for (const skill of skills) {
@@ -986,6 +1020,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // cloning/discovering/installing. The result is only needed later for
     // telemetry gating — it should never block user-visible output.
     const ownerRepoRaw = getOwnerRepo(parsed);
+
+    // Resolve the namespace prefix (if --prefix was passed) from the source
+    // repo. Computed once here and threaded into every install/lock call so the
+    // on-disk name, lock key, and frontmatter `name:` all agree.
+    const resolvedPrefix = resolvePrefix(options.prefix, ownerRepoRaw);
+    if (options.prefix && !resolvedPrefix) {
+      p.log.warn(
+        'Could not derive a --prefix from this source; installing without a prefix. Use --prefix=<value> to set one explicitly.'
+      );
+    }
+
     const repoPrivacyPromise: Promise<boolean | null> = (() => {
       if (!ownerRepoRaw) return Promise.resolve(null);
       const ownerRepo = parseOwnerRepo(ownerRepoRaw);
@@ -1445,7 +1490,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         targetAgents.map(async (agent) => ({
           skillName: skill.name,
           agent,
-          installed: await isSkillInstalled(skill.name, agent, { global: installGlobally }),
+          installed: await isSkillInstalled(buildInstallName(skill.name, resolvedPrefix), agent, {
+            global: installGlobally,
+          }),
         }))
       )
     );
@@ -1476,10 +1523,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       for (const skill of skills) {
         if (summaryLines.length > 0) summaryLines.push('');
 
+        const installName = buildInstallName(skill.name, resolvedPrefix);
         const canonicalPath =
           targetAgents.length === 1
-            ? getCanonicalPath(skill.name, { global: installGlobally, agent: targetAgents[0] })
-            : getCanonicalPath(skill.name, { global: installGlobally });
+            ? getCanonicalPath(installName, { global: installGlobally, agent: targetAgents[0] })
+            : getCanonicalPath(installName, { global: installGlobally });
         const shortCanonical = shortenPath(canonicalPath, cwd);
         summaryLines.push(`${pc.cyan(shortCanonical)}`);
         summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
@@ -1572,7 +1620,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           // Blob-based install: write files from snapshot
           const blobSkill = skill as BlobSkill;
           result = await installBlobSkillForAgent(
-            { installName: blobSkill.name, files: blobSkill.files },
+            {
+              installName: buildInstallName(blobSkill.name, resolvedPrefix),
+              files: blobSkill.files,
+            },
             agent,
             { global: installGlobally, mode: installMode }
           );
@@ -1581,6 +1632,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
+            prefix: resolvedPrefix,
           });
         }
         results.push({
@@ -1593,6 +1645,25 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     spinner.stop('Installation complete');
+
+    // When a prefix was applied, rewrite each installed SKILL.md's `name:` to
+    // the prefixed name so the agent actually invokes it as e.g.
+    // `marketing-skills-seo-audit`. Symlink mode shares one canonical copy, so
+    // dedupe paths; copy mode rewrites each agent's copy.
+    if (resolvedPrefix) {
+      const renamed = new Set<string>();
+      for (const skill of selectedSkills) {
+        const prefixedName = buildInstallName(skill.name || basename(skill.path), resolvedPrefix);
+        const displayName = getSkillDisplayName(skill);
+        for (const r of results) {
+          if (!r.success || r.skill !== displayName) continue;
+          const dir = r.canonicalPath || r.path;
+          if (!dir || renamed.has(dir)) continue;
+          renamed.add(dir);
+          await renameInstalledSkill(dir, prefixedName);
+        }
+      }
+    }
 
     console.log();
     const successful = results.filter((r) => r.success);
@@ -1688,7 +1759,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               if (hash) skillFolderHash = hash;
             }
 
-            await addSkillToLock(skill.name, {
+            await addSkillToLock(buildInstallName(skill.name, resolvedPrefix), {
               source: lockSource || normalizedSource,
               sourceType: parsed.type,
               sourceUrl: parsed.url,
@@ -1696,6 +1767,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
+              ...(resolvedPrefix && { prefix: resolvedPrefix }),
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -1718,13 +1790,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 : await computeSkillFolderHash(skill.path);
             const skillPathValue = skillFiles[skill.name];
             await addSkillToLocalLock(
-              skill.name,
+              buildInstallName(skill.name, resolvedPrefix),
               {
                 source: lockSource || parsed.url,
                 ref: parsed.ref,
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
+                ...(resolvedPrefix && { prefix: resolvedPrefix }),
               },
               cwd
             );
@@ -1986,6 +2059,14 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--prefix') {
+      // Bare `--prefix`: derive the prefix from the source repo name.
+      options.prefix = true;
+    } else if (arg!.startsWith('--prefix=')) {
+      // `--prefix=<value>`: custom prefix. The `=` form avoids ambiguity with
+      // the positional source argument (e.g. `add --prefix owner/repo`).
+      const value = arg!.slice('--prefix='.length).trim();
+      options.prefix = value.length > 0 ? value : true;
     } else if (arg === '--dangerously-accept-openclaw-risks') {
       options.dangerouslyAcceptOpenclawRisks = true;
     } else if (arg && !arg.startsWith('-')) {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1611,6 +1611,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       symlinkFailed?: boolean;
       error?: string;
       pluginName?: string;
+      agentType: AgentType;
     }[] = [];
 
     for (const skill of selectedSkills) {
@@ -1638,6 +1639,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         results.push({
           skill: getSkillDisplayName(skill),
           agent: agents[agent].displayName,
+          agentType: agent,
           pluginName: skill.pluginName,
           ...result,
         });
@@ -1657,6 +1659,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const displayName = getSkillDisplayName(skill);
         for (const r of results) {
           if (!r.success || r.skill !== displayName) continue;
+          if (r.agentType === 'eve') continue;
           const dirs = [r.canonicalPath, r.path].filter((dir): dir is string => Boolean(dir));
           for (const dir of dirs) {
             if (renamed.has(dir)) continue;

--- a/src/add.ts
+++ b/src/add.ts
@@ -1657,10 +1657,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const displayName = getSkillDisplayName(skill);
         for (const r of results) {
           if (!r.success || r.skill !== displayName) continue;
-          const dir = r.canonicalPath || r.path;
-          if (!dir || renamed.has(dir)) continue;
-          renamed.add(dir);
-          await renameInstalledSkill(dir, prefixedName);
+          const dirs = [r.canonicalPath, r.path].filter((dir): dir is string => Boolean(dir));
+          for (const dir of dirs) {
+            if (renamed.has(dir)) continue;
+            renamed.add(dir);
+            await renameInstalledSkill(dir, prefixedName);
+          }
         }
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,7 +136,7 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
-  --prefix[=<value>]     Namespace skills (e.g. marketing-skills-seo-audit); bare derives from the repo name
+  --prefix[=<value>]     Namespace skills; bare derives from the repo name
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,6 +136,7 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
+  --prefix[=<value>]     Namespace skills (e.g. marketing-skills-seo-audit); bare derives from the repo name
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -25,9 +25,11 @@ import {
 } from './git.ts';
 
 function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
-  return {
+  const client = {
     clone,
+    env: vi.fn(() => client),
   };
+  return client;
 }
 
 function mockExecFileSuccess(stdout = '', stderr = '') {

--- a/src/git.ts
+++ b/src/git.ts
@@ -101,14 +101,6 @@ function isAuthFailure(message: string): boolean {
 function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
   return simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
-    env: {
-      ...process.env,
-      GIT_TERMINAL_PROMPT: '0',
-      // When git-lfs IS installed, tell it not to download LFS content
-      // during checkout. See #952 for context and empirical impact.
-      GIT_LFS_SKIP_SMUDGE: '1',
-      ...extraEnv,
-    },
     // When git-lfs is NOT installed, GIT_LFS_SKIP_SMUDGE has no effect —
     // git sees `filter=lfs` in .gitattributes, tries to run
     // `git-lfs filter-process`, and aborts the checkout with:
@@ -128,6 +120,13 @@ function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
       'filter.lfs.clean=',
       'filter.lfs.process=',
     ],
+  }).env({
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+    // When git-lfs IS installed, tell it not to download LFS content
+    // during checkout. See #952 for context and empirical impact.
+    GIT_LFS_SKIP_SMUDGE: '1',
+    ...extraEnv,
   });
 }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -58,6 +58,79 @@ export function sanitizeName(name: string): string {
 }
 
 /**
+ * Apply a `<prefix>-` namespace to a (already-sanitized) skill name, e.g. to
+ * group a repo's skills under their source (`marketing-skills-seo-audit`). The
+ * prefix is sanitized with the same rules. To avoid double-prefixing, the name
+ * is returned unchanged when it already equals the prefix or already starts
+ * with `<prefix>-` (so a repo `browser-use` shipping a `browser-use` skill
+ * stays `browser-use`, not `browser-use-browser-use`).
+ */
+export function applyPrefix(name: string, prefix?: string): string {
+  if (!prefix) return name;
+  const p = sanitizeName(prefix);
+  if (!p || name === p || name.startsWith(`${p}-`)) return name;
+  return sanitizeName(`${p}-${name}`);
+}
+
+/**
+ * Strip a previously-applied `<prefix>-` namespace from a skill name,
+ * recovering the original (upstream) name. Used by `update` to re-target the
+ * unprefixed source skill before re-applying the prefix. Inverse of
+ * {@link applyPrefix}; a no-op when the name isn't actually prefixed.
+ */
+export function stripPrefix(name: string, prefix?: string): string {
+  if (!prefix) return name;
+  const p = sanitizeName(prefix);
+  return p && name.startsWith(`${p}-`) ? name.slice(p.length + 1) : name;
+}
+
+/**
+ * Build the install/lock name for a skill: the sanitized name, optionally
+ * namespaced under a `<prefix>-`. Centralizes the naming so the install dir,
+ * lock key, and frontmatter `name:` all agree.
+ */
+export function buildInstallName(rawName: string, prefix?: string): string {
+  return applyPrefix(sanitizeName(rawName), prefix);
+}
+
+/**
+ * Rewrite the `name:` value in a SKILL.md frontmatter block so the skill is
+ * actually invoked under its prefixed name (e.g. `marketing-skills-seo-audit`),
+ * not just stored in a prefixed folder. Operates only inside the leading
+ * `---` block, leaves the body untouched, and inserts a `name:` line if the
+ * frontmatter somehow lacks one. Returns the input unchanged when there is no
+ * frontmatter block. Idempotent: re-running with the same name is a no-op.
+ */
+export function rewriteFrontmatterName(raw: string, newName: string): string {
+  const match = raw.match(/^(---\r?\n)([\s\S]*?)(\r?\n---\r?\n?)([\s\S]*)$/);
+  if (!match) return raw;
+  const [, open, body, close, content] = match;
+  const nameLine = /^([ \t]*name:[ \t]*).*$/m;
+  const newBody = nameLine.test(body!)
+    ? body!.replace(nameLine, `$1${newName}`)
+    : `name: ${newName}\n${body}`;
+  return `${open}${newBody}${close}${content}`;
+}
+
+/**
+ * Apply {@link rewriteFrontmatterName} to an installed skill's SKILL.md in
+ * place. Best-effort: silently skips when the file is missing or unreadable so
+ * a rename never fails the install.
+ */
+export async function renameInstalledSkill(skillDir: string, newName: string): Promise<void> {
+  const skillMdPath = join(skillDir, 'SKILL.md');
+  try {
+    const raw = await readFile(skillMdPath, 'utf-8');
+    const rewritten = rewriteFrontmatterName(raw, newName);
+    if (rewritten !== raw) {
+      await writeFile(skillMdPath, rewritten, 'utf-8');
+    }
+  } catch {
+    // SKILL.md missing/unreadable — nothing to rename.
+  }
+}
+
+/**
  * Validates that a path is within an expected base directory
  * @param basePath - The expected base directory
  * @param targetPath - The path to validate
@@ -234,7 +307,7 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; prefix?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -250,9 +323,10 @@ export async function installSkillForAgent(
     };
   }
 
-  // Sanitize skill name to prevent directory traversal
+  // Sanitize skill name to prevent directory traversal, then namespace it
+  // under the optional prefix (e.g. `marketing-skills-seo-audit`).
   const rawSkillName = skill.name || basename(skill.path);
-  const skillName = sanitizeName(rawSkillName);
+  const skillName = applyPrefix(sanitizeName(rawSkillName), options.prefix);
 
   const installMode = options.mode ?? 'symlink';
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -58,10 +58,9 @@ export function sanitizeName(name: string): string {
 }
 
 /**
- * Apply a `<prefix>-` namespace to a (already-sanitized) skill name, e.g. to
- * group a repo's skills under their source (`marketing-skills-seo-audit`). The
- * prefix is sanitized with the same rules. To avoid double-prefixing, the name
- * is returned unchanged when it already equals the prefix or already starts
+ * Apply a `<prefix>-` namespace to a (already-sanitized) skill name. The prefix
+ * is sanitized with the same rules. To avoid double-prefixing, the name is
+ * returned unchanged when it already equals the prefix or already starts
  * with `<prefix>-` (so a repo `browser-use` shipping a `browser-use` skill
  * stays `browser-use`, not `browser-use-browser-use`).
  */
@@ -95,11 +94,11 @@ export function buildInstallName(rawName: string, prefix?: string): string {
 
 /**
  * Rewrite the `name:` value in a SKILL.md frontmatter block so the skill is
- * actually invoked under its prefixed name (e.g. `marketing-skills-seo-audit`),
- * not just stored in a prefixed folder. Operates only inside the leading
- * `---` block, leaves the body untouched, and inserts a `name:` line if the
- * frontmatter somehow lacks one. Returns the input unchanged when there is no
- * frontmatter block. Idempotent: re-running with the same name is a no-op.
+ * actually invoked under its prefixed name, not just stored in a prefixed
+ * folder. Operates only inside the leading `---` block, leaves the body
+ * untouched, and inserts a `name:` line if the frontmatter somehow lacks one.
+ * Returns the input unchanged when there is no frontmatter block. Idempotent:
+ * re-running with the same name is a no-op.
  */
 export function rewriteFrontmatterName(raw: string, newName: string): string {
   const match = raw.match(/^(---\r?\n)([\s\S]*?)(\r?\n---\r?\n?)([\s\S]*)$/);
@@ -324,7 +323,7 @@ export async function installSkillForAgent(
   }
 
   // Sanitize skill name to prevent directory traversal, then namespace it
-  // under the optional prefix (e.g. `marketing-skills-seo-audit`).
+  // under the optional prefix.
   const rawSkillName = skill.name || basename(skill.path);
   const skillName = applyPrefix(sanitizeName(rawSkillName), options.prefix);
 

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -33,6 +33,12 @@ export interface LocalSkillLockEntry {
    * computes the hash from actual file contents on disk.
    */
   computedHash: string;
+  /**
+   * Namespace prefix applied to this skill at install time (e.g. the source
+   * repo name). Recorded so `update` can re-apply the same `--prefix`, keeping
+   * the skill grouped/renamed across updates. Absent for unprefixed installs.
+   */
+  prefix?: string;
 }
 
 /**

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -35,6 +35,12 @@ export interface SkillLockEntry {
   updatedAt: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  /**
+   * Namespace prefix applied to this skill at install time (e.g. the source
+   * repo name). Recorded so `update` can re-apply the same `--prefix`, keeping
+   * the skill grouped/renamed across updates. Absent for unprefixed installs.
+   */
+  prefix?: string;
 }
 
 /**

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -42,6 +42,12 @@ function normalizeRelativePath(path: string): string {
   return path.split(sep).join('/').replace(/\/+/g, '/');
 }
 
+function asMetadataRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
 /**
  * Check if internal skills should be installed.
  * Internal skills are hidden by default unless INSTALL_INTERNAL_SKILLS=1 is set.
@@ -81,7 +87,8 @@ export async function parseSkillMd(
     // Skip internal skills unless:
     // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
     // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const isInternal = data.metadata?.internal === true;
+    const metadata = asMetadataRecord(data.metadata);
+    const isInternal = metadata?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
     }
@@ -91,7 +98,7 @@ export async function parseSkillMd(
       description: sanitizeMetadata(data.description),
       path: dirname(skillMdPath),
       rawContent: content,
-      metadata: data.metadata,
+      metadata,
     };
   } catch {
     return null;

--- a/src/update.ts
+++ b/src/update.ts
@@ -20,6 +20,7 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
 import { agents, isUniversalAgent } from './agents.ts';
 import { stripPrefix } from './installer.ts';
+import { parseSource } from './source-parser.ts';
 import type { AgentType } from './types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -551,7 +552,7 @@ export async function updateProjectSkills(
 
   for (const [source, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
-    const sourceUrl = firstEntry.source;
+    const sourceUrl = parseSource(firstEntry.source).url;
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)

--- a/src/update.ts
+++ b/src/update.ts
@@ -19,6 +19,7 @@ import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
 import { agents, isUniversalAgent } from './agents.ts';
+import { stripPrefix } from './installer.ts';
 import type { AgentType } from './types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -453,11 +454,17 @@ export async function updateGlobalSkills(
       );
       continue;
     }
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-      shell: process.platform === 'win32',
-    });
+    // Re-apply the recorded prefix so a prefixed skill stays prefixed on update.
+    const prefixArgs = update.entry.prefix ? [`--prefix=${update.entry.prefix}`] : [];
+    const result = spawnSync(
+      process.execPath,
+      [cliEntry, 'add', installUrl, '-g', '-y', ...prefixArgs],
+      {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+        shell: process.platform === 'win32',
+      }
+    );
 
     if (result.status === 0) {
       successCount++;
@@ -586,9 +593,13 @@ export async function updateProjectSkills(
       console.log(`${TEXT}Updating ${safeName}...${RESET}`);
       const installUrl = formatSourceInput(skill.entry.source, skill.entry.ref);
 
+      // The lock key is the prefixed name; --skill must match the unprefixed
+      // upstream skill, so strip the prefix and re-pass it via --prefix.
+      const targetSkill = stripPrefix(skill.name, skill.entry.prefix);
+      const prefixArgs = skill.entry.prefix ? [`--prefix=${skill.entry.prefix}`] : [];
       const result = spawnSync(
         process.execPath,
-        [cliEntry, 'add', installUrl, '--skill', skill.name, '-y'],
+        [cliEntry, 'add', installUrl, '--skill', targetSkill, '-y', ...prefixArgs],
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installSkillForAgent } from '../src/installer.ts';
+import { installSkillForAgent, renameInstalledSkill } from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
   const dir = join(root, 'source-skill');
@@ -40,6 +40,55 @@ describe('installer copy mode', () => {
       );
       await expect(access(join(installedDir, 'metadata.json'))).rejects.toThrow();
       await expect(access(join(installedDir, '.git'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('namespaces the install dir under a prefix', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-prefix-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+    const skillDir = await makeSkillSource(root, 'seo-audit');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: 'seo-audit', description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false, prefix: 'marketing-skills' }
+      );
+
+      expect(result.success).toBe(true);
+      await expect(
+        access(join(projectDir, '.agents/skills/marketing-skills-seo-audit/SKILL.md'))
+      ).resolves.toBeUndefined();
+      await expect(access(join(projectDir, '.agents/skills/seo-audit'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rewrites the installed SKILL.md name to the prefixed name', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-rename-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+    const skillDir = await makeSkillSource(root, 'seo-audit');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: 'seo-audit', description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false, prefix: 'marketing-skills' }
+      );
+      expect(result.success).toBe(true);
+
+      const installedDir = join(projectDir, '.agents/skills/marketing-skills-seo-audit');
+      await renameInstalledSkill(installedDir, 'marketing-skills-seo-audit');
+
+      const md = await readFile(join(installedDir, 'SKILL.md'), 'utf-8');
+      expect(md).toContain('name: marketing-skills-seo-audit');
+      expect(md).toContain('description: test');
+      expect(md).not.toContain('name: seo-audit');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -49,20 +49,20 @@ describe('installer copy mode', () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-prefix-'));
     const projectDir = join(root, 'project');
     await mkdir(projectDir, { recursive: true });
-    const skillDir = await makeSkillSource(root, 'seo-audit');
+    const skillDir = await makeSkillSource(root, 'tool');
 
     try {
       const result = await installSkillForAgent(
-        { name: 'seo-audit', description: 'test', path: skillDir },
+        { name: 'tool', description: 'test', path: skillDir },
         'codex',
-        { cwd: projectDir, mode: 'copy', global: false, prefix: 'marketing-skills' }
+        { cwd: projectDir, mode: 'copy', global: false, prefix: 'bundle' }
       );
 
       expect(result.success).toBe(true);
       await expect(
-        access(join(projectDir, '.agents/skills/marketing-skills-seo-audit/SKILL.md'))
+        access(join(projectDir, '.agents/skills/bundle-tool/SKILL.md'))
       ).resolves.toBeUndefined();
-      await expect(access(join(projectDir, '.agents/skills/seo-audit'))).rejects.toThrow();
+      await expect(access(join(projectDir, '.agents/skills/tool'))).rejects.toThrow();
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -72,23 +72,23 @@ describe('installer copy mode', () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-rename-'));
     const projectDir = join(root, 'project');
     await mkdir(projectDir, { recursive: true });
-    const skillDir = await makeSkillSource(root, 'seo-audit');
+    const skillDir = await makeSkillSource(root, 'tool');
 
     try {
       const result = await installSkillForAgent(
-        { name: 'seo-audit', description: 'test', path: skillDir },
+        { name: 'tool', description: 'test', path: skillDir },
         'codex',
-        { cwd: projectDir, mode: 'copy', global: false, prefix: 'marketing-skills' }
+        { cwd: projectDir, mode: 'copy', global: false, prefix: 'bundle' }
       );
       expect(result.success).toBe(true);
 
-      const installedDir = join(projectDir, '.agents/skills/marketing-skills-seo-audit');
-      await renameInstalledSkill(installedDir, 'marketing-skills-seo-audit');
+      const installedDir = join(projectDir, '.agents/skills/bundle-tool');
+      await renameInstalledSkill(installedDir, 'bundle-tool');
 
       const md = await readFile(join(installedDir, 'SKILL.md'), 'utf-8');
-      expect(md).toContain('name: marketing-skills-seo-audit');
+      expect(md).toContain('name: bundle-tool');
       expect(md).toContain('description: test');
-      expect(md).not.toContain('name: seo-audit');
+      expect(md).not.toContain('name: tool');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/sanitize-name.test.ts
+++ b/tests/sanitize-name.test.ts
@@ -8,7 +8,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { sanitizeName } from '../src/installer.ts';
+import {
+  sanitizeName,
+  applyPrefix,
+  stripPrefix,
+  buildInstallName,
+  rewriteFrontmatterName,
+} from '../src/installer.ts';
 
 describe('sanitizeName', () => {
   describe('basic transformations', () => {
@@ -134,5 +140,87 @@ describe('sanitizeName', () => {
       expect(sanitizeName('docs.example.com')).toBe('docs.example.com');
       expect(sanitizeName('bun.sh')).toBe('bun.sh');
     });
+  });
+});
+
+describe('applyPrefix', () => {
+  it('prepends a sanitized prefix', () => {
+    expect(applyPrefix('seo-audit', 'marketing-skills')).toBe('marketing-skills-seo-audit');
+    expect(applyPrefix('seo-audit', 'Marketing Skills')).toBe('marketing-skills-seo-audit');
+  });
+
+  it('is a no-op without a prefix', () => {
+    expect(applyPrefix('seo-audit')).toBe('seo-audit');
+    expect(applyPrefix('seo-audit', '')).toBe('seo-audit');
+  });
+
+  it('does not double-prefix', () => {
+    expect(applyPrefix('browser-use', 'browser-use')).toBe('browser-use');
+    expect(applyPrefix('marketing-skills-seo-audit', 'marketing-skills')).toBe(
+      'marketing-skills-seo-audit'
+    );
+  });
+});
+
+describe('stripPrefix', () => {
+  it('removes an applied prefix (inverse of applyPrefix)', () => {
+    expect(stripPrefix('marketing-skills-seo-audit', 'marketing-skills')).toBe('seo-audit');
+  });
+
+  it('is a no-op when not prefixed or no prefix given', () => {
+    expect(stripPrefix('seo-audit', 'marketing-skills')).toBe('seo-audit');
+    expect(stripPrefix('seo-audit')).toBe('seo-audit');
+    // Dedup case: name equals prefix, never had a `<prefix>-` segment.
+    expect(stripPrefix('browser-use', 'browser-use')).toBe('browser-use');
+  });
+
+  it('round-trips with applyPrefix', () => {
+    const prefix = 'marketing-skills';
+    expect(stripPrefix(applyPrefix('seo-audit', prefix), prefix)).toBe('seo-audit');
+  });
+});
+
+describe('buildInstallName', () => {
+  it('sanitizes the name when no prefix is given', () => {
+    expect(buildInstallName('My Skill')).toBe('my-skill');
+  });
+
+  it('namespaces under a prefix', () => {
+    expect(buildInstallName('seo-audit', 'marketing-skills')).toBe('marketing-skills-seo-audit');
+  });
+
+  it('does not double-prefix an already-prefixed name', () => {
+    expect(buildInstallName('browser-use', 'browser-use')).toBe('browser-use');
+    expect(buildInstallName('marketing-skills-seo-audit', 'marketing-skills')).toBe(
+      'marketing-skills-seo-audit'
+    );
+  });
+});
+
+describe('rewriteFrontmatterName', () => {
+  it('rewrites the name value inside frontmatter, leaving the body intact', () => {
+    const raw = `---\nname: seo-audit\ndescription: Audit SEO\n---\n# Body\ntext\n`;
+    const out = rewriteFrontmatterName(raw, 'marketing-skills-seo-audit');
+    expect(out).toContain('name: marketing-skills-seo-audit');
+    expect(out).toContain('description: Audit SEO');
+    expect(out).toContain('# Body');
+    expect(out).not.toContain('name: seo-audit');
+  });
+
+  it('is idempotent', () => {
+    const raw = `---\nname: marketing-skills-seo-audit\n---\nbody\n`;
+    expect(rewriteFrontmatterName(raw, 'marketing-skills-seo-audit')).toBe(raw);
+  });
+
+  it('inserts a name line when frontmatter lacks one', () => {
+    const raw = `---\ndescription: no name here\n---\nbody\n`;
+    const out = rewriteFrontmatterName(raw, 'prefixed-skill');
+    expect(out).toContain('name: prefixed-skill');
+    expect(out).toContain('description: no name here');
+  });
+
+  it('returns input unchanged when there is no frontmatter', () => {
+    const raw = `# Just markdown\nno frontmatter`;
+    expect(rewriteFrontmatterName(raw, 'whatever')).toBe(raw);
   });
 });

--- a/tests/sanitize-name.test.ts
+++ b/tests/sanitize-name.test.ts
@@ -145,38 +145,36 @@ describe('sanitizeName', () => {
 
 describe('applyPrefix', () => {
   it('prepends a sanitized prefix', () => {
-    expect(applyPrefix('seo-audit', 'marketing-skills')).toBe('marketing-skills-seo-audit');
-    expect(applyPrefix('seo-audit', 'Marketing Skills')).toBe('marketing-skills-seo-audit');
+    expect(applyPrefix('tool', 'bundle')).toBe('bundle-tool');
+    expect(applyPrefix('tool', 'Bundle Pack')).toBe('bundle-pack-tool');
   });
 
   it('is a no-op without a prefix', () => {
-    expect(applyPrefix('seo-audit')).toBe('seo-audit');
-    expect(applyPrefix('seo-audit', '')).toBe('seo-audit');
+    expect(applyPrefix('tool')).toBe('tool');
+    expect(applyPrefix('tool', '')).toBe('tool');
   });
 
   it('does not double-prefix', () => {
     expect(applyPrefix('browser-use', 'browser-use')).toBe('browser-use');
-    expect(applyPrefix('marketing-skills-seo-audit', 'marketing-skills')).toBe(
-      'marketing-skills-seo-audit'
-    );
+    expect(applyPrefix('bundle-tool', 'bundle')).toBe('bundle-tool');
   });
 });
 
 describe('stripPrefix', () => {
   it('removes an applied prefix (inverse of applyPrefix)', () => {
-    expect(stripPrefix('marketing-skills-seo-audit', 'marketing-skills')).toBe('seo-audit');
+    expect(stripPrefix('bundle-tool', 'bundle')).toBe('tool');
   });
 
   it('is a no-op when not prefixed or no prefix given', () => {
-    expect(stripPrefix('seo-audit', 'marketing-skills')).toBe('seo-audit');
-    expect(stripPrefix('seo-audit')).toBe('seo-audit');
+    expect(stripPrefix('tool', 'bundle')).toBe('tool');
+    expect(stripPrefix('tool')).toBe('tool');
     // Dedup case: name equals prefix, never had a `<prefix>-` segment.
     expect(stripPrefix('browser-use', 'browser-use')).toBe('browser-use');
   });
 
   it('round-trips with applyPrefix', () => {
-    const prefix = 'marketing-skills';
-    expect(stripPrefix(applyPrefix('seo-audit', prefix), prefix)).toBe('seo-audit');
+    const prefix = 'bundle';
+    expect(stripPrefix(applyPrefix('tool', prefix), prefix)).toBe('tool');
   });
 });
 
@@ -186,30 +184,28 @@ describe('buildInstallName', () => {
   });
 
   it('namespaces under a prefix', () => {
-    expect(buildInstallName('seo-audit', 'marketing-skills')).toBe('marketing-skills-seo-audit');
+    expect(buildInstallName('tool', 'bundle')).toBe('bundle-tool');
   });
 
   it('does not double-prefix an already-prefixed name', () => {
     expect(buildInstallName('browser-use', 'browser-use')).toBe('browser-use');
-    expect(buildInstallName('marketing-skills-seo-audit', 'marketing-skills')).toBe(
-      'marketing-skills-seo-audit'
-    );
+    expect(buildInstallName('bundle-tool', 'bundle')).toBe('bundle-tool');
   });
 });
 
 describe('rewriteFrontmatterName', () => {
   it('rewrites the name value inside frontmatter, leaving the body intact', () => {
-    const raw = `---\nname: seo-audit\ndescription: Audit SEO\n---\n# Body\ntext\n`;
-    const out = rewriteFrontmatterName(raw, 'marketing-skills-seo-audit');
-    expect(out).toContain('name: marketing-skills-seo-audit');
-    expect(out).toContain('description: Audit SEO');
+    const raw = `---\nname: tool\ndescription: Test tool\n---\n# Body\ntext\n`;
+    const out = rewriteFrontmatterName(raw, 'bundle-tool');
+    expect(out).toContain('name: bundle-tool');
+    expect(out).toContain('description: Test tool');
     expect(out).toContain('# Body');
-    expect(out).not.toContain('name: seo-audit');
+    expect(out).not.toContain('name: tool');
   });
 
   it('is idempotent', () => {
-    const raw = `---\nname: marketing-skills-seo-audit\n---\nbody\n`;
-    expect(rewriteFrontmatterName(raw, 'marketing-skills-seo-audit')).toBe(raw);
+    const raw = `---\nname: bundle-tool\n---\nbody\n`;
+    expect(rewriteFrontmatterName(raw, 'bundle-tool')).toBe(raw);
   });
 
   it('inserts a name line when frontmatter lacks one', () => {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -113,6 +113,9 @@ describe('Update Cleanup Unit Tests', () => {
       // Run update
       await updateProjectSkills();
 
+      // Verify shorthand lock sources are resolved to cloneable URLs for the deletion check
+      expect(git.cloneRepo).toHaveBeenCalledWith('https://github.com/owner/repo.git', undefined);
+
       // Verify prompt was shown
       expect(p.confirm).toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary
- add `skills add --prefix[=<value>]` to namespace installed skill names by source or custom prefix
- record prefix metadata in global and project lock files so updates preserve the namespaced install
- rewrite installed `SKILL.md` names for prefixed installs while preserving Eve frontmatter rules
- cover prefix parsing, install naming, update behavior, and Eve compatibility with tests

## Validation
- `pnpm format`
- `pnpm type-check`
- `pnpm test src/add.test.ts tests/installer-copy.test.ts tests/sanitize-name.test.ts tests/update.test.ts tests/eve-agent.test.ts`
- `pnpm test` currently has 3 local harness failures unrelated to this diff: banner assertions in `src/list.test.ts` and `tests/sync.test.ts` see empty stdout, and `src/remove.test.ts` takes the agent-detected non-interactive path instead of the prompt path. The branch does not modify those files.