### PR TITLE
fix(add): keep source field is owner/repo format

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -4,12 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, stripAnsi } from './test-utils.ts';
 import { shouldInstallInternalSkills } from './skills.ts';
-import {
-  parseAddOptions,
-  getLockSource,
-  getProjectLockSourceUrl,
-  formatEveInstallPromptMessage,
-} from './add.ts';
+import { parseAddOptions, getProjectLockSourceUrl, formatEveInstallPromptMessage } from './add.ts';
 
 const noDetectedAgentEnv = {
   AI_AGENT: '',
@@ -359,36 +354,6 @@ metadata:
   });
 });
 
-describe('getLockSource', () => {
-  it('preserves git@ SSH URLs for lock files', () => {
-    expect(getLockSource('git@github.com:owner/repo.git', 'owner/repo')).toBe(
-      'git@github.com:owner/repo.git'
-    );
-  });
-
-  it('preserves ssh:// SSH URLs for lock files', () => {
-    expect(getLockSource('ssh://git@stash.myrepo.com:7999/my/skills.git', 'my/skills')).toBe(
-      'ssh://git@stash.myrepo.com:7999/my/skills.git'
-    );
-  });
-
-  it('keeps normalized owner/repo for GitHub HTTPS remotes', () => {
-    expect(getLockSource('https://github.com/owner/repo.git', 'owner/repo')).toBe('owner/repo');
-  });
-
-  it('preserves self-hosted HTTPS Git URLs for lock files', () => {
-    expect(getLockSource('https://gitlab.example.com/acme/skills.git', 'acme/skills')).toBe(
-      'https://gitlab.example.com/acme/skills.git'
-    );
-  });
-
-  it('preserves gitlab.com HTTPS URLs for lock files', () => {
-    expect(getLockSource('https://gitlab.com/acme/skills.git', 'acme/skills')).toBe(
-      'https://gitlab.com/acme/skills.git'
-    );
-  });
-});
-
 describe('getProjectLockSourceUrl', () => {
   it('records sourceUrl for self-hosted GitLab HTTPS sources installed into project locks', () => {
     expect(getProjectLockSourceUrl('git', 'https://gitlab.example.com/acme/skills.git')).toBe(
@@ -403,7 +368,9 @@ describe('getProjectLockSourceUrl', () => {
   });
 
   it('keeps GitHub project locks compatible with existing shorthand entries', () => {
-    expect(getProjectLockSourceUrl('github', 'https://github.com/owner/repo.git')).toBeUndefined();
+    expect(getProjectLockSourceUrl('github', 'https://github.com/owner/repo.git')).toBe(
+      'https://github.com/owner/repo.git'
+    );
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -25,28 +25,13 @@ async function isSourcePrivate(source: string): Promise<boolean | null> {
   return isRepoPrivate(ownerRepo.owner, ownerRepo.repo);
 }
 
-export function getLockSource(parsedUrl: string, normalizedSource: string | null): string | null {
-  // Preserve SSH URLs in lock files instead of normalizing to owner/repo shorthand.
-  // When normalizedSource is used, parseSource() later resolves it to HTTPS,
-  // breaking restore for private repos that require SSH authentication.
-  const isSSH = parsedUrl.startsWith('git@') || parsedUrl.startsWith('ssh://');
-  if (isSSH) {
-    return parsedUrl;
-  }
-  if (parsedUrl.startsWith('http://') || parsedUrl.startsWith('https://')) {
-    try {
-      if (new URL(parsedUrl).hostname !== 'github.com') {
-        return parsedUrl;
-      }
-    } catch {
-      return normalizedSource;
-    }
-  }
-  return normalizedSource;
-}
-
-export function getProjectLockSourceUrl(sourceType: string, sourceUrl: string): string | undefined {
-  return sourceType === 'git' || sourceType === 'gitlab' ? sourceUrl : undefined;
+export function getProjectLockSourceUrl(
+  sourceType: SourceType,
+  sourceUrl: string
+): string | undefined {
+  return sourceType === 'git' || sourceType === 'gitlab' || sourceType === 'github'
+    ? sourceUrl
+    : undefined;
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
@@ -86,7 +71,7 @@ import {
   saveSelectedAgents,
 } from './skill-lock.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
-import type { Skill, AgentType } from './types.ts';
+import type { Skill, AgentType, SourceType } from './types.ts';
 import {
   tryBlobInstall,
   BLOB_ALLOWED_REPOS,
@@ -1789,7 +1774,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Normalize source to owner/repo format for telemetry
     const normalizedSource = getOwnerRepo(parsed);
 
-    const lockSource = getLockSource(parsed.url, normalizedSource);
     const projectLockSourceUrl = getProjectLockSourceUrl(parsed.type, parsed.url);
 
     // Only track if we have a valid remote source and it's not a private repo.
@@ -1855,16 +1839,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               const hash = await computeSkillFolderHash(skillDir);
               if (hash) skillFolderHash = hash;
             }
-
-            await addSkillToLock(skill.name, {
-              source: lockSource || normalizedSource,
-              sourceType: parsed.type,
-              sourceUrl: parsed.url,
-              ref: parsed.ref,
-              skillPath: skillPathValue,
-              skillFolderHash,
-              pluginName: skill.pluginName,
-            });
+            if (normalizedSource) {
+              await addSkillToLock(skill.name, {
+                source: normalizedSource,
+                sourceType: parsed.type,
+                sourceUrl: parsed.url,
+                ref: parsed.ref,
+                skillPath: skillPathValue,
+                skillFolderHash,
+                pluginName: skill.pluginName,
+              });
+            }
           } catch {
             // Don't fail installation if lock file update fails
           }
@@ -1895,19 +1880,21 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                   ? computeSingleFileSkillHash(skill.rawContent)
                   : await computeSkillFolderHash(skill.path);
             const skillPathValue = skillFiles[skill.name];
-            await addSkillToLocalLock(
-              skill.name,
-              {
-                source: lockSource || parsed.url,
-                ...(projectLockSourceUrl && { sourceUrl: projectLockSourceUrl }),
-                ref: parsed.ref,
-                sourceType: parsed.type,
-                ...(skillPathValue && { skillPath: skillPathValue }),
-                computedHash,
-                ...(recordSubagents && { subagents: eveSubagents }),
-              },
-              cwd
-            );
+            if (normalizedSource) {
+              await addSkillToLocalLock(
+                skill.name,
+                {
+                  source: normalizedSource,
+                  ...(projectLockSourceUrl && { sourceUrl: projectLockSourceUrl }),
+                  ref: parsed.ref,
+                  sourceType: parsed.type,
+                  ...(skillPathValue && { skillPath: skillPathValue }),
+                  computedHash,
+                  ...(recordSubagents && { subagents: eveSubagents }),
+                },
+                cwd
+              );
+            }
           } catch {
             // Don't fail installation if lock file update fails
           }

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, readdir, stat } from 'fs/promises';
 import { join, relative } from 'path';
 import { createHash } from 'crypto';
+import type { SourceType } from './types';
 
 const LOCAL_LOCK_FILE = 'skills-lock.json';
 const CURRENT_VERSION = 1;
@@ -20,7 +21,7 @@ export interface LocalSkillLockEntry {
   /** Branch or tag ref used for installation */
   ref?: string;
   /** The provider/source type (e.g., "github", "node_modules", "local") */
-  sourceType: string;
+  sourceType: SourceType;
   /**
    * Path to the skill's SKILL.md within the source repo (e.g., "skills/pdf/SKILL.md").
    * Required to re-install only this skill on update — without it, an update would

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import pc from 'picocolors';
+import type { SourceType } from './types.ts';
 
 const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
@@ -16,7 +17,7 @@ export interface SkillLockEntry {
   /** Normalized source identifier (e.g., "owner/repo", "mintlify/bun.com") */
   source: string;
   /** The provider/source type (e.g., "github", "mintlify", "huggingface", "local") */
-  sourceType: string;
+  sourceType: SourceType;
   /** The original URL used to install the skill (for re-fetching updates) */
   sourceUrl: string;
   /** Branch or tag ref used for installation (for ref-aware updates) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,8 +97,10 @@ export interface AgentConfig {
   showInUniversalPrompt?: boolean;
 }
 
+export type SourceType = 'github' | 'gitlab' | 'git' | 'local' | 'well-known' | 'node_modules';
+
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known';
+  type: SourceType;
   url: string;
   subpath?: string;
   localPath?: string;

--- a/src/update.ts
+++ b/src/update.ts
@@ -232,7 +232,7 @@ export async function getProjectSkillsForUpdate(
     if (entry.sourceType === 'node_modules' || entry.sourceType === 'local') {
       continue;
     }
-    skills.push({ name, source: entry.sourceUrl || entry.source, entry });
+    skills.push({ name, source: entry.source, entry });
   }
 
   return skills;
@@ -540,7 +540,7 @@ export async function updateProjectSkills(
 
   const bySource = new Map<string, typeof updatable>();
   for (const skill of updatable) {
-    const source = skill.entry.sourceUrl || skill.entry.source;
+    const source = skill.entry.source;
     const existing = bySource.get(source) || [];
     existing.push(skill);
     bySource.set(source, existing);
@@ -560,7 +560,7 @@ export async function updateProjectSkills(
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)
-      .filter(([_, entry]) => (entry.sourceUrl || entry.source) === source)
+      .filter(([_, entry]) => entry.source === source)
       .map(([name, _]) => name);
 
     let tempDir: string | null = null;


### PR DESCRIPTION
Keep the `source` field in `owner/repo` format, we already have the `sourceUrl` field.