### PR TITLE
Add Zaguán Blade support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -298,6 +298,7 @@ Skills can be installed to any of these agents:
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
 | Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
 | Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| Zaguán Blade | `zblade` | `.agents/skills/` | `~/.config/zblade/skills/` |
 | Zencoder, Zenflow | `zencoder`, `zenflow` | `.zencoder/skills/` | `~/.zencoder/skills/` |
 | Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "warp",
     "windsurf",
     "zed",
+    "zblade",
     "zencoder",
     "zenflow",
     "neovate",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -14,6 +14,7 @@ const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
+const zaguanBladeAppDataHome = process.env.APPDATA?.trim();
 
 function packageJsonHasDependency(packageJsonPath: string, dependencyName: string): boolean {
   try {
@@ -43,6 +44,38 @@ export function getOpenClawGlobalSkillsDir(
     return join(homeDir, '.moltbot/skills');
   }
   return join(homeDir, '.openclaw/skills');
+}
+
+export function getZaguanBladeGlobalSkillsDir(
+  homeDir = home,
+  configDir = configHome,
+  platformName: NodeJS.Platform = process.platform,
+  appDataHome = zaguanBladeAppDataHome,
+  joinPath: typeof join = join
+) {
+  return joinPath(
+    getZaguanBladeConfigDir(homeDir, configDir, platformName, appDataHome, joinPath),
+    'skills'
+  );
+}
+
+export function getZaguanBladeConfigDir(
+  homeDir = home,
+  configDir = configHome,
+  platformName: NodeJS.Platform = process.platform,
+  appDataHome = zaguanBladeAppDataHome,
+  joinPath: typeof join = join
+) {
+  if (platformName === 'win32') {
+    const windowsConfigDir = appDataHome || joinPath(homeDir, 'AppData', 'Roaming');
+    return joinPath(windowsConfigDir, 'zblade');
+  }
+
+  if (platformName === 'darwin') {
+    return joinPath(homeDir, 'Library', 'Application Support', 'zblade');
+  }
+
+  return joinPath(configDir, 'zblade');
 }
 
 export const agents: Record<AgentType, AgentConfig> = {
@@ -645,6 +678,15 @@ export const agents: Record<AgentType, AgentConfig> = {
         (!!zedAppDataHome && existsSync(join(zedAppDataHome, 'Zed'))) ||
         (!!zedFlatpakConfigHome && existsSync(join(zedFlatpakConfigHome, 'zed')))
       );
+    },
+  },
+  zblade: {
+    name: 'zblade',
+    displayName: 'Zaguán Blade',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: getZaguanBladeGlobalSkillsDir(),
+    detectInstalled: async () => {
+      return existsSync(getZaguanBladeConfigDir());
     },
   },
   zencoder: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export type AgentType =
   | 'warp'
   | 'windsurf'
   | 'zed'
+  | 'zblade'
   | 'zencoder'
   | 'zenflow'
   | 'pochi'

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -15,8 +15,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { homedir } from 'os';
-import { join } from 'path';
-import { agents } from '../src/agents.ts';
+import { join, win32 } from 'path';
+import { agents, getZaguanBladeGlobalSkillsDir } from '../src/agents.ts';
 
 describe('XDG config paths', () => {
   const home = homedir();
@@ -69,6 +69,47 @@ describe('XDG config paths', () => {
       expect(agents.goose.globalSkillsDir).not.toContain('Library');
       expect(agents.goose.globalSkillsDir).not.toContain('Preferences');
       expect(agents.goose.globalSkillsDir).not.toContain('AppData');
+    });
+  });
+
+  describe('Zaguán Blade', () => {
+    it('uses ~/.config/zblade/skills for global skills', () => {
+      const expected = join(home, '.config', 'zblade', 'skills');
+      expect(getZaguanBladeGlobalSkillsDir(home, join(home, '.config'), 'linux')).toBe(expected);
+    });
+
+    it('uses ~/Library/Application Support/zblade/skills on macOS', () => {
+      const expected = join(home, 'Library', 'Application Support', 'zblade', 'skills');
+      expect(getZaguanBladeGlobalSkillsDir(home, join(home, '.config'), 'darwin')).toBe(expected);
+    });
+
+    it('uses %APPDATA%\\zblade\\skills on Windows', () => {
+      const appData = 'C:\\Users\\test\\AppData\\Roaming';
+      expect(
+        getZaguanBladeGlobalSkillsDir(
+          'C:\\Users\\test',
+          'C:\\Users\\test\\.config',
+          'win32',
+          appData,
+          win32.join
+        )
+      ).toBe('C:\\Users\\test\\AppData\\Roaming\\zblade\\skills');
+    });
+
+    it('falls back to ~/AppData/Roaming/zblade/skills on Windows without APPDATA', () => {
+      expect(
+        getZaguanBladeGlobalSkillsDir(
+          'C:\\Users\\test',
+          'C:\\Users\\test\\.config',
+          'win32',
+          undefined,
+          win32.join
+        )
+      ).toBe('C:\\Users\\test\\AppData\\Roaming\\zblade\\skills');
+    });
+
+    it('uses the universal project skills directory', () => {
+      expect(agents.zblade.skillsDir).toBe('.agents/skills');
     });
   });
 


### PR DESCRIPTION
## Summary
Adds support for Zaguán Blade as an agent target in the `skills` CLI.

Zaguán Blade is a cross-platform AI coding editor by Zaguán Labs. It currently supports project-level skills from `.agents/skills`, with planned support for platform-specific global config directories.

Website: https://zblade.dev

## What Changed
- Adds `zblade` as a supported `--agent`
- Uses `.agents/skills` for project installs
- Adds platform-aware global skill paths:
  - Linux: `~/.config/zblade/skills`
  - macOS: `~/Library/Application Support/zblade/skills`
  - Windows: `%APPDATA%\zblade\skills`
- Updates generated README/package metadata
- Adds tests for global path resolution across Linux, macOS, and Windows

## Why
This lets users install shared Agent Skills for Zaguán Blade using the same CLI workflow as other supported editors and agents.

The editor is still new, but it follows the existing `.agents/skills` convention today, and this PR prepares the CLI for Blade’s upcoming global skill loading support.

## Validation

- `node scripts/sync-agents.ts`
- `node scripts/validate-agents.ts`
- `pnpm format`
- `pnpm test tests/xdg-config-paths.test.ts`