### PR TITLE
fix(installer): preserve copy modes and Claude symlinks

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,6 +10,7 @@ import {
   readFile,
   writeFile,
   stat,
+  chmod,
   realpath,
 } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -376,7 +377,7 @@ export async function installSkillForAgent(
     // actually used in this project. The skill is already available in .agents/skills/.
     if (!isGlobal && !isUniversalAgent(agentType)) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir)) {
+      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
         return {
           success: true,
           path: canonicalDir,
@@ -491,6 +492,8 @@ async function copyDirectory(src: string, dest: string, agentType?: AgentType): 
               dereference: true,
               recursive: true,
             });
+            const sourceStats = await stat(srcPath);
+            await chmod(destPath, sourceStats.mode & 0o777);
           } catch (err: unknown) {
             // Skip broken symlinks (e.g., pointing to absolute paths on another machine)
             // instead of aborting the entire install.

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
@@ -40,6 +40,36 @@ describe('installer copy mode', () => {
       );
       await expect(access(join(installedDir, 'metadata.json'))).rejects.toThrow();
       await expect(access(join(installedDir, '.git'))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves executable mode bits when copying files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-mode-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'copy-executable-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const scriptPath = join(skillDir, 'scripts', 'hello.sh');
+    await mkdir(join(skillDir, 'scripts'), { recursive: true });
+    await writeFile(scriptPath, '#!/bin/sh\necho hello\n', 'utf-8');
+    await chmod(scriptPath, 0o755);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+
+      const installedScript = join(projectDir, '.agents/skills', skillName, 'scripts', 'hello.sh');
+      const sourceMode = (await stat(scriptPath)).mode & 0o777;
+      const installedMode = (await stat(installedScript)).mode & 0o777;
+      expect(installedMode).toBe(sourceMode);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -184,6 +184,38 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('creates project-local Claude Code symlinks when .claude does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'fresh-claude-project-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      const claudeSkillDir = join(projectDir, '.claude/skills', skillName);
+
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+      expect((await lstat(claudeSkillDir)).isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Regression test for #294: universal-only global install should not create agent-specific symlinks
   it('does not create agent-specific symlinks for universal agents on global install', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));


### PR DESCRIPTION
Remakes #1149 with a signed commit and folds in the project-local Claude Code symlink fix from #1150.

## Summary
- Preserve executable permission bits when copy-mode installs copy files.
- Create project-local Claude Code symlinks even when `.claude/` does not already exist.
- Add regression coverage for both behaviors.

Closes #1140.
Closes #1138.
Supersedes #1149.
Supersedes #1150.

## Verification
- `pnpm exec vitest run tests/installer-copy.test.ts tests/installer-symlink.test.ts`