### PR TITLE
Add Eve subagent support to skills add/list/remove/update

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -407,6 +407,25 @@ describe('parseAddOptions', () => {
     expect(result.options.list).toBe(true);
     expect(result.options.global).toBe(true);
   });
+
+  it('should parse a single --subagent value', () => {
+    const result = parseAddOptions(['source', '--subagent', 'research']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.subagent).toEqual(['research']);
+  });
+
+  it('should parse multiple --subagent values', () => {
+    const result = parseAddOptions(['source', '--subagent', 'root', 'research', 'writer']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.subagent).toEqual(['root', 'research', 'writer']);
+  });
+
+  it('should parse --subagent alongside other flags', () => {
+    const result = parseAddOptions(['source', '--subagent', 'research', '-y']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.subagent).toEqual(['research']);
+    expect(result.options.yes).toBe(true);
+  });
 });
 
 describe('openclaw source blocking', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -47,6 +47,7 @@ import {
   getVisibleUniversalAgents,
   getNonUniversalAgents,
   isUniversalAgent,
+  getEveSubagents,
 } from './agents.ts';
 import {
   track,
@@ -233,6 +234,76 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
   } else {
     // Copy mode - all agents get copies
     const allNames = targetAgents.map((a) => agents[a].displayName);
+    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+  }
+
+  return lines;
+}
+
+/**
+ * A concrete install destination. For Eve, `subagent` optionally targets a
+ * subagent's skills directory (`agent/subagents/<name>/skills`); when omitted
+ * the skill installs to the root agent (`agent/skills`). Other agents never set
+ * `subagent`.
+ */
+interface InstallTarget {
+  agent: AgentType;
+  subagent?: string;
+}
+
+/** Human-readable label for an install target, e.g. "Eve (research)". */
+function targetDisplayName(target: InstallTarget): string {
+  const base = agents[target.agent].displayName;
+  return target.subagent ? `${base} (${target.subagent})` : base;
+}
+
+/** Stable key used to deduplicate / index per-target state. */
+function targetKey(target: InstallTarget): string {
+  return target.subagent ? `${target.agent}:${target.subagent}` : target.agent;
+}
+
+/**
+ * Expand the selected agents into concrete install targets, fanning Eve out
+ * across the chosen subagents (root and/or named subagents).
+ */
+function buildInstallTargets(
+  targetAgents: AgentType[],
+  eveSubagentTargets: Array<string | undefined>
+): InstallTarget[] {
+  const targets: InstallTarget[] = [];
+  for (const agent of targetAgents) {
+    if (agent === 'eve') {
+      for (const subagent of eveSubagentTargets) {
+        targets.push({ agent, subagent });
+      }
+    } else {
+      targets.push({ agent });
+    }
+  }
+  return targets;
+}
+
+/**
+ * Builds summary lines showing universal vs symlinked agents and Eve subagents.
+ */
+function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallMode): string[] {
+  const lines: string[] = [];
+  const rootAgents = targets.filter((t) => !t.subagent).map((t) => t.agent);
+  const subagentNames = targets.filter((t) => t.subagent).map(targetDisplayName);
+  const { universal, symlinked } = splitAgentsByType(rootAgents);
+
+  if (installMode === 'symlink') {
+    if (universal.length > 0) {
+      lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
+    }
+    if (symlinked.length > 0) {
+      lines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
+    }
+    if (subagentNames.length > 0) {
+      lines.push(`  ${pc.dim('copy →')} ${formatList(subagentNames)}`);
+    }
+  } else {
+    const allNames = targets.map(targetDisplayName);
     lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
   }
 
@@ -443,6 +514,11 @@ export interface AddOptions {
   fullDepth?: boolean;
   copy?: boolean;
   dangerouslyAcceptOpenclawRisks?: boolean;
+  /**
+   * Eve subagent targets. Each value is a subagent name; `root` (or `.`)
+   * selects the root agent. Implies installing for Eve.
+   */
+  subagent?: string[];
 }
 
 /**
@@ -1370,6 +1446,52 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    // An explicit --subagent flag implies the user wants to target Eve.
+    if (options.subagent && options.subagent.length > 0 && !targetAgents.includes('eve')) {
+      targetAgents = [...targetAgents, 'eve'];
+    }
+
+    // Eve supports subagents, each with their own skills directory at
+    // agent/subagents/<name>/skills in addition to the root agent/skills.
+    // When Eve is a target, choose which of those to install into.
+    let eveSubagentTargets: Array<string | undefined> = [undefined];
+    if (targetAgents.includes('eve')) {
+      const availableSubagents = getEveSubagents(process.cwd());
+
+      if (options.subagent && options.subagent.length > 0) {
+        // Non-interactive: 'root' or '.' selects the root agent.
+        eveSubagentTargets = options.subagent.map((s) =>
+          s === 'root' || s === '.' ? undefined : s
+        );
+      } else if (availableSubagents.length > 0 && !options.yes) {
+        const subagentChoices = [
+          { value: '', label: 'Root agent', hint: 'agent/skills' },
+          ...availableSubagents.map((name) => ({
+            value: name,
+            label: name,
+            hint: `agent/subagents/${name}/skills`,
+          })),
+        ];
+
+        const selectedSubagents = await p.multiselect({
+          message: 'Where should Eve skills be installed?',
+          options: subagentChoices,
+          initialValues: [''],
+          required: true,
+        });
+
+        if (p.isCancel(selectedSubagents)) {
+          p.cancel('Installation cancelled');
+          await cleanup(tempDir);
+          process.exit(0);
+        }
+
+        eveSubagentTargets = (selectedSubagents as string[]).map((s) => (s === '' ? undefined : s));
+      }
+    }
+
+    const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
+
     let installGlobally = options.global ?? false;
 
     // Check if any selected agents support global installation
@@ -1405,10 +1527,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
 
     // Only prompt for install mode when there are multiple unique target directories.
-    // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-    const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+    // When all selected targets share the same skillsDir, symlink vs copy is meaningless.
+    // Eve writes skill files directly into each (sub)agent dir, so a symlink prompt is
+    // never meaningful when every target is Eve.
+    const allEve = installTargets.every((t) => t.agent === 'eve');
+    const uniqueDirs = new Set(
+      installTargets.map((t) =>
+        t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir
+      )
+    );
 
-    if (!options.copy && !options.yes && uniqueDirs.size > 1) {
+    if (!options.copy && !options.yes && uniqueDirs.size > 1 && !allEve) {
       const modeChoice = await p.select({
         message: 'Installation method',
         options: [
@@ -1428,8 +1557,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       installMode = modeChoice as InstallMode;
-    } else if (uniqueDirs.size <= 1) {
-      // Single target directory — default to copy (no symlink needed)
+    } else if (uniqueDirs.size <= 1 || allEve) {
+      // Single target directory (or all-Eve) — default to copy (no symlink needed)
       installMode = 'copy';
     }
 
@@ -1437,24 +1566,27 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     // Build installation summary
     const summaryLines: string[] = [];
-    const agentNames = targetAgents.map((a) => agents[a].displayName);
 
     // Check if any skill will be overwritten (parallel)
     const overwriteChecks = await Promise.all(
       selectedSkills.flatMap((skill) =>
-        targetAgents.map(async (agent) => ({
+        installTargets.map(async (target) => ({
           skillName: skill.name,
-          agent,
-          installed: await isSkillInstalled(skill.name, agent, { global: installGlobally }),
+          target,
+          installed: await isSkillInstalled(skill.name, target.agent, {
+            global: installGlobally,
+            eveSubagent: target.subagent,
+          }),
         }))
       )
     );
+    // Keyed by skill name → target key → installed?
     const overwriteStatus = new Map<string, Map<string, boolean>>();
-    for (const { skillName, agent, installed } of overwriteChecks) {
+    for (const { skillName, target, installed } of overwriteChecks) {
       if (!overwriteStatus.has(skillName)) {
         overwriteStatus.set(skillName, new Map());
       }
-      overwriteStatus.get(skillName)!.set(agent, installed);
+      overwriteStatus.get(skillName)!.set(targetKey(target), installed);
     }
 
     // Group selected skills for summary
@@ -1477,17 +1609,21 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         if (summaryLines.length > 0) summaryLines.push('');
 
         const canonicalPath =
-          targetAgents.length === 1
-            ? getCanonicalPath(skill.name, { global: installGlobally, agent: targetAgents[0] })
+          installTargets.length === 1
+            ? getCanonicalPath(skill.name, {
+                global: installGlobally,
+                agent: installTargets[0]!.agent,
+                eveSubagent: installTargets[0]!.subagent,
+              })
             : getCanonicalPath(skill.name, { global: installGlobally });
         const shortCanonical = shortenPath(canonicalPath, cwd);
         summaryLines.push(`${pc.cyan(shortCanonical)}`);
-        summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+        summaryLines.push(...buildTargetSummaryLines(installTargets, installMode));
 
         const skillOverwrites = overwriteStatus.get(skill.name);
-        const overwriteAgents = targetAgents
-          .filter((a) => skillOverwrites?.get(a))
-          .map((a) => agents[a].displayName);
+        const overwriteAgents = installTargets
+          .filter((t) => skillOverwrites?.get(targetKey(t)))
+          .map(targetDisplayName);
 
         if (overwriteAgents.length > 0) {
           summaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
@@ -1566,7 +1702,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }[] = [];
 
     for (const skill of selectedSkills) {
-      for (const agent of targetAgents) {
+      for (const target of installTargets) {
+        const { agent, subagent } = target;
         let result;
         if (blobResult && 'files' in skill) {
           // Blob-based install: write files from snapshot
@@ -1574,18 +1711,19 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode }
+            { global: installGlobally, mode: installMode, eveSubagent: subagent }
           );
         } else {
           // Disk-based install: copy from cloned/local directory
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
+            eveSubagent: subagent,
           });
         }
         results.push({
           skill: getSkillDisplayName(skill),
-          agent: agents[agent].displayName,
+          agent: targetDisplayName(target),
           pluginName: skill.pluginName,
           ...result,
         });
@@ -1707,6 +1845,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Add to local lock file for project-scoped installs
     if (successful.length > 0 && !installGlobally) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
+      // Record Eve subagent placement (root = '') so `update` can restore it.
+      // Only meaningful when Eve is among the targets and a non-root subagent
+      // was selected; otherwise omit for a clean, minimal lock entry.
+      const eveSubagents = targetAgents.includes('eve')
+        ? eveSubagentTargets.map((s) => s ?? '')
+        : undefined;
+      const recordSubagents =
+        eveSubagents && (eveSubagents.length > 1 || eveSubagents.some((s) => s !== ''));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
@@ -1725,6 +1871,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
+                ...(recordSubagents && { subagents: eveSubagents }),
               },
               cwd
             );
@@ -1986,6 +2133,16 @@ export function parseAddOptions(args: string[]): { source: string[]; options: Ad
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--subagent') {
+      options.subagent = options.subagent || [];
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        options.subagent.push(nextArg);
+        i++;
+        nextArg = args[i];
+      }
+      i--; // Back up one since the loop will increment
     } else if (arg === '--dangerously-accept-openclaw-risks') {
       options.dangerouslyAcceptOpenclawRisks = true;
     } else if (arg && !arg.startsWith('-')) {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'os';
 import { join } from 'path';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { xdgConfig } from 'xdg-basedir';
 import type { AgentConfig, AgentType } from './types.ts';
 
@@ -727,6 +727,36 @@ export async function detectInstalledAgents(): Promise<AgentType[]> {
 
 export function getAgentConfig(type: AgentType): AgentConfig {
   return agents[type];
+}
+
+/**
+ * Directory (relative to an Eve project root) that holds subagents.
+ * Each subagent owns its own skills at `agent/subagents/<name>/skills`,
+ * mirroring the root agent's `agent/skills`.
+ */
+export const EVE_SUBAGENTS_DIR = join('agent', 'subagents');
+
+/**
+ * Discover the names of Eve subagents in a project.
+ *
+ * Eve supports subagents that each have their own skills directory at
+ * `agent/subagents/<name>/skills`. This returns the `<name>` of every
+ * subagent directory found under `agent/subagents/`, sorted alphabetically.
+ * Returns an empty list when the directory doesn't exist or can't be read.
+ */
+export function getEveSubagents(cwd: string = process.cwd()): string[] {
+  const dir = join(cwd, EVE_SUBAGENTS_DIR);
+  if (!existsSync(dir)) {
+    return [];
+  }
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -136,6 +136,7 @@ ${BOLD}Add Options:${RESET}
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts
   --copy                 Copy files instead of symlinking to agent directories
+  --subagent <names>     Install to Eve subagents (use 'root' for the root agent)
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -17,7 +17,13 @@ import { join, basename, normalize, resolve, sep, relative, dirname, extname } f
 import { homedir, platform } from 'os';
 import type { Skill, AgentType, RemoteSkill } from './types.ts';
 import type { WellKnownSkill } from './providers/wellknown.ts';
-import { agents, detectInstalledAgents, isUniversalAgent } from './agents.ts';
+import {
+  agents,
+  detectInstalledAgents,
+  isUniversalAgent,
+  getEveSubagents,
+  EVE_SUBAGENTS_DIR,
+} from './agents.ts';
 import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
 import { parseFrontmatter } from './frontmatter.ts';
 import { parseSkillMd } from './skills.ts';
@@ -94,13 +100,37 @@ export function getCanonicalSkillsDir(global: boolean, cwd?: string): string {
 }
 
 /**
+ * Resolve the skills directory for a specific Eve subagent, relative to the
+ * project root: `agent/subagents/<name>/skills`. The subagent name is
+ * sanitized to prevent directory traversal when it originates from user input.
+ */
+export function getEveSubagentSkillsDir(subagent: string, cwd?: string): string {
+  const baseDir = cwd || process.cwd();
+  return join(baseDir, EVE_SUBAGENTS_DIR, sanitizeName(subagent), 'skills');
+}
+
+/**
  * Gets the base directory for an agent's skills, respecting universal agents.
  * Universal agents always use the canonical directory, which prevents
  * redundant symlinks and double-listing of skills.
+ *
+ * For Eve, an optional `eveSubagent` targets a subagent's skills directory
+ * (`agent/subagents/<name>/skills`) instead of the root agent's `agent/skills`.
  */
-export function getAgentBaseDir(agentType: AgentType, global: boolean, cwd?: string): string {
+export function getAgentBaseDir(
+  agentType: AgentType,
+  global: boolean,
+  cwd?: string,
+  eveSubagent?: string
+): string {
   if (isUniversalAgent(agentType)) {
     return getCanonicalSkillsDir(global, cwd);
+  }
+
+  // Eve subagents are inherently project-scoped — they live under the project's
+  // agent/ directory, so the `global` flag does not apply here.
+  if (agentType === 'eve' && eveSubagent) {
+    return getEveSubagentSkillsDir(eveSubagent, cwd);
   }
 
   const agent = agents[agentType];
@@ -234,11 +264,12 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
+  const eveSubagent = options.eveSubagent;
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -259,12 +290,12 @@ export async function installSkillForAgent(
   // Canonical location: .agents/skills/<skill-name>
   const canonicalBase =
     agentType === 'eve' && installMode === 'symlink'
-      ? getAgentBaseDir(agentType, isGlobal, cwd)
+      ? getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent)
       : getCanonicalSkillsDir(isGlobal, cwd);
   const canonicalDir = join(canonicalBase, skillName);
 
   // Agent-specific location (for symlink)
-  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd);
+  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent);
   const agentDir = join(agentBase, skillName);
 
   // Validate paths
@@ -498,7 +529,7 @@ function getEveFlatSkillMarkdown(files: Array<{ path: string; contents: string }
 export async function isSkillInstalled(
   skillName: string,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string } = {}
+  options: { global?: boolean; cwd?: string; eveSubagent?: string } = {}
 ): Promise<boolean> {
   const agent = agents[agentType];
   const sanitized = sanitizeName(skillName);
@@ -510,7 +541,9 @@ export async function isSkillInstalled(
 
   const targetBase = options.global
     ? agent.globalSkillsDir!
-    : join(options.cwd || process.cwd(), agent.skillsDir);
+    : agentType === 'eve' && options.eveSubagent
+      ? getEveSubagentSkillsDir(options.eveSubagent, options.cwd)
+      : join(options.cwd || process.cwd(), agent.skillsDir);
 
   const skillDir = join(targetBase, sanitized);
 
@@ -529,13 +562,18 @@ export async function isSkillInstalled(
 export function getInstallPath(
   skillName: string,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string } = {}
+  options: { global?: boolean; cwd?: string; eveSubagent?: string } = {}
 ): string {
   const agent = agents[agentType];
   const cwd = options.cwd || process.cwd();
   const sanitized = sanitizeName(skillName);
 
-  const targetBase = getAgentBaseDir(agentType, options.global ?? false, options.cwd);
+  const targetBase = getAgentBaseDir(
+    agentType,
+    options.global ?? false,
+    options.cwd,
+    options.eveSubagent
+  );
   const installPath = join(targetBase, sanitized);
 
   if (!isPathSafe(targetBase, installPath)) {
@@ -550,12 +588,12 @@ export function getInstallPath(
  */
 export function getCanonicalPath(
   skillName: string,
-  options: { global?: boolean; cwd?: string; agent?: AgentType } = {}
+  options: { global?: boolean; cwd?: string; agent?: AgentType; eveSubagent?: string } = {}
 ): string {
   const sanitized = sanitizeName(skillName);
   const canonicalBase =
     options.agent === 'eve'
-      ? getAgentBaseDir('eve', options.global ?? false, options.cwd)
+      ? getAgentBaseDir('eve', options.global ?? false, options.cwd, options.eveSubagent)
       : getCanonicalSkillsDir(options.global ?? false, options.cwd);
   const canonicalPath = join(canonicalBase, sanitized);
 
@@ -575,12 +613,13 @@ export function getCanonicalPath(
 export async function installRemoteSkillForAgent(
   skill: RemoteSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+  const eveSubagent = options.eveSubagent;
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -598,12 +637,12 @@ export async function installRemoteSkillForAgent(
   // Canonical location: .agents/skills/<skill-name>
   const canonicalBase =
     agentType === 'eve' && installMode === 'symlink'
-      ? getAgentBaseDir(agentType, isGlobal, cwd)
+      ? getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent)
       : getCanonicalSkillsDir(isGlobal, cwd);
   const canonicalDir = join(canonicalBase, skillName);
 
   // Agent-specific location (for symlink)
-  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd);
+  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent);
   const agentDir = join(agentBase, skillName);
 
   // Validate paths
@@ -715,12 +754,13 @@ export async function installRemoteSkillForAgent(
 export async function installWellKnownSkillForAgent(
   skill: WellKnownSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+  const eveSubagent = options.eveSubagent;
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -738,12 +778,12 @@ export async function installWellKnownSkillForAgent(
   // Canonical location: .agents/skills/<skill-name>
   const canonicalBase =
     agentType === 'eve' && installMode === 'symlink'
-      ? getAgentBaseDir(agentType, isGlobal, cwd)
+      ? getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent)
       : getCanonicalSkillsDir(isGlobal, cwd);
   const canonicalDir = join(canonicalBase, skillName);
 
   // Agent-specific location (for symlink)
-  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd);
+  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent);
   const agentDir = join(agentBase, skillName);
 
   // Validate paths
@@ -860,12 +900,13 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
+  const eveSubagent = options.eveSubagent;
 
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {
@@ -877,7 +918,7 @@ export async function installBlobSkillForAgent(
   }
 
   const skillName = sanitizeName(skill.installName);
-  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd);
+  const agentBase = getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent);
 
   if (agentType === 'eve' && !isEvePackagedSkill(skill.files)) {
     const flatSkillPath = join(agentBase, toEveFlatSkillFileName(skill.installName));
@@ -907,7 +948,7 @@ export async function installBlobSkillForAgent(
 
   const canonicalBase =
     agentType === 'eve' && installMode === 'symlink'
-      ? getAgentBaseDir(agentType, isGlobal, cwd)
+      ? getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent)
       : getCanonicalSkillsDir(isGlobal, cwd);
   const canonicalDir = join(canonicalBase, skillName);
   const agentDir = join(agentBase, skillName);
@@ -1089,6 +1130,17 @@ export async function listInstalledSkills(
       // Avoid duplicate paths
       if (!scopes.some((s) => s.path === agentDir && s.global === isGlobal)) {
         scopes.push({ global: isGlobal, path: agentDir, agentType });
+      }
+
+      // Eve subagents keep their skills under agent/subagents/<name>/skills.
+      // These are project-scoped, so only scan them for the project scope.
+      if (agentType === 'eve' && !isGlobal) {
+        for (const subagent of getEveSubagents(cwd)) {
+          const subagentDir = getEveSubagentSkillsDir(subagent, cwd);
+          if (!scopes.some((s) => s.path === subagentDir && s.global === isGlobal)) {
+            scopes.push({ global: isGlobal, path: subagentDir, agentType });
+          }
+        }
       }
     }
 

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -33,6 +33,13 @@ export interface LocalSkillLockEntry {
    * computes the hash from actual file contents on disk.
    */
   computedHash: string;
+  /**
+   * Eve subagent targets this skill was installed into, so `update` can
+   * restore the same placement. Each entry is an Eve subagent directory name;
+   * the empty string `''` denotes the root agent (`agent/skills`). Omitted for
+   * non-Eve installs and for plain Eve root installs (treated as `['']`).
+   */
+  subagents?: string[];
 }
 
 /**

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
-import { agents, detectInstalledAgents } from './agents.ts';
+import { agents, detectInstalledAgents, getEveSubagents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
@@ -11,6 +11,7 @@ import {
   getInstallPath,
   getCanonicalPath,
   getCanonicalSkillsDir,
+  getEveSubagentSkillsDir,
   sanitizeName,
 } from './installer.ts';
 
@@ -67,6 +68,10 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     await scanDir(getCanonicalSkillsDir(false, cwd));
     for (const agent of Object.values(agents)) {
       await scanDir(join(cwd, agent.skillsDir));
+    }
+    // Eve subagents keep their skills under agent/subagents/<name>/skills.
+    for (const subagent of getEveSubagents(cwd)) {
+      await scanDir(getEveSubagentSkillsDir(subagent, cwd));
     }
   }
 
@@ -178,6 +183,12 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
           pathsToCleanup.add(join(agent.globalSkillsDir, sanitizedName));
         } else {
           pathsToCleanup.add(join(cwd, agent.skillsDir, sanitizedName));
+          // Eve skills may also live in subagent directories.
+          if (agentKey === 'eve') {
+            for (const subagent of getEveSubagents(cwd)) {
+              pathsToCleanup.add(join(getEveSubagentSkillsDir(subagent, cwd), sanitizedName));
+            }
+          }
         }
 
         for (const pathToCleanup of pathsToCleanup) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -586,9 +586,15 @@ export async function updateProjectSkills(
       console.log(`${TEXT}Updating ${safeName}...${RESET}`);
       const installUrl = formatSourceInput(skill.entry.source, skill.entry.ref);
 
+      // Preserve Eve subagent placement recorded at install time. The lock stores
+      // '' for the root agent, which maps to the `root` keyword for `add --subagent`.
+      const subagentArgs = skill.entry.subagents?.length
+        ? ['--subagent', ...skill.entry.subagents.map((s) => (s === '' ? 'root' : s))]
+        : [];
+
       const result = spawnSync(
         process.execPath,
-        [cliEntry, 'add', installUrl, '--skill', skill.name, '-y'],
+        [cliEntry, 'add', installUrl, '--skill', skill.name, ...subagentArgs, '-y'],
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',

--- a/tests/eve-agent.test.ts
+++ b/tests/eve-agent.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { detectInstalledAgents } from '../src/agents.ts';
-import { installBlobSkillForAgent, installSkillForAgent } from '../src/installer.ts';
+import { detectInstalledAgents, getEveSubagents } from '../src/agents.ts';
+import {
+  getAgentBaseDir,
+  getEveSubagentSkillsDir,
+  installBlobSkillForAgent,
+  installSkillForAgent,
+  isSkillInstalled,
+  listInstalledSkills,
+} from '../src/installer.ts';
 
 async function makeEveProject(): Promise<string> {
   const projectDir = await mkdtemp(join(tmpdir(), 'skills-eve-'));
@@ -14,6 +21,22 @@ async function makeEveProject(): Promise<string> {
     'utf-8'
   );
   return projectDir;
+}
+
+async function addEveSubagent(projectDir: string, name: string): Promise<void> {
+  await mkdir(join(projectDir, 'agent', 'subagents', name), { recursive: true });
+}
+
+async function makeSourceSkill(name: string): Promise<{ root: string; skillDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'skills-eve-source-'));
+  const skillDir = join(root, name);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${name} skill\n---\n# ${name}\n`,
+    'utf-8'
+  );
+  return { root, skillDir };
 }
 
 describe('Eve agent support', () => {
@@ -92,6 +115,153 @@ describe('Eve agent support', () => {
       expect(installed).toContain('description: "Blob skill"');
       expect(installed).not.toContain('name:');
     } finally {
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('Eve subagents', () => {
+  it('discovers subagent directories under agent/subagents, sorted', async () => {
+    const projectDir = await makeEveProject();
+    try {
+      await addEveSubagent(projectDir, 'writer');
+      await addEveSubagent(projectDir, 'research');
+      // A stray file should be ignored — only directories are subagents.
+      await writeFile(join(projectDir, 'agent', 'subagents', 'notes.txt'), 'x', 'utf-8');
+
+      expect(getEveSubagents(projectDir)).toEqual(['research', 'writer']);
+    } finally {
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns no subagents when agent/subagents is absent', async () => {
+    const projectDir = await makeEveProject();
+    try {
+      expect(getEveSubagents(projectDir)).toEqual([]);
+    } finally {
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves the base dir to the subagent skills directory', () => {
+    const cwd = '/tmp/eve-project';
+    expect(getAgentBaseDir('eve', false, cwd, 'research')).toBe(
+      join(cwd, 'agent', 'subagents', 'research', 'skills')
+    );
+    // No subagent → root agent skills dir.
+    expect(getAgentBaseDir('eve', false, cwd)).toBe(join(cwd, 'agent', 'skills'));
+  });
+
+  it('sanitizes subagent names to prevent path traversal', () => {
+    const cwd = '/tmp/eve-project';
+    const resolved = getEveSubagentSkillsDir('../../etc', cwd);
+    expect(resolved.startsWith(join(cwd, 'agent', 'subagents'))).toBe(true);
+    expect(resolved).not.toContain('..');
+  });
+
+  it('installs a disk skill into a subagent skills directory', async () => {
+    const projectDir = await makeEveProject();
+    await addEveSubagent(projectDir, 'research');
+    const { root, skillDir } = await makeSourceSkill('subagent-skill');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: 'subagent-skill', description: 'subagent-skill skill', path: skillDir },
+        'eve',
+        { cwd: projectDir, mode: 'copy', global: false, eveSubagent: 'research' }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(projectDir, 'agent/subagents/research/skills/subagent-skill'));
+
+      const installed = await readFile(
+        join(projectDir, 'agent/subagents/research/skills/subagent-skill/SKILL.md'),
+        'utf-8'
+      );
+      expect(installed).toContain('description: "subagent-skill skill"');
+
+      // The root agent dir should be untouched.
+      await expect(access(join(projectDir, 'agent/skills/subagent-skill'))).rejects.toBeTruthy();
+    } finally {
+      await rm(projectDir, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('installs a blob skill into a subagent skills directory', async () => {
+    const projectDir = await makeEveProject();
+    await addEveSubagent(projectDir, 'research');
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: 'blob-subagent',
+          files: [
+            {
+              path: 'SKILL.md',
+              contents: '---\nname: blob-subagent\ndescription: Blob subagent\n---\n# Blob\n',
+            },
+          ],
+        },
+        'eve',
+        { cwd: projectDir, mode: 'copy', global: false, eveSubagent: 'research' }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(projectDir, 'agent/subagents/research/skills/blob-subagent'));
+    } finally {
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports skills as installed per subagent via isSkillInstalled', async () => {
+    const projectDir = await makeEveProject();
+    await addEveSubagent(projectDir, 'research');
+    const { root, skillDir } = await makeSourceSkill('present');
+
+    try {
+      await installSkillForAgent(
+        { name: 'present', description: 'present skill', path: skillDir },
+        'eve',
+        { cwd: projectDir, mode: 'copy', global: false, eveSubagent: 'research' }
+      );
+
+      await expect(
+        isSkillInstalled('present', 'eve', { cwd: projectDir, eveSubagent: 'research' })
+      ).resolves.toBe(true);
+      // Not installed at the root agent.
+      await expect(isSkillInstalled('present', 'eve', { cwd: projectDir })).resolves.toBe(false);
+    } finally {
+      await rm(projectDir, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('scans subagent directories when listing installed skills', async () => {
+    const previousCwd = process.cwd();
+    const projectDir = await makeEveProject();
+    await addEveSubagent(projectDir, 'research');
+
+    // Place a packaged skill (with a parseable SKILL.md) directly in the
+    // subagent skills dir. We write it directly rather than via the eve
+    // installer because eve strips the `name:` field, which parseSkillMd
+    // requires — that is a separate, pre-existing eve quirk.
+    const subagentSkillDir = join(getEveSubagentSkillsDir('research', projectDir), 'listed-skill');
+    await mkdir(subagentSkillDir, { recursive: true });
+    await writeFile(
+      join(subagentSkillDir, 'SKILL.md'),
+      '---\nname: listed-skill\ndescription: Listed skill\n---\n# Listed\n',
+      'utf-8'
+    );
+
+    try {
+      process.chdir(projectDir);
+      const listed = await listInstalledSkills({ cwd: projectDir, global: false });
+      const names = listed.map((s) => s.name);
+      expect(names).toContain('listed-skill');
+    } finally {
+      process.chdir(previousCwd);
       await rm(projectDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Problem

Eve support (added in #1459) hardcodes the install path to `agent/skills`, which works for the root agent. But Eve also supports **subagents**, whose skills live at `agent/subagents/<name>/skills`. There was no way to install a skill into a subagent.

## What this does

When running `skills add` in an Eve project that has subagents, you can now choose where skills go:

- **Interactive:** after the existing "Install skills for Eve?" prompt, a multi-select appears — **Root agent** and each detected subagent — so you can install to root and/or any combination in one run.
- **Non-interactive:** a new `--subagent <names...>` flag (e.g. `--subagent root research writer`). `root` (or `.`) selects the root agent. Passing `--subagent` implies Eve.

If a project has no subagents, behavior is unchanged.

## Changes

- **`agents.ts`** — `getEveSubagents()` discovers `agent/subagents/*` dirs (+ `EVE_SUBAGENTS_DIR`).
- **`installer.ts`** — optional `eveSubagent` threaded through `getAgentBaseDir` and every `install*ForAgent` / `isSkillInstalled` / `getInstallPath` / `getCanonicalPath`; new `getEveSubagentSkillsDir` (subagent name sanitized against path traversal); `listInstalledSkills` scans subagent dirs.
- **`add.ts`** — subagent prompt + `--subagent` parsing; agents fan out into install targets so the summary, overwrite checks, install loop, and labels handle multiple Eve destinations.
- **`local-lock.ts`** — records `subagents` placement (`""` = root) so updates restore it.
- **`update.ts`** — replays `--subagent` from the lock on reinstall.
- **`remove.ts`** — discovers and cleans up skills across all subagent dirs.
- **`cli.ts`** — documents `--subagent`.

## Compatibility

Fully backward compatible — the `eveSubagent` parameter is optional everywhere and Eve projects without subagents are untouched.

## Testing

- New tests in `tests/eve-agent.test.ts` (subagent detection, path resolution, disk/blob install into a subagent, `isSkillInstalled` per subagent, list discovery) and `--subagent` parsing tests in `src/add.test.ts`.
- Manually verified end-to-end: single-subagent install, multi-target (root + 2 subagents) install with the correct lock entry, and `remove` cleaning all three locations.

## Notes

- The well-known endpoint flow (`handleWellKnownSkills`) is left Eve-root-only for now — it has no Eve prompt today and the installer change is backward compatible there.
- Separately noticed: eve installs strip the `name:` frontmatter and `parseSkillMd` requires a name, so skills installed *through the eve installer* don't appear in `skills list` (root or subagent) — a pre-existing quirk, not introduced here. Happy to address in a follow-up if desired.