### PR TITLE
docs: document skills.sh listing change requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,28 @@ Skills let agents perform specialized tasks like:
 
 Discover skills at **[skills.sh](https://skills.sh)**
 
+## Request skills.sh Listing Changes
+
+If you publish skills and need a skills.sh listing corrected, hidden, or redirected because a source or skill was
+deprecated, renamed, moved, or deleted, open an issue or pull request against this repository with the requested change.
+
+Keep each pull request focused on one kind of change. Do not combine a concrete listing cleanup with README, schema, or
+format changes.
+
+For a redirect, include:
+
+- the old skills.sh URL or slug
+- the replacement skills.sh URL or slug
+- evidence for the rename or move, such as a source repository commit, pull request, issue, or current file path
+- the date you verified the stale and replacement listings
+
+For a hidden or removed listing, include:
+
+- the skills.sh URL or slug that should be hidden or removed
+- whether the source repository, skill directory, or `SKILL.md` no longer exists
+- evidence for the deletion, deprecation, or invalid listing
+- the date you verified the stale listing
+
 ## Supported Agents
 
 Skills can be installed to any of these agents:


### PR DESCRIPTION
## What changed

Adds README guidance for authors who need skills.sh listings corrected, hidden, removed, or redirected after a source or skill is deprecated, renamed, moved, or deleted.

The section documents the information maintainers need for redirect and hide/remove requests:

- old skills.sh URL or slug
- replacement URL or slug, when applicable
- evidence from the source repository
- verification date

It also asks contributors to keep concrete listing cleanups separate from README, schema, or format changes.

## Why

Closes #1473.

The skills.sh contact page tells authors to open a PR against this repository for hidden or redirected listings and says the README documents the manifest format, but the current README does not give author-facing instructions for those requests.

This is intentionally docs-only. It does not add a schema or change any listing data.

## Checks

- `git diff --check`
- `pnpm format:check`