### PR TITLE
feat: add explicit skill file includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,26 @@ Skills let agents perform specialized tasks like:
 - Creating PRs following your team's conventions
 - Integrating with external tools (Linear, Notion, etc.)
 
+### Including Supporting Files
+
+By default, a root-level `SKILL.md` installed from a remote repository is treated as a single-file skill so the CLI does not copy an entire application repository into agent skill directories.
+
+If a skill needs supporting files, declare them explicitly in the `files` frontmatter field:
+
+```md
+---
+name: packaged-skill
+description: Demonstrates a skill that ships scripts and templates.
+files:
+  - scripts/
+  - templates/*.md
+  - config.example.json
+  - "!scripts/dev-only.js"
+---
+```
+
+`SKILL.md` is always included. Entries must be relative paths and can be exact files, directories ending in `/`, basic `*` / `**` globs, or negated patterns starting with `!`.
+
 Discover skills at **[skills.sh](https://skills.sh)**
 
 ## Supported Agents

--- a/src/add.ts
+++ b/src/add.ts
@@ -78,6 +78,7 @@ import {
   type BlobSkill,
   type BlobInstallResult,
 } from './blob.ts';
+import { hasExplicitSkillFileIncludes } from './skill-files.ts';
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
   setVersion(version);
@@ -1721,7 +1722,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             agent,
             { global: installGlobally, mode: installMode, eveSubagent: subagent }
           );
