### PR TITLE
Add ZCode agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -306,6 +306,7 @@ Skills can be installed to any of these agents:
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
 | PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
+| ZCode | `zcode` | `.zcode/skills/` | `~/.zcode/skills/` |
 <!-- supported-agents:end -->
 
 > [!NOTE]
@@ -431,6 +432,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.neovate/skills/`
 - `.pochi/skills/`
 - `.adal/skills/`
+- `.zcode/skills/`
 <!-- skill-discovery:end -->
 
 ### Plugin Manifest Discovery

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "pochi",
     "promptscript",
     "adal",
+    "zcode",
     "universal"
   ],
   "repository": {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -705,6 +705,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.adal'));
     },
   },
+  zcode: {
+    name: 'zcode',
+    displayName: 'ZCode',
+    skillsDir: '.zcode/skills',
+    globalSkillsDir: join(home, '.zcode/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.zcode'));
+    },
+  },
   universal: {
     name: 'universal',
     displayName: 'Universal',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -275,6 +275,7 @@ const PRIORITY_PREFIXES = [
   '.roo/skills/',
   '.trae/skills/',
   '.windsurf/skills/',
+  '.zcode/skills/',
   '.zencoder/skills/',
 ];
 

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -31,6 +31,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.roo/skills',
   '.trae/skills',
   '.windsurf/skills',
+  '.zcode/skills',
   '.zencoder/skills',
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export type AgentType =
   | 'pochi'
   | 'promptscript'
   | 'adal'
+  | 'zcode'
   | 'universal';
 
 export interface Skill {

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -114,5 +114,12 @@ describe('XDG config paths', () => {
       const expected = join(home, '.agents', 'skills');
       expect(agents.cline.globalSkillsDir).toBe(expected);
     });
+
+    it('zcode uses ~/.zcode/skills (home-based, not XDG)', () => {
+      const expected = join(home, '.zcode', 'skills');
+      expect(agents.zcode.globalSkillsDir).toBe(expected);
+      expect(agents.zcode.skillsDir).toBe('.zcode/skills');
+      expect(agents.zcode.displayName).toBe('ZCode');
+    });
   });
 });


### PR DESCRIPTION
## What

Adds **ZCode** as a supported agent.

## Why

[ZCode](https://z.ai) is an AI coding agent whose client reads skills from its own directories, alongside the shared `.agents/skills` locations. Registering it lets users install skills with the standard `npx skills add ... -a zcode` flow.

### ZCode skill discovery paths

Within each scope, ZCode reads `.zcode` before `.agents` (so `.zcode/skills` can override a same-named skill only inside ZCode):

| Scope | Paths (in precedence order) |
| --- | --- |
| User (global) | `~/.zcode/skills/`, `~/.agents/skills/` |
| Workspace | `<repo>/.zcode/skills/`, `<repo>/.agents/skills/` |

## Changes

- `src/types.ts` — add `'zcode'` to the `AgentType` union
- `src/agents.ts` — register the `zcode` config: `skillsDir: '.zcode/skills'`, `globalSkillsDir: ~/.zcode/skills`, `detectInstalled` via `~/.zcode`
- `src/skills.ts` — add `.zcode/skills` to `AGENT_PROJECT_SKILL_DIRS`
- `README.md` / `package.json` — regenerated agent list, supported-agents table, skill-discovery paths, and keywords
- `tests/xdg-config-paths.test.ts` — cover the zcode path config

Follows the existing non-universal agent pattern (e.g. cursor, codex). Installation goes through the canonical `.agents/skills` location with a symlink into `.zcode/skills`.

## Verification

- `node scripts/validate-agents.ts` — passes (no duplicate `displayName`)
- `pnpm exec vitest run tests/xdg-config-paths.test.ts` — 15/15 pass, including the new zcode case
- Full suite: 547 pass / 7 fail; all 7 failures are pre-existing Windows symlink-permission errors (`EPERM`) unrelated to this change (they fail identically on `main`)