### PR TITLE
fix(update): preserve non-GitHub lock source URLs

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,7 +4,12 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, stripAnsi } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import { parseAddOptions, getLockSource, formatEveInstallPromptMessage } from './add.ts';
+import {
+  parseAddOptions,
+  getLockSource,
+  getProjectLockSourceUrl,
+  formatEveInstallPromptMessage,
+} from './add.ts';
 
 const noDetectedAgentEnv = {
   AI_AGENT: '',
@@ -367,8 +372,38 @@ describe('getLockSource', () => {
     );
   });
 
-  it('keeps normalized owner/repo for non-SSH remotes', () => {
+  it('keeps normalized owner/repo for GitHub HTTPS remotes', () => {
     expect(getLockSource('https://github.com/owner/repo.git', 'owner/repo')).toBe('owner/repo');
+  });
+
+  it('preserves self-hosted HTTPS Git URLs for lock files', () => {
+    expect(getLockSource('https://gitlab.example.com/acme/skills.git', 'acme/skills')).toBe(
+      'https://gitlab.example.com/acme/skills.git'
+    );
+  });
+
+  it('preserves gitlab.com HTTPS URLs for lock files', () => {
+    expect(getLockSource('https://gitlab.com/acme/skills.git', 'acme/skills')).toBe(
+      'https://gitlab.com/acme/skills.git'
+    );
+  });
+});
+
+describe('getProjectLockSourceUrl', () => {
+  it('records sourceUrl for self-hosted GitLab HTTPS sources installed into project locks', () => {
+    expect(getProjectLockSourceUrl('git', 'https://gitlab.example.com/acme/skills.git')).toBe(
+      'https://gitlab.example.com/acme/skills.git'
+    );
+  });
+
+  it('records sourceUrl for GitLab sources installed into project locks', () => {
+    expect(getProjectLockSourceUrl('gitlab', 'https://gitlab.com/acme/skills.git')).toBe(
+      'https://gitlab.com/acme/skills.git'
+    );
+  });
+
+  it('keeps GitHub project locks compatible with existing shorthand entries', () => {
+    expect(getProjectLockSourceUrl('github', 'https://github.com/owner/repo.git')).toBeUndefined();
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -30,7 +30,23 @@ export function getLockSource(parsedUrl: string, normalizedSource: string | null
   // When normalizedSource is used, parseSource() later resolves it to HTTPS,
   // breaking restore for private repos that require SSH authentication.
   const isSSH = parsedUrl.startsWith('git@') || parsedUrl.startsWith('ssh://');
-  return isSSH ? parsedUrl : normalizedSource;
+  if (isSSH) {
+    return parsedUrl;
+  }
+  if (parsedUrl.startsWith('http://') || parsedUrl.startsWith('https://')) {
+    try {
+      if (new URL(parsedUrl).hostname !== 'github.com') {
+        return parsedUrl;
+      }
+    } catch {
+      return normalizedSource;
+    }
+  }
+  return normalizedSource;
+}
+
+export function getProjectLockSourceUrl(sourceType: string, sourceUrl: string): string | undefined {
+  return sourceType === 'git' || sourceType === 'gitlab' ? sourceUrl : undefined;
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
@@ -1774,6 +1790,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const normalizedSource = getOwnerRepo(parsed);
 
     const lockSource = getLockSource(parsed.url, normalizedSource);
+    const projectLockSourceUrl = getProjectLockSourceUrl(parsed.type, parsed.url);
 
     // Only track if we have a valid remote source and it's not a private repo.
     // repoPrivacyPromise was started early (right after parsing) so it has
@@ -1882,6 +1899,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skill.name,
               {
                 source: lockSource || parsed.url,
+                ...(projectLockSourceUrl && { sourceUrl: projectLockSourceUrl }),
                 ref: parsed.ref,
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),

--- a/src/install.ts
+++ b/src/install.ts
@@ -4,6 +4,7 @@ import { readLocalLock } from './local-lock.ts';
 import { runAdd } from './add.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { getUniversalAgents } from './agents.ts';
+import { buildLocalUpdateSource } from './update-source.ts';
 
 /**
  * Install all skills from the local skills-lock.json.
@@ -40,7 +41,13 @@ export async function runInstallFromLock(args: string[]): Promise<void> {
       continue;
     }
 
-    const installSource = entry.ref ? `${entry.source}#${entry.ref}` : entry.source;
+    const installSource = buildLocalUpdateSource(entry);
+    if (!installSource) {
+      p.log.error(
+        `Cannot restore ${pc.cyan(skillName)}: skills-lock.json is missing sourceUrl for this generic Git source`
+      );
+      continue;
+    }
     const existing = bySource.get(installSource);
     if (existing) {
       existing.skills.push(skillName);

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -15,6 +15,8 @@ const CURRENT_VERSION = 1;
 export interface LocalSkillLockEntry {
   /** Where the skill came from: npm package name, owner/repo, local path, etc. */
   source: string;
+  /** Original remote URL, when source was normalized for lock readability. */
+  sourceUrl?: string;
   /** Branch or tag ref used for installation */
   ref?: string;
   /** The provider/source type (e.g., "github", "node_modules", "local") */

--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -35,10 +35,31 @@ describe('update-source', () => {
       const result = buildUpdateInstallSource({
         source: 'owner/repo',
         sourceUrl: 'https://github.com/owner/repo.git',
+        sourceType: 'github',
         ref: 'feature/install',
         skillPath: 'skills/my-skill/SKILL.md',
       });
       expect(result).toBe('owner/repo/skills/my-skill#feature/install');
+    });
+
+    it('uses sourceUrl for non-GitHub sources with host-stripped source', () => {
+      const result = buildUpdateInstallSource({
+        source: 'acme/skills',
+        sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+        sourceType: 'git',
+        ref: 'main',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://gitlab.example.com/acme/skills.git#main');
+    });
+
+    it('fails closed for non-GitHub lock entries missing sourceUrl', () => {
+      const result = buildUpdateInstallSource({
+        source: 'acme/skills',
+        sourceType: 'git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBeNull();
     });
 
     it('falls back to sourceUrl when skillPath is missing', () => {
@@ -55,6 +76,7 @@ describe('update-source', () => {
     it('appends skill folder from skillPath with ref', () => {
       const result = buildLocalUpdateSource({
         source: 'owner/repo',
+        sourceType: 'github',
         ref: 'main',
         skillPath: 'skills/my-skill/SKILL.md',
       });
@@ -64,6 +86,7 @@ describe('update-source', () => {
     it('appends skill folder from skillPath without ref', () => {
       const result = buildLocalUpdateSource({
         source: 'owner/repo',
+        sourceType: 'github',
         skillPath: 'skills/my-skill/SKILL.md',
       });
       expect(result).toBe('owner/repo/skills/my-skill');
@@ -72,6 +95,7 @@ describe('update-source', () => {
     it('keeps root-level skillPath from collapsing to trailing slash', () => {
       const result = buildLocalUpdateSource({
         source: 'owner/repo',
+        sourceType: 'github',
         skillPath: 'SKILL.md',
       });
       expect(result).toBe('owner/repo');
@@ -80,6 +104,7 @@ describe('update-source', () => {
     it('falls back to bare source when skillPath is missing', () => {
       const result = buildLocalUpdateSource({
         source: 'owner/repo',
+        sourceType: 'github',
         ref: 'main',
       });
       expect(result).toBe('owner/repo#main');
@@ -116,6 +141,35 @@ describe('update-source', () => {
         skillPath: 'skills/my-skill/SKILL.md',
       });
       expect(result).toBe('https://github.com/owner/repo/skills/my-skill');
+    });
+
+    it('uses sourceUrl for self-hosted GitLab project lock entries', () => {
+      const result = buildLocalUpdateSource({
+        source: 'acme/skills',
+        sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+        sourceType: 'git',
+        ref: 'main',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('https://gitlab.example.com/acme/skills.git#main');
+    });
+
+    it('fails closed for generic git shorthand without sourceUrl', () => {
+      const result = buildLocalUpdateSource({
+        source: 'acme/skills',
+        sourceType: 'git',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('fails closed for legacy GitLab shorthands without sourceUrl', () => {
+      const result = buildLocalUpdateSource({
+        source: 'acme/skills',
+        sourceType: 'gitlab',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -1,12 +1,15 @@
 export interface UpdateSourceEntry {
   source: string;
-  sourceUrl: string;
+  sourceUrl?: string;
+  sourceType?: string;
   ref?: string;
   skillPath?: string;
 }
 
 export interface LocalUpdateSourceEntry {
   source: string;
+  sourceUrl?: string;
+  sourceType?: string;
   ref?: string;
   skillPath?: string;
 }
@@ -57,6 +60,24 @@ function supportsAppendedSubpath(source: string): boolean {
   return true;
 }
 
+function isBareShorthand(source: string): boolean {
+  return !source.includes(':') && !source.startsWith('.') && !source.startsWith('/');
+}
+
+function getLocalSource(entry: LocalUpdateSourceEntry): string | null {
+  if (entry.sourceUrl) {
+    return entry.sourceUrl;
+  }
+  // Older project locks normalized both generic Git and GitLab sources to an
+  // owner/repo shorthand. Without the original URL, treating either one as a
+  // source would incorrectly redirect the operation to GitHub.
+  const requiresSourceUrl = entry.sourceType === 'git' || entry.sourceType === 'gitlab';
+  if (requiresSourceUrl && isBareShorthand(entry.source)) {
+    return null;
+  }
+  return entry.source;
+}
+
 function appendFolderAndRef(source: string, skillPath: string, ref?: string): string {
   if (!supportsAppendedSubpath(source)) {
     return formatSourceInput(source, ref);
@@ -70,21 +91,38 @@ function appendFolderAndRef(source: string, skillPath: string, ref?: string): st
  * Build the source argument for `skills add` during update.
  * Uses shorthand form for path-targeted updates to avoid branch/path ambiguity.
  */
-export function buildUpdateInstallSource(entry: UpdateSourceEntry): string {
+export function buildUpdateInstallSource(entry: UpdateSourceEntry): string | null {
   if (!entry.skillPath) {
-    return formatSourceInput(entry.sourceUrl, entry.ref);
+    const source =
+      entry.sourceType && entry.sourceType !== 'github'
+        ? getLocalSource(entry)
+        : entry.sourceUrl || entry.source;
+    if (!source) {
+      return null;
+    }
+    return formatSourceInput(source, entry.ref);
   }
-  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
+  const source =
+    entry.sourceType && entry.sourceType !== 'github' ? getLocalSource(entry) : entry.source;
+  if (!source) {
+    return null;
+  }
+  return appendFolderAndRef(source, entry.skillPath, entry.ref);
 }
 
 /**
  * Build the source argument for `skills add` during project-level update.
- * Local lock entries don't carry `sourceUrl`, so we fall back to the bare
- * `source` identifier when no `skillPath` is available.
+ * Returns null for legacy generic-Git or GitLab lock entries whose source was
+ * normalized to an ambiguous owner/repo shorthand. Those entries lack the
+ * original host, so reinterpreting them as GitHub would be unsafe.
  */
-export function buildLocalUpdateSource(entry: LocalUpdateSourceEntry): string {
-  if (!entry.skillPath) {
-    return formatSourceInput(entry.source, entry.ref);
+export function buildLocalUpdateSource(entry: LocalUpdateSourceEntry): string | null {
+  const source = getLocalSource(entry);
+  if (!source) {
+    return null;
   }
-  return appendFolderAndRef(entry.source, entry.skillPath, entry.ref);
+  if (!entry.skillPath) {
+    return formatSourceInput(source, entry.ref);
+  }
+  return appendFolderAndRef(source, entry.skillPath, entry.ref);
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -232,7 +232,7 @@ export async function getProjectSkillsForUpdate(
     if (entry.sourceType === 'node_modules' || entry.sourceType === 'local') {
       continue;
     }
-    skills.push({ name, source: entry.source, entry });
+    skills.push({ name, source: entry.sourceUrl || entry.source, entry });
   }
 
   return skills;
@@ -444,6 +444,13 @@ export async function updateGlobalSkills(
     const safeName = sanitizeMetadata(update.name);
     console.log(`${TEXT}Updating ${safeName}...${RESET}`);
     const installUrl = buildUpdateInstallSource(update.entry);
+    if (!installUrl) {
+      failCount++;
+      console.log(
+        `  ${DIM}✗ Cannot update ${safeName}: lock file is missing sourceUrl for this generic Git source${RESET}`
+      );
+      continue;
+    }
 
     const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
     if (!existsSync(cliEntry)) {
@@ -533,7 +540,7 @@ export async function updateProjectSkills(
 
   const bySource = new Map<string, typeof updatable>();
   for (const skill of updatable) {
-    const source = skill.entry.source;
+    const source = skill.entry.sourceUrl || skill.entry.source;
     const existing = bySource.get(source) || [];
     existing.push(skill);
     bySource.set(source, existing);
@@ -549,15 +556,23 @@ export async function updateProjectSkills(
 
   for (const [source, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
-    const sourceUrl = firstEntry.source;
+    const sourceUrl = firstEntry.sourceUrl || firstEntry.source;
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)
-      .filter(([_, entry]) => entry.source === source)
+      .filter(([_, entry]) => (entry.sourceUrl || entry.source) === source)
       .map(([name, _]) => name);
 
     let tempDir: string | null = null;
     let deletedSkills: string[] = [];
+
+    if (buildLocalUpdateSource(firstEntry) === null) {
+      failCount += skillsForSource.length;
+      console.log(
+        `${DIM}✗ Cannot update ${source}: skills-lock.json is missing sourceUrl for this generic Git source${RESET}`
+      );
+      continue;
+    }
 
     try {
       tempDir = await cloneRepo(sourceUrl, ref);
@@ -589,7 +604,14 @@ export async function updateProjectSkills(
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);
       console.log(`${TEXT}Updating ${safeName}...${RESET}`);
-      const installUrl = formatSourceInput(skill.entry.source, skill.entry.ref);
+      const installUrl = buildLocalUpdateSource(skill.entry);
+      if (!installUrl) {
+        failCount++;
+        console.log(
+          `  ${DIM}✗ Cannot update ${safeName}: skills-lock.json is missing sourceUrl for this generic Git source${RESET}`
+        );
+        continue;
+      }
 
       // Preserve Eve subagent placement recorded at install time. The lock stores
       // '' for the root agent, which maps to the `root` keyword for `add --subagent`.
@@ -634,9 +656,15 @@ export function printLegacyProjectSkills(
     `${DIM}${legacy.length} project skill(s) cannot be updated automatically (installed before skillPath tracking):${RESET}`
   );
   for (const skill of legacy) {
-    const reinstall = formatSourceInput(skill.entry.source, skill.entry.ref);
+    const reinstall = buildLocalUpdateSource(skill.entry);
     console.log(`  ${TEXT}•${RESET} ${sanitizeMetadata(skill.name)}`);
-    console.log(`    ${DIM}To refresh: ${TEXT}npx skills add ${reinstall} -y${RESET}`);
+    if (reinstall) {
+      console.log(`    ${DIM}To refresh: ${TEXT}npx skills add ${reinstall} -y${RESET}`);
+    } else {
+      console.log(
+        `    ${DIM}To refresh: reinstall using the original full Git URL; this lock entry only has an ambiguous shorthand.${RESET}`
+      );
+    }
   }
 }
 

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runInstallFromLock } from '../src/install.ts';
+import * as localLock from '../src/local-lock.ts';
+import * as add from '../src/add.ts';
+
+vi.mock('../src/local-lock.ts');
+vi.mock('../src/add.ts');
+vi.mock('../src/sync.ts', () => ({
+  runSync: vi.fn(),
+  parseSyncOptions: vi.fn().mockReturnValue({ options: {} }),
+}));
+vi.mock('../src/agents.ts', () => ({
+  getUniversalAgents: vi.fn().mockReturnValue(['cursor']),
+}));
+
+describe('runInstallFromLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('restores self-hosted GitLab project locks from sourceUrl', async () => {
+    vi.mocked(localLock.readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {
+        'skill-a': {
+          source: 'acme/skills',
+          sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+          sourceType: 'git',
+          skillPath: 'skills/skill-a/SKILL.md',
+          computedHash: 'hash',
+        },
+      },
+    });
+
+    await runInstallFromLock([]);
+
+    expect(add.runAdd).toHaveBeenCalledWith(
+      ['https://gitlab.example.com/acme/skills.git'],
+      expect.objectContaining({
+        skill: ['skill-a'],
+        agent: ['cursor'],
+        yes: true,
+      })
+    );
+  });
+
+  it('does not restore generic git shorthands as GitHub without sourceUrl', async () => {
+    vi.mocked(localLock.readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {
+        'skill-a': {
+          source: 'acme/skills',
+          sourceType: 'git',
+          skillPath: 'skills/skill-a/SKILL.md',
+          computedHash: 'hash',
+        },
+      },
+    });
+
+    await runInstallFromLock([]);
+
+    expect(add.runAdd).not.toHaveBeenCalled();
+  });
+});

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -226,6 +226,32 @@ describe('local-lock', () => {
         await rm(dir, { recursive: true, force: true });
       }
     });
+
+    it('stores optional sourceUrl for normalized remote sources', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await addSkillToLocalLock(
+          'gitlab-skill',
+          {
+            source: 'acme/skills',
+            sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+            sourceType: 'git',
+            computedHash: 'hash123',
+          },
+          dir
+        );
+
+        const lock = await readLocalLock(dir);
+        expect(lock.skills['gitlab-skill']).toEqual({
+          source: 'acme/skills',
+          sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+          sourceType: 'git',
+          computedHash: 'hash123',
+        });
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('removeSkillFromLocalLock', () => {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -195,6 +195,62 @@ describe('Update Cleanup Unit Tests', () => {
       expect(p.confirm).not.toHaveBeenCalled();
       expect(remove.removeCommand).not.toHaveBeenCalled();
     });
+
+    it('uses sourceUrl for self-hosted GitLab project updates', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'acme/skills',
+            sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'git',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      expect(git.cloneRepo).toHaveBeenCalledWith(
+        'https://gitlab.example.com/acme/skills.git',
+        undefined
+      );
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv] = installCall!;
+      expect(argv).toEqual(
+        expect.arrayContaining(['add', 'https://gitlab.example.com/acme/skills.git', '--skill'])
+      );
+      expect(argv).not.toEqual(expect.arrayContaining(['acme/skills']));
+    });
+
+    it('does not reinterpret generic git shorthands as GitHub during project update', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'acme/skills',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'git',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      const result = await updateProjectSkills({ yes: true });
+
+      expect(result.failCount).toBe(1);
+      expect(git.cloneRepo).not.toHaveBeenCalled();
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateGlobalSkills', () => {
@@ -271,6 +327,45 @@ describe('Update Cleanup Unit Tests', () => {
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'skills/skill-a')
       );
+    });
+
+    it('uses sourceUrl when updating global non-GitHub sources with host-stripped source', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'acme/skills',
+            sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'git',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(git.cloneRepo).toHaveBeenCalledWith(
+        'https://gitlab.example.com/acme/skills.git',
+        undefined
+      );
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv] = installCall!;
+      expect(argv).toEqual(
+        expect.arrayContaining(['add', 'https://gitlab.example.com/acme/skills.git'])
+      );
+      expect(argv).not.toEqual(expect.arrayContaining(['acme/skills']));
     });
 
     it('spawns the update without a shell so a crafted ref cannot inject commands', async () => {


### PR DESCRIPTION
## Summary
- Preserve full non-GitHub Git URLs in project `skills-lock.json` entries via `sourceUrl`, while keeping GitHub shorthand lock entries compatible.
- Make project update, global update reinstalls, and `experimental_install` prefer `sourceUrl` and fail closed when a legacy generic `git` entry only has an ambiguous `owner/repo` source.
- Add regressions for self-hosted GitLab-style HTTPS sources, generic Git shorthand fallback prevention, and existing GitHub shorthand behavior.

Fixes #1516.

## Test plan
- `pnpm test src/update-source.test.ts tests/update.test.ts tests/local-lock.test.ts tests/install.test.ts src/add.test.ts`
- `pnpm format`
- `pnpm exec prettier --write tests/**/*.ts`
- `pnpm format:check`
- `pnpm type-check` *(fails on current main in unrelated `src/git.ts` and `src/skills.ts` type errors)*
- `pnpm test` *(focused new/changed tests pass; full suite has existing Windows/environment failures around symlink EPERM, banner output under agent detection, and one non-interactive remove prompt path)*