-        } else if (tempDir && skill.path === tempDir && skill.rawContent) {
+        } else if (
+          tempDir &&
+          skill.path === tempDir &&
+          skill.rawContent &&
+          !hasExplicitSkillFileIncludes(skill.fileIncludes)
+        ) {
           // Remote root-level SKILL.md: install the skill file, not the whole repository.
           result = await installBlobSkillForAgent(
             { installName: skill.name, files: [{ path: 'SKILL.md', contents: skill.rawContent }] },
@@ -1872,13 +1878,18 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
+            const matchingResult = successful.find((r) => r.skill === skillDisplayName);
+            const installedPath = matchingResult?.canonicalPath || matchingResult?.path;
             // For blob skills, use the snapshot hash; for disk skills, compute from files
             const computedHash =
               blobResult && 'snapshotHash' in skill
                 ? (skill as BlobSkill).snapshotHash
-                : tempDir && skill.path === tempDir && skill.rawContent
+                : tempDir &&
+                    skill.path === tempDir &&
+                    skill.rawContent &&
+                    !hasExplicitSkillFileIncludes(skill.fileIncludes)
                   ? computeSingleFileSkillHash(skill.rawContent)
-                  : await computeSkillFolderHash(skill.path);
+                  : await computeSkillFolderHash(installedPath || skill.path);
             const skillPathValue = skillFiles[skill.name];
             await addSkillToLocalLock(
               skill.name,

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -14,6 +14,11 @@ import { createHash } from 'node:crypto';
 import { parseFrontmatter } from './frontmatter.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import type { Skill } from './types.ts';
+import {
+  hasExplicitSkillFileIncludes,
+  parseSkillFileIncludes,
+  selectSkillSnapshotFiles,
+} from './skill-files.ts';
 
 // ─── Types ───
 
@@ -476,6 +481,7 @@ export async function tryBlobInstall(
     content: string;
     slug: string;
     metadata?: Record<string, unknown>;
+    fileIncludes?: string[];
   }> = [];
 
   for (const { mdPath, content } of mdFetches) {
@@ -499,6 +505,7 @@ export async function tryBlobInstall(
       content,
       slug: toSkillSlug(safeName),
       metadata: data.metadata as Record<string, unknown> | undefined,
+      fileIncludes: parseSkillFileIncludes(data),
     });
   }
 
@@ -546,9 +553,10 @@ export async function tryBlobInstall(
     // dump thousands of unrelated files into .agents/skills/<name>. Keep root
     // skills to their SKILL.md unless/until the skill spec gains an explicit
     // include list for supporting files.
-    const files = folderPath
-      ? download!.files
-      : download!.files.filter((file) => file.path.toLowerCase() === 'skill.md');
+    const files =
+      folderPath || hasExplicitSkillFileIncludes(skill.fileIncludes)
+        ? selectSkillSnapshotFiles(download!.files, skill.fileIncludes)
+        : download!.files.filter((file) => file.path.toLowerCase() === 'skill.md');
 
     return {
       name: skill.name,
@@ -557,6 +565,7 @@ export async function tryBlobInstall(
       // The installer uses the files array directly.
       path: '',
       rawContent: skill.content,
+      fileIncludes: skill.fileIncludes,
       metadata: skill.metadata,
       files,
       snapshotHash:

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -27,6 +27,7 @@ import {
 import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
 import { parseFrontmatter } from './frontmatter.ts';
 import { parseSkillMd } from './skills.ts';
+import { createSkillFileSelector, type SkillFileSelector } from './skill-files.ts';
 
 export type InstallMode = 'symlink' | 'copy';
 
@@ -335,7 +336,7 @@ export async function installSkillForAgent(
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir, agentType);
+      await copyDirectory(skill.path, agentDir, agentType, skill.fileIncludes);
 
       return {
         success: true,
@@ -356,7 +357,7 @@ export async function installSkillForAgent(
 
     // Symlink mode: copy to canonical location and symlink to agent location
     await cleanAndCreateDirectory(canonicalDir);
-    await copyDirectory(skill.path, canonicalDir, agentType);
+    await copyDirectory(skill.path, canonicalDir, agentType, skill.fileIncludes);
 
     // For universal agents with global install, the skill is already in the canonical
     // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
@@ -392,7 +393,7 @@ export async function installSkillForAgent(
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
       await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir, agentType);
+      await copyDirectory(skill.path, agentDir, agentType, skill.fileIncludes);
 
       return {
         success: true,
@@ -458,8 +459,26 @@ function stripIgnoredEveFrontmatter(raw: string): string {
   return `---\n${frontmatter}\n---\n${content.replace(/^\r?\n/u, '')}`;
 }
 
-async function copyDirectory(src: string, dest: string, agentType?: AgentType): Promise<void> {
-  await mkdir(dest, { recursive: true });
+async function copyDirectory(
+  src: string,
+  dest: string,
+  agentType?: AgentType,
+  fileIncludes?: readonly string[]
+): Promise<void> {
+  const selector = createSkillFileSelector(fileIncludes);
+  await copyDirectoryEntries(src, dest, src, selector, agentType);
+}
+
+async function copyDirectoryEntries(
+  src: string,
+  dest: string,
+  root: string,
+  selector: SkillFileSelector,
+  agentType?: AgentType
+): Promise<void> {
+  if (!selector.explicit) {
+    await mkdir(dest, { recursive: true });
+  }
 
   const entries = await readdir(src, { withFileTypes: true });
 
@@ -472,9 +491,14 @@ async function copyDirectory(src: string, dest: string, agentType?: AgentType): 
         const destPath = join(dest, entry.name);
 
         if (entry.isDirectory()) {
-          await copyDirectory(srcPath, destPath, agentType);
+          await copyDirectoryEntries(srcPath, destPath, root, selector, agentType);
         } else {
+          const relativePath = relative(root, srcPath).split(sep).join('/');
+          if (!selector.shouldInclude(relativePath)) return;
+
           try {
+            await mkdir(dirname(destPath), { recursive: true });
+
             if (agentType === 'eve' && entry.name.toLowerCase() === 'skill.md') {
               await writeFile(
                 destPath,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -15,6 +15,8 @@ export interface RemoteSkill {
   sourceUrl: string;
   /** Any additional metadata from frontmatter */
   metadata?: Record<string, unknown>;
+  /** Explicit payload include/exclude patterns from top-level SKILL.md `files` frontmatter */
+  fileIncludes?: string[];
 }
 
 /**

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -3,6 +3,7 @@ import { gunzipSync, inflateRawSync } from 'node:zlib';
 import { parseFrontmatter } from '../frontmatter.ts';
 import { sanitizeMetadata } from '../sanitize.ts';
 import type { HostProvider, ProviderMatch, RemoteSkill } from './types.ts';
+import { parseSkillFileIncludes, selectSkillFileMap } from '../skill-files.ts';
 
 const DISCOVERY_SCHEMA_V2 = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 const MAX_ARCHIVE_UNPACKED_BYTES = 50 * 1024 * 1024;
@@ -419,6 +420,7 @@ export class WellKnownProvider implements HostProvider {
       const content = await response.text();
       const { data } = parseFrontmatter(content);
       if (typeof data.name !== 'string' || typeof data.description !== 'string') return null;
+      const fileIncludes = parseSkillFileIncludes(data);
 
       const files = new Map<string, WellKnownFileContent>();
       files.set('SKILL.md', content);
@@ -450,7 +452,8 @@ export class WellKnownProvider implements HostProvider {
         installName: entry.name,
         sourceUrl: skillMdUrl,
         metadata: data.metadata,
-        files,
+        fileIncludes,
+        files: selectSkillFileMap(files, fileIncludes),
         indexEntry: entry.indexEntry,
       });
     } catch {
@@ -473,6 +476,7 @@ export class WellKnownProvider implements HostProvider {
         const content = new TextDecoder().decode(bytes);
         const { data } = parseFrontmatter(content);
         if (typeof data.name !== 'string' || typeof data.description !== 'string') return null;
+        const fileIncludes = parseSkillFileIncludes(data);
 
         const files = new Map<string, WellKnownFileContent>();
         files.set('SKILL.md', content);
@@ -484,6 +488,7 @@ export class WellKnownProvider implements HostProvider {
           installName: entry.name,
           sourceUrl: entry.artifactUrl,
           metadata: data.metadata,
+          fileIncludes,
           files,
           indexEntry: entry.indexEntry,
         });
@@ -499,6 +504,7 @@ export class WellKnownProvider implements HostProvider {
 
       const { data } = parseFrontmatter(content);
       if (typeof data.name !== 'string' || typeof data.description !== 'string') return null;
+      const fileIncludes = parseSkillFileIncludes(data);
 
       return this.createSkill({
         name: data.name,
@@ -507,7 +513,8 @@ export class WellKnownProvider implements HostProvider {
         installName: entry.name,
         sourceUrl: entry.artifactUrl,
         metadata: data.metadata,
-        files,
+        fileIncludes,
+        files: selectSkillFileMap(files, fileIncludes),
         indexEntry: entry.indexEntry,
       });
     } catch {
@@ -522,6 +529,7 @@ export class WellKnownProvider implements HostProvider {
     installName: string;
     sourceUrl: string;
     metadata: unknown;
+    fileIncludes?: string[];
     files: Map<string, WellKnownFileContent>;
     indexEntry: WellKnownSkillEntry;
   }): WellKnownSkill {
@@ -535,6 +543,7 @@ export class WellKnownProvider implements HostProvider {
         input.metadata && typeof input.metadata === 'object'
           ? (input.metadata as Record<string, unknown>)
           : undefined,
+      fileIncludes: input.fileIncludes,
       files: input.files,
       indexEntry: input.indexEntry,
     };

--- a/src/skill-files.ts
+++ b/src/skill-files.ts
@@ -1,0 +1,155 @@
+export type SkillFileIncludes = readonly string[];
+
+interface CompiledRule {
+  negate: boolean;
+  regex: RegExp;
+}
+
+export interface SkillFileSelector {
+  explicit: boolean;
+  shouldInclude: (filePath: string) => boolean;
+}
+
+export function parseSkillFileIncludes(data: Record<string, unknown>): string[] | undefined {
+  if (!Object.hasOwn(data, 'files')) return undefined;
+  if (!Array.isArray(data.files)) return undefined;
+
+  return data.files
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map(normalizeIncludePattern)
+    .filter((entry): entry is string => entry !== null);
+}
+
+export function hasExplicitSkillFileIncludes(fileIncludes: SkillFileIncludes | undefined): boolean {
+  return fileIncludes !== undefined;
+}
+
+export function createSkillFileSelector(fileIncludes?: SkillFileIncludes): SkillFileSelector {
+  const explicit = hasExplicitSkillFileIncludes(fileIncludes);
+  const rules = explicit ? (fileIncludes ?? []).map(compileRule).filter(isCompiledRule) : [];
+
+  return {
+    explicit,
+    shouldInclude(filePath: string): boolean {
+      const normalized = normalizeSkillFilePath(filePath);
+      if (!normalized) return false;
+      if (isRootSkillMd(normalized)) return true;
+      if (!explicit) return true;
+
+      let included = false;
+      for (const rule of rules) {
+        if (rule.regex.test(normalized)) {
+          included = !rule.negate;
+        }
+      }
+      return included;
+    },
+  };
+}
+
+export function selectSkillSnapshotFiles<T extends { path: string }>(
+  files: T[],
+  fileIncludes?: SkillFileIncludes
+): T[] {
+  const selector = createSkillFileSelector(fileIncludes);
+  return files.filter((file) => selector.shouldInclude(file.path));
+}
+
+export function selectSkillFileMap<T>(
+  files: Map<string, T>,
+  fileIncludes?: SkillFileIncludes
+): Map<string, T> {
+  const selector = createSkillFileSelector(fileIncludes);
+  return new Map([...files].filter(([filePath]) => selector.shouldInclude(filePath)));
+}
+
+function normalizeIncludePattern(input: string): string | null {
+  let pattern = input.trim();
+  if (!pattern) return null;
+
+  let negate = false;
+  if (pattern.startsWith('!')) {
+    negate = true;
+    pattern = pattern.slice(1).trim();
+  }
+
+  while (pattern.startsWith('./')) {
+    pattern = pattern.slice(2);
+  }
+
+  pattern = pattern.replace(/\/+/g, '/');
+  if (!isSafePattern(pattern)) return null;
+  return negate ? `!${pattern}` : pattern;
+}
+
+function normalizeSkillFilePath(filePath: string): string | null {
+  let normalized = filePath.trim().replace(/\\/g, '/').replace(/\/+/g, '/');
+  while (normalized.startsWith('./')) {
+    normalized = normalized.slice(2);
+  }
+
+  if (!isSafePattern(normalized)) return null;
+  return normalized;
+}
+
+function isSafePattern(pattern: string): boolean {
+  if (!pattern || pattern.includes('\0')) return false;
+  if (pattern.startsWith('/') || pattern.startsWith('\\')) return false;
+  if (/^[A-Za-z]:/.test(pattern)) return false;
+  if (pattern.includes('\\')) return false;
+
+  const withoutTrailingSlash = pattern.endsWith('/') ? pattern.slice(0, -1) : pattern;
+  if (!withoutTrailingSlash) return false;
+
+  return withoutTrailingSlash.split('/').every((segment) => segment !== '.' && segment !== '..');
+}
+
+function compileRule(rawPattern: string): CompiledRule | null {
+  const negate = rawPattern.startsWith('!');
+  const pattern = negate ? rawPattern.slice(1) : rawPattern;
+  const directory = pattern.endsWith('/');
+  const normalizedPattern = directory ? pattern.slice(0, -1) : pattern;
+  if (!normalizedPattern) return null;
+
+  const source = globToRegExpSource(normalizedPattern);
+  return {
+    negate,
+    regex: new RegExp(directory ? `^${source}(?:/.*)?$` : `^${source}$`),
+  };
+}
+
+function globToRegExpSource(pattern: string): string {
+  let source = '';
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i]!;
+    if (char === '*') {
+      if (pattern[i + 1] === '*' && pattern[i + 2] === '/') {
+        source += '(?:.*/)?';
+        i += 2;
+      } else if (pattern[i + 1] === '*') {
+        source += '.*';
+        i++;
+      } else {
+        source += '[^/]*';
+      }
+      continue;
+    }
+
+    source += escapeRegExp(char);
+  }
+
+  return source;
+}
+
+function escapeRegExp(char: string): string {
+  return /[\\^$+?.()|[\]{}]/.test(char) ? `\\${char}` : char;
+}
+
+function isCompiledRule(rule: CompiledRule | null): rule is CompiledRule {
+  return rule !== null;
+}
+
+function isRootSkillMd(path: string): boolean {
+  return path.toLowerCase() === 'skill.md';
+}

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -5,6 +5,7 @@ import { sanitizeMetadata } from './sanitize.ts';
 import type { Skill } from './types.ts';
 import { getPluginSkillPaths, getPluginGroupings } from './plugin-manifest.ts';
 import { readLocalLock } from './local-lock.ts';
+import { parseSkillFileIncludes } from './skill-files.ts';
 
 const SKIP_DIRS = ['node_modules', '.git', 'dist', 'build', '__pycache__'];
 
@@ -91,6 +92,7 @@ export async function parseSkillMd(
       description: sanitizeMetadata(data.description),
       path: dirname(skillMdPath),
       rawContent: content,
+      fileIncludes: parseSkillFileIncludes(data),
       metadata: data.metadata,
     };
   } catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,8 @@ export interface Skill {
   path: string;
   /** Raw SKILL.md content for hashing */
   rawContent?: string;
+  /** Explicit payload include/exclude patterns from top-level SKILL.md `files` frontmatter */
+  fileIncludes?: string[];
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
   metadata?: Record<string, unknown>;
@@ -126,4 +128,6 @@ export interface RemoteSkill {
   sourceIdentifier: string;
   /** Any additional metadata from frontmatter */
   metadata?: Record<string, unknown>;
+  /** Explicit payload include/exclude patterns from top-level SKILL.md `files` frontmatter */
+  fileIncludes?: string[];
 }

--- a/src/use.ts
+++ b/src/use.ts
@@ -11,6 +11,7 @@ import { getGitHubToken } from './skill-lock.ts';
 import { discoverSkills, filterSkills, getSkillDisplayName } from './skills.ts';
 import { getOwnerRepo, parseSource } from './source-parser.ts';
 import type { AgentType, Skill } from './types.ts';
+import { createSkillFileSelector, type SkillFileSelector } from './skill-files.ts';
 import {
   wellKnownProvider,
   type WellKnownSkill,
@@ -45,6 +46,7 @@ export type UseSkill =
       directoryName: string;
       rawContent?: string;
       path: string;
+      fileIncludes?: string[];
     }
   | {
       kind: 'well-known';
@@ -172,7 +174,7 @@ export async function materializeUseSkill(skill: UseSkill): Promise<Materialized
   } else if (skill.kind === 'well-known') {
     await writeMapFiles(skillDir, skill.files);
   } else {
-    await copySkillDirectory(skill.path, skillDir);
+    await copySkillDirectory(skill.path, skillDir, skill.fileIncludes);
   }
 
   const skillMd = skill.rawContent ?? (await readFile(join(skillDir, 'SKILL.md'), 'utf-8'));
@@ -292,6 +294,7 @@ export async function runUse(
           directoryName: selected.name,
           rawContent: selected.rawContent,
           path: selected.path,
+          fileIncludes: selected.fileIncludes,
         };
       }
     }
@@ -557,8 +560,25 @@ async function writeSafeFile(
   }
 }
 
-async function copySkillDirectory(src: string, dest: string): Promise<void> {
-  await mkdir(dest, { recursive: true });
+async function copySkillDirectory(
+  src: string,
+  dest: string,
+  fileIncludes?: readonly string[]
+): Promise<void> {
+  const selector = createSkillFileSelector(fileIncludes);
+  await copySkillDirectoryEntries(src, dest, src, selector);
+}
+
+async function copySkillDirectoryEntries(
+  src: string,
+  dest: string,
+  root: string,
+  selector: SkillFileSelector
+): Promise<void> {
+  if (!selector.explicit) {
+    await mkdir(dest, { recursive: true });
+  }
+
   const entries = await readdir(src, { withFileTypes: true });
 
   await Promise.all(
@@ -570,11 +590,15 @@ async function copySkillDirectory(src: string, dest: string): Promise<void> {
         if (!isPathSafe(dest, destPath)) return;
 
         if (entry.isDirectory()) {
-          await copySkillDirectory(srcPath, destPath);
+          await copySkillDirectoryEntries(srcPath, destPath, root, selector);
           return;
         }
 
+        const relPath = relative(root, srcPath).split(sep).join('/');
+        if (!selector.shouldInclude(relPath)) return;
+
         try {
+          await mkdir(dirname(destPath), { recursive: true });
           await cp(srcPath, destPath, { dereference: true, recursive: true });
         } catch (err) {
           if (

--- a/tests/blob-root-skill.test.ts
+++ b/tests/blob-root-skill.test.ts
@@ -8,6 +8,19 @@ description: Build durable backend AI agents with the eve framework.
 # eve
 `;
 
+const ROOT_SKILL_WITH_FILES_MD = `---
+name: packaged-root
+description: Root skill with explicit payload.
+files:
+  - SKILL.md
+  - scripts/
+  - templates/*.md
+  - config.example.json
+  - "!scripts/dev-only.js"
+---
+# Packaged Root
+`;
+
 function okResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -66,6 +79,50 @@ describe('tryBlobInstall root-level skills', () => {
     expect(result).not.toBeNull();
     expect(result!.skills).toHaveLength(1);
     expect(result!.skills[0]!.files).toEqual([{ path: 'SKILL.md', contents: ROOT_SKILL_MD }]);
+    expect(result!.skills[0]!.snapshotHash).not.toBe('full-repo-hash');
+  });
+
+  it('keeps explicit root skill payload files from files frontmatter', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        okResponse({
+          sha: 'root-tree-sha',
+          tree: [
+            { path: 'SKILL.md', type: 'blob', sha: 'skill-sha' },
+            { path: 'scripts/run.js', type: 'blob', sha: 'script-sha' },
+            { path: 'scripts/dev-only.js', type: 'blob', sha: 'dev-sha' },
+            { path: 'templates/card.md', type: 'blob', sha: 'template-sha' },
+            { path: 'templates/card.txt', type: 'blob', sha: 'template-txt-sha' },
+            { path: 'config.example.json', type: 'blob', sha: 'config-sha' },
+            { path: 'packages/app/src/index.ts', type: 'blob', sha: 'package-sha' },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(textResponse(ROOT_SKILL_WITH_FILES_MD))
+      .mockResolvedValueOnce(
+        okResponse({
+          hash: 'full-repo-hash',
+          files: [
+            { path: 'SKILL.md', contents: ROOT_SKILL_WITH_FILES_MD },
+            { path: 'scripts/run.js', contents: 'run' },
+            { path: 'scripts/dev-only.js', contents: 'dev' },
+            { path: 'templates/card.md', contents: '# Card' },
+            { path: 'templates/card.txt', contents: 'Card' },
+            { path: 'config.example.json', contents: '{}' },
+            { path: 'packages/app/src/index.ts', contents: 'export {}' },
+          ],
+        })
+      );
+
+    const result = await tryBlobInstall('vercel/packaged-root');
+
+    expect(result).not.toBeNull();
+    expect(result!.skills[0]!.files.map((file) => file.path)).toEqual([
+      'SKILL.md',
+      'scripts/run.js',
+      'templates/card.md',
+      'config.example.json',
+    ]);
     expect(result!.skills[0]!.snapshotHash).not.toBe('full-repo-hash');
   });
 

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -44,4 +44,66 @@ describe('installer copy mode', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('honors explicit file includes from SKILL.md frontmatter', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-files-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'explicit-files-skill';
+    const skillDir = join(root, 'source-skill');
+    await mkdir(join(skillDir, 'scripts'), { recursive: true });
+    await mkdir(join(skillDir, 'templates'), { recursive: true });
+    await mkdir(join(skillDir, 'docs'), { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      `---
+      name: ${skillName}
+      description: test
+      files:
+        - scripts/
+        - templates/card.md
+        - "!scripts/dev-only.js"
+      ---
+      # Skill
+      `,
+      'utf-8'
+    );
+    await writeFile(join(skillDir, 'scripts', 'run.js'), 'run\n', 'utf-8');
+    await writeFile(join(skillDir, 'scripts', 'dev-only.js'), 'dev\n', 'utf-8');
+    await writeFile(join(skillDir, 'templates', 'card.md'), '# Card\n', 'utf-8');
+    await writeFile(join(skillDir, 'templates', 'card.txt'), 'Card\n', 'utf-8');
+    await writeFile(join(skillDir, 'docs', 'README.md'), '# Docs\n', 'utf-8');
+
+    try {
+      const result = await installSkillForAgent(
+        {
+          name: skillName,
+          description: 'test',
+          path: skillDir,
+          fileIncludes: ['scripts/', 'templates/card.md', '!scripts/dev-only.js'],
+        },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedDir = join(projectDir, '.agents/skills', skillName);
+      await expect(readFile(join(installedDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        'explicit-files-skill'
+      );
+      await expect(readFile(join(installedDir, 'scripts', 'run.js'), 'utf-8')).resolves.toBe(
+        'run\n'
+      );
+      await expect(readFile(join(installedDir, 'templates', 'card.md'), 'utf-8')).resolves.toBe(
+        '# Card\n'
+      );
+      await expect(access(join(installedDir, 'scripts', 'dev-only.js'))).rejects.toThrow();
+      await expect(access(join(installedDir, 'templates', 'card.txt'))).rejects.toThrow();
+      await expect(access(join(installedDir, 'docs'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/skill-file-selection.test.ts
+++ b/tests/skill-file-selection.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSkillFileSelector,
+  parseSkillFileIncludes,
+  selectSkillFileMap,
+  selectSkillSnapshotFiles,
+} from '../src/skill-files.ts';
+
+describe('skill file includes', () => {
+  it('treats missing files frontmatter as non-explicit', () => {
+    expect(parseSkillFileIncludes({ name: 'x' })).toBeUndefined();
+    expect(parseSkillFileIncludes({ files: 'scripts/' })).toBeUndefined();
+    expect(createSkillFileSelector(undefined).explicit).toBe(false);
+  });
+
+  it('normalizes safe files entries and drops unsafe entries', () => {
+    expect(
+      parseSkillFileIncludes({
+        files: [
+          './SKILL.md',
+          'scripts/',
+          '!scripts/dev-only.sh',
+          '../outside',
+          '/absolute',
+          'C:\\absolute',
+          123,
+        ],
+      })
+    ).toEqual(['SKILL.md', 'scripts/', '!scripts/dev-only.sh']);
+  });
+
+  it('always includes root SKILL.md even when explicit includes omit or exclude it', () => {
+    const selector = createSkillFileSelector(['scripts/', '!SKILL.md']);
+
+    expect(selector.explicit).toBe(true);
+    expect(selector.shouldInclude('SKILL.md')).toBe(true);
+    expect(selector.shouldInclude('scripts/build.js')).toBe(true);
+    expect(selector.shouldInclude('README.md')).toBe(false);
+  });
+
+  it('supports exact files, directories, negation, and basic globs', () => {
+    const selector = createSkillFileSelector([
+      'scripts/',
+      'templates/*.md',
+      'references/**/*.md',
+      '!scripts/dev-only.js',
+    ]);
+
+    expect(selector.shouldInclude('scripts/run.js')).toBe(true);
+    expect(selector.shouldInclude('scripts/dev-only.js')).toBe(false);
+    expect(selector.shouldInclude('templates/card.md')).toBe(true);
+    expect(selector.shouldInclude('templates/card.txt')).toBe(false);
+    expect(selector.shouldInclude('references/topic.md')).toBe(true);
+    expect(selector.shouldInclude('references/deep/topic.md')).toBe(true);
+    expect(selector.shouldInclude('references/deep/topic.txt')).toBe(false);
+  });
+
+  it('filters snapshot arrays and file maps with the same selector semantics', () => {
+    const includes = ['scripts/', 'config.example.json', '!scripts/dev-only.js'];
+    const snapshot = selectSkillSnapshotFiles(
+      [
+        { path: 'SKILL.md', contents: '# Skill' },
+        { path: 'scripts/run.js', contents: 'run' },
+        { path: 'scripts/dev-only.js', contents: 'dev' },
+        { path: 'config.example.json', contents: '{}' },
+        { path: 'README.md', contents: 'readme' },
+      ],
+      includes
+    );
+
+    expect(snapshot.map((file) => file.path)).toEqual([
+      'SKILL.md',
+      'scripts/run.js',
+      'config.example.json',
+    ]);
+
+    const map = selectSkillFileMap(
+      new Map([
+        ['SKILL.md', '# Skill'],
+        ['scripts/run.js', 'run'],
+        ['README.md', 'readme'],
+      ]),
+      includes
+    );
+
+    expect([...map.keys()]).toEqual(['SKILL.md', 'scripts/run.js']);
+  });
+});

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -318,6 +318,51 @@ describe('WellKnownProvider', () => {
       expect(skills[0]!.files.has('references/README.md')).toBe(true);
     });
 
+    it('filters v0.2.0 archive payloads with files frontmatter', async () => {
+      const skillMd = `---
+name: archive-skill
+description: Archive skill.
+files:
+  - SKILL.md
+  - references/
+  - "!references/private.md"
+---
+# Archive`;
+      const archive = createTarGz({
+        'SKILL.md': skillMd,
+        'references/README.md': 'Reference',
+        'references/private.md': 'Private',
+        'scripts/run.js': 'run',
+      });
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === 'https://example.com/.well-known/agent-skills/index.json') {
+          return response({
+            $schema: SCHEMA_V2,
+            skills: [
+              {
+                name: 'archive-skill',
+                type: 'archive',
+                description: 'Archive skill.',
+                url: '/downloads/archive-skill.tar.gz',
+                digest: digest(archive),
+              },
+            ],
+          });
+        }
+        if (href === 'https://example.com/downloads/archive-skill.tar.gz') {
+          return response(archive, { headers: { 'content-type': 'application/gzip' } });
+        }
+        return response('not found', { status: 404 });
+      });
+
+      const skills = await provider.fetchAllSkills('https://example.com');
+
+      expect(skills).toHaveLength(1);
+      expect([...skills[0]!.files.keys()]).toEqual(['SKILL.md', 'references/README.md']);
+    });
+
     it('does not process unknown schemas', async () => {
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(
         response({


### PR DESCRIPTION
## Summary

Adds an opt-in `files` frontmatter field for skills that need supporting files.

Root-level remote skills still install only `SKILL.md` by default. A skill author must explicitly list supporting files before the CLI includes them.

## Problem

Today, a repo with a root-level `SKILL.md` installs only that file. This avoids accidentally copying entire app repos, but it also drops legitimate skill payloads such as scripts, templates, and example config files.

Example:

```md
---
name: packaged-skill
description: Uses scripts and templates.
files:
  - scripts/
  - templates/*.md
  - config.example.json
---
```

## Design

- `files` is opt-in only.
- Missing or non-array `files` preserves existing behavior.
- `SKILL.md` is always included.
- Supports exact files, directory entries ending in `/`, basic `*` / `**` globs, and `!` negation.
- Rejects unsafe absolute/traversal patterns.
- Applies the same selector across blob installs, local installs, well-known payloads, and `skills use`.

## Compatibility

This does not revert the root-level `SKILL.md` behavior. Root remote repos are still single-file by default, so app repos and monorepos are not copied wholesale.

Nested skills keep the existing behavior unless they explicitly define `files`.

Related: #1523, #1517, #1241.

## Validation

- `pnpm build`
- `pnpm format`
- `pnpm format:check`
- `./node_modules/.bin/vitest run tests/skill-file-selection.test.ts tests/blob-root-skill.test.ts tests/installer-copy.test.ts tests/wellknown-provider.test.ts`

## Local note

`pnpm test` locally reports 550/553 passing in my Codex-detected shell. The remaining failures are existing interactive-output expectations for banner/confirmation behavior, not related to this change.
