### PR TITLE
fix: install full skill directory for root-level SKILL.md repos

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { existsSync } from 'fs';
@@ -198,13 +197,6 @@ function shortenPath(fullPath: string, cwd: string): string {
     return '.' + fullPath.slice(cwd.length);
   }
   return fullPath;
-}
-
-function computeSingleFileSkillHash(contents: string): string {
-  const hash = createHash('sha256');
-  hash.update('SKILL.md');
-  hash.update(contents);
-  return hash.digest('hex');
 }
 
 /**
@@ -1736,15 +1728,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             agent,
             { global: installGlobally, mode: installMode, eveSubagent: subagent }
           );
-        } else if (tempDir && skill.path === tempDir && skill.rawContent) {
-          // Remote root-level SKILL.md: install the skill file, not the whole repository.
-          result = await installBlobSkillForAgent(
-            { installName: skill.name, files: [{ path: 'SKILL.md', contents: skill.rawContent }] },
-            agent,
-            { global: installGlobally, mode: installMode }
-          );
         } else {
-          // Disk-based install: copy from cloned/local directory
+          // Disk-based install: copy from cloned/local directory.
+          // Root-level skills (SKILL.md at repo root, so skill.path === tempDir)
+          // also take this path and are copied recursively (see installer.ts
+          // copyDirectory, which excludes .git), so their scripts/, references/,
+          // assets/, etc. are installed too. See issue #1603.
           result = await installSkillForAgent(skill, agent, {
             global: installGlobally,
             mode: installMode,
@@ -1894,9 +1883,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             const computedHash =
               blobResult && 'snapshotHash' in skill
                 ? (skill as BlobSkill).snapshotHash
-                : tempDir && skill.path === tempDir && skill.rawContent
-                  ? computeSingleFileSkillHash(skill.rawContent)
-                  : await computeSkillFolderHash(skill.path);
+                : await computeSkillFolderHash(skill.path);
             const skillPathValue = skillFiles[skill.name];
             await addSkillToLocalLock(
               skill.name,

--- a/tests/root-level-disk-install.test.ts
+++ b/tests/root-level-disk-install.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Isolate side-effecting UI / network deps so runAdd can run headless in CI.
+vi.mock('@clack/prompts', () => {
+  const noop = () => {};
+  return {
+    intro: noop,
+    outro: noop,
+    note: noop,
+    confirm: vi.fn().mockResolvedValue(true),
+    cancel: noop,
+    log: {
+      info: noop,
+      message: noop,
+      warn: noop,
+      error: (...a: unknown[]) => console.log('[clack.error]', ...a),
+      step: noop,
+      success: noop,
+    },
+    spinner: () => ({ start: noop, stop: noop }),
+  };
+});
+
+vi.mock('picocolors', () => {
+  const id = (s: string) => s;
+  const colors = [
+    'red',
+    'green',
+    'blue',
+    'yellow',
+    'cyan',
+    'white',
+    'black',
+    'dim',
+    'bold',
+    'bgRed',
+    'bgCyan',
+    'bgBlack',
+    'bgWhite',
+    'underline',
+    'inverse',
+    'magenta',
+    'gray',
+    'reset',
+  ];
+  const obj: any = id;
+  for (const c of colors) obj[c] = id;
+  return { default: obj };
+});
+
+vi.mock('../src/telemetry.ts', () => ({
+  track: vi.fn(),
+  setVersion: vi.fn(),
+  fetchAuditData: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../src/detect-agent.ts', () => ({
+  detectAgent: vi.fn().mockResolvedValue({ isAgent: false, agent: { name: 'none' } }),
+  getAgentType: vi.fn(),
+  ensureUniversalAgents: vi.fn((x: string[]) => x),
+}));
+
+// NOTE: do NOT mock ../src/agents.ts. installer.installSkillForAgent relies on the
+// real `agents` map (e.g. codex.skillsDir / globalSkillsDir); a stubbed map with only
+// `displayName` makes getAgentBaseDir() do join(baseDir, undefined) and throws
+// "The \"path\" argument must be of type string. Received undefined". We pass
+// `agent: ['codex']` to runAdd so the detectInstalledAgents() branch is skipped anyway.
+
+// Keep parseSource/getOwnerRepo real, but stub the only network call (isRepoPrivate)
+// so the test runs offline.
+vi.mock('../src/source-parser.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../src/source-parser.ts')>();
+  return {
+    ...actual,
+    isRepoPrivate: vi.fn().mockResolvedValue(false),
+  };
+});
+
+// Simulate a GitHub clone without touching the network: cloneRepo returns a local
+// fixture directory. cleanupTempDir is a no-op so we control teardown ourselves.
+vi.mock('../src/git.ts', () => ({
+  cloneRepo: vi.fn(),
+  cleanupTempDir: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { runAdd } from '../src/add.ts';
+import { cloneRepo } from '../src/git.ts';
+import * as installer from '../src/installer.ts';
+
+describe('root-level disk install (issue #1603)', () => {
+  let base: string;
+  let fixture: string; // a fake cloned repo (SKILL.md at the repo root)
+  let project: string; // install target cwd
+  let origCwd: string;
+  let spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'root-disk-'));
+    fixture = join(base, 'fixture-repo');
+    await mkdir(fixture, { recursive: true });
+    await writeFile(
+      join(fixture, 'SKILL.md'),
+      '---\nname: myrootskill\ndescription: root level skill\n---\n',
+      'utf-8'
+    );
+    await mkdir(join(fixture, 'scripts'), { recursive: true });
+    await writeFile(join(fixture, 'scripts', 'check-deps.mjs'), 'console.log("x")\n', 'utf-8');
+    await mkdir(join(fixture, 'references'), { recursive: true });
+    await writeFile(join(fixture, 'references', 'guide.md'), '# guide\n', 'utf-8');
+
+    project = join(base, 'project');
+    await mkdir(project, { recursive: true });
+    origCwd = process.cwd();
+    process.chdir(project);
+
+    // Drive the GitHub-clone code path (tempDir === skill.path) without network.
+    vi.mocked(cloneRepo).mockResolvedValue(fixture);
+
+    spy = vi.spyOn(installer, 'installSkillForAgent');
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    process.chdir(origCwd);
+    await rm(base, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('installs the full directory (scripts/ + references/) for a root-level SKILL.md repo', async () => {
+    // A github-style source goes through cloneRepo + discoverSkills(tempDir),
+    // where skill.path === tempDir. This is exactly the branch that dropped the
+    // supporting files before the fix (see issue #1603).
+    await runAdd(['someowner/somerepo'], {
+      yes: true,
+      agent: ['codex'],
+      global: false,
+      mode: 'copy',
+    });
+
+    // The disk-based install path must be used (not the blob single-file path).
+    expect(spy).toHaveBeenCalled();
+
+    const installed = join(project, '.agents', 'skills', 'myrootskill');
+    await expect(readFile(join(installed, 'SKILL.md'), 'utf-8')).resolves.toContain('myrootskill');
+    // Regression for #1603: supporting files must NOT be dropped.
+    await expect(readFile(join(installed, 'scripts', 'check-deps.mjs'), 'utf-8')).resolves.toBe(
+      'console.log("x")\n'
+    );
+    await expect(readFile(join(installed, 'references', 'guide.md'), 'utf-8')).resolves.toBe(
+      '# guide\n'
+    );
+  });
+});

--- a/tests/root-level-lock-hash.test.ts
+++ b/tests/root-level-lock-hash.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Isolate side-effecting UI / network deps so runAdd can run headless in CI.
+vi.mock('@clack/prompts', () => {
+  const noop = () => {};
+  return {
+    intro: noop,
+    outro: noop,
+    note: noop,
+    confirm: vi.fn().mockResolvedValue(true),
+    cancel: noop,
+    log: {
+      info: noop,
+      message: noop,
+      warn: noop,
+      error: (...a: unknown[]) => console.log('[clack.error]', ...a),
+      step: noop,
+      success: noop,
+    },
+    spinner: () => ({ start: noop, stop: noop }),
+  };
+});
+
+vi.mock('picocolors', () => {
+  const id = (s: string) => s;
+  const colors = [
+    'red',
+    'green',
+    'blue',
+    'yellow',
+    'cyan',
+    'white',
+    'black',
+    'dim',
+    'bold',
+    'bgRed',
+    'bgCyan',
+    'bgBlack',
+    'bgWhite',
+    'underline',
+    'inverse',
+    'magenta',
+    'gray',
+    'reset',
+  ];
+  const obj: any = id;
+  for (const c of colors) obj[c] = id;
+  return { default: obj };
+});
+
+vi.mock('../src/telemetry.ts', () => ({
+  track: vi.fn(),
+  setVersion: vi.fn(),
+  fetchAuditData: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../src/detect-agent.ts', () => ({
+  detectAgent: vi.fn().mockResolvedValue({ isAgent: false, agent: { name: 'none' } }),
+  getAgentType: vi.fn(),
+  ensureUniversalAgents: vi.fn((x: string[]) => x),
+}));
+
+// Keep parseSource/getOwnerRepo real, but stub the only network call (isRepoPrivate)
+// so the test runs offline.
+vi.mock('../src/source-parser.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../src/source-parser.ts')>();
+  return {
+    ...actual,
+    isRepoPrivate: vi.fn().mockResolvedValue(false),
+  };
+});
+
+// Simulate a GitHub clone without touching the network: cloneRepo returns a local
+// fixture directory.
+vi.mock('../src/git.ts', () => ({
+  cloneRepo: vi.fn(),
+  cleanupTempDir: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { runAdd } from '../src/add.ts';
+import { cloneRepo } from '../src/git.ts';
+
+async function makeRootSkill(root: string, scriptContents: string): Promise<void> {
+  await mkdir(join(root, 'scripts'), { recursive: true });
+  await writeFile(
+    join(root, 'SKILL.md'),
+    '---\nname: myrootskill\ndescription: root level skill\n---\n',
+    'utf-8'
+  );
+  await writeFile(join(root, 'scripts', 'check-deps.mjs'), scriptContents, 'utf-8');
+  await mkdir(join(root, 'references'), { recursive: true });
+  await writeFile(join(root, 'references', 'guide.md'), '# guide\n', 'utf-8');
+}
+
+async function readLockHash(project: string, name: string): Promise<string> {
+  const raw = await readFile(join(project, 'skills-lock.json'), 'utf-8');
+  const j = JSON.parse(raw) as { skills: Record<string, { computedHash: string }> };
+  return j.skills[name].computedHash;
+}
+
+describe('root-level lock hash covers the whole directory (issue #1603)', () => {
+  let base: string;
+  let origCwd: string;
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'root-hash-'));
+    origCwd = process.cwd();
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    process.chdir(origCwd);
+    await rm(base, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('changing a supporting file (scripts/) changes the computed lock hash', async () => {
+    // Two repos that differ ONLY in a supporting file (scripts/check-deps.mjs).
+    // SKILL.md and references/ are byte-identical. Before the fix, the lock hash used
+    // computeSingleFileSkillHash(SKILL.md contents), so both repos hashed the same
+    // and `skills update` could never detect a script change. After the fix it uses
+    // computeSkillFolderHash(skill.path), which includes scripts/, so the two hashes
+    // MUST differ.
+    const fa = join(base, 'fa');
+    await mkdir(fa, { recursive: true });
+    await makeRootSkill(fa, 'console.log("v1")\n');
+    const fb = join(base, 'fb');
+    await mkdir(fb, { recursive: true });
+    await makeRootSkill(fb, 'console.log("v2")\n');
+
+    const pa = join(base, 'pa');
+    await mkdir(pa, { recursive: true });
+    const pb = join(base, 'pb');
+    await mkdir(pb, { recursive: true });
+
+    // Install repo A -> capture lock hash.
+    process.chdir(pa);
+    vi.mocked(cloneRepo).mockResolvedValue(fa);
+    await runAdd(['owner/repo-a'], { yes: true, agent: ['codex'], global: false, mode: 'copy' });
+    const hashA = await readLockHash(pa, 'myrootskill');
+
+    // Install repo B (identical SKILL.md, different script) -> capture lock hash.
+    process.chdir(pb);
+    vi.mocked(cloneRepo).mockResolvedValue(fb);
+    await runAdd(['owner/repo-b'], { yes: true, agent: ['codex'], global: false, mode: 'copy' });
+    const hashB = await readLockHash(pb, 'myrootskill');
+
+    // Core regression: the directory hash must change when a supporting file changes,
+    // otherwise `skills update` cannot detect upstream script updates.
+    expect(hashA).not.toBe(hashB);
+  });
+});


### PR DESCRIPTION
When a skill repo places SKILL.md at the repository root, npx skills add cloned the repo but only installed SKILL.md, dropping scripts/, references/, assets/, etc. The root-level branch in runAdd() routed these to installBlobSkillForAgent with a single file, and the lock hash used computeSingleFileSkillHash, so updates never detected changes.

Root-level single-skill repos are valid per the Agent Skills spec (a skill is a directory containing SKILL.md; the repo root is that directory). This removes the special-case branch so root-level skills go through installSkillForAgent, which copies the directory recursively (copyDirectory excludes .git) and preserves binaries. The lock hash now uses computeSkillFolderHash so updates work.

Fixes #1603