### PR TITLE
[codex] Fix Windows update spawn

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -456,7 +456,6 @@ export async function updateGlobalSkills(
     const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
-      shell: process.platform === 'win32',
     });
 
     if (result.status === 0) {
@@ -598,7 +597,6 @@ export async function updateProjectSkills(
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
-          shell: process.platform === 'win32',
         }
       );
 


### PR DESCRIPTION
## Summary

Removes the Windows-only shell wrapper when `skills update` re-invokes the CLI to reinstall updated skills.

## Root cause

`spawnSync(process.execPath, args, { shell: true })` passes the Node executable path through `cmd.exe` on Windows. When Node is installed under `C:\Program Files\nodejs\node.exe`, `cmd.exe` splits the executable path at the space and attempts to run `C:\Program`, causing update reinstalls to fail and emit Node's `DEP0190` warning.

## Validation

- `pnpm test tests/update.test.ts`