### PR TITLE
feat: add Grok agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -272,6 +272,7 @@ Skills can be installed to any of these agents:
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Grok | `grok` | `.grok/skills/` | `~/.grok/skills/` |
 | Hermes Agent | `hermes-agent` | `.hermes/skills/` | `~/.hermes/skills/` |
 | inference.sh | `inference-sh` | `.inferencesh/skills/` | `~/.inferencesh/skills/` |
 | Jazz | `jazz` | `.jazz/skills/` | `~/.jazz/skills/` |
@@ -401,6 +402,7 @@ to also discover `SKILL.md` files outside these container directories
 - `agent/skills/`
 - `.forge/skills/`
 - `.goose/skills/`
+- `.grok/skills/`
 - `.hermes/skills/`
 - `.inferencesh/skills/`
 - `.jazz/skills/`

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "gemini-cli",
     "github-copilot",
     "goose",
+    "grok",
     "hermes-agent",
     "inference-sh",
     "jazz",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -334,6 +334,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(configHome, 'goose'));
     },
   },
+  grok: {
+    name: 'grok',
+    displayName: 'Grok',
+    skillsDir: '.grok/skills',
+    globalSkillsDir: join(home, '.grok/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.grok'));
+    },
+  },
   'hermes-agent': {
     name: 'hermes-agent',
     displayName: 'Hermes Agent',

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -21,6 +21,7 @@ const agentNameToType: Record<string, AgentType> = {
   'augment-cli': 'augment',
   opencode: 'opencode',
   'github-copilot': 'github-copilot',
+  grok: 'grok',
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type AgentType =
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'
+  | 'grok'
   | 'hermes-agent'
   | 'inference-sh'
   | 'iflow-cli'

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -198,6 +198,18 @@ describe('use command', () => {
       });
     });
 
+    it('starts Grok interactively with the prompt argument', async () => {
+      const fake = createFakeSpawn({ closeCode: 0 });
+
+      await expect(launchAgentInteractively('grok', 'prompt body', fake.spawn)).resolves.toBe(0);
+
+      expect(fake.calls[0]).toMatchObject({
+        command: 'grok',
+        args: ['prompt body'],
+        options: { stdio: 'inherit' },
+      });
+    });
+
     it('returns nonzero agent exit codes', async () => {
       const fake = createFakeSpawn({ closeCode: 37 });
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -82,6 +82,7 @@ const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 const USE_AGENT_CONFIGS: Partial<Record<AgentType, UseAgentConfig>> = {
   'claude-code': { command: 'claude', args: [] },
   codex: { command: 'codex', args: [] },
+  grok: { command: 'grok', args: [] },
 };
 const SUPPORTED_USE_AGENTS = Object.keys(USE_AGENT_CONFIGS) as AgentType[];
 

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -72,6 +72,17 @@ describe('XDG config paths', () => {
     });
   });
 
+  describe('Grok', () => {
+    it('uses .grok/skills for project skills', () => {
+      expect(agents.grok.skillsDir).toBe('.grok/skills');
+    });
+
+    it('uses ~/.grok/skills for global skills', () => {
+      const expected = join(home, '.grok', 'skills');
+      expect(agents.grok.globalSkillsDir).toBe(expected);
+    });
+  });
+
   describe('Antigravity CLI', () => {
     it('uses ~/.gemini/antigravity-cli/skills for global skills', () => {
       const expected = join(home, '.gemini', 'antigravity-cli', 'skills');


### PR DESCRIPTION
## Summary

Adds **Grok** (xAI coding agent) to the supported agents list so skills can be installed with:

```bash
npx skills add <source> -a grok
npx skills add <source> -a grok -g   # global: ~/.grok/skills/
```

| Scope | Path |
| --- | --- |
| Project | `.grok/skills/` |
| Global | `~/.grok/skills/` |

These match Grok’s documented skill discovery directories (`./.grok/skills/`, `~/.grok/skills/`). Detection uses the presence of `~/.grok`.

Also enables interactive use:

```bash
npx skills use <source> --skill <name> --agent grok
```

## Changes

- `src/types.ts` / `src/agents.ts` — `grok` agent config
- `src/use.ts` — launch via `grok` CLI
- `README.md` / `package.json` — regenerated via `scripts/sync-agents.ts`
- Tests for paths and `skills use --agent grok`

## Test plan

- [x] `node --experimental-strip-types scripts/validate-agents.ts`
- [x] `node --experimental-strip-types scripts/sync-agents.ts`
- [x] `pnpm exec vitest run tests/xdg-config-paths.test.ts src/use.test.ts -t "Grok|starts Grok"`
- [ ] Install a skill with `-a grok` and confirm it lands in `.grok/skills/` / `~/.grok/skills/`
- [ ] Grok discovers the installed skill