### PR TITLE
Skip global-unsupported auto agent targets

### DIFF
--- a/src/add-prompt.test.ts
+++ b/src/add-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { promptForAgents } from './add.js';
+import { ensureUniversalAgents, filterAgentsForRequestedScope, promptForAgents } from './add.js';
+import { agents, getUniversalAgents } from './agents.js';
 import * as skillLock from './skill-lock.js';
 import * as searchMultiselectModule from './prompts/search-multiselect.js';
 
@@ -99,5 +100,32 @@ describe('promptForAgents', () => {
     await promptForAgents('Select agents', choices);
 
     expect(skillLock.saveSelectedAgents).not.toHaveBeenCalled();
+  });
+});
+
+describe('global agent target selection', () => {
+  it('does not auto-add project-only universal agents for global installs', () => {
+    expect(getUniversalAgents()).toContain('promptscript');
+    expect(agents.promptscript.globalSkillsDir).toBeUndefined();
+
+    const selected = ensureUniversalAgents(['codex'], { global: true });
+
+    expect(selected).toContain('codex');
+    expect(selected).not.toContain('promptscript');
+  });
+
+  it('filters already-detected project-only agents from implicit global targets', () => {
+    const selected = filterAgentsForRequestedScope(
+      ensureUniversalAgents(['promptscript'], { global: true }),
+      { global: true }
+    );
+
+    expect(selected).not.toContain('promptscript');
+  });
+
+  it('filters unsupported agents from wildcard global targets', () => {
+    expect(filterAgentsForRequestedScope(['codex', 'promptscript'], { global: true })).toEqual([
+      'codex',
+    ]);
   });
 });

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -32,6 +32,21 @@ const noDetectedAgentEnv = {
   REPL_ID: '',
 };
 
