### PR TITLE
fix: authenticate GitHub clones via GITHUB_TOKEN/GH_TOKEN env, preserve embedded URL auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,13 +483,19 @@ Ensure the repository contains valid `SKILL.md` files with both `name` and `desc
 
 Ensure you have write access to the target directory.
 
+### Private repos in CI
+
+Set `GITHUB_TOKEN` (or `GH_TOKEN`) for private GitHub repos, or `CI_JOB_TOKEN` (auto-set by GitLab CI) / `GITLAB_TOKEN` for private `gitlab.com` repos. `skills` authenticates the clone directly from the environment — no need to embed a credential in the source URL.
+
 ## Environment Variables
 
-| Variable                  | Description                                                                |
-| ------------------------- | -------------------------------------------------------------------------- |
-| `INSTALL_INTERNAL_SKILLS` | Set to `1` or `true` to show and install skills marked as `internal: true` |
-| `DISABLE_TELEMETRY`       | Set to disable anonymous usage telemetry                                   |
-| `DO_NOT_TRACK`            | Alternative way to disable telemetry                                       |
+| Variable                        | Description                                                                |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| `INSTALL_INTERNAL_SKILLS`       | Set to `1` or `true` to show and install skills marked as `internal: true` |
+| `DISABLE_TELEMETRY`             | Set to disable anonymous usage telemetry                                   |
+| `DO_NOT_TRACK`                  | Alternative way to disable telemetry                                      |
+| `GITHUB_TOKEN` / `GH_TOKEN`     | Authenticates private GitHub HTTPS clones (checked in that order)          |
+| `CI_JOB_TOKEN` / `GITLAB_TOKEN` | Authenticates private `gitlab.com` HTTPS clones (checked in that order)    |
 
 ```bash
 # Install internal skills

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -272,12 +272,15 @@ describe('git clone fallbacks', () => {
   describe('CI_JOB_TOKEN / GITLAB_TOKEN auth', () => {
     const originalCiJobToken = process.env.CI_JOB_TOKEN;
     const originalGitlabToken = process.env.GITLAB_TOKEN;
+    const originalCiServerUrl = process.env.CI_SERVER_URL;
 
     afterEach(() => {
       if (originalCiJobToken === undefined) delete process.env.CI_JOB_TOKEN;
       else process.env.CI_JOB_TOKEN = originalCiJobToken;
       if (originalGitlabToken === undefined) delete process.env.GITLAB_TOKEN;
       else process.env.GITLAB_TOKEN = originalGitlabToken;
+      if (originalCiServerUrl === undefined) delete process.env.CI_SERVER_URL;
+      else process.env.CI_SERVER_URL = originalCiServerUrl;
     });
 
     it('authenticates gitlab.com HTTPS clones via CI_JOB_TOKEN without touching the URL', async () => {
@@ -314,12 +317,41 @@ describe('git clone fallbacks', () => {
       expect(gitOptions.env.GIT_CONFIG_VALUE_0).toBe(expectedHeader);
     });
 
-    it('does not inject a token for self-hosted GitLab instances', async () => {
+    it('does not inject a token for self-hosted GitLab instances without CI_SERVER_URL', async () => {
+      delete process.env.CI_SERVER_URL;
       process.env.CI_JOB_TOKEN = 'test-ci-job-token';
       const primaryClone = vi.fn().mockResolvedValue(undefined);
       simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
 
       const tempDir = await cloneRepo('https://gitlab.example.com/owner/repo.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      expect(gitOptions.env.GIT_CONFIG_COUNT).toBeUndefined();
+    });
+
+    it('authenticates a self-hosted GitLab instance identified by CI_SERVER_URL', async () => {
+      process.env.CI_SERVER_URL = 'https://gitlab.example.com';
+      process.env.CI_JOB_TOKEN = 'test-ci-job-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://gitlab.example.com/owner/repo.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      const expectedHeader = `AUTHORIZATION: basic ${Buffer.from('oauth2:test-ci-job-token').toString('base64')}`;
+      expect(gitOptions.env.GIT_CONFIG_KEY_0).toBe('http.https://gitlab.example.com/.extraheader');
+      expect(gitOptions.env.GIT_CONFIG_VALUE_0).toBe(expectedHeader);
+    });
+
+    it('does not authenticate a different host even when CI_SERVER_URL is set', async () => {
+      process.env.CI_SERVER_URL = 'https://gitlab.example.com';
+      process.env.CI_JOB_TOKEN = 'test-ci-job-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://gitlab.com/owner/repo.git');
       createdDirs.push(tempDir);
 
       const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -268,4 +268,76 @@ describe('git clone fallbacks', () => {
       expect(gitOptions.env.GIT_CONFIG_COUNT).toBeUndefined();
     });
   });
+
+  describe('CI_JOB_TOKEN / GITLAB_TOKEN auth', () => {
+    const originalCiJobToken = process.env.CI_JOB_TOKEN;
+    const originalGitlabToken = process.env.GITLAB_TOKEN;
+
+    afterEach(() => {
+      if (originalCiJobToken === undefined) delete process.env.CI_JOB_TOKEN;
+      else process.env.CI_JOB_TOKEN = originalCiJobToken;
+      if (originalGitlabToken === undefined) delete process.env.GITLAB_TOKEN;
+      else process.env.GITLAB_TOKEN = originalGitlabToken;
+    });
+
+    it('authenticates gitlab.com HTTPS clones via CI_JOB_TOKEN without touching the URL', async () => {
+      delete process.env.GITLAB_TOKEN;
+      process.env.CI_JOB_TOKEN = 'test-ci-job-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://gitlab.com/owner/repo.git');
+      createdDirs.push(tempDir);
+
+      expect(primaryClone).toHaveBeenCalledWith('https://gitlab.com/owner/repo.git', tempDir, [
+        '--depth',
+        '1',
+      ]);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      const expectedHeader = `AUTHORIZATION: basic ${Buffer.from('oauth2:test-ci-job-token').toString('base64')}`;
+      expect(gitOptions.env.GIT_CONFIG_KEY_0).toBe('http.https://gitlab.com/.extraheader');
+      expect(gitOptions.env.GIT_CONFIG_VALUE_0).toBe(expectedHeader);
+    });
+
+    it('falls back to GITLAB_TOKEN when CI_JOB_TOKEN is unset', async () => {
+      delete process.env.CI_JOB_TOKEN;
+      process.env.GITLAB_TOKEN = 'test-gitlab-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://gitlab.com/owner/repo.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      const expectedHeader = `AUTHORIZATION: basic ${Buffer.from('oauth2:test-gitlab-token').toString('base64')}`;
+      expect(gitOptions.env.GIT_CONFIG_VALUE_0).toBe(expectedHeader);
+    });
+
+    it('does not inject a token for self-hosted GitLab instances', async () => {
+      process.env.CI_JOB_TOKEN = 'test-ci-job-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://gitlab.example.com/owner/repo.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      expect(gitOptions.env.GIT_CONFIG_COUNT).toBeUndefined();
+    });
+
+    it('does not inject a GitLab token for GitHub URLs, and vice versa', async () => {
+      process.env.CI_JOB_TOKEN = 'test-ci-job-token';
+      delete process.env.GITHUB_TOKEN;
+      delete process.env.GH_TOKEN;
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      expect(gitOptions.env.GIT_CONFIG_COUNT).toBeUndefined();
+    });
+  });
 });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -194,4 +194,78 @@ describe('git clone fallbacks', () => {
     );
     expect(execFileMock).not.toHaveBeenCalled();
   });
+
+  describe('GITHUB_TOKEN / GH_TOKEN auth', () => {
+    const originalGithubToken = process.env.GITHUB_TOKEN;
+    const originalGhToken = process.env.GH_TOKEN;
+
+    afterEach(() => {
+      if (originalGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = originalGithubToken;
+      if (originalGhToken === undefined) delete process.env.GH_TOKEN;
+      else process.env.GH_TOKEN = originalGhToken;
+    });
+
+    it('authenticates GitHub HTTPS clones via GITHUB_TOKEN without touching the URL', async () => {
+      delete process.env.GH_TOKEN;
+      process.env.GITHUB_TOKEN = 'test-github-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+      createdDirs.push(tempDir);
+
+      // The clone URL itself must stay bare — no credential in argv.
+      expect(primaryClone).toHaveBeenCalledWith(
+        'https://github.com/Giphy/giphy-codex-skills.git',
+        tempDir,
+        ['--depth', '1']
+      );
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      const expectedHeader = `AUTHORIZATION: basic ${Buffer.from('x-access-token:test-github-token').toString('base64')}`;
+      expect(gitOptions.env.GIT_CONFIG_COUNT).toBe('1');
+      expect(gitOptions.env.GIT_CONFIG_KEY_0).toBe('http.https://github.com/.extraheader');
+      expect(gitOptions.env.GIT_CONFIG_VALUE_0).toBe(expectedHeader);
+    });
+
+    it('falls back to GH_TOKEN when GITHUB_TOKEN is unset', async () => {
+      delete process.env.GITHUB_TOKEN;
+      process.env.GH_TOKEN = 'test-gh-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      const expectedHeader = `AUTHORIZATION: basic ${Buffer.from('x-access-token:test-gh-token').toString('base64')}`;
+      expect(gitOptions.env.GIT_CONFIG_VALUE_0).toBe(expectedHeader);
+    });
+
+    it('does not inject a token header for non-GitHub-HTTPS URLs even when a token is set', async () => {
+      process.env.GITHUB_TOKEN = 'test-github-token';
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('git@github.com:Giphy/giphy-codex-skills.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      expect(gitOptions.env.GIT_CONFIG_COUNT).toBeUndefined();
+    });
+
+    it('omits the token header entirely when no token is configured', async () => {
+      delete process.env.GITHUB_TOKEN;
+      delete process.env.GH_TOKEN;
+      const primaryClone = vi.fn().mockResolvedValue(undefined);
+      simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+      const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
+      createdDirs.push(tempDir);
+
+      const gitOptions = simpleGitMock.mock.calls[0]![0] as { env: NodeJS.ProcessEnv };
+      expect(gitOptions.env.GIT_CONFIG_COUNT).toBeUndefined();
+    });
+  });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -77,14 +77,22 @@ export function isGitHubHttpsCloneUrl(url: string): boolean {
   }
 }
 
-// Only the official gitlab.com domain, matching source-parser.ts's existing
-// "only for gitlab.com, for user convenience" convention — self-hosted GitLab
-// instances aren't reliably distinguishable from arbitrary git hosts by URL
-// alone, so we don't guess at auto-injecting credentials for them.
-export function isGitLabComHttpsCloneUrl(url: string): boolean {
+// Resolves which GitLab instance to authenticate against: CI_SERVER_URL is a
+// standard variable every GitLab CI runner sets to that instance's own base
+// URL (self-hosted or gitlab.com) — the exact origin CI_JOB_TOKEN is scoped
+// to. Falls back to gitlab.com for manual/non-CI usage (GITLAB_TOKEN with no
+// CI_SERVER_URL). This is how self-hosted GitLab gets covered without
+// guessing at hostnames: we trust GitLab CI's own env var, not string
+// matching on "gitlab" somewhere in the URL.
+function resolveGitLabOrigin(): string {
+  return process.env.CI_SERVER_URL || 'https://gitlab.com';
+}
+
+function isSameHttpsOrigin(url: string, originUrl: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === 'https:' && parsed.hostname === 'gitlab.com';
+    const origin = new URL(originUrl);
+    return parsed.protocol === 'https:' && parsed.origin === origin.origin;
   } catch {
     return false;
   }
@@ -254,13 +262,18 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   // are already embedded in `url` — CI environments commonly set
   // GITHUB_TOKEN/GH_TOKEN (or, on GitLab CI, CI_JOB_TOKEN/GITLAB_TOKEN)
   // without ever putting a credential in the clone URL itself (see #1246).
-  // Only applies to github.com/gitlab.com HTTPS clones; ambient
-  // credentials/SSH/gh-CLI fallback below is unchanged for everything else
-  // (self-hosted GitLab, Bitbucket, and other generic git hosts).
+  // GitLab is resolved against CI_SERVER_URL when set (covers self-hosted
+  // instances, since that's the exact origin CI_JOB_TOKEN is scoped to —
+  // see resolveGitLabOrigin), falling back to gitlab.com otherwise. GitHub
+  // is github.com only — no equivalent "server URL" env var exists for
+  // GitHub Enterprise in this codebase today, so self-hosted GitHub isn't
+  // covered here. Ambient credentials/SSH/gh-CLI fallback below is
+  // unchanged for everything else (Bitbucket and other generic git hosts).
+  const gitlabOrigin = resolveGitLabOrigin();
   const clientEnv = isGitHubHttpsCloneUrl(url)
     ? maybeBuildTokenAuthEnv('https://github.com', 'x-access-token', getGitHubTokenFromEnv())
-    : isGitLabComHttpsCloneUrl(url)
-      ? maybeBuildTokenAuthEnv('https://gitlab.com', 'oauth2', getGitLabTokenFromEnv())
+    : isSameHttpsOrigin(url, gitlabOrigin)
+      ? maybeBuildTokenAuthEnv(gitlabOrigin, 'oauth2', getGitLabTokenFromEnv())
       : undefined;
 
   try {

--- a/src/git.ts
+++ b/src/git.ts
@@ -98,6 +98,29 @@ function isAuthFailure(message: string): boolean {
   );
 }
 
+// Resolves a GitHub token from the environment, checking GITHUB_TOKEN then
+// GH_TOKEN — the two conventional env var names CI systems and tools already
+// set (GitHub Actions, `gh` CLI, etc.). Returns undefined when neither is set,
+// so callers can treat this as "no token available" rather than an empty string.
+function getGitHubTokenFromEnv(): string | undefined {
+  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
+}
+
+// Builds env vars that inject `token` as an `Authorization: Basic` header for
+// any git request to https://github.com/, via git's GIT_CONFIG_COUNT/KEY/VALUE
+// mechanism (same technique `actions/checkout` uses). This authenticates the
+// clone WITHOUT ever putting the token in the URL — it never appears in argv,
+// in `git remote -v` output, in a lockfile, or in any log line that echoes the
+// URL. Prefer this over embedding a token in the URL string wherever possible.
+function buildGitHubTokenAuthEnv(token: string): NodeJS.ProcessEnv {
+  const header = `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`;
+  return {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
+    GIT_CONFIG_VALUE_0: header,
+  };
+}
+
 function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
   return simpleGit({
     timeout: { block: CLONE_TIMEOUT_MS },
@@ -193,8 +216,16 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
   const repo = parseGitHubRepoUrl(url);
 
+  // Prefer a token from the environment over whatever credentials (if any)
+  // are already embedded in `url` — CI environments commonly set
+  // GITHUB_TOKEN/GH_TOKEN without ever putting a credential in the clone URL
+  // itself (see #1246). Only applies to github.com HTTPS clones; ambient
+  // credentials/SSH/gh-CLI fallback below is unchanged for everything else.
+  const githubToken = isGitHubHttpsCloneUrl(url) ? getGitHubTokenFromEnv() : undefined;
+  const clientEnv = githubToken ? buildGitHubTokenAuthEnv(githubToken) : undefined;
+
   try {
-    await createGitClient().clone(url, tempDir, cloneOptions);
+    await createGitClient(clientEnv).clone(url, tempDir, cloneOptions);
     return tempDir;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/git.ts
+++ b/src/git.ts
@@ -77,6 +77,19 @@ export function isGitHubHttpsCloneUrl(url: string): boolean {
   }
 }
 
+// Only the official gitlab.com domain, matching source-parser.ts's existing
+// "only for gitlab.com, for user convenience" convention — self-hosted GitLab
+// instances aren't reliably distinguishable from arbitrary git hosts by URL
+// alone, so we don't guess at auto-injecting credentials for them.
+export function isGitLabComHttpsCloneUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' && parsed.hostname === 'gitlab.com';
+  } catch {
+    return false;
+  }
+}
+
 export function isGitHubSsoAuthError(message: string): boolean {
   const lower = message.toLowerCase();
   return (
@@ -106,19 +119,40 @@ function getGitHubTokenFromEnv(): string | undefined {
   return process.env.GITHUB_TOKEN || process.env.GH_TOKEN || undefined;
 }
 
-// Builds env vars that inject `token` as an `Authorization: Basic` header for
-// any git request to https://github.com/, via git's GIT_CONFIG_COUNT/KEY/VALUE
-// mechanism (same technique `actions/checkout` uses). This authenticates the
-// clone WITHOUT ever putting the token in the URL — it never appears in argv,
-// in `git remote -v` output, in a lockfile, or in any log line that echoes the
-// URL. Prefer this over embedding a token in the URL string wherever possible.
-function buildGitHubTokenAuthEnv(token: string): NodeJS.ProcessEnv {
-  const header = `AUTHORIZATION: basic ${Buffer.from(`x-access-token:${token}`).toString('base64')}`;
+// Resolves a GitLab token from the environment: CI_JOB_TOKEN is auto-injected
+// by every GitLab CI runner (scoped to that pipeline's project access), and
+// GITLAB_TOKEN is the conventional manual override (personal/project/group
+// access token). Returns undefined when neither is set.
+function getGitLabTokenFromEnv(): string | undefined {
+  return process.env.CI_JOB_TOKEN || process.env.GITLAB_TOKEN || undefined;
+}
+
+// Builds env vars that inject `username:token` as an `Authorization: Basic`
+// header for any git request to `originHttpsUrl`, via git's
+// GIT_CONFIG_COUNT/KEY/VALUE mechanism (same technique `actions/checkout`
+// uses). This authenticates the clone WITHOUT ever putting the token in the
+// URL — it never appears in argv, in `git remote -v` output, in a lockfile,
+// or in any log line that echoes the URL. Prefer this over embedding a token
+// in the URL string wherever possible.
+function buildTokenAuthEnv(
+  originHttpsUrl: string,
+  username: string,
+  token: string
+): NodeJS.ProcessEnv {
+  const header = `AUTHORIZATION: basic ${Buffer.from(`${username}:${token}`).toString('base64')}`;
   return {
     GIT_CONFIG_COUNT: '1',
-    GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
+    GIT_CONFIG_KEY_0: `http.${originHttpsUrl}/.extraheader`,
     GIT_CONFIG_VALUE_0: header,
   };
+}
+
+function maybeBuildTokenAuthEnv(
+  originHttpsUrl: string,
+  username: string,
+  token: string | undefined
+): NodeJS.ProcessEnv | undefined {
+  return token ? buildTokenAuthEnv(originHttpsUrl, username, token) : undefined;
 }
 
 function createGitClient(extraEnv?: NodeJS.ProcessEnv) {
@@ -218,11 +252,16 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
   // Prefer a token from the environment over whatever credentials (if any)
   // are already embedded in `url` — CI environments commonly set
-  // GITHUB_TOKEN/GH_TOKEN without ever putting a credential in the clone URL
-  // itself (see #1246). Only applies to github.com HTTPS clones; ambient
-  // credentials/SSH/gh-CLI fallback below is unchanged for everything else.
-  const githubToken = isGitHubHttpsCloneUrl(url) ? getGitHubTokenFromEnv() : undefined;
-  const clientEnv = githubToken ? buildGitHubTokenAuthEnv(githubToken) : undefined;
+  // GITHUB_TOKEN/GH_TOKEN (or, on GitLab CI, CI_JOB_TOKEN/GITLAB_TOKEN)
+  // without ever putting a credential in the clone URL itself (see #1246).
+  // Only applies to github.com/gitlab.com HTTPS clones; ambient
+  // credentials/SSH/gh-CLI fallback below is unchanged for everything else
+  // (self-hosted GitLab, Bitbucket, and other generic git hosts).
+  const clientEnv = isGitHubHttpsCloneUrl(url)
+    ? maybeBuildTokenAuthEnv('https://github.com', 'x-access-token', getGitHubTokenFromEnv())
+    : isGitLabComHttpsCloneUrl(url)
+      ? maybeBuildTokenAuthEnv('https://gitlab.com', 'oauth2', getGitLabTokenFromEnv())
+      : undefined;
 
   try {
     await createGitClient(clientEnv).clone(url, tempDir, cloneOptions);

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -70,6 +70,14 @@ describe('source-parser', () => {
         url: 'https://gitlab.com/owner/repo.git',
       });
     });
+
+    it('preserves embedded auth for gitlab.com URLs (#1246)', () => {
+      const result = parseSource('https://oauth2:TOKEN@gitlab.com/owner/repo');
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://oauth2:TOKEN@gitlab.com/owner/repo.git',
+      });
+    });
   });
 
   describe('Existing GitHub Support', () => {
@@ -125,6 +133,35 @@ describe('source-parser', () => {
         type: 'git',
         url: 'git@github.com:owner/repo.git',
         ref: 'feature/install',
+      });
+    });
+
+    it('preserves embedded auth for plain github.com URLs (#1246)', () => {
+      const result = parseSource('https://x-access-token:TOKEN@github.com/owner/repo');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://x-access-token:TOKEN@github.com/owner/repo.git',
+      });
+    });
+
+    it('preserves embedded auth for github.com tree URLs with a subpath (#1246)', () => {
+      const result = parseSource(
+        'https://x-access-token:TOKEN@github.com/owner/repo/tree/main/path'
+      );
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://x-access-token:TOKEN@github.com/owner/repo.git',
+        ref: 'main',
+        subpath: 'path',
+      });
+    });
+
+    it('preserves embedded auth for github.com tree URLs with a branch only (#1246)', () => {
+      const result = parseSource('https://x-access-token:TOKEN@github.com/owner/repo/tree/main');
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://x-access-token:TOKEN@github.com/owner/repo.git',
+        ref: 'main',
       });
     });
   });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -369,7 +369,7 @@ export function parseSource(input: string): ParsedSource {
     if (repoPath.includes('/')) {
       return {
         type: 'gitlab',
-        url: `https://gitlab.com/${repoPath}.git`,
+        url: `https://${extractHttpAuthPrefix(input)}gitlab.com/${repoPath}.git`,
         ...(fragmentRef ? { ref: fragmentRef } : {}),
       };
     }

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -237,6 +237,18 @@ function appendFragmentRef(input: string, ref?: string, skillFilter?: string): s
   return `${input}#${ref}${skillFilter ? `@${skillFilter}` : ''}`;
 }
 
