### PR TITLE
test: isolate CLI helpers from agent environment

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -17,27 +17,6 @@ function countPathLinesForSkill(text: string, skillName: string): number {
   ).length;
 }
 
-const noDetectedAgentEnv = {
-  AI_AGENT: '',
-  ANTIGRAVITY_AGENT: '',
-  AUGMENT_AGENT: '',
-  CLAUDE_CODE: '',
-  CLAUDE_CODE_IS_COWORK: '',
-  CLAUDECODE: '',
-  CODEX_CI: '',
-  CODEX_SANDBOX: '',
-  CODEX_THREAD_ID: '',
-  COPILOT_ALLOW_ALL: '',
-  COPILOT_GITHUB_TOKEN: '',
-  COPILOT_MODEL: '',
-  CURSOR_AGENT: '',
-  CURSOR_EXTENSION_HOST_ROLE: '',
-  CURSOR_TRACE_ID: '',
-  GEMINI_CLI: '',
-  OPENCODE_CLIENT: '',
-  REPL_ID: '',
-};
-
 describe('add command', () => {
   let testDir: string;
 
@@ -142,8 +121,7 @@ description: Shared install path regression test
 
     const result = runCli(
       ['add', sourceDir, '-y', '--agent', 'codex', 'cursor', 'cline'],
-      projectDir,
-      noDetectedAgentEnv
+      projectDir
     );
 
     expect(result.exitCode).toBe(0);
@@ -172,8 +150,7 @@ description: Mixed copied destination regression test
 
     const result = runCli(
       ['add', sourceDir, '-y', '--copy', '--agent', 'codex', 'cursor', 'openclaw'],
-      projectDir,
-      noDetectedAgentEnv
+      projectDir
     );
 
     expect(result.exitCode).toBe(0);
@@ -205,11 +182,7 @@ Instructions here.
       JSON.stringify({ dependencies: { eve: '^0.11.5' } })
     );
 
-    const result = runCli(
-      ['add', sourceDir, '-y', '--skill', 'eve-skill'],
-      projectDir,
-      noDetectedAgentEnv
-    );
+    const result = runCli(['add', sourceDir, '-y', '--skill', 'eve-skill'], projectDir);
 
     expect(result.stdout).toContain('Installing to: eve agent');
     expect(result.stdout).not.toContain('Installing to: Eve');

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -47,26 +47,7 @@ describe('skills CLI', () => {
 
   describe('no arguments', () => {
     it('should display banner', () => {
-      const result = runCli([], undefined, {
-        AI_AGENT: '',
-        ANTIGRAVITY_AGENT: '',
-        AUGMENT_AGENT: '',
-        CLAUDE_CODE: '',
-        CLAUDE_CODE_IS_COWORK: '',
-        CLAUDECODE: '',
-        CODEX_CI: '',
-        CODEX_SANDBOX: '',
-        CODEX_THREAD_ID: '',
-        COPILOT_ALLOW_ALL: '',
-        COPILOT_GITHUB_TOKEN: '',
-        COPILOT_MODEL: '',
-        CURSOR_AGENT: '',
-        CURSOR_EXTENSION_HOST_ROLE: '',
-        CURSOR_TRACE_ID: '',
-        GEMINI_CLI: '',
-        OPENCODE_CLIENT: '',
-        REPL_ID: '',
-      });
+      const result = runCli([]);
       const output = stripLogo(result.stdout);
       expect(output).toContain('The open agent skills ecosystem');
       expect(output).toContain('npx skills add');

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runCli, runCliWithInput, stripLogo } from './test-utils.ts';
+
+describe('CLI test environment', () => {
+  it('does not inherit the parent agent environment in runCli', () => {
+    vi.stubEnv('CODEX_SANDBOX', 'sandboxed');
+
+    try {
+      const result = runCli([]);
+
+      expect(stripLogo(result.stdout)).toContain('The open agent skills ecosystem');
+      expect(result.exitCode).toBe(0);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('does not inherit the parent agent environment in runCliWithInput', () => {
+    vi.stubEnv('CODEX_SANDBOX', 'sandboxed');
+
+    try {
+      const result = runCliWithInput([], '');
+
+      expect(stripLogo(result.stdout)).toContain('The open agent skills ecosystem');
+      expect(result.exitCode).toBe(0);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('allows tests to opt in to agent mode explicitly', () => {
+    const result = runCli([], undefined, { AI_AGENT: 'codex' });
+
+    expect(result.stdout).toBe('');
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -7,6 +7,42 @@ import { stripTerminalEscapes } from './sanitize.ts';
 // const PROJECT_ROOT = join(import.meta.dirname, '..');
 const CLI_PATH = join(import.meta.dirname, 'cli.ts');
 
+// Keep synchronized with the environment checks in @vercel/detect-agent@1.2.3
+// and the additional Cursor checks in detect-agent.ts. Filesystem-based detection
+// such as /opt/.devin is intentionally outside this environment-isolation helper.
+const AGENT_DETECTION_ENV_VARS = new Set(
+  [
+    'AI_AGENT',
+    'ANTIGRAVITY_AGENT',
+    'AUGMENT_AGENT',
+    'CLAUDE_CODE',
+    'CLAUDE_CODE_IS_COWORK',
+    'CLAUDECODE',
+    'CODEX_CI',
+    'CODEX_SANDBOX',
+    'CODEX_THREAD_ID',
+    'COPILOT_ALLOW_ALL',
+    'COPILOT_GITHUB_TOKEN',
+    'COPILOT_MODEL',
+    'CURSOR_AGENT',
+    'CURSOR_EXTENSION_HOST_ROLE',
+    'CURSOR_TRACE_ID',
+    'GEMINI_CLI',
+    'OPENCODE_CLIENT',
+    'REPL_ID',
+  ].map((name) => name.toUpperCase())
+);
+
+function createCliTestEnvironment(overrides?: Record<string, string>): NodeJS.ProcessEnv {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([name]) => !AGENT_DETECTION_ENV_VARS.has(name.toUpperCase())
+    )
+  );
+
+  return { ...env, ...overrides };
+}
+
 export function stripAnsi(str: string): string {
   return stripTerminalEscapes(str);
 }
@@ -53,7 +89,7 @@ function createIsolatedTestEnvironment(overrides?: Record<string, string>): {
   return {
     temporaryHome,
     env: {
-      ...process.env,
+      ...createCliTestEnvironment(),
       ...createTestHomeEnvironment(home),
       ...overrides,
     },
@@ -96,9 +132,10 @@ export function runCliOutput(args: string[], cwd?: string): string {
 export function runCliWithInput(
   args: string[],
   input: string,
-  cwd?: string
+  cwd?: string,
+  env?: Record<string, string>
 ): { stdout: string; stderr: string; exitCode: number } {
-  const { env, temporaryHome } = createIsolatedTestEnvironment();
+  const { env: testEnv, temporaryHome } = createIsolatedTestEnvironment(env);
 
   try {
     const output = execFileSync(process.execPath, [CLI_PATH, ...args], {
@@ -106,7 +143,7 @@ export function runCliWithInput(
       cwd,
       input: input + '\n',
       stdio: ['pipe', 'pipe', 'pipe'],
-      env,
+      env: testEnv,
     });
     return { stdout: stripAnsi(output), stderr: '', exitCode: 0 };
   } catch (error: any) {


### PR DESCRIPTION
CLI subprocesses inherited agent-detection variables such as `CODEX_SANDBOX` from the test runner, causing behavior to vary depending on where the suite was invoked.

Remove inherited detection variables in the shared helpers while applying explicit overrides afterward. Add focused helper regression coverage and remove duplicated per-test environment maps.
