### PR TITLE
test: allow LFS clone test time on Windows

### DIFF
--- a/tests/git-lfs-clone.test.ts
+++ b/tests/git-lfs-clone.test.ts
@@ -74,5 +74,5 @@ describe('cloneRepo LFS handling', () => {
     await expect(readFile(join(cloneDir, 'asset.bin'), 'utf8')).resolves.toBe(expectedContents);
     await cleanupTempDir(cloneDir);
     tempDirs.splice(tempDirs.indexOf(cloneDir), 1);
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
The LFS-less clone integration test runs several real Git commands and can exceed Vitest's default 5-second timeout on Windows. Give only that test a 20-second timeout; production clone behavior is unchanged.