### PR TITLE
feat: include skill description in list output

### DIFF
--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -115,6 +115,7 @@ description: A skill for JSON testing
       expect(Array.isArray(parsed)).toBe(true);
       expect(parsed.length).toBe(1);
       expect(parsed[0].name).toBe('json-skill');
+      expect(parsed[0].description).toBe('A skill for JSON testing');
       expect(parsed[0].path).toContain('json-skill');
       expect(parsed[0].scope).toBe('project');
       expect(Array.isArray(parsed[0].agents)).toBe(true);
@@ -173,8 +174,7 @@ This is a test skill.
       const result = runCli(['list'], testDir);
       expect(result.stdout).toContain('test-skill');
       expect(result.stdout).toContain('Project Skills');
-      // Description should not be shown
-      expect(result.stdout).not.toContain('A test skill for listing');
+      expect(result.stdout).toContain('A test skill for listing');
       expect(result.exitCode).toBe(0);
     });
 

--- a/src/list.ts
+++ b/src/list.ts
@@ -95,6 +95,7 @@ export async function runList(args: string[]): Promise<void> {
   if (options.json) {
     const jsonOutput = installedSkills.map((skill) => ({
       name: skill.name,
+      description: skill.description,
       path: skill.canonicalPath,
       scope: skill.scope,
       agents: skill.agents.map((a) => agents[a].displayName),
@@ -142,6 +143,11 @@ export async function runList(args: string[]): Promise<void> {
     console.log(
       `${prefix}${CYAN}${paddedName}${RESET} ${DIM}${paddedPath}${RESET} ${DIM}Agents:${RESET} ${agentInfo}`
     );
+
+    const description = sanitizeMetadata(skill.description ?? '');
+    if (description) {
+      console.log(`${prefix}  ${TEXT}${description}${RESET}`);
+    }
   }
 
   console.log(`${BOLD}${scopeLabel} Skills${RESET}`);


### PR DESCRIPTION
## Summary

- Adds the `description` field to both human-readable and `--json` output of the `list` command
- Previously, descriptions were parsed from SKILL.md frontmatter but never displayed — this makes it easier to identify skills at a glance, especially when names collide across providers
- Human-readable output prints an indented description line under each skill's name/path/agents line (skipped when the description is empty)
- JSON output now includes a `description` field in each skill object

This is a rebased re-implementation of #889 (original branch had conflicts with recent `src/list.ts` changes), keeping the same intent and output shape.

## Example

**Before:**

​```
sample-skill  ./.agents/skills/sample-skill  Agents: Codex, Cursor
​```

**After:**

​```
sample-skill  ./.agents/skills/sample-skill  Agents: Codex, Cursor
  A demo skill that helps disambiguate via descriptions
​```

**JSON (`--json`) before:**

​```json
[{ "name": "sample-skill", "path": "...", "scope": "project", "agents": ["Codex", "Cursor"] }]
​```

**JSON (`--json`) after:**

​```json
[{ "name": "sample-skill", "description": "A demo skill that helps disambiguate via descriptions", "path": "...", "scope": "project", "agents": ["Codex", "Cursor"] }]
​```

## Test plan

- [x] Flipped existing test that asserted description was NOT shown → now asserts it IS shown
- [x] Added `description` assertion to the JSON output test
- [x] `pnpm test src/list.test.ts` — 27/28 pass (the one pre-existing failure, `should include list command in banner`, also fails on `main` and is unrelated)
- [x] `pnpm test tests/list-installed.test.ts` — `listInstalledSkills` unit tests pass (description field already populated by parser)
- [x] Manual: `pnpm dev list` and `pnpm dev list --json` show the new description line/field

Rebased follow-up of #889.