### PR TITLE
feat: add Azure DevOps support and --source-type option for source interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,17 @@ npx skills add https://github.com/vercel-labs/agent-skills/tree/main/skills/web-
 # GitLab URL
 npx skills add https://gitlab.com/org/repo
 
+# Azure DevOps URL (dev.azure.com or *.visualstudio.com)
+npx skills add https://org@dev.azure.com/org/project/_git/repo
+
 # Any git URL
 npx skills add git@github.com:vercel-labs/agent-skills.git
 
 # Local path
 npx skills add ./my-local-skills
+
+# Force how a source is interpreted (for self-hosted / unrecognized hosts)
+npx skills add https://git.internal.example.com/team/repo --source-type git
 ```
 
 ### Options
@@ -58,6 +64,7 @@ npx skills add ./my-local-skills
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+| `--source-type <type>`    | Force the source type instead of auto-detecting it (`github`, `gitlab`, `azure`, `git`, `local`, `well-known`)                                     |
 
 ### Examples
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -4,7 +4,15 @@ import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { sep, join, dirname } from 'path';
-import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
+import {
+  parseSource,
+  getOwnerRepo,
+  parseOwnerRepo,
+  isRepoPrivate,
+  isSourceType,
+  SOURCE_TYPES,
+  type SourceType,
+} from './source-parser.ts';
 import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 
@@ -46,7 +54,9 @@ export function getLockSource(parsedUrl: string, normalizedSource: string | null
 }
 
 export function getProjectLockSourceUrl(sourceType: string, sourceUrl: string): string | undefined {
-  return sourceType === 'git' || sourceType === 'gitlab' ? sourceUrl : undefined;
+  return sourceType === 'git' || sourceType === 'gitlab' || sourceType === 'azure'
+    ? sourceUrl
+    : undefined;
 }
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
@@ -552,6 +562,12 @@ export interface AddOptions {
   all?: boolean;
   fullDepth?: boolean;
   copy?: boolean;
+  /**
+   * Force the source to be interpreted as a specific type instead of
+   * auto-detecting it (`--source-type`). Useful for self-hosted or otherwise
+   * unrecognized Git hosts.
+   */
+  sourceType?: SourceType;
   /**
    * Eve subagent targets. Each value is a subagent name; `root` (or `.`)
    * selects the root agent. Implies installing for Eve.
@@ -1092,7 +1108,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const spinner = p.spinner();
 
     spinner.start('Parsing source...');
-    const parsed = parseSource(source);
+    const parsed = parseSource(source, { sourceType: options.sourceType });
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
@@ -2183,6 +2199,15 @@ export function parseAddOptions(args: string[]): {
       options.fullDepth = true;
     } else if (arg === '--copy') {
       options.copy = true;
+    } else if (arg === '--source-type') {
+      const value = args[++i];
+      if (value === undefined) {
+        errors.push(`--source-type requires a value (${SOURCE_TYPES.join(', ')})`);
+      } else if (!isSourceType(value)) {
+        errors.push(`Invalid --source-type "${value}". Valid values: ${SOURCE_TYPES.join(', ')}`);
+      } else {
+        options.sourceType = value;
+      }
     } else if (arg === '--subagent') {
       options.subagent = options.subagent || [];
       i++;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,11 +143,15 @@ ${BOLD}Add Options:${RESET}
   --subagent <names>     Install to Eve subagents (use 'root' for the root agent)
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
+  --source-type <type>   Force the source type instead of auto-detecting it
+                         (github, gitlab, azure, git, local, well-known)
 
 ${BOLD}Use Options:${RESET}
   -s, --skill <skill>    Specify the skill to use
   -a, --agent <agent>    Start one supported agent interactively
   --full-depth           Search all subdirectories even when a root SKILL.md exists
+  --source-type <type>   Force the source type instead of auto-detecting it
+                         (github, gitlab, azure, git, local, well-known)
   --dangerously-accept-openclaw-risks
                          Allow unverified OpenClaw community skills
 

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseSource } from './source-parser.js';
+import { parseSource, getOwnerRepo } from './source-parser.js';
 
 describe('source-parser', () => {
   describe('GitLab Custom Domains & Subgroups', () => {
@@ -125,6 +125,161 @@ describe('source-parser', () => {
         type: 'git',
         url: 'git@github.com:owner/repo.git',
         ref: 'feature/install',
+      });
+    });
+  });
+
+  describe('Azure DevOps', () => {
+    it('parses a dev.azure.com URL with the org as user info', () => {
+      const result = parseSource(
+        'https://acme@dev.azure.com/acme/shared-resources/_git/skills-repo'
+      );
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'https://acme@dev.azure.com/acme/shared-resources/_git/skills-repo',
+      });
+    });
+
+    it('parses a dev.azure.com URL without user info', () => {
+      const result = parseSource('https://dev.azure.com/myorg/myproject/_git/myrepo');
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+      });
+    });
+
+    it('extracts branch (?version=GB…) and subpath (?path=…)', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?path=%2Fskills%2Ffoo&version=GBmain'
+      );
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+        ref: 'main',
+        subpath: 'skills/foo',
+      });
+    });
+
+    it('extracts a tag ref from ?version=GT…', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?version=GTv1.2.0'
+      );
+      expect(result).toMatchObject({
+        type: 'azure',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+        ref: 'v1.2.0',
+      });
+    });
+
+    it('ignores a commit ref (?version=GC…) since it can not be shallow cloned', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?version=GCabc123'
+      );
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+      });
+    });
+
+    it('treats a #branch fragment as a ref', () => {
+      const result = parseSource('https://dev.azure.com/myorg/myproject/_git/myrepo#develop');
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+        ref: 'develop',
+      });
+    });
+
+    it('parses a legacy visualstudio.com URL', () => {
+      const result = parseSource('https://myaccount.visualstudio.com/myproject/_git/myrepo');
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'https://myaccount.visualstudio.com/myproject/_git/myrepo',
+      });
+    });
+
+    it('parses the SSH v3 form', () => {
+      const result = parseSource('git@ssh.dev.azure.com:v3/myorg/myproject/myrepo');
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'git@ssh.dev.azure.com:v3/myorg/myproject/myrepo',
+      });
+    });
+
+    it('does not treat a non-_git dev.azure.com URL as a repo', () => {
+      const result = parseSource('https://dev.azure.com/myorg/myproject/_build');
+      expect(result.type).not.toBe('azure');
+    });
+
+    it('derives org/repo via getOwnerRepo', () => {
+      const result = parseSource(
+        'https://acme@dev.azure.com/acme/shared-resources/_git/skills-repo'
+      );
+      expect(getOwnerRepo(result)).toBe('acme/skills-repo');
+    });
+  });
+
+  describe('--source-type override', () => {
+    it('forces an unrecognized host to be cloned as a generic git URL', () => {
+      const result = parseSource('https://git.internal.corp/team/repo', { sourceType: 'git' });
+      expect(result).toEqual({
+        type: 'git',
+        url: 'https://git.internal.corp/team/repo',
+      });
+    });
+
+    it('forces azure parsing and normalization', () => {
+      const result = parseSource(
+        'https://dev.azure.com/myorg/myproject/_git/myrepo?version=GBmain',
+        { sourceType: 'azure' }
+      );
+      expect(result).toEqual({
+        type: 'azure',
+        url: 'https://dev.azure.com/myorg/myproject/_git/myrepo',
+        ref: 'main',
+      });
+    });
+
+    it('forces a github classification while reusing URL normalization', () => {
+      const result = parseSource('https://github.com/owner/repo/tree/main/path', {
+        sourceType: 'github',
+      });
+      expect(result).toEqual({
+        type: 'github',
+        url: 'https://github.com/owner/repo.git',
+        ref: 'main',
+        subpath: 'path',
+      });
+    });
+
+    it('forces gitlab classification for an unrecognized host', () => {
+      const result = parseSource('https://git.internal.corp/group/repo', {
+        sourceType: 'gitlab',
+      });
+      expect(result).toEqual({
+        type: 'gitlab',
+        url: 'https://git.internal.corp/group/repo',
+      });
+    });
+
+    it('carries a #ref fragment through a forced git source', () => {
+      const result = parseSource('https://git.internal.corp/team/repo#release', {
+        sourceType: 'git',
+      });
+      expect(result).toEqual({
+        type: 'git',
+        url: 'https://git.internal.corp/team/repo',
+        ref: 'release',
+      });
+    });
+
+    it('forces a well-known classification', () => {
+      const result = parseSource('https://github.com/owner/repo', {
+        sourceType: 'well-known',
+      });
+      expect(result).toEqual({
+        type: 'well-known',
+        url: 'https://github.com/owner/repo',
       });
     });
   });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -1,6 +1,31 @@
 import { isAbsolute, resolve } from 'path';
 import type { ParsedSource } from './types.ts';
 
+/** The set of source types that can be forced via `--source-type`. */
+export type SourceType = ParsedSource['type'];
+
+export const SOURCE_TYPES: readonly SourceType[] = [
+  'github',
+  'gitlab',
+  'azure',
+  'git',
+  'local',
+  'well-known',
+];
+
+/** Type guard for validating a user-supplied `--source-type` value. */
+export function isSourceType(value: string): value is SourceType {
+  return (SOURCE_TYPES as readonly string[]).includes(value);
+}
+
+interface ParseSourceOptions {
+  /**
+   * Force the parsed source to a specific type instead of auto-detecting it.
+   * Useful for self-hosted or otherwise unrecognized Git hosts.
+   */
+  sourceType?: SourceType;
+}
+
 /**
  * Extract owner/repo (or group/subgroup/repo for GitLab) from a parsed source
  * for lockfile tracking and telemetry.
@@ -10,6 +35,12 @@ import type { ParsedSource } from './types.ts';
 export function getOwnerRepo(parsed: ParsedSource): string | null {
   if (parsed.type === 'local') {
     return null;
+  }
+
+  // Azure DevOps URLs use an `{org}/{project}/_git/{repo}` structure, so derive
+  // a clean `org/repo` identifier rather than the raw path.
+  if (parsed.type === 'azure') {
+    return parseAzureDevOpsUrl(parsed.url)?.ownerRepo ?? null;
   }
 
   // Handle Git SSH URLs (e.g., git@gitlab.com:owner/repo.git, git@github.com:owner/repo.git)
@@ -121,6 +152,136 @@ export function sanitizeSubpath(subpath: string): string {
 }
 
 /**
+ * Whether a hostname belongs to Azure DevOps (either the modern
+ * `dev.azure.com` host or the legacy `<account>.visualstudio.com` hosts).
+ */
+function isAzureDevOpsHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  return lower === 'dev.azure.com' || lower.endsWith('.visualstudio.com');
+}
+
+interface AzureDevOpsParseResult {
+  /** Normalized clone URL (query/fragment stripped). */
+  url: string;
+  /** Branch or tag resolved from `?version=GB…/GT…`. */
+  ref?: string;
+  /** Subpath resolved from `?path=…`. */
+  subpath?: string;
+  /** `org/repo` identifier for telemetry and lock tracking. */
+  ownerRepo?: string;
+}
+
+/**
+ * Parse an Azure DevOps repository URL.
+ *
+ * Recognizes:
+ *   - HTTPS: https://[user@]dev.azure.com/{org}/{project}/_git/{repo}
+ *   - Legacy HTTPS: https://{account}.visualstudio.com/[{collection}/]{project}/_git/{repo}
+ *   - SSH: git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+ *
+ * The identifying marker for HTTPS URLs is the `/_git/` path segment. Azure
+ * encodes the target folder and branch as query parameters
+ * (`?path=/dir&version=GBmain`), which are lifted into `subpath` and `ref`.
+ *
+ * Returns null when the input is not a recognizable Azure DevOps repo URL.
+ */
+function parseAzureDevOpsUrl(input: string): AzureDevOpsParseResult | null {
+  // SSH form: git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+  const sshMatch = input.match(/^git@ssh\.dev\.azure\.com:v3\/(.+)$/i);
+  if (sshMatch) {
+    const segments = sshMatch[1]!
+      .replace(/\.git$/, '')
+      .split('/')
+      .filter(Boolean);
+    // Need at least {org}/{repo}; canonical form is {org}/{project}/{repo}.
+    if (segments.length < 2) {
+      return null;
+    }
+    const org = segments[0]!;
+    const repo = segments[segments.length - 1]!;
+    return {
+      url: `git@ssh.dev.azure.com:v3/${segments.join('/')}`,
+      ownerRepo: `${org}/${repo}`,
+    };
+  }
+
+  if (!/^https?:\/\//i.test(input)) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return null;
+  }
+
+  if (!isAzureDevOpsHost(parsed.hostname)) {
+    return null;
+  }
+
+  // Keep the raw (percent-encoded) segments so the clone URL preserves any
+  // encoding in project names (e.g. spaces -> %20).
+  const encodedSegments = parsed.pathname.split('/').filter(Boolean);
+  const gitIndex = encodedSegments.findIndex((seg) => seg.toLowerCase() === '_git');
+  // Require at least one segment before `_git` (the org/project) and a repo after it.
+  if (gitIndex < 1 || gitIndex >= encodedSegments.length - 1) {
+    return null;
+  }
+
+  const repoSegment = encodedSegments[gitIndex + 1]!.replace(/\.git$/, '');
+  if (!repoSegment) {
+    return null;
+  }
+
+  const auth = parsed.username ? `${parsed.username}@` : '';
+  const pathToRepo = [...encodedSegments.slice(0, gitIndex), '_git', repoSegment].join('/');
+  const cloneUrl = `${parsed.protocol}//${auth}${parsed.host}/${pathToRepo}`;
+
+  // org is the first path segment for dev.azure.com; for *.visualstudio.com the
+  // account lives in the subdomain but the first path segment (project) is a
+  // reasonable, stable identifier for telemetry/lock purposes.
+  const org = decodeAzureComponent(encodedSegments[0]!);
+  const repo = decodeAzureComponent(repoSegment);
+
+  let ref: string | undefined;
+  const version = parsed.searchParams.get('version');
+  if (version) {
+    const prefix = version.slice(0, 2).toUpperCase();
+    const value = version.slice(2);
+    // GB = branch, GT = tag. GC (commit) is skipped: a commit SHA can't be
+    // used with `git clone --branch --depth 1`.
+    if ((prefix === 'GB' || prefix === 'GT') && value) {
+      ref = value;
+    }
+  }
+
+  let subpath: string | undefined;
+  const pathParam = parsed.searchParams.get('path');
+  if (pathParam) {
+    const trimmed = pathParam.replace(/^\/+/, '').replace(/\/+$/, '');
+    if (trimmed) {
+      subpath = sanitizeSubpath(trimmed);
+    }
+  }
+
+  return {
+    url: cloneUrl,
+    ownerRepo: `${org}/${repo}`,
+    ...(ref ? { ref } : {}),
+    ...(subpath ? { subpath } : {}),
+  };
+}
+
+function decodeAzureComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
  * Check if a string represents a local file system path
  */
 function isLocalPath(input: string): boolean {
@@ -181,6 +342,11 @@ function looksLikeGitSource(input: string): boolean {
       if (parsed.hostname === 'gitlab.com') {
         return /^\/.+?\/[^/]+(?:\.git)?(?:\/-\/tree\/[^/]+(?:\/.*)?)?\/?$/.test(pathname);
       }
+
+      // Azure DevOps repo URLs are identified by the `/_git/` path segment.
+      if (isAzureDevOpsHost(parsed.hostname)) {
+        return pathname.includes('/_git/');
+      }
     } catch {
       // Fall through to generic checks below.
     }
@@ -198,7 +364,12 @@ function looksLikeGitSource(input: string): boolean {
   );
 }
 
