### PR TITLE
docs: fix agent metadata script commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,8 @@ pnpm format
 pnpm format:check
 
 # Validate and sync agent metadata/docs
-pnpm run -C scripts validate-agents.ts
-pnpm run -C scripts sync-agents.ts
+node scripts/validate-agents.ts
+node scripts/sync-agents.ts
 ```
 
 ## Code Style
@@ -168,5 +168,5 @@ npm publish
 ## Adding a New Agent
 
 1. Add the agent definition to `src/agents.ts`
-2. Run `pnpm run -C scripts validate-agents.ts` to validate
-3. Run `pnpm run -C scripts sync-agents.ts` to update README.md and package keywords
+2. Run `node scripts/validate-agents.ts` to validate
+3. Run `node scripts/sync-agents.ts` to update README.md and package keywords


### PR DESCRIPTION
## Summary

Run `validate-agents.ts` and `sync-agents.ts` through Node from the repository root instead of asking pnpm to treat `scripts/` as a separate package.

## Validation

- `pnpm install --frozen-lockfile`
- `node scripts/validate-agents.ts`
- `node scripts/sync-agents.ts`
- `pnpm format:check`
- attest reports zero broken bindings in the modified instructions

This docs-only correction was found with the attest static instruction-binding scan.
