### PR TITLE
docs(find-skills): remove non-existent `npx skills check` command

### DIFF
--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -26,7 +26,6 @@ The Skills CLI (`npx skills`) is the package manager for the open agent skills e
 
 - `npx skills find [query] [--owner <owner>]` - Search for skills interactively or by keyword, optionally scoped to a GitHub owner
 - `npx skills add <package>` - Install a skill from GitHub or other sources
-- `npx skills check` - Check for skill updates
 - `npx skills update` - Update all installed skills
 
 **Browse skills at:** https://skills.sh/


### PR DESCRIPTION
## What

Removes the `npx skills check` line from `skills/find-skills/SKILL.md`'s **Key commands** list.

## Why

There is no `check` subcommand in the CLI. `npx skills --help` lists: `add`, `use`, `remove`, `list`/`ls`, `find`, `update` (alias `upgrade`), `init`, and the experimental `install`/`sync`.

The command that updates installed skills is `npx skills update`, which is **already listed on the very next line**. So the `check` entry is both incorrect and redundant — an agent following the skill's own guidance would emit an invalid command.

## Change

```diff
 - `npx skills add <package>` - Install a skill from GitHub or other sources
-- `npx skills check` - Check for skill updates
 - `npx skills update` - Update all installed skills
```

Docs-only, single line removed. Verified against CLI v1.5.14.