### PR TITLE
feat(agents): add support for CUGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Skills can be installed to any of these agents:
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
 | Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
 | Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
+| CUGA | `cuga` | `.cuga/skills/` | `~/.cuga/skills/` |
 | Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
 | Deep Agents | `deepagents` | `.agents/skills/` | `~/.deepagents/agent/skills/` |
 | Devin for Terminal | `devin` | `.devin/skills/` | `~/.config/devin/skills/` |
@@ -397,6 +398,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.continue/skills/`
 - `.cortex/skills/`
 - `.crush/skills/`
+- `.cuga/skills/`
 - `.devin/skills/`
 - `.factory/skills/`
 - `agent/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -237,6 +237,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.config/crush'));
     },
   },
+  cuga: {
+    name: 'cuga',
+    displayName: 'CUGA',
+    skillsDir: '.cuga/skills',
+    globalSkillsDir: join(home, '.cuga/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.cuga'));
+    },
+  },
   cursor: {
     name: 'cursor',
     displayName: 'Cursor',

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type AgentType =
   | 'continue'
   | 'cortex'
   | 'crush'
+  | 'cuga'
   | 'cursor'
   | 'deepagents'
   | 'devin'


### PR DESCRIPTION
## Summary
- Adds CUGA (IBM's open-source agent, https://github.com/cuga-project/cuga-agent) (800+ stars) to the supported agents registry
- CUGA reads skills from `.cuga/skills/` (project) and `~/.cuga/skills/` (global), following the same pattern already used for IBM Bob and Terramind
- Updates the README's Supported Agents table and skill discovery list

## Test plan
- [x] `pnpm test` passes with the same results as `main` (6 pre-existing failures unrelated to this change, 576 passing)
- [x] `pnpm type-check` has the same pre-existing errors as `main` (unrelated to this change)