### PR TITLE
fix: authenticate tree fetch on private-repo 401/404, not only rate-limit

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -100,6 +100,7 @@ export function resetRepoTreeAuthState(): void {
 interface BranchFetchResult {
   tree: RepoTree | null;
   rateLimited: boolean;
+  authRetryable: boolean;
 }
 
 async function fetchTreeBranch(
@@ -130,6 +131,7 @@ async function fetchTreeBranch(
       return {
         tree: { sha: data.sha, branch, tree: data.tree },
         rateLimited: false,
+        authRetryable: false,
       };
     }
 
@@ -137,10 +139,27 @@ async function fetchTreeBranch(
     // (A bare 403 means permission denied, which is not retryable here.)
     const rateLimited =
       response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0';
-    return { tree: null, rateLimited };
+    // A private repo answers 401/404 to an anonymous request (GitHub hides its
+    // existence); a token may turn that into a 200. See issue #1318.
+    const authRetryable = response.status === 401 || response.status === 404;
+    return { tree: null, rateLimited, authRetryable };
   } catch {
-    return { tree: null, rateLimited: false };
+    return { tree: null, rateLimited: false, authRetryable: false };
   }
+}
+
+async function fetchTreeWithToken(
+  ownerRepo: string,
+  branches: string[],
+  getToken: () => string | null
+): Promise<RepoTree | null> {
+  const token = getToken();
+  if (!token) return null;
+  for (const branch of branches) {
+    const result = await fetchTreeBranch(ownerRepo, branch, token);
+    if (result.tree) return result.tree;
+  }
+  return null;
 }
 
 /**
@@ -149,11 +168,13 @@ async function fetchTreeBranch(
  * Tries branches in order: ref (if specified), then main, then master.
  *
  * Authentication is lazy: by default the call goes out unauthenticated,
- * which is enough for the vast majority of users (60 req/hr per IP).
- * Only if GitHub responds with a rate-limit 403 do we ask the optional
- * `getToken` callback for a token and retry. This avoids invoking
- * `gh auth token` on every install, which corporate endpoint security
- * tools flag as suspicious credential extraction. See issue #523.
+ * which is enough for the vast majority of users (60 req/hr per IP). We only
+ * ask the optional `getToken` callback for a token and retry when the
+ * unauthenticated attempt fails in a way a token can fix: a rate-limit 403,
+ * or the 401/404 a private repo returns to anonymous requests. A bare
+ * permission-denied 403 is neither, so we never invoke `gh auth token` for it,
+ * which corporate endpoint security tools flag as suspicious credential
+ * extraction. See issues #523 and #1318.
  */
 export async function fetchRepoTree(
   ownerRepo: string,
@@ -165,17 +186,12 @@ export async function fetchRepoTree(
   // Fast path: once we've seen a rate limit in this process, don't bother
   // retrying unauth on subsequent calls. Go straight to auth.
   if (_rateLimitedThisSession && getToken) {
-    const token = getToken();
-    if (!token) return null;
-    for (const branch of branches) {
-      const result = await fetchTreeBranch(ownerRepo, branch, token);
-      if (result.tree) return result.tree;
-    }
-    return null;
+    return fetchTreeWithToken(ownerRepo, branches, getToken);
   }
 
   // First pass: unauthenticated.
   let rateLimited = false;
+  let authRetryable = false;
   for (const branch of branches) {
     const result = await fetchTreeBranch(ownerRepo, branch, null);
     if (result.tree) return result.tree;
@@ -185,20 +201,21 @@ export async function fetchRepoTree(
       rateLimited = true;
       break;
     }
+    if (result.authRetryable) {
+      // A private repo answers 401/404 to anonymous requests on every branch,
+      // so stop and retry the whole set once with a token.
+      authRetryable = true;
+      break;
+    }
   }
 
-  if (!rateLimited || !getToken) return null;
+  if (!getToken || !(rateLimited || authRetryable)) return null;
 
-  // Lazy fallback: rate limit hit and a token resolver was provided.
-  _rateLimitedThisSession = true;
-  const token = getToken();
-  if (!token) return null;
+  // Remember an IP-level rate limit so later calls skip the unauth pass.
+  // A private-repo 404 is per-repo, not per-IP, so it must not set this flag.
+  if (rateLimited) _rateLimitedThisSession = true;
 
-  for (const branch of branches) {
-    const result = await fetchTreeBranch(ownerRepo, branch, token);
-    if (result.tree) return result.tree;
-  }
-  return null;
+  return fetchTreeWithToken(ownerRepo, branches, getToken);
 }
 
 /**

--- a/tests/blob-fetch-tree-auth.test.ts
+++ b/tests/blob-fetch-tree-auth.test.ts
@@ -46,6 +46,13 @@ function permissionDeniedResponse(): Response {
   });
 }
 
+function notFoundResponse(): Response {
+  return new Response(JSON.stringify({ message: 'Not Found' }), {
+    status: 404,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
 describe('fetchRepoTree lazy auth fallback', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
@@ -104,6 +111,58 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
     expect(result).toBeNull();
     expect(getToken).not.toHaveBeenCalled();
+  });
+
+  it('invokes the token resolver and retries with auth when a private repo 404s unauthenticated', async () => {
+    // GitHub answers 404 (not 403) to anonymous requests for a private repo,
+    // to avoid leaking its existence. The token must be tried on 404. See #1318.
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse())
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE));
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const result = await fetchRepoTree('private/repo', 'master', getToken);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer ghp_fake_token'
+    );
+  });
+
+  it('does not flip the session rate-limit flag on a private-repo 404', async () => {
+    // A 404 is per-repo, not an IP-level rate limit, so a later source must
+    // still attempt the unauthenticated request first.
+    fetchMock
+      .mockResolvedValueOnce(notFoundResponse()) // call 1: unauth → 404
+      .mockResolvedValueOnce(okResponse(SAMPLE_TREE)) // call 1: auth retry → 200
+      .mockResolvedValueOnce(okResponse({ ...SAMPLE_TREE, sha: 'public01' })); // call 2: unauth → 200
+    const getToken = vi.fn(() => 'ghp_fake_token');
+
+    const first = await fetchRepoTree('private/repo', 'master', getToken);
+    const second = await fetchRepoTree('public/repo', 'main', getToken);
+
+    expect(first?.sha).toBe('deadbeef');
+    expect(second?.sha).toBe('public01');
+    // call 1: unauth + auth = 2; call 2: unauth only = 1 → 3 total.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const secondCallFirstInit = fetchMock.mock.calls[2]?.[1] as RequestInit;
+    expect(
+      (secondCallFirstInit.headers as Record<string, string>)['Authorization']
+    ).toBeUndefined();
+    // The token is consulted only for the private repo, not the public one.
+    expect(getToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null gracefully when a private repo 404s and no token resolver is provided', async () => {
+    fetchMock.mockResolvedValueOnce(notFoundResponse());
+
+    const result = await fetchRepoTree('private/repo', 'master');
+
+    expect(result).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('returns null gracefully when rate-limited and no token resolver is provided', async () => {


### PR DESCRIPTION
## Summary

`skills update` can never refresh skills installed from a **private** GitHub repo. It reports `✗ Failed to fetch tree for <org>/<repo>` and then `✓ All global skills are up to date`, applying nothing — even though the same skills were installable via `add` (which clones over the user's git auth) and a valid token is available.

Fixes #1318.

## Root cause

The update *check* goes through `fetchRepoTree` → `fetchTreeBranch`, which only consulted the `getToken` resolver after a **rate-limit 403** (`x-ratelimit-remaining: 0`). A private repo answers **404** to an anonymous request (GitHub hides its existence), so:

- the first unauthenticated pass returns 404 on every branch,
- `rateLimited` stays `false`, and
- `fetchRepoTree` returns `null` with the token **never tried**.

Because the *check* stage fails here, the clone-based *apply* stage (which would have worked) is never reached. Setting `GITHUB_TOKEN`/`GH_TOKEN` doesn't help, because the first per-source request is hardcoded to send no token.

## Fix

Treat the **401/404** from an anonymous request as *auth-retryable* and retry the branch set once with a token — mirroring the existing rate-limit fallback. This keeps the lazy-auth design intact:

- Public repos still resolve on the unauthenticated first pass (no token, no `gh auth token` subprocess) — the common case is unchanged.
- A bare permission-denied **403** stays non-retryable, so `gh auth token` is still never spawned for it. This preserves the behavior #523 added (corporate endpoint-security tools flag `gh auth token` as credential extraction), and the existing "does not invoke the token resolver on a non-rate-limit 403" test still passes.
- A private-repo 404 is per-repo, not per-IP, so it does **not** flip the session-wide `_rateLimitedThisSession` fast-path the way an IP-level rate-limit 403 does.

The two authenticated retry loops (rate-limit fast path + post-failure fallback) are deduped into a small `fetchTreeWithToken` helper.

## Tests

Added to `tests/blob-fetch-tree-auth.test.ts`:

- private-repo **404** unauth → token resolver invoked → authenticated retry → success
- a 404 does **not** flip the session rate-limit flag (a later source still tries unauthenticated first; the token is consulted only for the private repo)
- 404 with no token resolver returns `null` gracefully

All 9 tests in that file pass; the directly-related `tests/update.test.ts` is also green. (Some unrelated suites — `list`, `remove`, `sync` — fail identically on a pristine `main` in my environment, and `tsc --noEmit` reports pre-existing errors in `src/git.ts`/`src/skills.ts`; neither is touched by this change.)

## Related, but out of scope

A commenter on #1318 noted a second variant: when the lock `source` is a GitHub **SSH** URL (`git@github.com:<org>/<repo>.git`), the update path interpolates it verbatim into the REST path and 404s *regardless* of token, because `owner/repo` is never parsed out. That's a separate fix in the update path (resolve `entry.source` through `getOwnerRepo()` before calling `fetchRepoTree`) and is left for a follow-up; the core "404 never authenticates" bug fixed here applies to the normal `<org>/<repo>` shorthand.
