### PR TITLE
Redirect moved Abyrd9 documentation skills

### DIFF
--- a/skills-sh-overrides.json
+++ b/skills-sh-overrides.json
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "redirects": [
+    {
+      "from": "abyrd9/skills/bun-docs",
+      "to": "abyrd9/doc-skills/bun-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/capacitor-docs",
+      "to": "abyrd9/doc-skills/capacitor-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/drizzle-docs",
+      "to": "abyrd9/doc-skills/drizzle-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/electron-docs",
+      "to": "abyrd9/doc-skills/electron-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/langgraph-js-docs",
+      "to": "abyrd9/doc-skills/langgraph-js-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/lexical-docs",
+      "to": "abyrd9/doc-skills/lexical-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/lucia-docs",
+      "to": "abyrd9/doc-skills/lucia-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/openai-realtime-docs",
+      "to": "abyrd9/doc-skills/openai-realtime-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/react-docs",
+      "to": "abyrd9/doc-skills/react-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/react-effects-docs",
+      "to": "abyrd9/doc-skills/react-effects-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/tanstack-docs",
+      "to": "abyrd9/doc-skills/tanstack-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    },
+    {
+      "from": "abyrd9/skills/xstate-docs",
+      "to": "abyrd9/doc-skills/xstate-docs",
+      "reason": "The skill moved from Abyrd9/skills to the dedicated Abyrd9/doc-skills repository.",
+      "evidence": [
+        "https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b",
+        "https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1"
+      ],
+      "verifiedAt": "2026-07-15"
+    }
+  ],
+  "hidden": []
+}


### PR DESCRIPTION
## What changed

Adds 12 skills.sh redirects from documentation skills formerly published under `abyrd9/skills` to their new canonical locations under `abyrd9/doc-skills`.

## Why

The documentation skills were moved into a dedicated public repository:

- Removed from the old source in [Abyrd9/skills@50ffabb](https://github.com/Abyrd9/skills/commit/50ffabb0250ee73ed57f7cdb2fbb2b0266cad14b)
- Published in the new source in [Abyrd9/doc-skills@a5333e6](https://github.com/Abyrd9/doc-skills/commit/a5333e64a6e8022cdc0e4ec8c51d019104fbe7d1)

The CLI now discovers 5 skills in `Abyrd9/skills` and 12 skills in `Abyrd9/doc-skills`, but the old skills.sh source page still retains all 17 entries. These redirects make the moved skills resolve to their current source instead of leaving duplicate stale listings.

## Checks

- `jq -e` structural validation: 12 unique redirects, 0 hidden entries, matching source and destination slugs
- `bunx prettier@3.8.1 --check skills-sh-overrides.json`
- `git diff --check`
- `npx skills add Abyrd9/skills --list` finds 5 skills
- `npx skills add Abyrd9/doc-skills --list` finds 12 skills
