### PR TITLE
fix: preserve embedded userinfo in github/gitlab URL normalization

### DIFF
--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -128,4 +128,73 @@ describe('source-parser', () => {
       });
     });
   });
+
+  describe('Embedded credentials (userinfo) preservation', () => {
+    it('preserves x-access-token userinfo on a plain GitHub URL', () => {
+      const result = parseSource('https://x-access-token:GHTOKEN@github.com/org/private-repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://x-access-token:GHTOKEN@github.com/org/private-repo.git',
+      });
+    });
+
+    it('preserves userinfo on a GitHub /tree/branch URL', () => {
+      const result = parseSource(
+        'https://x-access-token:GHTOKEN@github.com/org/private-repo/tree/main'
+      );
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://x-access-token:GHTOKEN@github.com/org/private-repo.git',
+        ref: 'main',
+      });
+    });
+
+    it('preserves userinfo on a GitHub /tree/branch/path URL', () => {
+      const result = parseSource(
+        'https://x-access-token:GHTOKEN@github.com/org/private-repo/tree/main/skills/foo'
+      );
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://x-access-token:GHTOKEN@github.com/org/private-repo.git',
+        ref: 'main',
+        subpath: 'skills/foo',
+      });
+    });
+
+    it('preserves user:pass userinfo and drops .git suffix on GitHub URL', () => {
+      const result = parseSource('https://user:pass@github.com/org/private-repo.git');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://user:pass@github.com/org/private-repo.git',
+      });
+    });
+
+    it('preserves userinfo on a gitlab.com URL', () => {
+      const result = parseSource('https://x-access-token:GLTOKEN@gitlab.com/group/private-repo');
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://x-access-token:GLTOKEN@gitlab.com/group/private-repo.git',
+      });
+    });
+
+    it('preserves userinfo on a custom GitLab instance /-/tree/ URL', () => {
+      const result = parseSource(
+        'https://token:secret@git.corp.com/group/subgroup/project/-/tree/main/src'
+      );
+      expect(result).toMatchObject({
+        type: 'gitlab',
+        url: 'https://token:secret@git.corp.com/group/subgroup/project.git',
+        ref: 'main',
+        subpath: 'src',
+      });
+    });
+
+    it('leaves credential-free URLs unchanged', () => {
+      const result = parseSource('https://github.com/org/public-repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.com/org/public-repo.git',
+      });
+    });
+  });
 });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -256,6 +256,14 @@ export function parseSource(input: string): ParsedSource {
   } = parseFragmentRef(input);
   input = inputWithoutFragment;
 
+  // Preserve any userinfo (e.g. `x-access-token:TOKEN@` or `user:pass@`) embedded
+  // in an HTTPS URL. Without this, normalization below reconstructs the URL without
+  // the credentials the caller deliberately threaded through, and clones of private
+  // repos fail (or prompt) even when correctly authenticated. Captured from the
+  // original input, before alias resolution replaces it.
+  const authMatch = input.match(/^https?:\/\/([^/@]+@)/);
+  const auth = authMatch ? authMatch[1]! : '';
+
   // Resolve source aliases before parsing
   const alias = SOURCE_ALIASES[input];
   if (alias) {
@@ -287,7 +295,7 @@ export function parseSource(input: string): ParsedSource {
     const [, owner, repo, ref, subpath] = githubTreeWithPathMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      url: `https://${auth}github.com/${owner}/${repo}.git`,
       ref: ref || fragmentRef,
       subpath: subpath ? sanitizeSubpath(subpath) : subpath,
     };
@@ -299,7 +307,7 @@ export function parseSource(input: string): ParsedSource {
     const [, owner, repo, ref] = githubTreeMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      url: `https://${auth}github.com/${owner}/${repo}.git`,
       ref: ref || fragmentRef,
     };
   }
@@ -311,7 +319,7 @@ export function parseSource(input: string): ParsedSource {
     const cleanRepo = repo!.replace(/\.git$/, '');
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${cleanRepo}.git`,
+      url: `https://${auth}github.com/${owner}/${cleanRepo}.git`,
       ...(fragmentRef ? { ref: fragmentRef } : {}),
     };
   }
@@ -327,6 +335,7 @@ export function parseSource(input: string): ParsedSource {
     if (hostname !== 'github.com' && repoPath) {
       return {
         type: 'gitlab',
+        // hostname already includes any userinfo (the anchored regex captures it).
         url: `${protocol}://${hostname}/${repoPath.replace(/\.git$/, '')}.git`,
         ref: ref || fragmentRef,
         subpath: subpath ? sanitizeSubpath(subpath) : subpath,
@@ -341,6 +350,7 @@ export function parseSource(input: string): ParsedSource {
     if (hostname !== 'github.com' && repoPath) {
       return {
         type: 'gitlab',
+        // hostname already includes any userinfo (the anchored regex captures it).
         url: `${protocol}://${hostname}/${repoPath.replace(/\.git$/, '')}.git`,
         ref: ref || fragmentRef,
       };
@@ -357,7 +367,7 @@ export function parseSource(input: string): ParsedSource {
     if (repoPath.includes('/')) {
       return {
         type: 'gitlab',
-        url: `https://gitlab.com/${repoPath}.git`,
+        url: `https://${auth}gitlab.com/${repoPath}.git`,
         ...(fragmentRef ? { ref: fragmentRef } : {}),
       };
     }


### PR DESCRIPTION
## Summary

Fixes #1246.

`parseSource` in `src/source-parser.ts` stripped the userinfo segment (e.g. `x-access-token:TOKEN@` or `user:pass@`) from HTTPS URLs when reconstructing the normalized clone URL. The subsequent `git clone` then ran unauthenticated and failed on private repos even when the caller had correctly threaded a token through the URL — a common pattern for non-interactive automation (`gh` clone, Actions checkout, internal CLIs bootstrapping skills).

## Fix

- Capture the userinfo once from the original input (before alias resolution reassigns `input`):
  ```ts
  const authMatch = input.match(/^https?:\/\/([^/@]+@)/);
  const auth = authMatch ? authMatch[1]! : '';
  ```
- Thread `${auth}` back into the reconstructed URL for the branches that rebuild from a hardcoded/substring host and therefore dropped it:
  - `githubTreeWithPathMatch`, `githubTreeMatch`, `githubRepoMatch` (the three named in the issue)
  - `gitlabRepoMatch` (`gitlab.com/…`) — same latent bug, fixed for consistency
- The GitLab `/-/tree/` branches are intentionally **left unchanged**: their anchored regex already captures any userinfo inside the `hostname` group, so prepending `auth` there would duplicate it.
