### PR TITLE
fix(update): print child process output on failure

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -31,6 +31,39 @@ const BOLD = '\x1b[1m';
 const DIM = '\x1b[38;5;102m';
 const TEXT = '\x1b[38;5;145m';
 
+function getSpawnOutput(output: unknown): string {
+  let text = '';
+  if (typeof output === 'string') {
+    text = output;
+  } else if (Buffer.isBuffer(output)) {
+    text = output.toString('utf-8');
+  }
+  return text
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed && !/^[◐◓◑◒]\s/.test(trimmed);
+    })
+    .join('\n')
+    .trim();
+}
+
+function printSpawnFailureOutput(result: { stdout?: unknown; stderr?: unknown }): void {
+  const stderr = getSpawnOutput(result.stderr);
+  const stdout = getSpawnOutput(result.stdout);
+
+  if (stderr) {
+    console.log(`${DIM}  stderr:${RESET}`);
+    console.log(stderr);
+  }
+  if (stdout && stdout !== stderr) {
+    console.log(`${DIM}  stdout:${RESET}`);
+    console.log(stdout);
+  }
+}
+
 // ============================================
 // Scope Detection and Prompt
 // ============================================
@@ -468,6 +501,7 @@ export async function processWellKnownUpdates(
       } else {
         failCount++;
         console.log(`  ${DIM}✗ Failed to update ${safeName}${RESET}`);
+        printSpawnFailureOutput(spawnResult);
       }
     }
   }
@@ -710,6 +744,7 @@ export async function updateGlobalSkills(
     } else {
       failCount++;
       console.log(`  ${DIM}✗ Failed to update ${safeName}${RESET}`);
+      printSpawnFailureOutput(result);
     }
   }
 
@@ -916,6 +951,7 @@ export async function updateProjectSkills(
       } else {
         failCount++;
         console.log(`  ${DIM}✗ Failed to update ${safeName}${RESET}`);
+        printSpawnFailureOutput(result);
       }
     }
   }

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -8,6 +8,7 @@ import * as localLock from '../src/local-lock.ts';
 import * as skillLock from '../src/skill-lock.ts';
 import * as remove from '../src/remove.ts';
 import * as p from '@clack/prompts';
+import * as childProcess from 'child_process';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -740,6 +741,58 @@ describe('Update Cleanup Unit Tests', () => {
       await runUpdate(['--project', '--yes']);
 
       expect(process.exitCode).toBeUndefined();
+    });
+
+    it('should print child process output when global update install fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          { path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'sha1' },
+          { path: 'skills/skill-a', type: 'tree', sha: 'new-hash' },
+        ],
+      });
+      vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-hash');
+      vi.mocked(childProcess.spawnSync).mockReturnValueOnce({
+        status: 1,
+        signal: null,
+        error: undefined,
+        pid: 123,
+        output: [null, 'install stdout detail', 'install stderr detail'],
+        stdout: 'install stdout detail',
+        stderr: 'install stderr detail',
+      });
+
+      try {
+        await updateGlobalSkills({ yes: true });
+
+        const output = consoleSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+        expect(output).toContain('Failed to update skill-a');
+        expect(output).toContain('stderr:');
+        expect(output).toContain('install stderr detail');
+        expect(output).toContain('stdout:');
+        expect(output).toContain('install stdout detail');
+      } finally {
+        consoleSpy.mockRestore();
+      }
     });
   });
 });

--- a/tests/wellknown-update.test.ts
+++ b/tests/wellknown-update.test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { checkWellKnownForUpdates, type WellKnownUpdateItem } from '../src/update.ts';
+import { spawnSync } from 'child_process';
+import {
+  checkWellKnownForUpdates,
+  processWellKnownUpdates,
+  type WellKnownUpdateItem,
+} from '../src/update.ts';
 import {
   computeWellKnownSkillDigest,
   wellKnownProvider,
   type WellKnownSkill,
 } from '../src/providers/index.ts';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawnSync: vi.fn().mockReturnValue({ status: 0 }),
+  };
+});
 
 const BASE_URL = 'https://skills.example.com/p/testpack';
 
@@ -76,6 +89,7 @@ async function digestOf(name: string, contents = V1_CONTENTS): Promise<string> {
 }
 
 afterEach(() => {
+  vi.clearAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -254,5 +268,36 @@ describe('checkWellKnownForUpdates', () => {
       .map((call) => String(call[0]))
       .filter((url) => url.endsWith('/SKILL.md'));
     expect(fileCalls).toEqual([`${BASE_URL}/.well-known/skills/alpha-skill/SKILL.md`]);
+  });
+
+  it('prints child process output when well-known reinstall fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    stubWellKnownServer(v2Index([{ name: 'alpha-skill', digest: DIGEST_A }]));
+    vi.mocked(spawnSync).mockReturnValueOnce({
+      status: 1,
+      signal: null,
+      error: undefined,
+      pid: 123,
+      output: [null, 'install stdout detail', 'install stderr detail'],
+      stdout: 'install stdout detail',
+      stderr: 'install stderr detail',
+    });
+
+    try {
+      await processWellKnownUpdates(
+        new Map([[BASE_URL, [{ name: 'alpha-skill', digest: DIGEST_STALE }]]]),
+        true,
+        { yes: true }
+      );
+
+      const output = consoleSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+      expect(output).toContain('Failed to update alpha-skill');
+      expect(output).toContain('stderr:');
+      expect(output).toContain('install stderr detail');
+      expect(output).toContain('stdout:');
+      expect(output).toContain('install stdout detail');
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- print captured child process stderr/stdout when an internal update reinstall fails
- strip ANSI control sequences and spinner progress lines before replaying captured output
- add regression coverage for global update reinstall failures

## Why

The update command runs the CLI entrypoint in a child process with stdout/stderr piped. When the child process fails, the current output only reports `Failed to update <skill>`, hiding the underlying `skills add` error that was already captured.

Related to #371 and helps diagnose update failures such as #1376.

## Follow-up after rebase

- Rebased this PR onto current `upstream/main` (`ab4fc49`).
- Preserved the failure-output replay across the refactored global and project update paths.
- Extended the same stderr/stdout replay to well-known update reinstalls introduced after the original PR.
- Added regression coverage for both regular global update failures and well-known reinstall failures.

## Tests

- `pnpm format`
- `pnpm format:check`
- `pnpm vitest run tests/update.test.ts tests/wellknown-update.test.ts`
