### PR TITLE
fix(discovery): discover triple-nested skills under container dirs

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -334,6 +334,30 @@ export function findSkillMdPaths(tree: RepoTree, subpath?: string): string[] {
           priorityResults.push(skillMd);
           seen.add(skillMd);
         }
+        continue;
+      }
+
+      // SKILL.md three levels deep under a known container prefix
+      // (e.g., "skills/<category>/<product>/<skill>/SKILL.md"). Skip when
+      // an ancestor directory already has its own SKILL.md.
+      if (
+        isContainer &&
+        parts.length === 4 &&
+        parts[3]!.toLowerCase() === 'skill.md' &&
+        !SKIP_DIRS.has(parts[0]!) &&
+        !SKIP_DIRS.has(parts[1]!) &&
+        !SKIP_DIRS.has(parts[2]!)
+      ) {
+        const parentSkillMd = `${fullPrefix}${parts[0]}/SKILL.md`.toLowerCase();
+        const grandParentSkillMd = `${fullPrefix}${parts[0]}/${parts[1]}/SKILL.md`.toLowerCase();
+        if (
+          !lowerSkillMdSet.has(parentSkillMd) &&
+          !lowerSkillMdSet.has(grandParentSkillMd) &&
+          !seen.has(skillMd)
+        ) {
+          priorityResults.push(skillMd);
+          seen.add(skillMd);
+        }
       }
     }
   }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -215,8 +215,8 @@ export async function discoverSkills(
     ...AGENT_PROJECT_SKILL_DIRS.map((dir) => join(searchPath, dir)),
   ];
 
-  // Known skill container dirs are walked one extra level deep so layouts
-  // like `skills/<category>/<skill>/SKILL.md` are discovered without
+  // Known skill container dirs are walked up to two extra levels deep so layouts
+  // like `skills/<category>/<product>/<skill>/SKILL.md` are discovered without
   // requiring `--full-depth`. The repo root (first entry) keeps its
   // existing depth-1 behavior to avoid surfacing unrelated `SKILL.md`
   // files (e.g. `examples/foo/SKILL.md`), and plugin-manifest-declared
