### PR TITLE
feat: support skills pack install shorthands

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -4,7 +4,13 @@ import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { sep, join, dirname } from 'path';
-import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
+import {
+  parseSource,
+  getOwnerRepo,
+  getSkillsPackId,
+  parseOwnerRepo,
+  isRepoPrivate,
+} from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
@@ -53,6 +59,7 @@ import {
 } from './agents.ts';
 import {
   track,
+  trackPackInstall,
   setVersion,
   fetchAuditData,
   type AuditResponse,
@@ -554,8 +561,13 @@ async function handleWellKnownSkills(
 ): Promise<void> {
   spinner.start('Discovering skills from well-known endpoint...');
 
-  // Fetch all skills from the well-known endpoint
-  const skills = await wellKnownProvider.fetchAllSkills(url);
+  // Fetch all skills from the well-known endpoint. skills.sh pack manifests
+  // include a short-lived receipt authorizing the completed-install callback.
+  const discovery = await wellKnownProvider.fetchAllSkillsWithContext(url);
+  const skills = discovery.skills;
+  const packId = getSkillsPackId(url);
+  const packReceipt =
+    packId && discovery.packInstall?.packId === packId ? discovery.packInstall.receipt : null;
 
   if (skills.length === 0) {
     spinner.stop(pc.red('No skills found'));
@@ -836,9 +848,13 @@ async function handleWellKnownSkills(
     }
   }
 
-  // Kick off privacy check early so it runs in parallel with installation
+  // Kick off privacy check early so it runs in parallel with installation.
+  // Pack installs have their own server-side analytics endpoint and must not
+  // be reported as generic well-known installs.
   const sourceIdentifier = wellKnownProvider.getSourceIdentifier(url);
-  const wellKnownPrivacyPromise = isSourcePrivate(sourceIdentifier).catch(() => null);
+  const wellKnownPrivacyPromise = packId
+    ? null
+    : isSourcePrivate(sourceIdentifier).catch(() => null);
 
   spinner.start('Installing skills...');
 
@@ -873,24 +889,38 @@ async function handleWellKnownSkills(
   const successful = results.filter((r) => r.success);
   const failed = results.filter((r) => !r.success);
 
-  // Build skillFiles map: { skillName: sourceUrl }
-  const skillFiles: Record<string, string> = {};
-  for (const skill of selectedSkills) {
-    skillFiles[skill.installName] = skill.sourceUrl;
-  }
+  if (packId && packReceipt) {
+    const installedSkillCount = new Set(successful.map((result) => result.skill)).size;
+    if (installedSkillCount > 0) {
+      trackPackInstall({
+        packUrl: url,
+        packId,
+        receipt: packReceipt,
+        agents: targetAgents,
+        global: installGlobally,
+        installedSkillCount,
+      });
+    }
+  } else {
+    // Build skillFiles map: { skillName: sourceUrl }
+    const skillFiles: Record<string, string> = {};
+    for (const skill of selectedSkills) {
+      skillFiles[skill.installName] = skill.sourceUrl;
+    }
 
-  // Privacy promise was started before installation — should be resolved by now
-  const isPrivate = await wellKnownPrivacyPromise;
-  if (isPrivate !== true) {
-    track({
-      event: 'install',
-      source: sourceIdentifier,
-      skills: selectedSkills.map((s) => s.installName).join(','),
-      agents: targetAgents.join(','),
-      ...(installGlobally && { global: '1' }),
-      skillFiles: JSON.stringify(skillFiles),
-      sourceType: 'well-known',
-    });
+    // Privacy promise was started before installation — should be resolved by now
+    const isPrivate = await wellKnownPrivacyPromise;
+    if (isPrivate !== true) {
+      track({
+        event: 'install',
+        source: sourceIdentifier,
+        skills: selectedSkills.map((s) => s.installName).join(','),
+        agents: targetAgents.join(','),
+        ...(installGlobally && { global: '1' }),
+        skillFiles: JSON.stringify(skillFiles),
+        sourceType: 'well-known',
+      });
+    }
   }
 
   // Add to skill lock file for update tracking (only for global installs)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,9 +107,11 @@ function showHelp(): void {
 ${BOLD}Usage:${RESET} skills <command> [options]
 
 ${BOLD}Manage Skills:${RESET}
-  add <package>        Add a skill package (alias: a)
+  add <package>        Add a skill package or pack (alias: a)
                        e.g. vercel-labs/agent-skills
                             https://github.com/vercel-labs/agent-skills
+                            skills.sh/p/<pack-id>
+                            pack:<pack-id>
   use <package>@<skill>
                        Generate a prompt for using one skill without installing it
   remove [skills]      Remove installed skills
@@ -172,6 +174,8 @@ ${BOLD}Options:${RESET}
 
 ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills add vercel-labs/agent-skills
+  ${DIM}$${RESET} skills add skills.sh/p/<pack-id>
+  ${DIM}$${RESET} skills add pack:<pack-id>
   ${DIM}$${RESET} skills use vercel-labs/agent-skills@vercel-optimize | claude
   ${DIM}$${RESET} skills use vercel-labs/agent-skills --skill vercel-optimize --agent claude-code
   ${DIM}$${RESET} skills add vercel-labs/agent-skills -g

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -36,6 +36,12 @@ export interface WellKnownIndexV2 {
   skills: WellKnownSkillEntryV2[];
 }
 
+/** Optional skills.sh extension for an authenticated pack install callback. */
+export interface WellKnownPackInstall {
+  packId: string;
+  receipt: string;
+}
+
 /**
  * Represents a v0.2.0 skill artifact entry in index.json.
  */
@@ -70,6 +76,22 @@ type NormalizedWellKnownEntry =
       digest: string;
       indexEntry: WellKnownSkillEntryV2;
     };
+
+interface WellKnownIndexCandidate {
+  index: WellKnownIndex;
+  entries: NormalizedWellKnownEntry[];
+  /** Present only on skills.sh pack manifests. */
+  packInstall: WellKnownPackInstall | null;
+  resolvedBaseUrl: string;
+  resolvedWellKnownPath: string;
+  indexUrl: string;
+}
+
+export interface WellKnownSkillsDiscovery {
+  skills: WellKnownSkill[];
+  /** Present only when the manifest authorizes a pack install callback. */
+  packInstall: WellKnownPackInstall | null;
+}
 
 /**
  * Represents a skill with all installable files fetched from a well-known endpoint.
@@ -139,6 +161,7 @@ export class WellKnownProvider implements HostProvider {
   async fetchIndex(baseUrl: string): Promise<{
     index: WellKnownIndex;
     entries: NormalizedWellKnownEntry[];
+    packInstall: WellKnownPackInstall | null;
     resolvedBaseUrl: string;
     resolvedWellKnownPath: string;
     indexUrl: string;
@@ -147,15 +170,7 @@ export class WellKnownProvider implements HostProvider {
     return candidates[0] ?? null;
   }
 
-  private async fetchIndexCandidates(baseUrl: string): Promise<
-    Array<{
-      index: WellKnownIndex;
-      entries: NormalizedWellKnownEntry[];
-      resolvedBaseUrl: string;
-      resolvedWellKnownPath: string;
-      indexUrl: string;
-    }>
-  > {
+  private async fetchIndexCandidates(baseUrl: string): Promise<WellKnownIndexCandidate[]> {
     try {
       const parsed = new URL(baseUrl);
       const basePath = parsed.pathname.replace(/\/$/, '');
@@ -182,13 +197,7 @@ export class WellKnownProvider implements HostProvider {
         }
       }
 
-      const candidates: Array<{
-        index: WellKnownIndex;
-        entries: NormalizedWellKnownEntry[];
-        resolvedBaseUrl: string;
-        resolvedWellKnownPath: string;
-        indexUrl: string;
-      }> = [];
+      const candidates: WellKnownIndexCandidate[] = [];
 
       for (const { indexUrl, baseUrl: resolvedBase, wellKnownPath } of urlsToTry) {
         try {
@@ -202,6 +211,7 @@ export class WellKnownProvider implements HostProvider {
           candidates.push({
             index: normalized.index,
             entries: normalized.entries,
+            packInstall: normalized.packInstall,
             resolvedBaseUrl: resolvedBase,
             resolvedWellKnownPath: wellKnownPath,
             indexUrl,
@@ -221,7 +231,11 @@ export class WellKnownProvider implements HostProvider {
     rawIndex: unknown,
     indexUrl: string,
     resolvedWellKnownPath: string
-  ): { index: WellKnownIndex; entries: NormalizedWellKnownEntry[] } | null {
+  ): {
+    index: WellKnownIndex;
+    entries: NormalizedWellKnownEntry[];
+    packInstall: WellKnownPackInstall | null;
+  } | null {
     if (!rawIndex || typeof rawIndex !== 'object') return null;
 
     const record = rawIndex as Record<string, unknown>;
@@ -250,7 +264,11 @@ export class WellKnownProvider implements HostProvider {
       }
 
       if (entries.length === 0) return null;
-      return { index: { $schema: DISCOVERY_SCHEMA_V2, skills: v2Entries }, entries };
+      return {
+        index: { $schema: DISCOVERY_SCHEMA_V2, skills: v2Entries },
+        entries,
+        packInstall: this.parsePackInstall(record.pack_install),
+      };
     }
 
     // Per the v0.2.0 draft, an absent $schema means legacy/v0.1.0.
@@ -275,7 +293,28 @@ export class WellKnownProvider implements HostProvider {
       });
     }
 
-    return { index: { skills: v1Entries }, entries };
+    return {
+      index: { skills: v1Entries },
+      entries,
+      packInstall: this.parsePackInstall(record.pack_install),
+    };
+  }
+
+  private parsePackInstall(value: unknown): WellKnownPackInstall | null {
+    if (!value || typeof value !== 'object') return null;
+
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.pack_id !== 'string' ||
+      !/^[A-Za-z0-9][A-Za-z0-9_-]{0,119}$/.test(record.pack_id) ||
+      typeof record.receipt !== 'string' ||
+      record.receipt.length < 16 ||
+      record.receipt.length > 2_048
+    ) {
+      return null;
+    }
+
+    return { packId: record.pack_id, receipt: record.receipt };
   }
 
   private getLegacySkillBaseUrl(indexUrl: string, wellKnownPath: string): string {
@@ -542,6 +581,11 @@ export class WellKnownProvider implements HostProvider {
 
   /** Fetch all skills from a well-known endpoint. */
   async fetchAllSkills(url: string): Promise<WellKnownSkill[]> {
+    return (await this.fetchAllSkillsWithContext(url)).skills;
+  }
+
+  /** Fetch all skills together with any pack-specific install receipt. */
+  async fetchAllSkillsWithContext(url: string): Promise<WellKnownSkillsDiscovery> {
     try {
       const candidates = await this.fetchIndexCandidates(url);
 
@@ -551,12 +595,14 @@ export class WellKnownProvider implements HostProvider {
         const skills = results.filter(
           (s: WellKnownSkill | null): s is WellKnownSkill => s !== null
         );
-        if (skills.length > 0) return skills;
+        if (skills.length > 0) {
+          return { skills, packInstall: result.packInstall };
+        }
       }
 
-      return [];
+      return { skills: [], packInstall: null };
     } catch {
-      return [];
+      return { skills: [], packInstall: null };
     }
   }
 

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -4,7 +4,7 @@ import type { ParsedSource } from './types.ts';
 /**
  * Extract owner/repo (or group/subgroup/repo for GitLab) from a parsed source
  * for lockfile tracking and telemetry.
- * Returns null for local paths or unparseable sources.
+ * Returns null for local paths, skills.sh pack URLs, or unparseable sources.
  * Supports any Git host with an owner/repo URL structure, including GitLab subgroups.
  */
 export function getOwnerRepo(parsed: ParsedSource): string | null {
@@ -48,6 +48,14 @@ export function getOwnerRepo(parsed: ParsedSource): string | null {
 
   try {
     const url = new URL(parsed.url);
+    if (
+      parsed.type === 'well-known' &&
+      (url.hostname === 'skills.sh' || url.hostname === 'www.skills.sh') &&
+      url.pathname.startsWith('/p/')
+    ) {
+      return null;
+    }
+
     // Get pathname, remove leading slash and trailing .git
     let path = url.pathname.slice(1);
     path = path.replace(/\.git$/, '');
@@ -144,6 +152,8 @@ const SOURCE_ALIASES: Record<string, string> = {
   'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
 };
 
+const SKILLS_PACK_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,119}$/;
+
 interface FragmentRefResult {
   inputWithoutFragment: string;
   ref?: string;
@@ -237,6 +247,42 @@ function appendFragmentRef(input: string, ref?: string, skillFilter?: string): s
   return `${input}#${ref}${skillFilter ? `@${skillFilter}` : ''}`;
 }
 
+function assertValidSkillsPackId(packId: string): void {
+  if (!SKILLS_PACK_ID_RE.test(packId)) {
+    throw new Error(
+      `Invalid skills pack id: "${packId}". Pack ids must start with a letter or number and contain only letters, numbers, hyphens, and underscores.`
+    );
+  }
+}
+
+function normalizeSkillsPackSource(input: string): string | null {
+  const packPrefixMatch = input.match(/^pack:(.*)$/);
+  if (packPrefixMatch) {
+    const packId = packPrefixMatch[1]!.trim();
+    assertValidSkillsPackId(packId);
+    return `https://skills.sh/p/${packId}`;
+  }
+
+  const skillsShPackMatch = input.match(/^(?:www\.)?skills\.sh\/p(?:\/(.*))?$/i);
+  if (!skillsShPackMatch) {
+    return null;
+  }
+
+  const packPath = skillsShPackMatch[1];
+  if (!packPath) {
+    throw new Error('Invalid skills pack source: expected skills.sh/p/<pack-id>.');
+  }
+
+  const packIdMatch = packPath.match(/^([^/?#]+)\/?$/);
+  if (!packIdMatch) {
+    throw new Error('Invalid skills pack source: expected skills.sh/p/<pack-id>.');
+  }
+
+  const packId = packIdMatch[1]!;
+  assertValidSkillsPackId(packId);
+  return `https://skills.sh/p/${packId}`;
+}
+
 export function parseSource(input: string): ParsedSource {
   // Local path: absolute, relative, or current directory
   if (isLocalPath(input)) {
@@ -260,6 +306,14 @@ export function parseSource(input: string): ParsedSource {
   const alias = SOURCE_ALIASES[input];
   if (alias) {
     input = alias;
+  }
+
+  const skillsPackUrl = normalizeSkillsPackSource(input);
+  if (skillsPackUrl) {
+    return {
+      type: 'well-known',
+      url: skillsPackUrl,
+    };
   }
 
   // Prefix shorthand: github:owner/repo -> owner/repo (handled by existing shorthand logic)

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -48,11 +48,7 @@ export function getOwnerRepo(parsed: ParsedSource): string | null {
 
   try {
     const url = new URL(parsed.url);
-    if (
-      parsed.type === 'well-known' &&
-      (url.hostname === 'skills.sh' || url.hostname === 'www.skills.sh') &&
-      url.pathname.startsWith('/p/')
-    ) {
+    if (parsed.type === 'well-known' && getSkillsPackId(url.toString())) {
       return null;
     }
 
@@ -153,6 +149,26 @@ const SOURCE_ALIASES: Record<string, string> = {
 };
 
 const SKILLS_PACK_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,119}$/;
+
+/**
+ * Return a pack identifier only for a canonical skills.sh pack URL.
+ *
+ * Keep this separate from generic well-known URLs: callers use it to skip
+ * per-skill telemetry and emit one completed-pack event instead.
+ */
+export function getSkillsPackId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'skills.sh' && parsed.hostname !== 'www.skills.sh') {
+      return null;
+    }
+
+    const match = parsed.pathname.match(/^\/p\/([A-Za-z0-9][A-Za-z0-9_-]{0,119})\/?$/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
 
 interface FragmentRefResult {
   inputWithoutFragment: string;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -17,6 +17,18 @@ interface InstallTelemetryData {
   sourceType?: string;
 }
 
+interface PackInstallTelemetryData {
+  /** Canonical skills.sh pack URL, including the pack ID. */
+  packUrl: string;
+  packId: string;
+  /** Short-lived, server-signed receipt from the pack manifest. */
+  receipt: string;
+  agents: string[];
+  global: boolean;
+  /** Count unique skills that installed to at least one target agent. */
+  installedSkillCount: number;
+}
+
 interface RemoveTelemetryData {
   event: 'remove';
   source?: string;
@@ -171,6 +183,42 @@ export function track(data: TelemetryData): void {
     pendingTelemetry.push(p);
   } catch {
     // Silently fail - telemetry should never break the CLI
+  }
+}
+
+/**
+ * Report a completed skills.sh pack installation directly to the pack owner.
+ *
+ * Packs must not use generic skill telemetry: that would attribute every
+ * member skill to `skills.sh`, lose the pack identity, and could reveal the
+ * contents of a private pack. This request is best effort just like track().
+ */
+export function trackPackInstall(data: PackInstallTelemetryData): void {
+  if (!isEnabled() || data.installedSkillCount < 1) return;
+
+  try {
+    const packUrl = new URL(data.packUrl);
+    const callbackUrl = new URL(
+      `/api/p/${encodeURIComponent(data.packId)}/install`,
+      packUrl.origin
+    );
+
+    const p = fetch(callbackUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        receipt: data.receipt,
+        agents: [...new Set(data.agents)].sort(),
+        global: data.global,
+        installed_skill_count: data.installedSkillCount,
+        cli_version: cliVersion ?? 'unknown',
+      }),
+    })
+      .catch(() => {})
+      .then(() => {});
+    pendingTelemetry.push(p);
+  } catch {
+    // Invalid telemetry URLs must never affect installation.
   }
 }
 

--- a/tests/pack-telemetry.test.ts
+++ b/tests/pack-telemetry.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushTelemetry, setVersion, trackPackInstall } from '../src/telemetry.ts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.DISABLE_TELEMETRY;
+  delete process.env.DO_NOT_TRACK;
+});
+
+describe('trackPackInstall', () => {
+  it('reports one completed pack install to the pack callback', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 202 }));
+    setVersion('1.5.16');
+
+    trackPackInstall({
+      packUrl: 'https://skills.sh/p/frontend-pack-A1b2C3d4',
+      packId: 'frontend-pack-A1b2C3d4',
+      receipt: 'receipt-token-123456',
+      agents: ['codex', 'claude-code', 'codex'],
+      global: true,
+      installedSkillCount: 2,
+    });
+    await flushTelemetry();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0]!;
+    expect(url.toString()).toBe('https://skills.sh/api/p/frontend-pack-A1b2C3d4/install');
+    expect(options).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(options?.body))).toMatchObject({
+      receipt: 'receipt-token-123456',
+      agents: ['claude-code', 'codex'],
+      global: true,
+      installed_skill_count: 2,
+      cli_version: '1.5.16',
+    });
+  });
+
+  it('does not report an install with no successful skills', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+    trackPackInstall({
+      packUrl: 'https://skills.sh/p/frontend-pack-A1b2C3d4',
+      packId: 'frontend-pack-A1b2C3d4',
+      receipt: 'receipt-token-123456',
+      agents: ['codex'],
+      global: false,
+      installedSkillCount: 0,
+    });
+    await flushTelemetry();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -208,6 +208,41 @@ describe('parseSource', () => {
     });
   });
 
+  describe('skills pack shorthand tests', () => {
+    it('skills.sh/p/<id> parses as a well-known source', () => {
+      const result = parseSource('skills.sh/p/frontend-pack-A1b2C3d4');
+      expect(result.type).toBe('well-known');
+      expect(result.url).toBe('https://skills.sh/p/frontend-pack-A1b2C3d4');
+    });
+
+    it('www.skills.sh/p/<id> parses as a canonical well-known source', () => {
+      const result = parseSource('www.skills.sh/p/frontend_pack-A1b2C3d4/');
+      expect(result.type).toBe('well-known');
+      expect(result.url).toBe('https://skills.sh/p/frontend_pack-A1b2C3d4');
+    });
+
+    it('pack:<id> parses as a skills.sh pack well-known source', () => {
+      const result = parseSource('pack:frontend-pack-A1b2C3d4');
+      expect(result.type).toBe('well-known');
+      expect(result.url).toBe('https://skills.sh/p/frontend-pack-A1b2C3d4');
+    });
+
+    it('https://skills.sh/p/<id> remains a well-known source', () => {
+      const result = parseSource('https://skills.sh/p/frontend-pack-A1b2C3d4');
+      expect(result.type).toBe('well-known');
+      expect(result.url).toBe('https://skills.sh/p/frontend-pack-A1b2C3d4');
+    });
+
+    it('rejects invalid pack ids', () => {
+      expect(() => parseSource('pack:')).toThrow('Invalid skills pack id');
+      expect(() => parseSource('pack:../secret')).toThrow('Invalid skills pack id');
+      expect(() => parseSource('skills.sh/p/')).toThrow('Invalid skills pack source');
+      expect(() => parseSource('skills.sh/p/frontend-pack/extra')).toThrow(
+        'Invalid skills pack source'
+      );
+    });
+  });
+
   describe('Local path tests', () => {
     it('Local path - relative with ./', () => {
       const result = parseSource('./my-skills');
@@ -315,6 +350,16 @@ describe('getOwnerRepo', () => {
 
   it('getOwnerRepo - local path returns null', () => {
     const parsed = parseSource('./my-skills');
+    expect(getOwnerRepo(parsed)).toBeNull();
+  });
+
+  it('getOwnerRepo - skills pack shorthand returns null', () => {
+    const parsed = parseSource('skills.sh/p/frontend-pack-A1b2C3d4');
+    expect(getOwnerRepo(parsed)).toBeNull();
+  });
+
+  it('getOwnerRepo - skills.sh pack URL returns null', () => {
+    const parsed = parseSource('https://www.skills.sh/p/frontend-pack-A1b2C3d4');
     expect(getOwnerRepo(parsed)).toBeNull();
   });
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { platform } from 'os';
-import { parseSource, getOwnerRepo } from '../src/source-parser.ts';
+import { parseSource, getOwnerRepo, getSkillsPackId } from '../src/source-parser.ts';
 
 const isWindows = platform() === 'win32';
 
@@ -240,6 +240,17 @@ describe('parseSource', () => {
       expect(() => parseSource('skills.sh/p/frontend-pack/extra')).toThrow(
         'Invalid skills pack source'
       );
+    });
+
+    it('extracts only canonical skills.sh pack IDs', () => {
+      expect(getSkillsPackId('https://skills.sh/p/frontend-pack-A1b2C3d4')).toBe(
+        'frontend-pack-A1b2C3d4'
+      );
+      expect(getSkillsPackId('https://www.skills.sh/p/frontend_pack-A1b2C3d4/')).toBe(
+        'frontend_pack-A1b2C3d4'
+      );
+      expect(getSkillsPackId('https://skills.sh/p/a/b')).toBeNull();
+      expect(getSkillsPackId('https://example.com/p/a')).toBeNull();
     });
   });
 

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -192,6 +192,46 @@ describe('WellKnownProvider', () => {
       expect(skills[0]!.files.has('references/README.md')).toBe(true);
     });
 
+    it('returns the optional skills.sh pack install receipt', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (
+          href === 'https://skills.sh/p/frontend-pack-A1b2C3d4/.well-known/agent-skills/index.json'
+        ) {
+          return response({
+            skills: [
+              {
+                name: 'legacy-skill',
+                description: 'Legacy skill.',
+                files: ['SKILL.md'],
+              },
+            ],
+            pack_install: {
+              pack_id: 'frontend-pack-A1b2C3d4',
+              receipt: 'signed-receipt-123456',
+            },
+          });
+        }
+        if (
+          href ===
+          'https://skills.sh/p/frontend-pack-A1b2C3d4/.well-known/agent-skills/legacy-skill/SKILL.md'
+        ) {
+          return response('---\nname: legacy-skill\ndescription: Legacy skill.\n---\n# Legacy');
+        }
+        return response('not found', { status: 404 });
+      });
+
+      const discovery = await provider.fetchAllSkillsWithContext(
+        'https://skills.sh/p/frontend-pack-A1b2C3d4'
+      );
+
+      expect(discovery.skills).toHaveLength(1);
+      expect(discovery.packInstall).toEqual({
+        packId: 'frontend-pack-A1b2C3d4',
+        receipt: 'signed-receipt-123456',
+      });
+    });
+
     it('keeps supporting path-relative legacy indexes like code.claude.com/docs', async () => {
       vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
         const href = String(url);


### PR DESCRIPTION
## Summary

Adds CLI parsing for shareable skills pack install strings:

- `npx skills add skills.sh/p/<pack-id>`
- `npx skills add www.skills.sh/p/<pack-id>`
- `npx skills add pack:<pack-id>`
- full `https://skills.sh/p/<pack-id>` URLs continue to use the existing well-known path

The new shorthand parser normalizes pack inputs to `https://skills.sh/p/<pack-id>` and returns a `well-known` parsed source, so installation continues through the existing well-known provider and installer flow. It also validates pack ids before fallback parsing so malformed pack strings do not get interpreted as GitHub shorthand.

I intentionally did not add bare `<pack-id>` parsing because it would be ambiguous with existing source forms. `pack:<id>` gives us a short explicit form for copy/paste installs.

## Details

- Adds a pack-id validator and `skills.sh/p/<id>` / `pack:<id>` normalization in `parseSource()`.
- Prevents skills.sh pack URLs from being treated as fake `owner/repo` values for repo privacy and audit lookups.
- Updates `skills --help` examples to show pack install forms.
- Adds parser regression tests for valid shorthand, full URL behavior, invalid pack ids, and `getOwnerRepo()` behavior for pack URLs.

## Test Plan

- [x] `pnpm test tests/source-parser.test.ts`
- [x] `pnpm format:check`
- [ ] `pnpm type-check` currently fails on untouched `main` files:
  - `src/git.ts:102` (`SimpleGitOptions` does not accept `env`)
  - `src/skills.ts:84` / `src/skills.ts:94` (frontmatter typing)
