### PR TITLE
fix: apply claude-code symlink exemption to blob install path

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1015,10 +1015,12 @@ export async function installBlobSkillForAgent(
     }
 
     // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project.
+    // whose config directory doesn't already exist in the project. Claude Code is
+    // exempted since it can be explicitly selected as the install target even when
+    // .claude/ doesn't exist yet (see installSkillForAgent for the same exemption).
     if (!isGlobal && !isUniversalAgent(agentType)) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir)) {
+      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
         return {
           success: true,
           path: canonicalDir,

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installSkillForAgent } from '../src/installer.ts';
+import { installSkillForAgent, installBlobSkillForAgent } from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
   const dir = join(root, 'source-skill');
@@ -195,6 +195,47 @@ describe('installer symlink regression', () => {
     try {
       const result = await installSkillForAgent(
         { name: skillName, description: 'test', path: skillDir },
+        'claude-code',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      const claudeSkillDir = join(projectDir, '.claude/skills', skillName);
+
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+      expect((await lstat(claudeSkillDir)).isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // Regression test for #1607: same claude-code exemption as installSkillForAgent,
+  // but for the blob install path (used by `skills add <owner>/<repo>`).
+  it('creates project-local Claude Code symlinks for blob installs when .claude does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'fresh-claude-blob-skill';
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            {
+              path: 'SKILL.md',
+              contents: `---\nname: ${skillName}\ndescription: test\n---\n`,
+            },
+          ],
+        },
         'claude-code',
         { cwd: projectDir, mode: 'symlink', global: false }
       );


### PR DESCRIPTION
## Summary

- `installSkillForAgent` already exempts `claude-code` from the "skip symlink if the agent's config dir doesn't exist yet" guard (added recently), so explicitly selecting Claude Code as the install target works even when `.claude/` doesn't exist.
- `installBlobSkillForAgent` — the path used by `skills add <owner>/<repo>` — has the same guard but was missing that exemption. As a result, project-level installs of a remote skill for Claude Code silently skipped creating the `.claude/skills` symlink whenever `.claude/` didn't already exist, leaving the skill only reachable via `.agents/skills`, with no error or warning shown.
- This applies the same `agentType !== 'claude-code'` exemption to `installBlobSkillForAgent`, matching the existing behavior in `installSkillForAgent`.

Fixes #1607

## Test plan

- [x] Added a regression test mirroring the existing `installSkillForAgent` claude-code test, but for `installBlobSkillForAgent`
- [x] Confirmed the new test fails without the fix and passes with it
- [x] `npx vitest run tests/installer-symlink.test.ts` passes (7/7)
- [x] Full test suite: same 6 pre-existing failures on `main` and on this branch (unrelated to this change)
- [x] `pnpm run format` — no changes needed elsewhere