### PR TITLE
fix: never spawn skill updates through a shell

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -456,7 +456,12 @@ export async function updateGlobalSkills(
     const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
       stdio: ['inherit', 'pipe', 'pipe'],
       encoding: 'utf-8',
-      shell: process.platform === 'win32',
+      // Never spawn through a shell. process.execPath is an absolute path to the
+      // node binary, so no shell is needed to resolve it. installUrl is derived
+      // from the lock file (and ref is URL-decoded, so influenceable by whoever
+      // publishes a skill); a shell on Windows would let metacharacters in that
+      // value inject commands. Passing argv directly keeps it inert.
+      shell: false,
     });
 
     if (result.status === 0) {
@@ -598,7 +603,11 @@ export async function updateProjectSkills(
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
-          shell: process.platform === 'win32',
+          // Never spawn through a shell — same reasoning as updateGlobalSkills:
+          // execPath is absolute (no shell resolution needed) and installUrl/ref
+          // come from the lock file, so a shell would allow command injection on
+          // Windows. Pass argv directly instead.
+          shell: false,
         }
       );
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { spawnSync } from 'child_process';
 import { updateProjectSkills, updateGlobalSkills } from '../src/update.ts';
 import * as git from '../src/git.ts';
 import * as skills from '../src/skills.ts';
@@ -267,6 +268,56 @@ describe('Update Cleanup Unit Tests', () => {
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'skills/skill-a')
       );
+    });
+
+    it('spawns the update without a shell so a crafted ref cannot inject commands', async () => {
+      // Force the Windows code path so this regression fails on the old
+      // `shell: process.platform === 'win32'` even when the test host is not
+      // Windows. The value is read inside spawnSync's options at call time.
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+      try {
+        vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+          version: 3,
+          skills: {
+            'skill-a': {
+              source: 'owner/repo',
+              skillPath: 'skills/skill-a/SKILL.md',
+              sourceType: 'github',
+              skillFolderHash: 'old-hash',
+              // Attacker-influenceable ref carrying a shell metacharacter.
+              ref: 'main&calc',
+              installedAt: '',
+              updatedAt: '',
+            },
+          },
+        });
+
+        vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+          sha: 'rootsha',
+          branch: 'main',
+          tree: [{ path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'sha1' }],
+        });
+        vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
+        // Latest hash differs from the lock -> an update is queued -> spawnSync runs.
+        vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-hash');
+
+        await updateGlobalSkills({ yes: true });
+
+        const installCall = vi
+          .mocked(spawnSync)
+          .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+        expect(installCall).toBeDefined();
+
+        const [, argv, options] = installCall!;
+        // The security invariant: no shell, so argv is passed to execvp verbatim.
+        expect((options as { shell?: boolean }).shell).toBe(false);
+        // The crafted ref rides inside a discrete argv element, never a command string.
+        expect(argv).toEqual(expect.arrayContaining([expect.stringContaining('main&calc')]));
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## What

Stop spawning skill updates through a shell. `updateGlobalSkills` and `updateProjectSkills` in `src/update.ts` called `spawnSync(process.execPath, [...], { shell: process.platform === 'win32' })`. This changes both to `shell: false`.

## Why (security)

The argv passed to that `spawnSync` includes `installUrl`, which is built from lock-file fields via `buildUpdateInstallSource` / `formatSourceInput`. The git `ref` embedded in it comes from a URL fragment that is URL-decoded (`decodeURIComponent` in `source-parser.ts`), so its value is influenceable by whoever authors an installed skill.

With `shell: true` on Windows, Node concatenates the args into a command line handled by `cmd.exe` **without escaping metacharacters**. A crafted ref such as `main&calc` would break out of the intended argument and run an arbitrary command when a user later runs `skills update`.

Chain: (a) Windows host, (b) user installs a skill from an attacker-controlled repo whose ref/branch carries shell metacharacters, (c) user runs `skills update`.

## Why `shell: false` is safe

`process.execPath` is an absolute path to the `node` binary, so no shell is needed to resolve the command (a shell is only required for `.cmd`/`.bat` shims, which this is not). `shell: false` passes argv to `execvp` verbatim on every platform, so the dangerous value can never be re-parsed by a shell.

## Tests

Added a regression test in `tests/update.test.ts` that forces the Windows code path (so it fails on the old behavior regardless of the test host), triggers an update whose lock entry has a `ref` containing a shell metacharacter, and asserts the spawn uses `shell: false` with the crafted ref carried in a discrete argv element.

- `pnpm test tests/update.test.ts` — passes (6/6)
- `pnpm build` and `pnpm format:check` — clean