+function isolatedAgentEnv(home: string): Record<string, string> {
+  return {
+    ...noDetectedAgentEnv,
+    APPDATA: join(home, 'appdata'),
+    AUTOHAND_HOME: join(home, '.autohand'),
+    CLAUDE_CONFIG_DIR: join(home, '.claude'),
+    CODEX_HOME: join(home, '.codex'),
+    FLATPAK_XDG_CONFIG_HOME: join(home, '.flatpak-config'),
+    HERMES_HOME: join(home, '.hermes'),
+    HOME: home,
+    VIBE_HOME: join(home, '.vibe'),
+    XDG_CONFIG_HOME: join(home, '.config'),
+  };
+}
+
 describe('add command', () => {
   let testDir: string;
 
@@ -151,6 +166,72 @@ Instructions here.
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
     expect(existsSync(join(projectDir, 'agent', 'skills', 'eve-skill', 'SKILL.md'))).toBe(true);
+  });
+
+  it('should skip detected PromptScript when global install targets are implicit', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'promptscript-global-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: promptscript-global-skill
+description: PromptScript global regression
+---
+
+# PromptScript Global Regression
+`
+    );
+
+    const projectDir = join(testDir, 'promptscript-project');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, 'promptscript.yaml'), 'name: promptscript-project\n');
+
+    const result = runCli(
+      ['add', sourceDir, '-g', '-y', '--skill', 'promptscript-global-skill'],
+      projectDir,
+      isolatedAgentEnv(projectDir)
+    );
+    const output = result.stdout + result.stderr;
+
+    expect(result.exitCode).toBe(0);
+    expect(output).not.toContain('PromptScript does not support global skill installation');
+    expect(output).not.toContain('Failed to install');
+  });
+
+  it('should not prefer detected Eve when global install targets are implicit', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'eve-global-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: eve-global-skill
+description: Eve global regression
+---
+
+# Eve Global Regression
+`
+    );
+
+    const projectDir = join(testDir, 'eve-project');
+    mkdirSync(join(projectDir, 'agent'), { recursive: true });
+    writeFileSync(
+      join(projectDir, 'package.json'),
+      JSON.stringify({ dependencies: { eve: '^0.11.5' } })
+    );
+
+    const result = runCli(
+      ['add', sourceDir, '-g', '-y', '--skill', 'eve-global-skill'],
+      projectDir,
+      isolatedAgentEnv(projectDir)
+    );
+    const output = result.stdout + result.stderr;
+
+    expect(result.exitCode).toBe(0);
+    expect(output).not.toContain('Installing to: eve agent');
+    expect(output).not.toContain('Eve does not support global skill installation');
+    expect(output).not.toContain('Failed to install');
   });
 
   it('should filter skills by name with --skill flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -351,17 +351,34 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
  * Ensures universal agents are always included in the target agents list.
  * Used when -y flag is passed or when auto-selecting agents.
  */
-function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
+export function ensureUniversalAgents(
+  targetAgents: AgentType[],
+  options: { global?: boolean } = {}
+): AgentType[] {
   const universalAgents = getUniversalAgents();
   const result = [...targetAgents];
 
   for (const ua of universalAgents) {
+    if (options.global && agents[ua].globalSkillsDir === undefined) {
+      continue;
+    }
     if (!result.includes(ua)) {
       result.push(ua);
     }
   }
 
   return result;
+}
+
+export function filterAgentsForRequestedScope(
+  targetAgents: AgentType[],
+  options: { global?: boolean } = {}
+): AgentType[] {
+  if (!options.global) {
+    return targetAgents;
+  }
+
+  return targetAgents.filter((agent) => agents[agent].globalSkillsDir !== undefined);
 }
 
 /**
@@ -670,7 +687,7 @@ async function handleWellKnownSkills(
 
   if (options.agent?.includes('*')) {
     // --agent '*' selects all agents
-    targetAgents = validAgents as AgentType[];
+    targetAgents = filterAgentsForRequestedScope(validAgents as AgentType[], options);
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -690,7 +707,7 @@ async function handleWellKnownSkills(
 
     if (installedAgents.length === 0) {
       if (options.yes) {
-        targetAgents = validAgents as AgentType[];
+        targetAgents = filterAgentsForRequestedScope(validAgents as AgentType[], options);
         p.log.info('Installing to all agents');
       } else {
         p.log.info('Select agents to install skills to');
@@ -715,7 +732,10 @@ async function handleWellKnownSkills(
       }
     } else if (installedAgents.length === 1 || options.yes) {
       // Auto-select detected agents + ensure universal agents are included
-      targetAgents = ensureUniversalAgents(installedAgents);
+      targetAgents = filterAgentsForRequestedScope(
+        ensureUniversalAgents(installedAgents, options),
+        options
+      );
       if (installedAgents.length === 1) {
         const firstAgent = installedAgents[0]!;
         p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
@@ -764,6 +784,10 @@ async function handleWellKnownSkills(
     }
 
     installGlobally = scope as boolean;
+  }
+
+  if (!options.agent || options.agent.includes('*')) {
+    targetAgents = filterAgentsForRequestedScope(targetAgents, { global: installGlobally });
   }
 
   // Determine install mode (symlink vs copy)
@@ -1066,7 +1090,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     if (!options.agent || options.agent.length === 0) {
       const mappedAgent = getAgentType(agentResult.agent.name);
       if (mappedAgent) {
-        options.agent = ensureUniversalAgents([mappedAgent]);
+        options.agent = filterAgentsForRequestedScope(
+          ensureUniversalAgents([mappedAgent], options),
+          options
+        );
       }
     }
   }
@@ -1367,7 +1394,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     if (options.agent?.includes('*')) {
       // --agent '*' selects all agents
-      targetAgents = validAgents as AgentType[];
+      targetAgents = filterAgentsForRequestedScope(validAgents as AgentType[], options);
       p.log.info(`Installing to all ${targetAgents.length} agents`);
     } else if (options.agent && options.agent.length > 0) {
       const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -1386,7 +1413,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const totalAgents = Object.keys(agents).length;
       spinner.stop(`${totalAgents} agents`);
 
-      if (installedAgents.includes('eve') && (options.yes || !agentResult.isAgent)) {
+      if (
+        !options.global &&
+        installedAgents.includes('eve') &&
+        (options.yes || !agentResult.isAgent)
+      ) {
         const useEve = options.yes
           ? true
           : await p.confirm({
@@ -1416,7 +1447,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
       } else if (installedAgents.length === 0) {
         if (options.yes) {
-          targetAgents = validAgents as AgentType[];
+          targetAgents = filterAgentsForRequestedScope(validAgents as AgentType[], options);
           p.log.info('Installing to all agents');
         } else {
           p.log.info('Select agents to install skills to');
@@ -1444,7 +1475,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
       } else if (installedAgents.length === 1 || options.yes) {
         // Auto-select detected agents + ensure universal agents are included
-        targetAgents = ensureUniversalAgents(installedAgents);
+        targetAgents = filterAgentsForRequestedScope(
+          ensureUniversalAgents(installedAgents, options),
+          options
+        );
         if (installedAgents.length === 1) {
           const firstAgent = installedAgents[0]!;
           p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
@@ -1510,8 +1544,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
-
     let installGlobally = options.global ?? false;
 
     // Check if any selected agents support global installation
@@ -1542,6 +1574,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       installGlobally = scope as boolean;
     }
+
+    if (!options.agent || options.agent.includes('*')) {
+      targetAgents = filterAgentsForRequestedScope(targetAgents, { global: installGlobally });
+    }
+
+    const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
 
     // Determine install mode (symlink vs copy)
     let installMode: InstallMode = options.copy ? 'copy' : 'symlink';


### PR DESCRIPTION
## Summary

- skip project-only agents when global installs auto-expand universal targets
- apply the same global-support filter to `--agent '*'` / `--all` target selection
- add regression coverage so PromptScript and Eve stay project-only without showing up as automatic global failures

## Why

`ensureUniversalAgents()` adds every agent that shares `.agents/skills`. PromptScript is in that shared project path, but it intentionally has no global skills directory. In global non-interactive installs this can produce a red PromptScript failure even though the compatible agents installed fine.

## Approach

This PR filters unsupported agents only when the target list is implicit: detected agents, auto-selected universal agents, `--agent '*'`, or `--all`. Explicit targets are left alone, so `-a promptscript -g` still reports that PromptScript does not support global installs. That keeps user intent visible and keeps project-only agents project-only.

## Related open PRs

There are a few open fixes around the same failure:

- #1365 gives PromptScript a global skills dir. I avoided that because the current support table marks PromptScript as project-only, and this bug is caused by automatic target expansion rather than missing PromptScript storage.
- #1362, #1421, #1479, and #1561 also skip unsupported global targets in different ways. #1561 is the closest in spirit. This PR is intentionally narrow: keep explicit unsupported selections as errors, and filter only implicit/global target expansion paths.

If maintainers prefer one of the existing PRs, this can be folded into or closed in favor of that one.

## Validation

- `corepack pnpm vitest run src/add-prompt.test.ts src/add.test.ts`
- `corepack pnpm vitest run src/add-prompt.test.ts src/add.test.ts tests/installer-copy.test.ts tests/installer-symlink.test.ts tests/update.test.ts`
- `corepack pnpm format:check`
- `corepack pnpm build`
- built CLI smoke test with temporary `HOME` / `CODEX_HOME` against a local skill source; confirmed the PromptScript failure is no longer printed

## Local check notes

`corepack pnpm type-check` currently fails on upstream `main` in unrelated files (`src/git.ts`, `src/skills.ts`). Full `vitest -- --run` also has environment-sensitive failures in this Codex session because agent detection changes CLI output and one global listing test scans the real home directory. The focused add/install regression tests above pass.