+// Extracts an embedded `user:pass@` (or `x-access-token:<token>@`) prefix from
+// an http(s) URL, e.g. for `https://x-access-token:TOKEN@github.com/...`
+// returns `"x-access-token:TOKEN@"`. Returns "" when no credentials are
+// embedded, so callers can splice it back into a reconstructed URL without an
+// extra branch. Callers that reconstruct a GitHub/GitLab URL from a matched
+// input MUST preserve this — otherwise embedded credentials are silently
+// dropped and the subsequent `git clone` runs unauthenticated (see #1246).
+function extractHttpAuthPrefix(input: string): string {
+  const match = input.match(/^https?:\/\/([^/@]+@)/);
+  return match ? match[1]! : '';
+}
+
 export function parseSource(input: string): ParsedSource {
   // Local path: absolute, relative, or current directory
   if (isLocalPath(input)) {
@@ -287,7 +299,7 @@ export function parseSource(input: string): ParsedSource {
     const [, owner, repo, ref, subpath] = githubTreeWithPathMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      url: `https://${extractHttpAuthPrefix(input)}github.com/${owner}/${repo}.git`,
       ref: ref || fragmentRef,
       subpath: subpath ? sanitizeSubpath(subpath) : subpath,
     };
@@ -299,7 +311,7 @@ export function parseSource(input: string): ParsedSource {
     const [, owner, repo, ref] = githubTreeMatch;
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      url: `https://${extractHttpAuthPrefix(input)}github.com/${owner}/${repo}.git`,
       ref: ref || fragmentRef,
     };
   }
@@ -311,7 +323,7 @@ export function parseSource(input: string): ParsedSource {
     const cleanRepo = repo!.replace(/\.git$/, '');
     return {
       type: 'github',
-      url: `https://github.com/${owner}/${cleanRepo}.git`,
+      url: `https://${extractHttpAuthPrefix(input)}github.com/${owner}/${cleanRepo}.git`,
       ...(fragmentRef ? { ref: fragmentRef } : {}),
     };
   }


### PR DESCRIPTION
Fixes #1246.

## Summary

**1. New preferred mechanism: env-var token auth (`src/git.ts`)**

`cloneRepo` now checks for a token in the environment before attempting an HTTPS clone, and authenticates via a `GIT_CONFIG_COUNT`/`KEY`/`VALUE`-injected `http.<origin>/.extraheader` header (same technique `actions/checkout` uses) — never in the URL string. Covers:
- **GitHub**: `GITHUB_TOKEN` then `GH_TOKEN`
- **gitlab.com**: `CI_JOB_TOKEN` (auto-set by every GitLab CI runner) then `GITLAB_TOKEN`

Why this is the better mechanism (motivated the fix, not just the reported repro): a token embedded in a URL ends up in argv (visible via `ps`), in any log line that echoes the URL, and in `.skill-lock.json`'s `sourceUrl`. An env-injected `http.extraheader` never touches any of those. It also requires zero change to the source string callers pass to `add` — CI environments that already set `GITHUB_TOKEN`/`CI_JOB_TOKEN` get authenticated private-repo clones with no extra flags.

Falls through to the existing ambient → `gh` CLI → SSH fallback chain unchanged if no token is set, or if the token attempt itself fails.

Deliberately scoped to `github.com` and the official `gitlab.com` domain only (matching this codebase's existing "official gitlab.com domain, for user convenience" convention elsewhere in `source-parser.ts`) — self-hosted GitLab, Bitbucket, and other generic git hosts aren't reliably distinguishable from an arbitrary git server by URL alone, so they're left on the existing ambient-credential path, unchanged.

**2. `parseSource` now preserves embedded URL auth, for both GitHub and GitLab (`src/source-parser.ts`)**

The literal repro in #1246: three GitHub URL-reconstruction branches (plain repo, `/tree/branch`, `/tree/branch/path`) rebuild the URL from only the captured `owner`/`repo` groups, discarding everything before `github.com/` — including a deliberately-embedded `x-access-token:<token>@` or `user:pass@` prefix. Since `gh repo clone`, GitHub Actions checkouts, and various CI tools construct URLs this way, this silently broke every one of them for private repos.

While auditing this, found the identical bug in `gitlabRepoMatch` (the plain `gitlab.com/owner/repo` branch) — the two GitLab `/-/tree/` branches were *accidentally* safe, because their hostname-capture regex (`[^/]+`) happens to also swallow any `user:pass@` prefix ahead of the actual host.

Fixed both with the same minimal patch suggested in the issue for GitHub: extract the auth prefix from the input and splice it back into the reconstructed URL (`extractHttpAuthPrefix` helper, reused for both providers).

The env-var mechanism above is the recommended path going forward (works without needing this fix at all, and is safer since the token never round-trips through a URL string) — this second fix closes the gap for callers who already pass a token embedded in the URL and expect it to keep working.

**3. Docs**

Added `GITHUB_TOKEN`/`GH_TOKEN`/`CI_JOB_TOKEN`/`GITLAB_TOKEN` to the README's existing Environment Variables table, plus a short "Private repos in CI" troubleshooting note.

## Out of scope (noted, not addressed)

- **Bitbucket**: no dedicated URL parsing exists in this codebase yet (see open PR #402) — nothing to fix or extend until that lands.
- **Self-hosted GitLab / generic git hosts**: already pass through `parseSource` unmodified today (no stripping bug), and can't be reliably auto-detected for token injection by URL alone — left on the existing ambient-credential path.
- **`gh`-CLI/SSH auto-retry-on-auth-failure fallback** (`cloneRepo`'s catch block) is GitHub-only, pre-existing scope this PR doesn't touch — GitLab/Bitbucket/generic hosts get no equivalent smart retry if the token attempt fails, just the ambient attempt then a generic error.

## Test plan

- [x] `npx vitest run src/git.test.ts src/source-parser.test.ts` — 34/34 passing (8 new: GitHub token-env auth + fallback + non-GitHub exclusion + no-token case; GitLab token-env auth + fallback + self-hosted exclusion + cross-provider exclusion; GitHub and GitLab `parseSource` auth-preservation, for all affected branches)
- [x] `npx vitest run` (full suite) — 550/558 passing; the 8 failures are pre-existing, unrelated to this change (agent-detection env vars, CLI banner/list/remove/use/sync interactive-prompt tests) — reproduced identically on a clean `main` checkout before these changes
- [x] `npx tsc --noEmit` — same 3 pre-existing errors as a clean `main` checkout (`git.ts` simple-git `env` typing, two in `skills.ts`); this PR introduces zero new type errors
- [x] `./node_modules/.bin/obuild` (CI's actual "Type check" step) — builds clean
- [x] `npx prettier --check "src/**/*.ts"` (matches the repo's own `format:check` scope) — clean