### PR TITLE
test: isolate CLI home directories

### DIFF
--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
 import { parseListOptions } from './list.ts';
 
@@ -18,6 +18,21 @@ describe('list command', () => {
       rmSync(testDir, { recursive: true, force: true });
     }
   });
+
+  function createTestSkill(root: string, name: string, description: string): string {
+    const skillDir = join(root, '.agents', 'skills', name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: ${name}
+description: ${description}
+---
+# ${name}
+`
+    );
+    return skillDir;
+  }
 
   describe('parseListOptions', () => {
     it('should parse empty args', () => {
@@ -96,18 +111,7 @@ describe('list command', () => {
     });
 
     it('should output valid JSON with --json flag', () => {
-      const skillDir = join(testDir, '.agents', 'skills', 'json-skill');
-      mkdirSync(skillDir, { recursive: true });
-      writeFileSync(
-        join(skillDir, 'SKILL.md'),
-        `---
-name: json-skill
-description: A skill for JSON testing
----
-
-# JSON Skill
-`
-      );
+      createTestSkill(testDir, 'json-skill', 'A skill for JSON testing');
 
       const result = runCli(['list', '--json'], testDir);
       expect(result.exitCode).toBe(0);
@@ -123,19 +127,8 @@ description: A skill for JSON testing
     });
 
     it('should output multiple skills as JSON array', () => {
-      const skill1Dir = join(testDir, '.agents', 'skills', 'skill-alpha');
-      const skill2Dir = join(testDir, '.agents', 'skills', 'skill-beta');
-      mkdirSync(skill1Dir, { recursive: true });
-      mkdirSync(skill2Dir, { recursive: true });
-
-      writeFileSync(
-        join(skill1Dir, 'SKILL.md'),
-        `---\nname: skill-alpha\ndescription: Alpha\n---\n# Alpha\n`
-      );
-      writeFileSync(
-        join(skill2Dir, 'SKILL.md'),
-        `---\nname: skill-beta\ndescription: Beta\n---\n# Beta\n`
-      );
+      createTestSkill(testDir, 'skill-alpha', 'Alpha');
+      createTestSkill(testDir, 'skill-beta', 'Beta');
 
       const result = runCli(['list', '--json'], testDir);
       expect(result.exitCode).toBe(0);
@@ -154,21 +147,7 @@ description: A skill for JSON testing
     });
 
     it('should list project skills', () => {
-      // Create a skill in the canonical location
-      const skillDir = join(testDir, '.agents', 'skills', 'test-skill');
-      mkdirSync(skillDir, { recursive: true });
-      writeFileSync(
-        join(skillDir, 'SKILL.md'),
-        `---
-name: test-skill
-description: A test skill for listing
----
-
-# Test Skill
-
-This is a test skill.
-`
-      );
+      createTestSkill(testDir, 'test-skill', 'A test skill for listing');
 
       const result = runCli(['list'], testDir);
       expect(result.stdout).toContain('test-skill');
@@ -179,31 +158,8 @@ This is a test skill.
     });
 
     it('should list multiple skills', () => {
-      // Create multiple skills
-      const skill1Dir = join(testDir, '.agents', 'skills', 'skill-one');
-      const skill2Dir = join(testDir, '.agents', 'skills', 'skill-two');
-      mkdirSync(skill1Dir, { recursive: true });
-      mkdirSync(skill2Dir, { recursive: true });
-
-      writeFileSync(
-        join(skill1Dir, 'SKILL.md'),
-        `---
-name: skill-one
-description: First skill
----
-# Skill One
-`
-      );
-
-      writeFileSync(
-        join(skill2Dir, 'SKILL.md'),
-        `---
-name: skill-two
-description: Second skill
----
-# Skill Two
-`
-      );
+      createTestSkill(testDir, 'skill-one', 'First skill');
+      createTestSkill(testDir, 'skill-two', 'Second skill');
 
       const result = runCli(['list'], testDir);
       expect(result.stdout).toContain('skill-one');
@@ -213,22 +169,15 @@ description: Second skill
     });
 
     it('should respect -g flag for global only', () => {
-      // Create a project skill (should not be shown with -g)
-      const skillDir = join(testDir, '.agents', 'skills', 'project-skill');
-      mkdirSync(skillDir, { recursive: true });
-      writeFileSync(
-        join(skillDir, 'SKILL.md'),
-        `---
-name: project-skill
-description: A project skill
----
-# Project Skill
-`
-      );
+      createTestSkill(testDir, 'project-skill', 'A project skill');
 
-      const result = runCli(['list', '-g'], testDir);
+      const testHome = join(testDir, 'home');
+      createTestSkill(testHome, 'global-skill', 'A global skill');
+
+      const result = runCli(['list', '-g'], testDir, { HOME: testHome });
       // Should not show project skill when -g is specified
       expect(result.stdout).not.toContain('project-skill');
+      expect(result.stdout).toContain('global-skill');
       expect(result.stdout).toContain('Global Skills');
     });
 
