### PR TITLE
fix: update skills-lock.json on project-scoped skill removal

### DIFF
--- a/src/remove.ts
+++ b/src/remove.ts
@@ -6,6 +6,7 @@ import { agents, detectInstalledAgents, getEveSubagents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock } from './skill-lock.ts';
+import { removeSkillFromLocalLock } from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -237,6 +238,8 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       if (isGlobal) {
         await removeSkillFromLock(skillName);
+      } else {
+        await removeSkillFromLocalLock(skillName);
       }
 
       results.push({


### PR DESCRIPTION
## Summary

`removeCommand()` in `src/remove.ts` only calls `removeSkillFromLock()` (global lock) when `--global` is set. The local `skills-lock.json` was never updated for project-scoped removals, leaving stale entries behind.

This adds the missing call to `removeSkillFromLocalLock()` in the non-global branch, mirroring the existing global-lock cleanup.

`removeSkillFromLocalLock()` already exists in `src/local-lock.ts` — it was simply never wired up in the remove path.
