### PR TITLE
fix(update): preserve plugin grouping after global updates

### DIFF
--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  buildLocalUpdateSource,
-  buildUpdateInstallSource,
-  formatSourceInput,
-} from './update-source.ts';
+import { buildLocalUpdateSource, formatSourceInput } from './update-source.ts';
 
 describe('update-source', () => {
   describe('formatSourceInput', () => {
@@ -17,37 +13,6 @@ describe('update-source', () => {
       expect(formatSourceInput('https://github.com/owner/repo.git')).toBe(
         'https://github.com/owner/repo.git'
       );
-    });
-  });
-
-  describe('buildUpdateInstallSource', () => {
-    it('builds root-level install source without trailing slash', () => {
-      const result = buildUpdateInstallSource({
-        source: 'owner/repo',
-        sourceUrl: 'https://github.com/owner/repo.git',
-        ref: 'feature/install',
-        skillPath: 'SKILL.md',
-      });
-      expect(result).toBe('owner/repo#feature/install');
-    });
-
-    it('builds nested skill install source with ref', () => {
-      const result = buildUpdateInstallSource({
-        source: 'owner/repo',
-        sourceUrl: 'https://github.com/owner/repo.git',
-        ref: 'feature/install',
-        skillPath: 'skills/my-skill/SKILL.md',
-      });
-      expect(result).toBe('owner/repo/skills/my-skill#feature/install');
-    });
-
-    it('falls back to sourceUrl when skillPath is missing', () => {
-      const result = buildUpdateInstallSource({
-        source: 'owner/repo',
-        sourceUrl: 'https://github.com/owner/repo.git',
-        ref: 'feature/install',
-      });
-      expect(result).toBe('https://github.com/owner/repo.git#feature/install');
     });
   });
 

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -1,10 +1,3 @@
-export interface UpdateSourceEntry {
-  source: string;
-  sourceUrl: string;
-  ref?: string;
-  skillPath?: string;
-}
-
 export interface LocalUpdateSourceEntry {
   source: string;
   ref?: string;
@@ -64,17 +57,6 @@ function appendFolderAndRef(source: string, skillPath: string, ref?: string): st
   const folder = deriveSkillFolder(skillPath);
   const withFolder = folder ? `${source}/${folder}` : source;
   return ref ? `${withFolder}#${ref}` : withFolder;
-}
-
-/**
- * Build the source argument for `skills add` during update.
- * Uses shorthand form for path-targeted updates to avoid branch/path ambiguity.
- */
-export function buildUpdateInstallSource(entry: UpdateSourceEntry): string {
-  if (!entry.skillPath) {
-    return formatSourceInput(entry.sourceUrl, entry.ref);
-  }
-  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
 }
 
 /**

--- a/src/update.ts
+++ b/src/update.ts
@@ -7,11 +7,7 @@ import pc from 'picocolors';
 
 import { readSkillLock, getGitHubToken, type SkillLockEntry } from './skill-lock.ts';
 import { computeSkillFolderHash, readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
-import {
-  formatSourceInput,
-  buildUpdateInstallSource,
-  buildLocalUpdateSource,
-} from './update-source.ts';
+import { formatSourceInput, buildLocalUpdateSource } from './update-source.ts';
 import { cloneRepo, cleanupTempDir } from './git.ts';
 import { discoverSkills } from './skills.ts';
 import { fetchRepoTree, findSkillMdPaths, getSkillFolderHashFromTree } from './blob.ts';
@@ -443,7 +439,7 @@ export async function updateGlobalSkills(
   for (const update of updates) {
     const safeName = sanitizeMetadata(update.name);
     console.log(`${TEXT}Updating ${safeName}...${RESET}`);
-    const installUrl = buildUpdateInstallSource(update.entry);
+    const installUrl = formatSourceInput(update.entry.source, update.entry.ref);
 
     const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
     if (!existsSync(cliEntry)) {
@@ -453,11 +449,15 @@ export async function updateGlobalSkills(
       );
       continue;
     }
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-      shell: process.platform === 'win32',
-    });
+    const result = spawnSync(
+      process.execPath,
+      [cliEntry, 'add', installUrl, '--skill', update.name, '-g', '-y', '--full-depth'],
+      {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+        shell: process.platform === 'win32',
+      }
+    );
 
     if (result.status === 0) {
       successCount++;
@@ -584,7 +584,7 @@ export async function updateProjectSkills(
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);
       console.log(`${TEXT}Updating ${safeName}...${RESET}`);
-      const installUrl = formatSourceInput(skill.entry.source, skill.entry.ref);
+      const installUrl = buildLocalUpdateSource(skill.entry);
 
       // Preserve Eve subagent placement recorded at install time. The lock stores
       // '' for the root agent, which maps to the `root` keyword for `add --subagent`.

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -7,6 +7,7 @@ import * as localLock from '../src/local-lock.ts';
 import * as skillLock from '../src/skill-lock.ts';
 import * as remove from '../src/remove.ts';
 import * as p from '@clack/prompts';
+import { spawnSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -155,6 +156,21 @@ describe('Update Cleanup Unit Tests', () => {
 
       // Verify removeCommand was NOT called
       expect(remove.removeCommand).not.toHaveBeenCalled();
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        process.execPath,
+        [
+          expect.stringMatching(/bin[/\\]cli\.mjs$/),
+          'add',
+          'owner/repo/skills/skill-a',
+          '--skill',
+          'skill-a',
+          '-y',
+        ],
+        expect.objectContaining({
+          encoding: 'utf-8',
+        })
+      );
     });
 
     it('should skip deletion when isTTY is false', async () => {
@@ -266,6 +282,55 @@ describe('Update Cleanup Unit Tests', () => {
       expect(git.cloneRepo).toHaveBeenCalledWith('git@github.com:owner/repo.git', undefined);
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'skills/skill-a')
+      );
+    });
+
+    it('should reinstall global updates from the source root without the blob fast path', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'grill-me': {
+            source: 'vercel-labs/skills',
+            sourceUrl: 'https://github.com/vercel-labs/skills.git',
+            ref: 'feature/install',
+            skillPath: 'skills/grill-me/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+            pluginName: 'mattpocock-skills',
+          },
+        },
+      });
+
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          { path: 'skills/grill-me/SKILL.md', type: 'blob', sha: 'sha1' },
+          { path: 'skills/grill-me', type: 'tree', sha: 'new-hash' },
+        ],
+      });
+      vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/grill-me/SKILL.md']);
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        process.execPath,
+        [
+          expect.stringMatching(/bin[/\\]cli\.mjs$/),
+          'add',
+          'vercel-labs/skills#feature/install',
+          '--skill',
+          'grill-me',
+          '-g',
+          '-y',
+          '--full-depth',
+        ],
+        expect.objectContaining({
+          encoding: 'utf-8',
+        })
       );
     });
   });


### PR DESCRIPTION
Fixes #1495

## Summary
- Reinstall global updates from the original source/ref with `--skill <name>` instead of reinstalling from the skill folder subpath.
- Pass `--full-depth` for global update reinstalls so plugin manifests are discovered through the clone path instead of the GitHub blob fast path dropping `pluginName` metadata.
- Keep project updates targeted to the recorded `skillPath` through `buildLocalUpdateSource`.
- Remove the obsolete global update subpath helper and add regression coverage for global plugin-skill updates and project subpath updates.

## Tests
- `pnpm exec vitest run tests/update.test.ts src/update-source.test.ts`
- `pnpm format:check`
- `pnpm build`