@@ -240,18 +189,7 @@ description: A project skill
     });
 
     it('should filter by valid agent', () => {
-      // Create a skill
-      const skillDir = join(testDir, '.agents', 'skills', 'test-skill');
-      mkdirSync(skillDir, { recursive: true });
-      writeFileSync(
-        join(skillDir, 'SKILL.md'),
-        `---
-name: test-skill
-description: A test skill
----
-# Test Skill
-`
-      );
+      createTestSkill(testDir, 'test-skill', 'A test skill');
 
       const result = runCli(['list', '-a', 'claude-code'], testDir);
       expect(result.stdout).toContain('test-skill');
@@ -259,18 +197,7 @@ description: A test skill
     });
 
     it('should ignore directories without SKILL.md', () => {
-      // Create a valid skill
-      const validDir = join(testDir, '.agents', 'skills', 'valid-skill');
-      mkdirSync(validDir, { recursive: true });
-      writeFileSync(
-        join(validDir, 'SKILL.md'),
-        `---
-name: valid-skill
-description: Valid skill
----
-# Valid
-`
-      );
+      createTestSkill(testDir, 'valid-skill', 'Valid skill');
 
       // Create an invalid directory (no SKILL.md)
       const invalidDir = join(testDir, '.agents', 'skills', 'invalid-skill');
@@ -284,18 +211,7 @@ description: Valid skill
     });
 
     it('should handle SKILL.md with missing frontmatter', () => {
-      // Create a valid skill
-      const validDir = join(testDir, '.agents', 'skills', 'valid-skill');
-      mkdirSync(validDir, { recursive: true });
-      writeFileSync(
-        join(validDir, 'SKILL.md'),
-        `---
-name: valid-skill
-description: Valid skill
----
-# Valid
-`
-      );
+      createTestSkill(testDir, 'valid-skill', 'Valid skill');
 
       // Create a skill with invalid SKILL.md (no frontmatter)
       const invalidDir = join(testDir, '.agents', 'skills', 'invalid-skill');
@@ -309,17 +225,7 @@ description: Valid skill
     });
 
     it('should show skill path', () => {
-      const skillDir = join(testDir, '.agents', 'skills', 'test-skill');
-      mkdirSync(skillDir, { recursive: true });
-      writeFileSync(
-        join(skillDir, 'SKILL.md'),
-        `---
-name: test-skill
-description: A test skill
----
-# Test Skill
-`
-      );
+      createTestSkill(testDir, 'test-skill', 'A test skill');
 
       const result = runCli(['list'], testDir);
       // Path is shown inline with skill name (handles both Unix / and Windows \)

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -23,14 +23,18 @@ describe('remove command', { timeout: 30000 }, () => {
     }
   });
 
-  function createTestSkill(name: string, description?: string) {
-    const skillDir = join(skillsDir, name);
+  function createTestSkill(
+    name: string,
+    description = `A test skill called ${name}`,
+    targetSkillsDir = skillsDir
+  ): string {
+    const skillDir = join(targetSkillsDir, name);
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(
       join(skillDir, 'SKILL.md'),
       `---
 name: ${name}
-description: ${description || `A test skill called ${name}`}
+description: ${description}
 ---
 
 # ${name}
@@ -38,6 +42,7 @@ description: ${description || `A test skill called ${name}`}
 This is a test skill.
 `
     );
+    return skillDir;
   }
 
   function createAgentSkillsDir(agentName: string) {
@@ -200,14 +205,21 @@ This is a test skill.
   });
 
   describe('global flag', () => {
-    beforeEach(() => {
-      createTestSkill('global-skill');
-    });
+    it('should remove a skill from the isolated global home', () => {
+      const testHome = join(testDir, 'home');
+      const globalSkillDir = createTestSkill(
+        'global-skill',
+        'A global skill',
+        join(testHome, '.agents', 'skills')
+      );
 
-    it('should accept --global flag without error', () => {
-      const result = runCli(['remove', 'global-skill', '--global', '-y'], testDir);
-      // Command should run without error (skill may not be found in global scope from test dir)
+      const result = runCli(['remove', 'global-skill', '--global', '-y'], testDir, {
+        HOME: testHome,
+      });
+
       expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Successfully removed');
+      expect(existsSync(globalSkillDir)).toBe(false);
     });
   });
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,4 +1,6 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { stripTerminalEscapes } from './sanitize.ts';
 
@@ -21,18 +23,57 @@ export function hasLogo(str: string): boolean {
   return str.includes('███') || str.includes('╔') || str.includes('╚');
 }
 
+export function createTestHomeEnvironment(home: string): Record<string, string> {
+  return {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: join(home, '.config'),
+    XDG_DATA_HOME: join(home, '.local', 'share'),
+    XDG_STATE_HOME: join(home, '.local', 'state'),
+    XDG_CACHE_HOME: join(home, '.cache'),
+    APPDATA: join(home, 'AppData', 'Roaming'),
+    LOCALAPPDATA: join(home, 'AppData', 'Local'),
+    CODEX_HOME: join(home, '.codex'),
+    CLAUDE_CONFIG_DIR: join(home, '.claude'),
+    VIBE_HOME: join(home, '.vibe'),
+    HERMES_HOME: join(home, '.hermes'),
+    AUTOHAND_HOME: join(home, '.autohand'),
+    FLATPAK_XDG_CONFIG_HOME: join(home, '.var', 'app'),
+    DISABLE_TELEMETRY: '1',
+  };
+}
+
+function createIsolatedTestEnvironment(overrides?: Record<string, string>): {
+  env: NodeJS.ProcessEnv;
+  temporaryHome: string;
+} {
+  const temporaryHome = mkdtempSync(join(tmpdir(), 'skills-cli-test-home-'));
+  const home = overrides?.HOME || overrides?.USERPROFILE || temporaryHome;
+
+  return {
+    temporaryHome,
+    env: {
+      ...process.env,
+      ...createTestHomeEnvironment(home),
+      ...overrides,
+    },
+  };
+}
+
 export function runCli(
   args: string[],
   cwd?: string,
   env?: Record<string, string>,
   timeout?: number
 ): { stdout: string; stderr: string; exitCode: number } {
+  const { env: testEnv, temporaryHome } = createIsolatedTestEnvironment(env);
+
   try {
-    const output = execSync(`node "${CLI_PATH}" ${args.join(' ')}`, {
+    const output = execFileSync(process.execPath, [CLI_PATH, ...args], {
       encoding: 'utf-8',
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: env ? { ...process.env, ...env } : undefined,
+      env: testEnv,
       timeout: timeout ?? 30000,
     });
     return { stdout: stripAnsi(output), stderr: '', exitCode: 0 };
@@ -42,6 +83,8 @@ export function runCli(
       stderr: stripAnsi(error.stderr || ''),
       exitCode: error.status || 1,
     };
+  } finally {
+    rmSync(temporaryHome, { recursive: true, force: true });
   }
 }
 
@@ -55,12 +98,15 @@ export function runCliWithInput(
   input: string,
   cwd?: string
 ): { stdout: string; stderr: string; exitCode: number } {
+  const { env, temporaryHome } = createIsolatedTestEnvironment();
+
   try {
-    const output = execSync(`node "${CLI_PATH}" ${args.join(' ')}`, {
+    const output = execFileSync(process.execPath, [CLI_PATH, ...args], {
       encoding: 'utf-8',
       cwd,
       input: input + '\n',
       stdio: ['pipe', 'pipe', 'pipe'],
+      env,
     });
     return { stdout: stripAnsi(output), stderr: '', exitCode: 0 };
   } catch (error: any) {
@@ -69,5 +115,7 @@ export function runCliWithInput(
       stderr: stripAnsi(error.stderr || ''),
       exitCode: error.status || 1,
     };
+  } finally {
+    rmSync(temporaryHome, { recursive: true, force: true });
   }
 }

--- a/tests/list-installed.test.ts
+++ b/tests/list-installed.test.ts
@@ -1,12 +1,27 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, writeFile, rm, symlink } from 'fs/promises';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import { mkdir, mkdtemp, writeFile, rm, symlink } from 'fs/promises';
 import { join } from 'path';
-import { homedir, tmpdir } from 'os';
-import { listInstalledSkills } from '../src/installer.ts';
-import * as agentsModule from '../src/agents.ts';
+import { tmpdir } from 'os';
+import { createTestHomeEnvironment } from '../src/test-utils.ts';
+
+let listInstalledSkills: typeof import('../src/installer.ts').listInstalledSkills;
+let agentsModule: typeof import('../src/agents.ts');
 
 describe('listInstalledSkills', () => {
   let testDir: string;
+  let testHome: string;
+
+  beforeAll(async () => {
+    testHome = await mkdtemp(join(tmpdir(), 'skills-list-installed-home-'));
+
+    for (const [name, value] of Object.entries(createTestHomeEnvironment(testHome))) {
+      vi.stubEnv(name, value);
+    }
+
+    vi.resetModules();
+    agentsModule = await import('../src/agents.ts');
+    ({ listInstalledSkills } = await import('../src/installer.ts'));
+  });
 
   beforeEach(async () => {
     testDir = join(tmpdir(), `add-skill-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -14,7 +29,13 @@ describe('listInstalledSkills', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await rm(testDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await rm(testHome, { recursive: true, force: true });
   });
 
   // Helper to create a skill directory with SKILL.md
@@ -116,19 +137,20 @@ ${skillData.description}
   });
 
   it('should handle global scope option', async () => {
-    // Test with global: true - verifies the function doesn't crash
-    // Note: This checks ~/.agents/skills, results depend on system state
+    vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue([]);
+
     const skills = await listInstalledSkills({
       global: true,
       cwd: testDir,
     });
-    expect(Array.isArray(skills)).toBe(true);
+
+    expect(skills).toEqual([]);
   });
 
   it('attributes global canonical skills to universal agents with native global dirs', async () => {
     vi.spyOn(agentsModule, 'detectInstalledAgents').mockResolvedValue(['opencode']);
 
-    const skillDir = join(homedir(), '.agents', 'skills', 'opencode-global-attribution-test');
+    const skillDir = join(testHome, '.agents', 'skills', 'opencode-global-attribution-test');
     await mkdir(skillDir, { recursive: true });
     await writeFile(
       join(skillDir, 'SKILL.md'),
@@ -151,7 +173,6 @@ description: Test OpenCode global attribution
       expect(skill).toBeDefined();
       expect(skill!.agents).toContain('opencode');
     } finally {
-      vi.restoreAllMocks();
       await rm(skillDir, { recursive: true, force: true });
     }
   });
@@ -188,8 +209,6 @@ description: Test OpenCode global attribution
     // Should only show amp, not kimi-code-cli
     expect(skills[0]!.agents).toContain('amp');
     expect(skills[0]!.agents).not.toContain('kimi-code-cli');
-
-    vi.restoreAllMocks();
   });
 
   // Directory symlinks pointing at a real skill dir should be discovered.
@@ -260,7 +279,5 @@ description: A skill in cursor directory
     expect(skills).toHaveLength(1);
     expect(skills[0]!.name).toBe('cursor-skill');
     expect(skills[0]!.agents).toContain('cursor');
-
-    vi.restoreAllMocks();
   });
 });


### PR DESCRIPTION
CLI tests previously inherited real home and agent configuration paths, which allowed developer-specific global skill state to affect results and risked writing outside test fixtures.

Run CLI processes with temporary home environments, clean them up after execution, and use `execFileSync()` so arguments are passed without shell interpolation. Exercise global list and remove behavior against explicit isolated fixtures, while local skill helpers keep repeated setup concise.