### PR TITLE
feat(agents): add Pool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -289,6 +289,7 @@ Skills can be installed to any of these agents:
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
+| Pool | `pool` | `.poolside/skills/` | `~/.config/poolside/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
@@ -417,6 +418,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.openhands/skills/`
 - `.ona/skills/`
 - `.pi/skills/`
+- `.poolside/skills/`
 - `.qoder/skills/`
 - `.qwen/skills/`
 - `.reasonix/skills/`

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "openhands",
     "ona",
     "pi",
+    "pool",
     "qoder",
     "qoder-cn",
     "qwen-code",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -506,6 +506,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.pi/agent'));
     },
   },
+  pool: {
+    name: 'pool',
+    displayName: 'Pool',
+    skillsDir: '.poolside/skills',
+    globalSkillsDir: join(configHome, 'poolside/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(configHome, 'poolside'));
+    },
+  },
   qoder: {
     name: 'qoder',
     displayName: 'Qoder',

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export type AgentType =
   | 'openhands'
   | 'ona'
   | 'pi'
+  | 'pool'
   | 'qoder'
   | 'qoder-cn'
   | 'qwen-code'


### PR DESCRIPTION
Adds support for [Pool](https://poolside.ai), Poolside's coding agent.

## Changes
- Add `'pool'` to the `AgentType` union in `src/types.ts`
- Add Pool agent configuration in `src/agents.ts`
  - Display name: Pool
  - Project path: `.poolside/skills/`
  - Global path: `~/.config/poolside/skills/`
  - Detection: presence of `~/.config/poolside`
- Update README.md supported-agents table
- Update package.json keywords with `pool`
