### PR TITLE
feat: add Amazon Quick support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [68 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -243,6 +243,7 @@ Skills can be installed to any of these agents:
 | Agent | `--agent` | Project Path | Global Path |
 |-------|-----------|--------------|-------------|
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
+| Amazon Quick | `amazon-quick` | `.quickwork/skills/` | `~/.quickwork/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
 | Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
 | Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~/.gemini/antigravity-cli/skills/` |
@@ -382,6 +383,7 @@ to also discover `SKILL.md` files outside these container directories
 - `skills/.experimental/`
 - `skills/.system/`
 - `.aider-desk/skills/`
+- `.quickwork/skills/`
 - `.agents/skills/`
 - `data/skills/`
 - `.autohand/skills/`
@@ -506,6 +508,7 @@ Telemetry is automatically disabled in CI environments.
 
 - [Agent Skills Specification](https://agentskills.io)
 - [Skills Directory](https://skills.sh)
+- [Amazon Quick Skills Documentation](https://docs.aws.amazon.com/quick/latest/userguide/skills-and-agents-desktop.html)
 - [Amp Skills Documentation](https://ampcode.com/manual#agent-skills)
 - [Antigravity Skills Documentation](https://antigravity.google/docs/skills)
 - [Factory AI / Droid Skills Documentation](https://docs.factory.ai/cli/configuration/skills)

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "skills",
     "ai-agents",
     "aider-desk",
+    "amazon-quick",
     "amp",
     "antigravity",
     "antigravity-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -12,6 +12,7 @@ const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude'
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
+const quickHome = process.env.QUICKWORK_HOME?.trim() || join(home, '.quickwork');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
 
@@ -53,6 +54,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.aider-desk/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.aider-desk'));
+    },
+  },
+  'amazon-quick': {
+    name: 'amazon-quick',
+    displayName: 'Amazon Quick',
+    skillsDir: '.quickwork/skills',
+    globalSkillsDir: join(quickHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(quickHome);
     },
   },
   amp: {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -272,6 +272,7 @@ const PRIORITY_PREFIXES = [
   '.openhands/skills/',
   '.pi/skills/',
   '.qoder/skills/',
+  '.quickwork/skills/',
   '.roo/skills/',
   '.trae/skills/',
   '.windsurf/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -28,6 +28,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.openhands/skills',
   '.pi/skills',
   '.qoder/skills',
+  '.quickwork/skills',
   '.roo/skills',
   '.trae/skills',
   '.windsurf/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type AgentType =
   | 'aider-desk'
+  | 'amazon-quick'
   | 'amp'
   | 'antigravity'
   | 'antigravity-cli'


### PR DESCRIPTION
Add Amazon Quick as a supported agent. Amazon Quick's desktop app loads SKILL.md folders on demand from its ~/.quickwork directory (overridable via QUICKWORK_HOME).

- add 'amazon-quick' to AgentType union
- add agent config (.quickwork/skills project + ~/.quickwork/skills global)
- register .quickwork/skills in skill discovery (skills.ts, blob.ts)
- regenerate README supported-agents table and package.json keywords
- add Amazon Quick skills docs link to README