### PR TITLE
feat: add RoleCraft as a recognized agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -252,7 +252,7 @@ Skills can be installed to any of these agents:
 | IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
+| Cline, Dexto, Kimi Code CLI, Loaf, RoleCraft, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `rolecraft`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codemaker | `codemaker` | `.codemaker/skills/` | `~/.codemaker/skills/` |

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "replit",
     "reasonix",
     "rovodev",
+    "rolecraft",
     "roo",
     "tabnine-cli",
     "terramind",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -561,6 +561,18 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.rovodev'));
     },
   },
+  rolecraft: {
+    name: 'rolecraft',
+    displayName: 'RoleCraft',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
+    detectInstalled: async () => {
+      return (
+        existsSync(join(home, '.agents', '.skill-lock.json')) ||
+        existsSync(join(home, '.agents', 'skills'))
+      );
+    },
+  },
   roo: {
     name: 'roo',
     displayName: 'Roo Code',


### PR DESCRIPTION
## Summary

Adds [RoleCraft](https://github.com/sametcelikbicak/rolecraft) as a recognized agent in the skills CLI.

## Changes

- **src/agents.ts**: Added `rolecraft` agent definition (universal, `.agents/skills/`)
- **README.md, package.json**: Auto-updated via `scripts/sync-agents.ts`

## Details

- skillsDir: `.agents/skills/` (universal, same as OpenCode/Amp/Codex)
- globalSkillsDir: `~/.agents/skills/`
- Detection: `~/.agents/.skill-lock.json` or `~/.agents/skills/`
- Supports 66+ agent install targets