### PR TITLE
Add ZCode agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -301,6 +301,7 @@ Skills can be installed to any of these agents:
 | Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
 | Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
 | Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| ZCode | `zcode` | `.zcode/skills/` | `~/.zcode/skills/` |
 | Zencoder, Zenflow | `zencoder`, `zenflow` | `.zencoder/skills/` | `~/.zencoder/skills/` |
 | Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
@@ -427,6 +428,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.tinycloud/skills/`
 - `.trae/skills/`
 - `.windsurf/skills/`
+- `.zcode/skills/`
 - `.zencoder/skills/`
 - `.neovate/skills/`
 - `.pochi/skills/`

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "warp",
     "windsurf",
     "zed",
+    "zcode",
     "zencoder",
     "zenflow",
     "neovate",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -45,6 +45,13 @@ export function getOpenClawGlobalSkillsDir(
   return join(homeDir, '.openclaw/skills');
 }
 
+export function isZCodeInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  return pathExists(join(homeDir, '.zcode')) || pathExists('/Applications/ZCode.app');
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   'aider-desk': {
     name: 'aider-desk',
@@ -645,6 +652,15 @@ export const agents: Record<AgentType, AgentConfig> = {
         (!!zedAppDataHome && existsSync(join(zedAppDataHome, 'Zed'))) ||
         (!!zedFlatpakConfigHome && existsSync(join(zedFlatpakConfigHome, 'zed')))
       );
+    },
+  },
+  zcode: {
+    name: 'zcode',
+    displayName: 'ZCode',
+    skillsDir: '.zcode/skills',
+    globalSkillsDir: join(home, '.zcode/skills'),
+    detectInstalled: async () => {
+      return isZCodeInstalled();
     },
   },
   zencoder: {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -275,6 +275,7 @@ const PRIORITY_PREFIXES = [
   '.roo/skills/',
   '.trae/skills/',
   '.windsurf/skills/',
+  '.zcode/skills/',
   '.zencoder/skills/',
 ];
 

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -31,6 +31,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.roo/skills',
   '.trae/skills',
   '.windsurf/skills',
+  '.zcode/skills',
   '.zencoder/skills',
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export type AgentType =
   | 'warp'
   | 'windsurf'
   | 'zed'
+  | 'zcode'
   | 'zencoder'
   | 'zenflow'
   | 'pochi'

--- a/tests/zcode-agent.test.ts
+++ b/tests/zcode-agent.test.ts
@@ -1,0 +1,31 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { describe, expect, it } from 'vitest';
+import { agents, isZCodeInstalled } from '../src/agents.ts';
+
+describe('ZCode agent support', () => {
+  it('uses ~/.zcode/skills for global skills', () => {
+    expect(agents.zcode.name).toBe('zcode');
+    expect(agents.zcode.displayName).toBe('ZCode');
+    expect(agents.zcode.skillsDir).toBe('.zcode/skills');
+    expect(agents.zcode.globalSkillsDir).toBe(join(homedir(), '.zcode', 'skills'));
+  });
+
+  it('detects ZCode from its home directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.zcode');
+
+    expect(isZCodeInstalled(home, exists)).toBe(true);
+  });
+
+  it('detects ZCode from the macOS app bundle', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === '/Applications/ZCode.app';
+
+    expect(isZCodeInstalled(home, exists)).toBe(true);
+  });
+
+  it('returns false when no known ZCode path exists', () => {
+    expect(isZCodeInstalled('/tmp/home', () => false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add a `zcode` agent adapter using `.zcode/skills` and `~/.zcode/skills`
- detect ZCode from `~/.zcode` or the macOS app bundle at `/Applications/ZCode.app`
- include `.zcode/skills` in local/blob skill discovery paths
- update generated README/package metadata and add focused adapter tests

## Verification

- `corepack pnpm exec vitest run tests/zcode-agent.test.ts tests/full-depth-discovery.test.ts tests/blob-root-skill.test.ts`
- `corepack pnpm format:check`
- `node scripts/validate-agents.ts`

Note: `corepack pnpm type-check` currently fails on upstream `main` with existing errors in `src/git.ts` and `src/skills.ts`; this branch does not introduce new type-check failures beyond that baseline.