### PR TITLE
fix(add): duplicate copied install paths in add output

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -11,6 +11,12 @@ import {
   formatEveInstallPromptMessage,
 } from './add.ts';
 
+function countPathLinesForSkill(text: string, skillName: string): number {
+  return (
+    text.match(new RegExp(`→ .*${skillName.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}`, 'g')) || []
+  ).length;
+}
+
 const noDetectedAgentEnv = {
   AI_AGENT: '',
   ANTIGRAVITY_AGENT: '',
@@ -114,6 +120,65 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('deduplicates copied install paths for universal agents sharing the same directory', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'shared-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: shared-skill
+description: Shared install path regression test
+---
+
+# Shared Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = runCli(
+      ['add', sourceDir, '-y', '--agent', 'codex', 'cursor', 'cline'],
+      projectDir,
+      noDetectedAgentEnv
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Installed 1 skill');
+    expect(result.stdout).toContain('✓ shared-skill (copied)');
+    expect(countPathLinesForSkill(result.stdout, 'shared-skill')).toBe(1);
+  });
+
+  it('preserves distinct copied install paths when --copy targets different agent directories', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'multi-target-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: multi-target-skill
+description: Mixed copied destination regression test
+---
+
+# Multi Target Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = runCli(
+      ['add', sourceDir, '-y', '--copy', '--agent', 'codex', 'cursor', 'openclaw'],
+      projectDir,
+      noDetectedAgentEnv
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('✓ multi-target-skill (copied)');
+    expect(countPathLinesForSkill(result.stdout, 'multi-target-skill')).toBe(2);
   });
 
   it('should describe Eve project installs as for the eve agent to use', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -977,9 +977,13 @@ async function handleWellKnownSkills(
       if (firstResult.mode === 'copy') {
         // Copy mode: show skill name and list all agent paths
         resultLines.push(`${pc.green('✓')} ${skillName} ${pc.dim('(copied)')}`);
+        const shortPathsSet = new Set<string>();
         for (const r of skillResults) {
           const shortPath = shortenPath(r.path, cwd);
-          resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
+          if (!shortPathsSet.has(shortPath)) {
+            shortPathsSet.add(shortPath);
+            resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
+          }
         }
       } else {
         // Symlink mode: show canonical path and universal/symlinked agents
@@ -1953,9 +1957,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           if (firstResult.mode === 'copy') {
             // Copy mode: show skill name and list all agent paths
             resultLines.push(`${pc.green('✓')} ${entry.skill} ${pc.dim('(copied)')}`);
+            const shortPathsSet = new Set<string>();
             for (const r of skillResults) {
               const shortPath = shortenPath(r.path, cwd);
-              resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
+              if (!shortPathsSet.has(shortPath)) {
+                shortPathsSet.add(shortPath);
+                resultLines.push(`  ${pc.dim('→')} ${shortPath}`);
+              }
             }
           } else {
             // Symlink mode: show canonical path and universal/symlinked agents

--- a/src/add.ts
+++ b/src/add.ts
@@ -78,7 +78,6 @@ import { detectAgent, getAgentType } from './detect-agent.ts';
 import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
 import {
   addSkillToLock,
-  fetchSkillFolderHash,
   getGitHubToken,
   isPromptDismissed,
   dismissPrompt,


### PR DESCRIPTION
## Credit

This change was originally authored by [@onstash](https://github.com/onstash) in #1650. This PR preserves Santosh Venkatraman as the Git commit author and rebases the same implementation onto current `main` with signed commits.

Supersedes #1650.

## Summary

Fix duplicate copied-path lines in `skills add` output when multiple selected agents resolve to the same install directory.

- Deduplicate copied install paths within each skill result block.
- Preserve distinct destination paths.
- Keep the regression coverage from the original PR.

## Validation

- `pnpm test src/add.test.ts`
- `pnpm format:check`