### PR TITLE
Clarify GitHub auth fallback status

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -569,7 +569,7 @@ async function handleWellKnownSkills(
   options: AddOptions,
   spinner: ReturnType<typeof p.spinner>
 ): Promise<void> {
-  spinner.start('Discovering skills from well-known endpoint...');
+  spinner.start('Discovering skills from well-known endpoint…');
 
   // Fetch all skills from the well-known endpoint
   const skills = await wellKnownProvider.fetchAllSkills(url);
@@ -646,7 +646,7 @@ async function handleWellKnownSkills(
     const skillChoices = skills.map((s) => ({
       value: s,
       label: s.installName,
-      hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
+      hint: s.description.length > 60 ? s.description.slice(0, 57) + '…' : s.description,
     }));
 
     const selected = await multiselect({
@@ -682,7 +682,7 @@ async function handleWellKnownSkills(
 
     targetAgents = options.agent as AgentType[];
   } else {
-    spinner.start('Loading agents...');
+    spinner.start('Loading agents…');
     const installedAgents = await detectInstalledAgents();
     const totalAgents = Object.keys(agents).length;
     spinner.stop(`${totalAgents} agents`);
@@ -857,7 +857,7 @@ async function handleWellKnownSkills(
   const sourceIdentifier = wellKnownProvider.getSourceIdentifier(url);
   const wellKnownPrivacyPromise = isSourcePrivate(sourceIdentifier).catch(() => null);
 
-  spinner.start('Installing skills...');
+  spinner.start('Installing skills…');
 
   const results: {
     skill: string;
@@ -1094,7 +1094,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   try {
     const spinner = p.spinner();
 
-    spinner.start('Parsing source...');
+    spinner.start('Parsing source…');
     const parsed = parseSource(source);
     spinner.stop(
       `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
@@ -1135,7 +1135,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     if (parsed.type === 'local') {
       // Use local path directly, no cloning needed
-      spinner.start('Validating local path...');
+      spinner.start('Validating local path…');
       if (!existsSync(parsed.localPath!)) {
         spinner.stop(pc.red('Path not found'));
         p.outro(pc.red(`Local path does not exist: ${parsed.localPath}`));
@@ -1143,7 +1143,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
       spinner.stop('Local path validated');
 
-      spinner.start('Discovering skills...');
+      spinner.start('Discovering skills…');
       skills = await discoverSkills(parsed.localPath!, parsed.subpath, {
         includeInternal,
         fullDepth: options.fullDepth,
@@ -1158,7 +1158,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const isSelfHostedRepo =
         !!ownerRepo && Object.hasOwn(BLOB_ALLOWED_REPOS, ownerRepo.toLowerCase());
       if (ownerRepo && owner && (isSelfHostedRepo || BLOB_ALLOWED_OWNERS.includes(owner))) {
-        spinner.start('Fetching skills...');
+        spinner.start('Fetching skills…');
         blobResult = await tryBlobInstall(ownerRepo, {
           subpath: parsed.subpath,
           skillFilter: parsed.skillFilter,
@@ -1167,7 +1167,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           includeInternal,
         });
         if (!blobResult) {
-          spinner.stop(pc.dim('Falling back to clone...'));
+          spinner.stop(pc.dim('Falling back to clone…'));
         }
       }
 
@@ -1176,11 +1176,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         spinner.stop(`Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
       } else {
         // Blob failed — fall back to git clone
-        spinner.start('Cloning repository...');
+        spinner.start('Cloning repository…');
         tempDir = await cloneRepo(parsed.url, parsed.ref);
         spinner.stop('Repository cloned');
 
-        spinner.start('Discovering skills...');
+        spinner.start('Discovering skills…');
         skills = await discoverSkills(tempDir, parsed.subpath, {
           includeInternal,
           fullDepth: options.fullDepth,
@@ -1188,11 +1188,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     } else {
       // GitLab, git URL, or --full-depth: always clone
-      spinner.start('Cloning repository...');
+      spinner.start('Cloning repository…');
       tempDir = await cloneRepo(parsed.url, parsed.ref);
       spinner.stop('Repository cloned');
 
-      spinner.start('Discovering skills...');
+      spinner.start('Discovering skills…');
       skills = await discoverSkills(tempDir, parsed.subpath, {
         includeInternal,
         fullDepth: options.fullDepth,
@@ -1323,7 +1323,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           grouped[groupName]!.push({
             value: s,
             label: getSkillDisplayName(s),
-            hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
+            hint: s.description.length > 60 ? s.description.slice(0, 57) + '…' : s.description,
           });
         }
 
@@ -1336,7 +1336,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const skillChoices = sortedSkills.map((s) => ({
           value: s,
           label: getSkillDisplayName(s),
-          hint: s.description.length > 60 ? s.description.slice(0, 57) + '...' : s.description,
+          hint: s.description.length > 60 ? s.description.slice(0, 57) + '…' : s.description,
         }));
 
         selected = await multiselect({
@@ -1384,7 +1384,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       targetAgents = options.agent as AgentType[];
     } else {
-      spinner.start('Loading agents...');
+      spinner.start('Loading agents…');
       const installedAgents = await detectInstalledAgents();
       const totalAgents = Object.keys(agents).length;
       spinner.stop(`${totalAgents} agents`);
@@ -1710,7 +1710,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    spinner.start('Installing skills...');
+    spinner.start('Installing skills…');
 
     const results: {
       skill: string;
@@ -2107,7 +2107,7 @@ async function promptForFindSkills(
       }
 
       console.log();
-      p.log.step('Installing find-skills skill...');
+      p.log.step('Installing find-skills skill…');
 
       try {
         // Call runAdd directly

--- a/src/find.ts
+++ b/src/find.ts
@@ -164,7 +164,7 @@ async function runSearchPrompt(initialQuery = '', owner?: string): Promise<Searc
     if (!query || query.length < 2) {
       lines.push(`${DIM}Start typing to search (min 2 chars)${RESET}`);
     } else if (results.length === 0 && loading) {
-      lines.push(`${DIM}Searching...${RESET}`);
+      lines.push(`${DIM}Searching…${RESET}`);
     } else if (results.length === 0) {
       lines.push(`${DIM}No skills found${RESET}`);
     } else {
@@ -179,7 +179,7 @@ async function runSearchPrompt(initialQuery = '', owner?: string): Promise<Searc
         const source = skill.source ? ` ${DIM}${skill.source}${RESET}` : '';
         const installs = formatInstalls(skill.installs);
         const installsBadge = installs ? ` ${CYAN}${installs}${RESET}` : '';
-        const loadingIndicator = loading && i === 0 ? ` ${DIM}...${RESET}` : '';
+        const loadingIndicator = loading && i === 0 ? ` ${DIM}…${RESET}` : '';
 
         lines.push(`  ${arrow} ${name}${source}${installsBadge}${loadingIndicator}`);
       }
@@ -397,7 +397,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
   const skillName = selected.name;
 
   console.log();
-  console.log(`${TEXT}Installing ${BOLD}${skillName}${RESET} from ${DIM}${pkg}${RESET}...`);
+  console.log(`${TEXT}Installing ${BOLD}${skillName}${RESET} from ${DIM}${pkg}${RESET}…`);
   console.log();
 
   // Run add directly since we're in the same CLI

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -210,7 +210,7 @@ export async function searchMultiselect<T>(
             lines.push(`${S_BAR}    ${S_BULLET} ${pc.bold(item.label)}`);
           }
           if (lockedSection.hiddenCount && lockedSection.hiddenCount > 0) {
-            lines.push(`${S_BAR}    ${pc.dim(`...and ${lockedSection.hiddenCount} more`)}`);
+            lines.push(`${S_BAR}    ${pc.dim(`…and ${lockedSection.hiddenCount} more`)}`);
           }
           lines.push(`${S_BAR}`);
           lines.push(

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -39,7 +39,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
   const spinner = p.spinner();
 
-  spinner.start('Scanning for installed skills...');
+  spinner.start('Scanning for installed skills…');
   const skillNamesSet = new Set<string>();
 
   const scanDir = async (dir: string) => {
@@ -156,7 +156,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
   }
 
-  spinner.start('Removing skills...');
+  spinner.start('Removing skills…');
 
   const results: {
     skill: string;

--- a/src/skill-lock.test.ts
+++ b/src/skill-lock.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execSync } = vi.hoisted(() => ({ execSync: vi.fn() }));
+
+vi.mock('child_process', () => ({ execSync }));
+
+import { getGitHubToken, resetGhAuthWarning } from './skill-lock.ts';
+
+describe('getGitHubToken', () => {
+  const originalGitHubToken = process.env.GITHUB_TOKEN;
+  const originalGhToken = process.env.GH_TOKEN;
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    resetGhAuthWarning();
+    execSync.mockReset().mockReturnValue('ghp_test_token\n');
+    stderrWrite = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stderrWrite.mockRestore();
+    if (originalGitHubToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalGitHubToken;
+    }
+    if (originalGhToken === undefined) {
+      delete process.env.GH_TOKEN;
+    } else {
+      process.env.GH_TOKEN = originalGhToken;
+    }
+  });
+
+  it('describes the gh fallback as an automatic status, not an instruction', () => {
+    expect(getGitHubToken()).toBe('ghp_test_token');
+
+    const status = stderrWrite.mock.calls.map(([message]) => String(message)).join('');
+    expect(status).toContain('GitHub API request limit reached');
+    expect(status).toContain('checking existing');
+    expect(status).toContain('authentication…');
+    expect(status).not.toContain('Tip:');
+    expect(status).not.toContain('to continue');
+  });
+});

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -136,7 +136,7 @@ export function resetGhAuthWarning(): void {
  * Tries in order:
  * 1. GITHUB_TOKEN environment variable (silent)
  * 2. GH_TOKEN environment variable (silent)
- * 3. gh CLI auth token, if gh is installed. Prints a one-time warning to
+ * 3. gh CLI auth token, if gh is installed. Prints a one-time status to
  *    stderr before invoking `gh auth token`, because that subprocess call
  *    is flagged by some corporate endpoint security tooling (Defender, etc.)
  *    as credential extraction. Callers should invoke this function lazily
@@ -154,11 +154,11 @@ export function getGitHubToken(): string | null {
     return process.env.GH_TOKEN;
   }
 
-  // Last resort: spawn gh CLI. Warn the user once per process before doing so.
+  // Last resort: spawn gh CLI. Make the automatic credential check clear once
+  // per process before doing so, without suggesting the user needs to act.
   if (!_ghWarningShown) {
     process.stderr.write(
-      `${pc.yellow('│')}  ${pc.yellow('GitHub rate limit reached')} — using your ${pc.cyan('gh')} login to continue.\n` +
-        `${pc.yellow('│')}  ${pc.dim(`Tip: set ${pc.cyan('GITHUB_TOKEN')} to avoid this prompt, or use ${pc.cyan('--full-depth')} to clone instead.\n`)}`
+      `${pc.dim('│  GitHub API request limit reached; checking existing ')}${pc.cyan('gh')}${pc.dim(' authentication…\n')}`
     );
     _ghWarningShown = true;
   }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -166,7 +166,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   const spinner = p.spinner();
 
   // 1. Discover skills from node_modules
-  spinner.start('Scanning node_modules for skills...');
+  spinner.start('Scanning node_modules for skills…');
   const discoveredSkills = await discoverNodeModuleSkills(cwd);
 
   if (discoveredSkills.length === 0) {
@@ -242,7 +242,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     }
     targetAgents = options.agent as AgentType[];
   } else {
-    spinner.start('Loading agents...');
+    spinner.start('Loading agents…');
     const installedAgents = await detectInstalledAgents();
     const totalAgents = Object.keys(agents).length;
     spinner.stop(`${totalAgents} agents`);
@@ -343,7 +343,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   }
 
   // 5. Install skills (always project-scoped, always symlink)
-  spinner.start('Syncing skills...');
+  spinner.start('Syncing skills…');
 
   const results: Array<{
     skill: string;

--- a/src/update.ts
+++ b/src/update.ts
@@ -272,7 +272,7 @@ export async function checkAndPromptForDeletions(
 
       if (confirmed && !p.isCancel(confirmed)) {
         for (const s of deletedSkills) {
-          console.log(`${DIM}Removing${RESET} ${s}...`);
+          console.log(`${DIM}Removing${RESET} ${s}…`);
           await removeCommand([s], { yes: true, global: isGlobal });
         }
       }
@@ -442,7 +442,7 @@ export async function updateGlobalSkills(
 
   for (const update of updates) {
     const safeName = sanitizeMetadata(update.name);
-    console.log(`${TEXT}Updating ${safeName}...${RESET}`);
+    console.log(`${TEXT}Updating ${safeName}…${RESET}`);
     const installUrl = buildUpdateInstallSource(update.entry);
     if (!installUrl) {
       failCount++;
@@ -535,7 +535,7 @@ export async function updateProjectSkills(
     console.log(`${TEXT}Updating for: ${targetParts.join(', ')}${RESET}`);
   }
 
-  console.log(`${TEXT}Refreshing ${updatable.length} skill(s)...${RESET}`);
+  console.log(`${TEXT}Refreshing ${updatable.length} skill(s)…${RESET}`);
   console.log();
 
   const bySource = new Map<string, typeof updatable>();
@@ -603,7 +603,7 @@ export async function updateProjectSkills(
 
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);
-      console.log(`${TEXT}Updating ${safeName}...${RESET}`);
+      console.log(`${TEXT}Updating ${safeName}…${RESET}`);
       const installUrl = buildLocalUpdateSource(skill.entry);
       if (!installUrl) {
         failCount++;
@@ -673,9 +673,9 @@ export async function runUpdate(args: string[] = []): Promise<void> {
   const scope = await resolveUpdateScope(options);
 
   if (options.skills) {
-    console.log(`${TEXT}Updating ${options.skills.join(', ')}...${RESET}`);
+    console.log(`${TEXT}Updating ${options.skills.join(', ')}…${RESET}`);
   } else {
-    console.log(`${TEXT}Checking for skill updates...${RESET}`);
+    console.log(`${TEXT}Checking for skill updates…${RESET}`);
   }
   console.log();
 


### PR DESCRIPTION
## Summary
- describe the `gh auth token` fallback as an automatic status rather than a user instruction
- use the single-character ellipsis consistently in CLI progress and truncation text
- cover the updated auth-status copy

## Verification
- `pnpm test src/skill-lock.test.ts tests/blob-fetch-tree-auth.test.ts`
- `pnpm build`
- `pnpm format:check`

`pnpm type-check` still reports existing errors in `src/git.ts` and `src/skills.ts`. The full suite has environment-dependent failures around agent detection, global skill lookup, and the no-argument CLI banner.