### PR TITLE
Fix project update deletion check for GitHub shorthand sources

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -19,6 +19,7 @@ import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
 import { agents, isUniversalAgent } from './agents.ts';
+import { parseSource } from './source-parser.ts';
 import type { AgentType } from './types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -279,6 +280,13 @@ export async function checkAndPromptForDeletions(
     }
   }
   return deletedSkills;
+}
+
+function getProjectCloneSource(entry: LocalSkillLockEntry): string {
+  if (entry.sourceType !== 'github') {
+    return entry.source;
+  }
+  return parseSource(entry.source).url;
 }
 
 export async function updateGlobalSkills(
@@ -544,7 +552,6 @@ export async function updateProjectSkills(
 
   for (const [source, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
-    const sourceUrl = firstEntry.source;
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)
@@ -555,6 +562,7 @@ export async function updateProjectSkills(
     let deletedSkills: string[] = [];
 
     try {
+      const sourceUrl = getProjectCloneSource(firstEntry);
       tempDir = await cloneRepo(sourceUrl, ref);
       const discovered = await discoverSkills(tempDir);
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -191,6 +191,33 @@ describe('Update Cleanup Unit Tests', () => {
       expect(p.confirm).not.toHaveBeenCalled();
       expect(remove.removeCommand).not.toHaveBeenCalled();
     });
+
+    it('should clone GitHub shorthand project sources with a cloneable URL', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            ref: 'feature/install',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      expect(git.cloneRepo).toHaveBeenCalledWith(
+        'https://github.com/owner/repo.git',
+        'feature/install'
+      );
+    });
   });
 
   describe('updateGlobalSkills', () => {


### PR DESCRIPTION
## Problem
Project-scoped updates can print this warning before still updating the skill successfully:

```text
✗ Failed to check for deleted skills from justjavac/minecraft-agent
```

This happens when `skills-lock.json` stores a GitHub source as shorthand, for example `justjavac/minecraft-agent`. The project update deletion check passed that raw shorthand directly to `cloneRepo()`, which effectively tried to clone `justjavac/minecraft-agent`. Git cannot clone that form directly, even though the later install/update path succeeds because it parses the shorthand into `https://github.com/justjavac/minecraft-agent.git`.

## Summary
- Normalize GitHub project lock sources before the project update deletion check clones the source repo.
- Keep non-GitHub project sources on their existing clone path.
- Add a regression test for owner/repo project lock entries with refs.

## Testing
- corepack pnpm vitest run tests/update.test.ts
- corepack pnpm prettier --check src/update.ts tests/update.test.ts
- git diff --check

Note: corepack pnpm tsc --noEmit still reports existing type errors in src/git.ts and src/skills.ts that are unrelated to this change.