### PR TITLE
fix(detect-agent): ignore Cursor integrated terminal false positives

### DIFF
--- a/src/detect-agent.test.ts
+++ b/src/detect-agent.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('detectAgent', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('does not treat Cursor integrated terminal (CURSOR_TRACE_ID only) as agent', async () => {
+    vi.stubEnv('CURSOR_TRACE_ID', 'trace-123');
+    vi.stubEnv('CURSOR_AGENT', '');
+    vi.stubEnv('CURSOR_EXTENSION_HOST_ROLE', '');
+
+    const { detectAgent } = await import('./detect-agent.ts');
+    const result = await detectAgent();
+
+    expect(result.isAgent).toBe(false);
+  });
+
+  it('treats Cursor agent execution (CURSOR_AGENT) as agent', async () => {
+    vi.stubEnv('CURSOR_TRACE_ID', 'trace-123');
+    vi.stubEnv('CURSOR_AGENT', '1');
+
+    const { detectAgent } = await import('./detect-agent.ts');
+    const result = await detectAgent();
+
+    expect(result.isAgent).toBe(true);
+    expect(result.agent?.name).toBe('cursor-cli');
+  });
+
+  it('treats Cursor agent execution (agent-exec role) as agent', async () => {
+    vi.stubEnv('CURSOR_TRACE_ID', 'trace-123');
+    vi.stubEnv('CURSOR_EXTENSION_HOST_ROLE', 'agent-exec');
+
+    const { detectAgent } = await import('./detect-agent.ts');
+    const result = await detectAgent();
+
+    expect(result.isAgent).toBe(true);
+    expect(result.agent?.name).toBe('cursor-cli');
+  });
+});

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -5,6 +5,36 @@ import type { AgentType } from './types.ts';
 let cachedResult: AgentResult | null = null;
 
 /**
+ * @vercel/detect-agent treats any CURSOR_TRACE_ID as a Cursor agent, but that
+ * variable is also present in Cursor's integrated terminal for regular user
+ * sessions. Require stronger execution signals before enabling agent mode.
+ */
+function hasStrongCursorAgentSignal(): boolean {
+  return (
+    Boolean(process.env.CURSOR_AGENT?.trim()) ||
+    process.env.CURSOR_EXTENSION_HOST_ROLE === 'agent-exec'
+  );
+}
+
+function refineAgentResult(result: AgentResult): AgentResult {
+  if (!result.isAgent || !result.agent) {
+    return result;
+  }
+
+  if (result.agent.name === 'cursor' || result.agent.name === 'cursor-cli') {
+    if (!hasStrongCursorAgentSignal()) {
+      return { isAgent: false, agent: undefined };
+    }
+
+    if (result.agent.name === 'cursor') {
+      return { isAgent: true, agent: { name: 'cursor-cli' } };
+    }
+  }
+
+  return result;
+}
+
+/**
  * Map from @vercel/detect-agent names to skills-cli AgentType identifiers.
  * Only includes agents that exist in both systems.
  */
@@ -29,7 +59,7 @@ const agentNameToType: Record<string, AgentType> = {
  */
 export async function detectAgent(): Promise<AgentResult> {
   if (cachedResult) return cachedResult;
-  cachedResult = await determineAgent();
+  cachedResult = refineAgentResult(await determineAgent());
   if (cachedResult.isAgent) {
     setDetectedAgent(cachedResult.agent.name);
   }


### PR DESCRIPTION
## Summary

Stop treating Cursor's integrated terminal as an automated agent when only `CURSOR_TRACE_ID` is present.

## Motivation

Running `skills add` inside Cursor's integrated terminal was incorrectly detected as an agent session, which auto-enabled `-y` and installed all skills non-interactively.

`@vercel/detect-agent` maps `CURSOR_TRACE_ID` to the `cursor` agent, but that env var is also set for regular user terminal sessions — not just agent execution.

Fixes #1233

## Changes

- Add `hasStrongCursorAgentSignal()` requiring `CURSOR_AGENT` or `CURSOR_EXTENSION_HOST_ROLE=agent-exec`
- Add `refineAgentResult()` to downgrade weak Cursor detections before caching
- Normalize strong-signal `cursor` results to `cursor-cli` when upstream returns early on `CURSOR_TRACE_ID`
- Add regression tests in `src/detect-agent.test.ts`

## Tests

```bash
npm test -- src/detect-agent.test.ts
```

Result: 3 passed

## Notes

- Real Cursor agent runs that set `CURSOR_AGENT` or `agent-exec` continue to use non-interactive mode as intended.
- Other agents detected by `@vercel/detect-agent` are unchanged.