-function parseFragmentRef(input: string): FragmentRefResult {
+/**
+ * Split an optional `#ref` / `#ref@skill` fragment from an input,
+ * unconditionally (used when the caller already knows the source is git-backed,
+ * e.g. via an explicit `--source-type`).
+ */
+function splitFragmentRef(input: string): FragmentRefResult {
   const hashIndex = input.indexOf('#');
   if (hashIndex < 0) {
     return { inputWithoutFragment: input };
@@ -206,10 +377,7 @@ function parseFragmentRef(input: string): FragmentRefResult {
 
   const inputWithoutFragment = input.slice(0, hashIndex);
   const fragment = input.slice(hashIndex + 1);
-
-  // Treat URL fragments as git refs only for git-like sources.
-  // This avoids changing behavior for generic well-known URLs.
-  if (!fragment || !looksLikeGitSource(inputWithoutFragment)) {
+  if (!fragment) {
     return { inputWithoutFragment: input };
   }
 
@@ -230,6 +398,24 @@ function parseFragmentRef(input: string): FragmentRefResult {
   };
 }
 
+function parseFragmentRef(input: string): FragmentRefResult {
+  const hashIndex = input.indexOf('#');
+  if (hashIndex < 0) {
+    return { inputWithoutFragment: input };
+  }
+
+  const inputWithoutFragment = input.slice(0, hashIndex);
+  const fragment = input.slice(hashIndex + 1);
+
+  // Treat URL fragments as git refs only for git-like sources.
+  // This avoids changing behavior for generic well-known URLs.
+  if (!fragment || !looksLikeGitSource(inputWithoutFragment)) {
+    return { inputWithoutFragment: input };
+  }
+
+  return splitFragmentRef(input);
+}
+
 function appendFragmentRef(input: string, ref?: string, skillFilter?: string): string {
   if (!ref) {
     return input;
@@ -237,7 +423,12 @@ function appendFragmentRef(input: string, ref?: string, skillFilter?: string): s
   return `${input}#${ref}${skillFilter ? `@${skillFilter}` : ''}`;
 }
 
-export function parseSource(input: string): ParsedSource {
+export function parseSource(input: string, options: ParseSourceOptions = {}): ParsedSource {
+  // An explicit `--source-type` overrides auto-detection.
+  if (options.sourceType) {
+    return parseForcedSource(input, options.sourceType);
+  }
+
   // Local path: absolute, relative, or current directory
   if (isLocalPath(input)) {
     const resolvedPath = resolve(input);
@@ -389,6 +580,21 @@ export function parseSource(input: string): ParsedSource {
     };
   }
 
+  // Azure DevOps URL: https://[user@]dev.azure.com/{org}/{project}/_git/{repo}
+  // (also *.visualstudio.com and the SSH v3 form). Identified by the `/_git/`
+  // path segment. Must be checked before the well-known fallback so these
+  // repositories aren't misread as generic well-known endpoints.
+  const azureParsed = parseAzureDevOpsUrl(input);
+  if (azureParsed) {
+    return {
+      type: 'azure',
+      url: azureParsed.url,
+      ...(azureParsed.ref || fragmentRef ? { ref: azureParsed.ref || fragmentRef } : {}),
+      ...(azureParsed.subpath ? { subpath: azureParsed.subpath } : {}),
+      ...(fragmentSkillFilter ? { skillFilter: fragmentSkillFilter } : {}),
+    };
+  }
+
   // Well-known skills: arbitrary HTTP(S) URLs that aren't GitHub/GitLab
   // This is the final fallback for URLs - we'll check for /.well-known/agent-skills/index.json
   // then fall back to /.well-known/skills/index.json
@@ -404,6 +610,63 @@ export function parseSource(input: string): ParsedSource {
     type: 'git',
     url: input,
     ...(fragmentRef ? { ref: fragmentRef } : {}),
+  };
+}
+
+/**
+ * Parse a source with an explicit, user-supplied type (`--source-type`),
+ * bypassing host-based auto-detection.
+ *
+ * For the Git-backed types we still reuse the normal parser to normalize the
+ * URL (e.g. GitHub tree paths, GitLab subgroups, Azure `?path=`/`?version=`),
+ * then stamp the requested type. When the host isn't recognized, the input is
+ * treated as a direct clone URL so unrecognized/self-hosted Git servers work.
+ */
+function parseForcedSource(input: string, type: SourceType): ParsedSource {
+  if (type === 'local') {
+    const resolvedPath = resolve(input);
+    return { type: 'local', url: resolvedPath, localPath: resolvedPath };
+  }
+
+  if (type === 'well-known') {
+    return { type: 'well-known', url: input };
+  }
+
+  // Git-backed types: peel off an optional #ref / #ref@skill fragment.
+  const { inputWithoutFragment, ref, skillFilter } = splitFragmentRef(input);
+
+  if (type === 'azure') {
+    const azure = parseAzureDevOpsUrl(inputWithoutFragment);
+    const resolvedRef = azure?.ref || ref;
+    const resolvedSubpath = azure?.subpath;
+    return {
+      type: 'azure',
+      url: azure?.url ?? inputWithoutFragment,
+      ...(resolvedRef ? { ref: resolvedRef } : {}),
+      ...(resolvedSubpath ? { subpath: resolvedSubpath } : {}),
+      ...(skillFilter ? { skillFilter } : {}),
+    };
+  }
+
+  // github / gitlab / git: reuse auto-detection to normalize the URL when it's
+  // a recognizable host, otherwise fall back to a direct clone URL.
+  const detected = parseSource(inputWithoutFragment);
+  if (detected.type !== 'local' && detected.type !== 'well-known') {
+    const resolvedRef = detected.ref ?? ref;
+    const resolvedSkill = skillFilter ?? detected.skillFilter;
+    return {
+      ...detected,
+      type,
+      ...(resolvedRef ? { ref: resolvedRef } : {}),
+      ...(resolvedSkill ? { skillFilter: resolvedSkill } : {}),
+    };
+  }
+
+  return {
+    type,
+    url: inputWithoutFragment,
+    ...(ref ? { ref } : {}),
+    ...(skillFilter ? { skillFilter } : {}),
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known';
+  type: 'github' | 'gitlab' | 'azure' | 'git' | 'local' | 'well-known';
   url: string;
   subpath?: string;
   localPath?: string;

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -71,7 +71,8 @@ function getLocalSource(entry: LocalUpdateSourceEntry): string | null {
   // Older project locks normalized both generic Git and GitLab sources to an
   // owner/repo shorthand. Without the original URL, treating either one as a
   // source would incorrectly redirect the operation to GitHub.
-  const requiresSourceUrl = entry.sourceType === 'git' || entry.sourceType === 'gitlab';
+  const requiresSourceUrl =
+    entry.sourceType === 'git' || entry.sourceType === 'gitlab' || entry.sourceType === 'azure';
   if (requiresSourceUrl && isBareShorthand(entry.source)) {
     return null;
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -170,6 +170,9 @@ export function getSkipReason(entry: SkillLockEntry): string {
   if (entry.sourceType === 'git') {
     return 'Git URL';
   }
+  if (entry.sourceType === 'azure') {
+    return 'Azure DevOps repo';
+  }
   if (entry.sourceType === 'well-known') {
     return 'Well-known skill';
   }

--- a/src/use.ts
+++ b/src/use.ts
@@ -9,7 +9,13 @@ import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { sanitizeName } from './installer.ts';
 import { getGitHubToken } from './skill-lock.ts';
 import { discoverSkills, filterSkills, getSkillDisplayName } from './skills.ts';
-import { getOwnerRepo, parseSource } from './source-parser.ts';
+import {
+  getOwnerRepo,
+  parseSource,
+  isSourceType,
+  SOURCE_TYPES,
+  type SourceType,
+} from './source-parser.ts';
 import type { AgentType, Skill } from './types.ts';
 import {
   wellKnownProvider,
@@ -23,6 +29,11 @@ export interface UseOptions {
   fullDepth?: boolean;
   dangerouslyAcceptOpenclawRisks?: boolean;
   help?: boolean;
+  /**
+   * Force the source to be interpreted as a specific type instead of
+   * auto-detecting it (`--source-type`).
+   */
+  sourceType?: SourceType;
 }
 
 export interface ParseUseOptionsResult {
@@ -100,6 +111,17 @@ export function parseUseOptions(args: string[]): ParseUseOptionsResult {
       options.fullDepth = true;
     } else if (arg === '--dangerously-accept-openclaw-risks') {
       options.dangerouslyAcceptOpenclawRisks = true;
+    } else if (arg === '--source-type') {
+      const value = args[i + 1];
+      if (value === undefined || value.startsWith('-')) {
+        errors.push(`--source-type requires a value (${SOURCE_TYPES.join(', ')})`);
+      } else if (!isSourceType(value)) {
+        errors.push(`Invalid --source-type "${value}". Valid values: ${SOURCE_TYPES.join(', ')}`);
+        i++;
+      } else {
+        options.sourceType = value;
+        i++;
+      }
     } else if (arg === '--skill' || arg === '-s') {
       const value = args[i + 1];
       if (!value || value.startsWith('-')) {
@@ -212,7 +234,7 @@ export async function runUse(
     }
 
     const source = sourceArgs[0]!;
-    const parsed = parseSource(source);
+    const parsed = parseSource(source, { sourceType: options.sourceType });
     const ownerRepoRaw = getOwnerRepo(parsed);
     const sourceOwner = ownerRepoRaw?.split('/')[0]?.toLowerCase();
 


### PR DESCRIPTION
Adding support for ADO by default (using the standard ADO in the cloud URL Scheme), as well as a way for the user to specify source-type if they're using an on prem TFS or even other source control repositories like BitBucket or Gitea

Solves #737, addresses #277 in a generic manner, allowing both Bitbucket datacenter and cloud. This will also address any future issues that may come up around git platforms that are either self hosted or the ones that aren't as well known