### PR TITLE
fix(add): skip global-unsupported agents for implicit global installs

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -9,6 +9,7 @@ import {
   getLockSource,
   getProjectLockSourceUrl,
   formatEveInstallPromptMessage,
+  filterImplicitUnsupportedGlobalAgents,
 } from './add.ts';
 
 function countPathLinesForSkill(text: string, skillName: string): number {
@@ -156,6 +157,36 @@ description: Mixed copied destination regression test
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('✓ multi-target-skill (copied)');
     expect(countPathLinesForSkill(result.stdout, 'multi-target-skill')).toBe(2);
+  });
+
+  it('should skip global-unsupported agents for implicit global installs', () => {
+    const result = filterImplicitUnsupportedGlobalAgents(
+      ['codex', 'promptscript', 'eve'],
+      { global: true },
+      true
+    );
+
+    expect(result).toEqual(['codex']);
+  });
+
+  it('should skip global-unsupported auto-selected detected agents', () => {
+    const result = filterImplicitUnsupportedGlobalAgents(
+      ['codex', 'promptscript'],
+      { global: true, agent: ['codex', 'promptscript'], agentAutoSelected: true },
+      true
+    );
+
+    expect(result).toEqual(['codex']);
+  });
+
+  it('should preserve explicitly requested global-unsupported agents', () => {
+    const result = filterImplicitUnsupportedGlobalAgents(
+      ['promptscript'],
+      { global: true, agent: ['promptscript'] },
+      true
+    );
+
+    expect(result).toEqual(['promptscript']);
   });
 
   it('should describe Eve project installs as for the eve agent to use', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -355,6 +355,20 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
   return result;
 }
 
+export function filterImplicitUnsupportedGlobalAgents(
+  targetAgents: AgentType[],
+  options: AddOptions,
+  installGlobally: boolean
+): AgentType[] {
+  if (!installGlobally) return targetAgents;
+
+  const explicitSpecificAgents =
+    options.agent !== undefined && options.agent.length > 0 && !options.agent.includes('*');
+  if (explicitSpecificAgents && !options.agentAutoSelected) return targetAgents;
+
+  return targetAgents.filter((agent) => agents[agent].globalSkillsDir !== undefined);
+}
+
 /**
  * Builds result lines from installation results, splitting by universal vs symlinked
  */
@@ -543,6 +557,8 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  /** Internal: true when agent targets were inferred from detected agent context. */
+  agentAutoSelected?: boolean;
   /**
    * Eve subagent targets. Each value is a subagent name; `root` (or `.`)
    * selects the root agent. Implies installing for Eve.
@@ -756,6 +772,8 @@ async function handleWellKnownSkills(
 
     installGlobally = scope as boolean;
   }
+
+  targetAgents = filterImplicitUnsupportedGlobalAgents(targetAgents, options, installGlobally);
 
   // Determine install mode (symlink vs copy)
   let installMode: InstallMode = options.copy ? 'copy' : 'symlink';
@@ -1062,6 +1080,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const mappedAgent = getAgentType(agentResult.agent.name);
       if (mappedAgent) {
         options.agent = ensureUniversalAgents([mappedAgent]);
+        options.agentAutoSelected = true;
       }
     }
   }
@@ -1494,8 +1513,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
-
     let installGlobally = options.global ?? false;
 
     // Check if any selected agents support global installation
@@ -1526,6 +1543,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       installGlobally = scope as boolean;
     }
+
+    targetAgents = filterImplicitUnsupportedGlobalAgents(targetAgents, options, installGlobally);
+
+    const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
 
     // Determine install mode (symlink vs copy)
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';


### PR DESCRIPTION
## Summary

- filter global-unsupported agents out of implicit/no-agent global install targets
- preserve explicit targets, so `--agent promptscript -g` still reports the unsupported-agent error
- add unit coverage for implicit, auto-selected, and explicit cases

Fixes #1352
Fixes #1424
Fixes #1496

## Why

`ensureUniversalAgents()` adds every universal agent, and PromptScript is universal but has no `globalSkillsDir`. So `skills add <source> -g` installs the canonical `.agents/skills` copy fine, then still reports:

`PromptScript: PromptScript does not support global skill installation`

Implicit global targets should skip agents that can't be installed globally. Explicit ones should keep erroring.

`selectAgentsInteractive()` already filters these agents, so this only covers the non-interactive paths.

## Validation

Rebased on `main` (v1.5.20):

- `tsc --noEmit` and `prettier --check src/add.ts src/add.test.ts` clean
- `vitest run src/add.test.ts` — 49/49 pass
- full suite green except 3 pre-existing `detect-agent.test.ts` env failures on unmodified `main`

Before, in a Codex-like env:

```
■  Failed to install 1
   ✗ global-skill → PromptScript: PromptScript does not support global skill installation
```

After: installs clean, no failure line. `--agent promptscript -g` still errors.

## Note

The `useEve` branch sets `targetAgents = ['eve']`, which this filter empties. I couldn't reach it end-to-end, but happy to guard it if you'd rather close that off here.
