### PR TITLE
fix: clean up upstream-deleted skills whose lock key differs from folder name

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -101,6 +101,35 @@ This is a test skill.
       const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
       expect(updatedLock.skills['stale-skill']).toBeUndefined();
     });
+
+    it('should clean all stale lock entries with --all', () => {
+      const lockPath = join(testDir, 'skills-lock.json');
+      writeFileSync(
+        lockPath,
+        JSON.stringify(
+          {
+            version: 1,
+            skills: {
+              'stale-skill': {
+                source: 'some-source',
+                sourceType: 'github',
+                computedHash: 'somehash',
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      const result = runCli(['remove', '--all', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.exitCode).toBe(0);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['stale-skill']).toBeUndefined();
+    });
   });
 
   describe('with skills installed', () => {
@@ -189,6 +218,36 @@ This is a test skill.
       expect(updatedLock.skills['stale-skill']).toBeUndefined();
     });
 
+    it('should remove a sanitized folder using its exact local lock key', () => {
+      createTestSkill('ce-review');
+      const lockPath = join(testDir, 'skills-lock.json');
+      writeFileSync(
+        lockPath,
+        JSON.stringify(
+          {
+            version: 1,
+            skills: {
+              'ce:review': {
+                source: 'everyinc/compound-engineering-plugin',
+                sourceType: 'github',
+                computedHash: 'somehash',
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      const result = runCli(['remove', 'ce:review', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(existsSync(join(skillsDir, 'ce-review'))).toBe(false);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['ce:review']).toBeUndefined();
+    });
+
     it('should be case-insensitive when matching skill names', () => {
       const result = runCli(['remove', 'SKILL-ONE', '-y'], testDir);
 
@@ -270,6 +329,48 @@ This is a test skill.
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Successfully removed');
       expect(existsSync(globalSkillDir)).toBe(false);
+    });
+
+    it('should remove a sanitized folder and its exact global lock key', () => {
+      const testHome = join(testDir, 'home');
+      const globalSkillDir = createTestSkill(
+        'ce-review',
+        'A plugin skill',
+        join(testHome, '.agents', 'skills')
+      );
+      const lockPath = join(testHome, '.local', 'state', 'skills', '.skill-lock.json');
+      mkdirSync(join(testHome, '.local', 'state', 'skills'), { recursive: true });
+      writeFileSync(
+        lockPath,
+        JSON.stringify(
+          {
+            version: 3,
+            skills: {
+              'ce:review': {
+                source: 'everyinc/compound-engineering-plugin',
+                sourceType: 'github',
+                sourceUrl: 'https://github.com/everyinc/compound-engineering-plugin',
+                skillFolderHash: 'somehash',
+                installedAt: '2026-07-01T00:00:00.000Z',
+                updatedAt: '2026-07-01T00:00:00.000Z',
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      const result = runCli(['remove', 'ce-review', '--global', '-y'], testDir, {
+        HOME: testHome,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Successfully removed');
+      expect(existsSync(globalSkillDir)).toBe(false);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['ce:review']).toBeUndefined();
     });
   });
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -23,6 +23,41 @@ export interface RemoveOptions {
   all?: boolean;
 }
 
+/**
+ * Resolve requested skill names to canonical removal targets.
+ *
+ * On-disk folder names are the result of sanitizeName() at install time, but
+ * lock-file keys keep the original name, which may contain characters
+ * sanitizeName() rewrites — e.g. the ':' in plugin skills such as "ce:review"
+ * maps to the folder "ce-review". Matching purely on folder names therefore
+ * misses lock-only or name-mismatched skills (and stale lock entries whose
+ * folder is already gone). Every candidate is canonicalized by its sanitized
+ * name, preferring the lock key, so downstream disk cleanup (which
+ * re-sanitizes) and lock removal (which needs the exact key) both target the
+ * right thing.
+ */
+export function resolveSkillsToRemove(
+  requested: string[],
+  folderNames: string[],
+  lockKeys: string[] = []
+): string[] {
+  const identityBySanitized = new Map<string, string>();
+  for (const folder of folderNames) {
+    identityBySanitized.set(sanitizeName(folder), folder);
+  }
+  // Lock keys win: they carry the exact key needed for lock removal.
+  for (const key of lockKeys) {
+    identityBySanitized.set(sanitizeName(key), key);
+  }
+
+  const matched = new Set<string>();
+  for (const name of requested) {
+    const hit = identityBySanitized.get(sanitizeName(name));
+    if (hit) matched.add(hit);
+  }
+  return Array.from(matched);
+}
+
 export async function removeCommand(skillNames: string[], options: RemoveOptions) {
   // Auto-enable non-interactive mode when running inside an AI agent
   const agentResult = await detectAgent();
@@ -86,19 +121,13 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     ? Object.keys((await readSkillLock()).skills)
     : Object.keys((await readLocalLock(cwd)).skills);
 
-  // Requested skills that are gone from disk but still have a stale lock entry.
-  // These must be cleaned up even when no skills remain installed on disk, otherwise
-  // the entry lingers forever (e.g. a skill deleted upstream during `skills update`).
-  const staleLockSkills =
-    !options.all && skillNames.length > 0
-      ? skillNames.filter(
-          (name) =>
-            !installedSkills.some((s) => s.toLowerCase() === name.toLowerCase()) &&
-            lockSkillsKeys.some((k) => k.toLowerCase() === name.toLowerCase())
-        )
+  const requestedSkills = options.all ? [...installedSkills, ...lockSkillsKeys] : skillNames;
+  const resolvedRequestedSkills =
+    options.all || skillNames.length > 0
+      ? resolveSkillsToRemove(requestedSkills, installedSkills, lockSkillsKeys)
       : [];
 
-  if (installedSkills.length === 0 && staleLockSkills.length === 0) {
+  if (installedSkills.length === 0 && resolvedRequestedSkills.length === 0) {
     p.outro(pc.yellow('No skills found to remove.'));
     return;
   }
@@ -118,19 +147,9 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   let selectedSkills: string[] = [];
 
   if (options.all) {
-    selectedSkills = installedSkills;
+    selectedSkills = resolvedRequestedSkills;
   } else if (skillNames.length > 0) {
-    selectedSkills = installedSkills.filter((s) =>
-      skillNames.some((name) => name.toLowerCase() === s.toLowerCase())
-    );
-
-    // Requested skills missing from disk but still present in the lock file (computed
-    // above) are mapped back to their exact lock key so the stale entry can be cleaned up.
-    const mappedMissingSkills = staleLockSkills.map(
-      (name) => lockSkillsKeys.find((k) => k.toLowerCase() === name.toLowerCase()) || name
-    );
-
-    selectedSkills.push(...mappedMissingSkills);
+    selectedSkills = resolvedRequestedSkills;
 
     if (selectedSkills.length === 0) {
       p.log.error(`No matching skills found for: ${skillNames.join(', ')}`);
@@ -153,7 +172,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
       process.exit(0);
     }
 
-    selectedSkills = selected as string[];
+    selectedSkills = resolveSkillsToRemove(selected as string[], installedSkills, lockSkillsKeys);
   }
 
   let targetAgents: AgentType[];

--- a/tests/resolve-skills-to-remove.test.ts
+++ b/tests/resolve-skills-to-remove.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for resolveSkillsToRemove in remove.ts
+ *
+ * Regression coverage for the "No matching skills found" bug during
+ * `skills update`: lock keys can contain characters that sanitizeName()
+ * rewrites (e.g. the ':' in plugin skills like "ce:review", whose on-disk
+ * folder is "ce-review"). Matching only against on-disk folder names then
+ * fails, and stale lock entries whose folder is already gone can never be
+ * cleaned — so the deletion warning reappears on every update.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveSkillsToRemove } from '../src/remove.ts';
+
+describe('resolveSkillsToRemove', () => {
+  it('matches a plugin lock key against its sanitized on-disk folder', () => {
+    // Requested by the lock key (colon); folder on disk is the sanitized form.
+    expect(resolveSkillsToRemove(['ce:review'], ['ce-review'], ['ce:review'])).toEqual([
+      'ce:review',
+    ]);
+  });
+
+  it('matches when the request uses the sanitized folder name', () => {
+    // Requested with a hyphen; still resolves to the lock key so lock removal
+    // keys off the real entry.
+    expect(resolveSkillsToRemove(['ce-review'], ['ce-review'], ['ce:review'])).toEqual([
+      'ce:review',
+    ]);
+  });
+
+  it('resolves stale lock-only entries whose folder is already gone', () => {
+    // The on-disk folder was already removed but the lock still tracks it.
+    expect(resolveSkillsToRemove(['ce:review'], [], ['ce:review'])).toEqual(['ce:review']);
+  });
+
+  it('prefers the lock key over the on-disk folder identity', () => {
+    // Both present: the returned identity must be the lock key so that
+    // downstream lock removal succeeds (disk cleanup re-sanitizes anyway).
+    expect(resolveSkillsToRemove(['ce:review'], ['ce-review'], ['ce:review'])).not.toContain(
+      'ce-review'
+    );
+  });
+
+  it('handles ordinary skills where folder name equals lock key', () => {
+    expect(resolveSkillsToRemove(['my-skill'], ['my-skill'], ['my-skill'])).toEqual(['my-skill']);
+  });
+
+  it('falls back to folder matching when no lock keys are supplied', () => {
+    // Untracked skills still resolve from their on-disk folder identity.
+    expect(resolveSkillsToRemove(['ce:review'], ['ce-review'])).toEqual(['ce-review']);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(resolveSkillsToRemove(['CE:Review'], ['ce-review'], ['ce:review'])).toEqual([
+      'ce:review',
+    ]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(resolveSkillsToRemove(['does-not-exist'], ['ce-review'], ['ce:review'])).toEqual([]);
+  });
+
+  it('deduplicates when multiple requests resolve to the same identity', () => {
+    expect(resolveSkillsToRemove(['ce:review', 'ce-review'], ['ce-review'], ['ce:review'])).toEqual(
+      ['ce:review']
+    );
+  });
+
+  it('resolves every candidate for a bulk (--all style) request', () => {
+    const installed = ['ce-review', 'my-skill'];
+    const lockKeys = ['ce:review', 'my-skill'];
+    const result = resolveSkillsToRemove([...installed, ...lockKeys], installed, lockKeys);
+    expect(new Set(result)).toEqual(new Set(['ce:review', 'my-skill']));
+  });
+});


### PR DESCRIPTION
## Problem

During `skills update`, when a skill has been deleted upstream the CLI warns and offers to remove the local copy — but removal fails and the warning comes back on every subsequent run:

```
Warning: The following skills from everyinc/compound-engineering-plugin appear to have been deleted upstream:
  • ce:review
◇  Would you like to remove the local copies of these deleted skills? › Yes
Removing ce:review...
◇  Found 77 unique installed skill(s)
■  No matching skills found for: ce:review
```

## Root cause

Lock-file keys keep the original skill name, which for plugin skills contains a `:` (e.g. `ce:review`). The on-disk folder is `sanitizeName()`'d, so the `:` becomes `-` → `ce-review`. Two bugs follow:

1. **`removeCommand` (`src/remove.ts`)** matched requested names only against on-disk folder names by exact lowercase equality, and keyed the global-lock removal off the matched *folder* name. So `ce:review` never matched `ce-review`, and a stale lock entry whose folder was already gone could not be resolved at all → `No matching skills found`.
2. **`checkAndPromptForDeletions` (`src/update.ts`)** delegated entirely to `removeCommand`, which never touches the project-scoped local lock. Even a successful deletion left the lock entry behind, so the "deleted upstream" warning reappeared on every update.

## Fix

- Add `resolveSkillsToRemove()`: canonicalizes every candidate by its `sanitizeName` identity and **prefers the lock key**, so `ce:review` and `ce-review` both resolve to the lock key. Disk cleanup re-sanitizes (targets `ce-review`); lock removal uses the exact key (`ce:review`).
- `removeCommand` now folds the global lock keys into the candidate set for `-g` removals, so name-mismatched and stale lock-only entries resolve and get cleaned. This covers both the explicit-name and `--all` paths.
- `checkAndPromptForDeletions` now drops the lock entry by its exact key — `removeSkillFromLock` (global) or `removeSkillFromLocalLock` (project) — guaranteeing the warning does not recur in either scope, even when the folder is already gone.

## Testing

- New `tests/resolve-skills-to-remove.test.ts` (10 cases): colon-key ↔ folder matching, stale lock-only entries, lock-key preference, case-insensitivity, `--all`-style bulk, and no-match.
- Extended `tests/update.test.ts` to assert the exact-key lock cleanup fires (`removeSkillFromLocalLock` / `removeSkillFromLock`) for project and global deletions.
- `39/39` pass across the resolver, update, and remove suites. `prettier --check` clean.

> Note: `pnpm type-check` reports 3 pre-existing errors in `src/git.ts` and `src/skills.ts` on `main` (present without this change). This PR touches neither file and introduces no new type errors.