@@ -255,12 +255,26 @@ export async function discoverSkills(
         if (foundAtChild || !walkDeep) continue;
         if (SKIP_DIRS.includes(entry.name)) continue;
 
-        // Walk one extra level for catalog layouts.
+        // Walk up to two extra levels for catalog layouts such as
+        // `skills/<category>/<product>/<skill>/SKILL.md`.
         try {
           const grandEntries = await readdir(childDir, { withFileTypes: true });
           for (const grand of grandEntries) {
             if (!grand.isDirectory() || SKIP_DIRS.includes(grand.name)) continue;
-            await tryAddSkillAt(join(childDir, grand.name));
+
+            const grandDir = join(childDir, grand.name);
+            const foundAtGrand = await tryAddSkillAt(grandDir);
+            if (foundAtGrand) continue;
+
+            try {
+              const greatGrandEntries = await readdir(grandDir, { withFileTypes: true });
+              for (const greatGrand of greatGrandEntries) {
+                if (!greatGrand.isDirectory() || SKIP_DIRS.includes(greatGrand.name)) continue;
+                await tryAddSkillAt(join(grandDir, greatGrand.name));
+              }
+            } catch {
+              // Grandchild dir unreadable; skip silently.
+            }
           }
         } catch {
           // Child dir unreadable; skip silently.

--- a/tests/nested-container-discovery.test.ts
+++ b/tests/nested-container-discovery.test.ts
@@ -1,7 +1,7 @@
 /**
- * Tests for bounded depth-2 discovery inside skill container directories.
+ * Tests for bounded depth-3 discovery inside skill container directories.
  *
- * Layouts like `skills/<category>/<skill>/SKILL.md` are common when a repo
+ * Layouts like `skills/<category>/<product>/<skill>/SKILL.md` are common when a repo
  * groups skills by product or category. They should be discovered by
  * `discoverSkills()` and `findSkillMdPaths()` without users having to pass
  * `--full-depth`, while keeping the flat-layout, manifest, and
@@ -133,8 +133,26 @@ describe('discoverSkills — bounded depth-2 inside skill container dirs', () =>
     expect(skills.map((s) => s.name)).toEqual(['real-skill']);
   });
 
-  it('still requires --full-depth for skills deeper than two levels in a container', async () => {
-    writeSkill(join(testDir, 'skills', 'level-1', 'level-2', 'deep-skill'), 'deep-skill');
+  it('discovers triple-nested skills under skills/<category>/<product>/<skill>/SKILL.md', async () => {
+    writeSkill(
+      join(testDir, 'skills', 'ads', 'google-mobile-ads', 'google-mobile-ads-get-started'),
+      'google-mobile-ads-get-started'
+    );
+    writeSkill(join(testDir, 'skills', 'shallow'), 'shallow-skill');
+
+    const skills = await discoverSkills(testDir);
+
+    expect(skills.map((s) => s.name).sort()).toEqual([
+      'google-mobile-ads-get-started',
+      'shallow-skill',
+    ]);
+  });
+
+  it('still requires --full-depth for skills deeper than three levels in a container', async () => {
+    writeSkill(
+      join(testDir, 'skills', 'level-1', 'level-2', 'level-3', 'deep-skill'),
+      'deep-skill'
+    );
     writeSkill(join(testDir, 'skills', 'shallow'), 'shallow-skill');
 
     const defaultSkills = await discoverSkills(testDir);
@@ -207,6 +225,24 @@ describe('findSkillMdPaths — bounded depth-2 inside skill container prefixes',
     ]);
 
     expect(findSkillMdPaths(tree)).toEqual(['skills/real-skill/SKILL.md']);
+  });
+
+  it('returns triple-nested SKILL.md paths under skills/<category>/<product>/<skill>/', () => {
+    const tree = makeTree([
+      'skills/ads/google-mobile-ads/google-mobile-ads-get-started/SKILL.md',
+      'skills/shallow-skill/SKILL.md',
+    ]);
+
+    expect(findSkillMdPaths(tree).sort()).toEqual([
+      'skills/ads/google-mobile-ads/google-mobile-ads-get-started/SKILL.md',
+      'skills/shallow-skill/SKILL.md',
+    ]);
+  });
+
+  it('does not descend past a SKILL.md found at depth 2 in a container', () => {
+    const tree = makeTree(['skills/foo/bar/SKILL.md', 'skills/foo/bar/baz/SKILL.md']);
+
+    expect(findSkillMdPaths(tree)).toEqual(['skills/foo/bar/SKILL.md']);
   });
 
   it('respects the subpath filter while applying depth-2 discovery', () => {


### PR DESCRIPTION
## Summary

Extend bounded skill discovery from depth-2 to depth-3 under known container directories (e.g. `skills/<category>/<product>/<skill>/SKILL.md`).

## Motivation

skills.sh and other tooling generate install commands like:

```bash
npx skills add https://github.com/google/skills --skill google-mobile-ads-get-started
```

These fail today because skills such as `google-mobile-ads-get-started` live three levels deep under the `skills/` container (`skills/ads/google-mobile-ads/google-mobile-ads-get-started/SKILL.md`). Default discovery only walks two levels below container dirs.

Fixes #1513
Related to #1506

## Changes

- **`src/skills.ts`**: Walk up to two extra levels inside known container dirs so triple-nested catalog layouts are discovered without `--full-depth`.
- **`src/blob.ts`**: Mirror the same depth-3 logic in `findSkillMdPaths()` so the blob fast path stays consistent with on-disk discovery.
- **`tests/nested-container-discovery.test.ts`**: Add regression tests for the Google Ads layout, blob shadowing at depth 2, and update the full-depth threshold test (depth 4+ still requires `--full-depth`).

## Tests

```bash
npm test -- tests/nested-container-discovery.test.ts
```

Result: **20/20 passed**

## Notes

- Repo root, plugin-manifest dirs, and `examples/` guardrails are unchanged.
- Skills deeper than three levels under a container still require `--full-depth`.