### PR TITLE
[skills.sh] Redirect LilMGenius/skills listings to LilMGenius/paperthin

### DIFF
--- a/skills-sh-overrides.json
+++ b/skills-sh-overrides.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "redirects": [
+    {
+      "from": "LilMGenius/skills/re0",
+      "to": "LilMGenius/paperthin/re0",
+      "reason": "Source repo renamed LilMGenius/skills -> LilMGenius/paperthin (GitHub 301-redirects); the skill moved with it.",
+      "evidence": ["https://github.com/LilMGenius/paperthin"],
+      "verifiedAt": "2026-06-21"
+    },
+    {
+      "from": "LilMGenius/skills/re0-git",
+      "to": "LilMGenius/paperthin/re0-git",
+      "reason": "Source repo renamed LilMGenius/skills -> LilMGenius/paperthin (GitHub 301-redirects); the skill moved with it.",
+      "evidence": ["https://github.com/LilMGenius/paperthin"],
+      "verifiedAt": "2026-06-21"
+    },
+    {
+      "from": "LilMGenius/skills/shower",
+      "to": "LilMGenius/paperthin/shower",
+      "reason": "Source repo renamed LilMGenius/skills -> LilMGenius/paperthin (GitHub 301-redirects); the skill moved with it.",
+      "evidence": ["https://github.com/LilMGenius/paperthin"],
+      "verifiedAt": "2026-06-21"
+    },
+    {
+      "from": "LilMGenius/skills/ssotize",
+      "to": "LilMGenius/paperthin/ssotize",
+      "reason": "Source repo renamed LilMGenius/skills -> LilMGenius/paperthin (GitHub 301-redirects); the skill moved with it.",
+      "evidence": ["https://github.com/LilMGenius/paperthin"],
+      "verifiedAt": "2026-06-21"
+    },
+    {
+      "from": "LilMGenius/skills/tasting",
+      "to": "LilMGenius/paperthin/tasting",
+      "reason": "Source repo renamed LilMGenius/skills -> LilMGenius/paperthin (GitHub 301-redirects); the skill moved with it.",
+      "evidence": ["https://github.com/LilMGenius/paperthin"],
+      "verifiedAt": "2026-06-21"
+    },
+    {
+      "from": "LilMGenius/skills/ssotchk",
+      "to": "LilMGenius/paperthin/ssotchk",
+      "reason": "Source repo renamed LilMGenius/skills -> LilMGenius/paperthin (GitHub 301-redirects); the skill moved with it.",
+      "evidence": ["https://github.com/LilMGenius/paperthin"],
+      "verifiedAt": "2026-06-21"
+    },
+    {
+      "from": "LilMGenius/skills/ssot-check",
+      "to": "LilMGenius/paperthin/ssotchk",
+      "reason": "Skill renamed ssot-check -> ssotchk and the repo renamed skills -> paperthin; ssot-check no longer exists in the source.",
+      "evidence": ["https://github.com/LilMGenius/paperthin/blob/main/skills/cross/ssotchk/SKILL.md"],
+      "verifiedAt": "2026-06-21"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Adds `skills-sh-overrides.json` with 7 redirects that consolidate the now-split listings for my collection after I renamed both the repo and one skill.

## Redirects

| from (stale) | to (canonical) |
|---|---|
| `LilMGenius/skills/re0` | `LilMGenius/paperthin/re0` |
| `LilMGenius/skills/re0-git` | `LilMGenius/paperthin/re0-git` |
| `LilMGenius/skills/shower` | `LilMGenius/paperthin/shower` |
| `LilMGenius/skills/ssotize` | `LilMGenius/paperthin/ssotize` |
| `LilMGenius/skills/tasting` | `LilMGenius/paperthin/tasting` |
| `LilMGenius/skills/ssotchk` | `LilMGenius/paperthin/ssotchk` |
| `LilMGenius/skills/ssot-check` | `LilMGenius/paperthin/ssotchk` |

## Why

The repo was renamed `LilMGenius/skills` → `LilMGenius/paperthin` (GitHub 301-redirects the old name), and the skill `ssot-check` was renamed to `ssotchk`. skills.sh now shows two separate listings — the stale `LilMGenius/skills` one still holds the bulk of the installs while the canonical `LilMGenius/paperthin` listing starts fresh. The contact page directs authors to open a PR here for listings that need to be corrected/redirected after a rename or move.

## Notes

- **Overlaps with #1472**: that PR (draft) introduces this same `skills-sh-overrides.json`. Happy to fold these entries into #1472 instead, or rebase to append once either lands — whichever you prefer.
- **Scope**: this PR touches only `skills-sh-overrides.json`, per the guidance in #1474 to keep concrete listing cleanups separate from README/schema/format changes.
- **Format**: follows the schema proposed in #1472; I'll adapt to whatever the maintainers finalize. Opened as draft to mirror the still-in-review state of #1472/#1474.
- This consolidates the listing onto the canonical repo; whether the historical install counts are summed is of course up to the skills.sh backend.

## Evidence

- Repo rename / 301 redirect: https://github.com/LilMGenius/paperthin
- `ssotchk` (replacement for `ssot-check`): https://github.com/LilMGenius/paperthin/blob/main/skills/cross/ssotchk/SKILL.md
