### PR TITLE
fix(update): show skipped skills when checkable skills are current

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -659,8 +659,13 @@ export async function updateGlobalSkills(
 
   if (updates.length === 0) {
     if (!wkChanged) {
-      console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+      const message =
+        skipped.length > 0
+          ? '✓ All checkable global skills are up to date'
+          : '✓ All global skills are up to date';
+      console.log(`${TEXT}${message}${RESET}`);
     }
+    printSkippedSkills(skipped);
     return { successCount, failCount, checkedCount };
   }
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -741,5 +741,58 @@ describe('Update Cleanup Unit Tests', () => {
 
       expect(process.exitCode).toBeUndefined();
     });
+
+    it('should report skipped global skills when all checkable skills are up to date', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      let output = '';
+
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'abc',
+            installedAt: '',
+            updatedAt: '',
+          },
+          'well-known-skill': {
+            source: 'example.com',
+            sourceUrl: 'https://example.com/.well-known/agent-skills/well-known-skill/SKILL.md',
+            sourceType: 'well-known',
+            skillFolderHash: '',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          { path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'sha1' },
+          { path: 'skills/skill-a', type: 'tree', sha: 'abc' },
+        ],
+      });
+      vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('abc');
+
+      try {
+        await updateGlobalSkills({ yes: true });
+      } finally {
+        output = logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+        logSpy.mockRestore();
+      }
+
+      expect(output).toContain('All checkable global skills are up to date');
+      expect(output).toContain('1 skill(s) cannot be checked automatically');
+      expect(output).toContain('well-known-skill');
+      expect(output).toContain('Well-known skill');
+      expect(output).toContain('To update:');
+      expect(output).toContain('npx skills add https://example.com -g -y');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- clarify the no-update message when some global skills cannot be checked automatically
- print skipped global skills before returning when all checkable global skills are current
- add a regression test for mixed checkable GitHub and skipped legacy/well-known skills

## Why

When `skills update -g` has a mix of checkable skills and skipped skills, and the checkable skills are already current, the command currently reports `All global skills are up to date` and returns without showing the skipped entries. That hides the fact that some installed skills were never checked and still require a manual refresh.

## Follow-up after rebase

- Rebased this PR onto current `upstream/main` (`ab4fc49`).
- Resolved the conflict with the newer well-known update flow.
- Preserved upstream behavior that suppresses an extra up-to-date summary when well-known updates already produced change output.
- Kept this PR focused on the remaining skipped-entry case, including old lock entries and entries without automatic version tracking.
- Signed the rebased commit with a verified SSH signature.

## Tests

- `pnpm format`
- `pnpm format:check`
- `pnpm vitest run tests/update.test.ts`
