### PR TITLE
fix(git): block ext transport

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -194,4 +194,11 @@ describe('git clone fallbacks', () => {
     );
     expect(execFileMock).not.toHaveBeenCalled();
   });
+
+  it('rejects the command-executing ext transport before invoking git', async () => {
+    await expect(cloneRepo('ext::sh -c id')).rejects.toThrow('Unsupported Git transport: ext');
+
+    expect(simpleGitMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -189,6 +189,10 @@ function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message:
 }
 
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
+  if (/^ext::/i.test(url)) {
+    throw new GitCloneError('Unsupported Git transport: ext', url);
+  }
+
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
   const repo = parseGitHubRepoUrl(url);


### PR DESCRIPTION
## Summary

- reject command-executing `ext::` sources at the shared clone boundary
- fail before creating a temporary directory or invoking Git
- add a regression test verifying neither Git nor the GitHub CLI is called

## Testing

- `pnpm test src/git.test.ts --run`
- `pnpm exec prettier --check src/git.ts src/git.test.ts`