### PR TITLE
fix: validate update options

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -88,6 +88,16 @@ describe('skills CLI', () => {
     });
   });
 
+  describe('update options', () => {
+    it('should reject unknown options before running update', () => {
+      const result = runCli(['update', '--dry-run', '-g']);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Unknown option: --dry-run');
+      expect(result.stdout).not.toContain('Checking for skill updates');
+    });
+  });
+
   describe('logo display', () => {
     it('should not display logo for list command', () => {
       const output = runCliOutput(['list']);

--- a/src/update.ts
+++ b/src/update.ts
@@ -40,10 +40,12 @@ export interface UpdateCheckOptions {
   yes?: boolean;
   /** Optional skill name(s) to filter on (positional args) */
   skills?: string[];
+  /** Command-line parsing errors that should stop before checking for updates */
+  errors?: string[];
 }
 
 export function parseUpdateOptions(args: string[]): UpdateCheckOptions {
-  const options: UpdateCheckOptions = {};
+  const options: UpdateCheckOptions = { errors: [] };
   const positional: string[] = [];
   for (const arg of args) {
     if (arg === '-g' || arg === '--global') {
@@ -52,6 +54,8 @@ export function parseUpdateOptions(args: string[]): UpdateCheckOptions {
       options.project = true;
     } else if (arg === '-y' || arg === '--yes') {
       options.yes = true;
+    } else if (arg.startsWith('-')) {
+      options.errors!.push(`Unknown option: ${arg}`);
     } else if (!arg.startsWith('-')) {
       positional.push(arg);
     }
@@ -633,6 +637,14 @@ export function printLegacyProjectSkills(
 
 export async function runUpdate(args: string[] = []): Promise<void> {
   const options = parseUpdateOptions(args);
+
+  if (options.errors?.length) {
+    for (const error of options.errors) {
+      console.error(error);
+    }
+    process.exit(1);
+  }
+
   const scope = await resolveUpdateScope(options);
 
   if (options.skills) {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { updateProjectSkills, updateGlobalSkills } from '../src/update.ts';
+import { parseUpdateOptions, updateProjectSkills, updateGlobalSkills } from '../src/update.ts';
 import * as git from '../src/git.ts';
 import * as skills from '../src/skills.ts';
 import * as blob from '../src/blob.ts';
@@ -267,6 +267,15 @@ describe('Update Cleanup Unit Tests', () => {
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'skills/skill-a')
       );
+    });
+  });
+});
+
+describe('parseUpdateOptions', () => {
+  it('rejects unknown flags instead of silently ignoring them', () => {
+    expect(parseUpdateOptions(['--dry-run', '-g'])).toEqual({
+      errors: ['Unknown option: --dry-run'],
+      global: true,
     });
   });
 });


### PR DESCRIPTION
I just faced this issue #1393 while using the cmd on my workspace as well.

## Summary

- reject unknown `skills update` options before resolving update scope or checking locks
- add parser and CLI regression coverage for `skills update --dry-run -g`

## Why

`skills update` previously ignored unknown flags. A command like `skills update --dry-run -g` looked like a safe preview but actually ran as `skills update -g`, which could update global skills unexpectedly.



## Verification

- `pnpm test tests/update.test.ts src/cli.test.ts`
- `pnpm format:check`
- `node src/cli.ts update --dry-run -g` exits with `Unknown option: --dry-run`