### PR TITLE
fix: block unsafe git transports

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -118,7 +118,18 @@ describe('git clone fallbacks', () => {
     expect(execFileMock).toHaveBeenNthCalledWith(
       2,
       'gh',
-      ['repo', 'clone', 'Giphy/giphy-codex-skills', tempDir, '--', '--depth=1'],
+      [
+        'repo',
+        'clone',
+        'Giphy/giphy-codex-skills',
+        tempDir,
+        '--',
+        '-c',
+        'protocol.ext.allow=never',
+        '-c',
+        'protocol.fd.allow=never',
+        '--depth=1',
+      ],
       expect.any(Object),
       expect.any(Function)
     );
@@ -192,6 +203,28 @@ describe('git clone fallbacks', () => {
     await expect(cloneRepo('git@github.com:Giphy/giphy-codex-skills.git')).rejects.toThrow(
       GitCloneError
     );
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('configures git to deny command-executing transports', async () => {
+    const primaryClone = vi.fn().mockResolvedValue(undefined);
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+    createdDirs.push(tempDir);
+
+    expect(simpleGitMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.arrayContaining(['protocol.ext.allow=never', 'protocol.fd.allow=never']),
+      })
+    );
+  });
+
+  it('rejects unsafe git transports before invoking git', async () => {
+    await expect(cloneRepo('ext::sh -c id')).rejects.toThrow('Unsafe git source');
+    await expect(cloneRepo('fd::3')).rejects.toThrow('Unsafe git source');
+
+    expect(simpleGitMock).not.toHaveBeenCalled();
     expect(execFileMock).not.toHaveBeenCalled();
   });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { assertSafeGitCloneUrl } from './source-parser.ts';
 
 const DEFAULT_CLONE_TIMEOUT_MS = 300_000; // 5 minutes
 const CLONE_TIMEOUT_MS = (() => {
@@ -13,6 +14,14 @@ const CLONE_TIMEOUT_MS = (() => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CLONE_TIMEOUT_MS;
 })();
 const execFileAsync = promisify(execFile);
+const SAFE_GIT_CONFIG = ['protocol.ext.allow=never', 'protocol.fd.allow=never'];
+const SAFE_GIT_CLONE_CONFIG_ARGS = SAFE_GIT_CONFIG.flatMap((entry) => ['-c', entry]);
+
+type GitClientOptionsWithEnv = {
+  timeout: { block: number };
+  env: NodeJS.ProcessEnv;
+  config: string[];
+};
 
 interface GitHubRepoInfo {
   owner: string;
@@ -99,7 +108,7 @@ function isAuthFailure(message: string): boolean {
 }
 
 function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
-  return simpleGit({
+  const options: GitClientOptionsWithEnv = {
     timeout: { block: CLONE_TIMEOUT_MS },
     env: {
       ...process.env,
@@ -123,12 +132,14 @@ function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
     //
     // Reported downstream: heygen-com/hyperframes#407.
     config: [
+      ...SAFE_GIT_CONFIG,
       'filter.lfs.required=false',
       'filter.lfs.smudge=',
       'filter.lfs.clean=',
       'filter.lfs.process=',
     ],
-  });
+  };
+  return simpleGit(options as unknown as Parameters<typeof simpleGit>[0]);
 }
 
 async function resetTempDir(dir: string): Promise<void> {
@@ -153,10 +164,14 @@ async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): 
   }
 
   const gitFlags = ref ? ['--depth=1', '--branch', ref] : ['--depth=1'];
-  await execFileAsync('gh', ['repo', 'clone', cloneTarget, tempDir, '--', ...gitFlags], {
-    timeout: CLONE_TIMEOUT_MS,
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-  });
+  await execFileAsync(
+    'gh',
+    ['repo', 'clone', cloneTarget, tempDir, '--', ...SAFE_GIT_CLONE_CONFIG_ARGS, ...gitFlags],
+    {
+      timeout: CLONE_TIMEOUT_MS,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    }
+  );
   return true;
 }
 
@@ -189,6 +204,8 @@ function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message:
 }
 
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
+  assertSafeGitCloneUrl(url);
+
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
   const repo = parseGitHubRepoUrl(url);

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -81,7 +81,8 @@ export async function parseSkillMd(
     // Skip internal skills unless:
     // 1. INSTALL_INTERNAL_SKILLS=1 is set, OR
     // 2. includeInternal option is true (e.g., when user explicitly requests a skill)
-    const isInternal = data.metadata?.internal === true;
+    const metadata = data.metadata as Record<string, unknown> | undefined;
+    const isInternal = metadata?.internal === true;
     if (isInternal && !shouldInstallInternalSkills() && !options?.includeInternal) {
       return null;
     }
@@ -91,7 +92,7 @@ export async function parseSkillMd(
       description: sanitizeMetadata(data.description),
       path: dirname(skillMdPath),
       rawContent: content,
-      metadata: data.metadata,
+      metadata,
     };
   } catch {
     return null;

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -198,6 +198,34 @@ function looksLikeGitSource(input: string): boolean {
   );
 }
 
+const SAFE_GIT_URL_PROTOCOLS = new Set(['http:', 'https:', 'ssh:', 'git:']);
+const GIT_SCP_URL_RE = /^git@[A-Za-z0-9.-]+:[^\s\0]+$/;
+
+export function isSafeGitCloneUrl(input: string): boolean {
+  if (/[\0-\x20\x7f]/.test(input)) {
+    return false;
+  }
+
+  if (GIT_SCP_URL_RE.test(input)) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(input);
+    return SAFE_GIT_URL_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function assertSafeGitCloneUrl(input: string): void {
+  if (!isSafeGitCloneUrl(input)) {
+    throw new Error(
+      'Unsafe git source: only http://, https://, ssh://, git://, and git@host:path transports are allowed.'
+    );
+  }
+}
+
 function parseFragmentRef(input: string): FragmentRefResult {
   const hashIndex = input.indexOf('#');
   if (hashIndex < 0) {
@@ -400,6 +428,7 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // Fallback: treat as direct git URL
+  assertSafeGitCloneUrl(input);
   return {
     type: 'git',
     url: input,

--- a/src/update.ts
+++ b/src/update.ts
@@ -20,6 +20,7 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
 import { agents, isUniversalAgent } from './agents.ts';
 import type { AgentType } from './types.ts';
+import { parseSource } from './source-parser.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -191,6 +192,17 @@ export function getInstallSource(skill: SkippedSkill): string {
     }
   }
   return formatSourceInput(url, skill.ref);
+}
+
+function resolveGitCloneSource(source: string, ref?: string): { url: string; ref?: string } {
+  const parsed = parseSource(formatSourceInput(source, ref));
+  if (parsed.type === 'local' || parsed.type === 'well-known') {
+    throw new Error(`Source ${source} is not a git repository`);
+  }
+  return {
+    url: parsed.url,
+    ref: parsed.ref ?? ref,
+  };
 }
 
 export function printSkippedSkills(skipped: SkippedSkill[]): void {
@@ -376,7 +388,8 @@ export async function updateGlobalSkills(
         continue;
       }
 
-      tempDir = await cloneRepo(sourceUrl, firstEntry.ref);
+      const cloneSource = resolveGitCloneSource(sourceUrl, firstEntry.ref);
+      tempDir = await cloneRepo(cloneSource.url, cloneSource.ref);
       const discoveredPaths = (await discoverSkills(tempDir)).map((skill) => {
         return join(relative(tempDir!, skill.path), 'SKILL.md').split(sep).join('/');
       });
@@ -544,7 +557,6 @@ export async function updateProjectSkills(
 
   for (const [source, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
-    const sourceUrl = firstEntry.source;
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)
@@ -553,9 +565,18 @@ export async function updateProjectSkills(
 
     let tempDir: string | null = null;
     let deletedSkills: string[] = [];
+    let cloneSource: { url: string; ref?: string };
 
     try {
-      tempDir = await cloneRepo(sourceUrl, ref);
+      cloneSource = resolveGitCloneSource(firstEntry.source, ref);
+    } catch {
+      console.log(`${DIM}✗ Refusing unsafe git source from skills-lock.json: ${source}${RESET}`);
+      failCount += skillsForSource.length;
+      continue;
+    }
+
+    try {
+      tempDir = await cloneRepo(cloneSource.url, cloneSource.ref);
       const discovered = await discoverSkills(tempDir);
 
       const discoveredPaths = discovered.map((s) => {
@@ -584,7 +605,7 @@ export async function updateProjectSkills(
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);
       console.log(`${TEXT}Updating ${safeName}...${RESET}`);
-      const installUrl = formatSourceInput(skill.entry.source, skill.entry.ref);
+      const installUrl = buildLocalUpdateSource(skill.entry);
 
       // Preserve Eve subagent placement recorded at install time. The lock stores
       // '' for the root agent, which maps to the `root` keyword for `add --subagent`.

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -269,6 +269,21 @@ describe('parseSource', () => {
       expect(result.url).toBe('ssh://git@git.example.com:7999/owner/repo.git');
       expect(result.ref).toBe('release-2026');
     });
+
+    it('Git URL - git protocol', () => {
+      const result = parseSource('git://git.example.com/owner/repo.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('git://git.example.com/owner/repo.git');
+    });
+
+    it('rejects command-executing and local git transports', () => {
+      expect(() => parseSource('ext::sh -c id')).toThrow('Unsafe git source');
+      expect(() => parseSource('fd::3')).toThrow('Unsafe git source');
+      expect(() => parseSource('file:///tmp/repo.git')).toThrow('Unsafe git source');
+      expect(() => parseSource('rsync://git.example.com/owner/repo.git')).toThrow(
+        'Unsafe git source'
+      );
+    });
   });
 });
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -9,6 +9,7 @@ import * as remove from '../src/remove.ts';
 import * as p from '@clack/prompts';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { spawnSync } from 'child_process';
 
 // Mock dependencies
 vi.mock('../src/git.ts');
@@ -190,6 +191,26 @@ describe('Update Cleanup Unit Tests', () => {
 
       expect(p.confirm).not.toHaveBeenCalled();
       expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
+
+    it('refuses unsafe git sources from project skills-lock.json before cloning or updating', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'evil-skill': {
+            source: 'ext::sh -c id',
+            skillPath: 'skills/evil/SKILL.md',
+            sourceType: 'git',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      const result = await updateProjectSkills({ yes: true });
+
+      expect(result.failCount).toBe(1);
+      expect(git.cloneRepo).not.toHaveBeenCalled();
+      expect(spawnSync).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- reject unsafe direct Git transports before parser fallback or cloning
- add `protocol.ext.allow=never` and `protocol.fd.allow=never` to Git clone invocations, including the `gh repo clone` fallback
- normalize lockfile update sources through the source parser before cloning, so malicious project `skills-lock.json` sources are refused before update work runs
- tighten SKILL metadata typing so full TypeScript validation passes

## Testing
- `pnpm exec prettier --check src/git.ts src/source-parser.ts src/update.ts src/skills.ts src/git.test.ts tests/source-parser.test.ts tests/update.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run src/git.test.ts tests/source-parser.test.ts tests/update.test.ts`
- `pnpm exec vitest run` currently reports 543 passing / 5 failing in unrelated list/remove/sync banner/global-scope tests