### PR TITLE
Add OMP agent target

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -244,6 +244,7 @@ Skills can be installed to any of these agents:
 |-------|-----------|--------------|-------------|
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
+| OMP | `omp` | `.omp/skills/` | `~/.omp/agent/skills/` |
 | Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
 | Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~/.gemini/antigravity-cli/skills/` |
 | AstrBot | `astrbot` | `data/skills/` | `~/.astrbot/data/skills/` |
@@ -383,6 +384,7 @@ to also discover `SKILL.md` files outside these container directories
 - `skills/.system/`
 - `.aider-desk/skills/`
 - `.agents/skills/`
+- `.omp/skills/`
 - `data/skills/`
 - `.autohand/skills/`
 - `.augment/skills/`

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ai-agents",
     "aider-desk",
     "amp",
+    "omp",
     "antigravity",
     "antigravity-cli",
     "astrbot",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -14,6 +14,10 @@ const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
+const ompProfile = process.env.OMP_PROFILE?.trim();
+const ompAgentDir = ompProfile
+  ? join(home, '.omp/profiles', ompProfile, 'agent')
+  : join(home, '.omp/agent');
 
 function packageJsonHasDependency(packageJsonPath: string, dependencyName: string): boolean {
   try {
@@ -62,6 +66,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(configHome, 'agents/skills'),
     detectInstalled: async () => {
       return existsSync(join(configHome, 'amp'));
+    },
+  },
+  omp: {
+    name: 'omp',
+    displayName: 'OMP',
+    skillsDir: '.omp/skills',
+    globalSkillsDir: join(ompAgentDir, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(ompAgentDir);
     },
   },
   antigravity: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type AgentType =
   | 'aider-desk'
   | 'amp'
+  | 'omp'
   | 'antigravity'
   | 'antigravity-cli'
   | 'astrbot'

--- a/tests/omp-agent.test.ts
+++ b/tests/omp-agent.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runCli } from '../src/test-utils.ts';
+
+function createSkillSource(root: string, skillName: string): string {
+  const sourceDir = join(root, 'source');
+  const skillDir = join(sourceDir, skillName);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${skillName}\ndescription: OMP test skill\n---\n# ${skillName}\n`
+  );
+  return sourceDir;
+}
+
+function isolatedEnv(root: string): Record<string, string> {
+  const home = join(root, 'home');
+  mkdirSync(home, { recursive: true });
+
+  return {
+    HOME: home,
+    USERPROFILE: home,
+  };
+}
+
+describe('OMP agent support', () => {
+  let root: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'skills-omp-agent-'));
+    projectDir = join(root, 'project');
+    mkdirSync(projectDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('installs project skills into .omp/skills when --agent omp is used', () => {
+    const skillName = 'omp-project-skill';
+    const sourceDir = createSkillSource(root, skillName);
+    mkdirSync(join(projectDir, '.omp'), { recursive: true });
+
+    const result = runCli(
+      ['add', sourceDir, '--skill', skillName, '--agent', 'omp', '-y'],
+      projectDir,
+      isolatedEnv(root)
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Done!');
+
+    const installedSkill = join(projectDir, '.omp', 'skills', skillName, 'SKILL.md');
+    expect(readFileSync(installedSkill, 'utf-8')).toContain(`name: ${skillName}`);
+  });
+
+  it('lists and removes project skills from .omp/skills with --agent omp', () => {
+    const skillName = 'omp-list-remove-skill';
+    const skillDir = join(projectDir, '.omp', 'skills', skillName);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: OMP list/remove skill\n---\n# ${skillName}\n`
+    );
+
+    const env = isolatedEnv(root);
+    const listResult = runCli(['list', '--agent', 'omp', '--json'], projectDir, env);
+
+    expect(listResult.exitCode).toBe(0);
+    const listed = JSON.parse(listResult.stdout.trim());
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      name: skillName,
+      scope: 'project',
+      agents: ['OMP'],
+    });
+    expect(listed[0].path).toMatch(/\.omp[/\\]skills[/\\]omp-list-remove-skill$/);
+
+    const removeResult = runCli(['remove', skillName, '--agent', 'omp', '-y'], projectDir, env);
+
+    expect(removeResult.exitCode).toBe(0);
+    expect(removeResult.stdout).toContain('Successfully removed');
+    expect(existsSync(skillDir)).toBe(false);
+  });
+
+  it('installs global skills into HOME/.omp/agent/skills when --agent omp --global is used', () => {
+    const skillName = 'omp-global-skill';
+    const sourceDir = createSkillSource(root, skillName);
+    const env = { ...isolatedEnv(root), OMP_PROFILE: '' };
+
+    const result = runCli(
+      ['add', sourceDir, '--skill', skillName, '--agent', 'omp', '--global', '-y'],
+      projectDir,
+      env
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Done!');
+
+    const installedSkill = join(env.HOME, '.omp', 'agent', 'skills', skillName, 'SKILL.md');
+    expect(readFileSync(installedSkill, 'utf-8')).toContain(`name: ${skillName}`);
+  });
+
+  it('installs profile global skills into HOME/.omp/profiles/<profile>/agent/skills', () => {
+    const skillName = 'omp-profile-global-skill';
+    const sourceDir = createSkillSource(root, skillName);
+    const env = { ...isolatedEnv(root), OMP_PROFILE: 'myprofile' };
+
+    const result = runCli(
+      ['add', sourceDir, '--skill', skillName, '--agent', 'omp', '--global', '-y'],
+      projectDir,
+      env
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Done!');
+
+    const installedSkill = join(
+      env.HOME,
+      '.omp',
+      'profiles',
+      'myprofile',
+      'agent',
+      'skills',
+      skillName,
+      'SKILL.md'
+    );
+    expect(readFileSync(installedSkill, 'utf-8')).toContain(`name: ${skillName}`);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `omp` as a supported agent target.
- Install project skills to `.omp/skills` and global skills to `~/.omp/agent/skills` by default.
- Honor `OMP_PROFILE=<name>` for profile-scoped global installs at `~/.omp/profiles/<name>/agent/skills`.
- Regenerate the supported agents docs/keywords and cover add/list/remove behavior for OMP.

## Tests
- `pnpm exec vitest run tests/omp-agent.test.ts tests/xdg-config-paths.test.ts`
- `pnpm exec prettier --check src/agents.ts src/types.ts tests/omp-agent.test.ts package.json`

Note: `pnpm exec tsc --noEmit` currently reports pre-existing errors in `src/git.ts` and `src/skills.ts` unrelated to this change.