### PR TITLE
chore: require Node.js 22.20 or newer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -59,7 +59,7 @@ body:
     attributes:
       label: Node.js Version
       description: What version of Node.js are you using?
-      placeholder: e.g., 20.10.0
+      placeholder: e.g., 22.20.0
     validations:
       required: false
 

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -20,11 +20,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -46,8 +43,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,23 @@ on:
 jobs:
   checks:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        node-version: ['22.20.0', '24', '26']
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
 
       - name: Install dependencies
@@ -36,7 +38,7 @@ jobs:
         run: pnpm build
 
       - name: Prettier
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '24'
         run: pnpm format:check
 
       - name: Tests
@@ -49,13 +51,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: '24'
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: "24"
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "xdg-basedir": "^5.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22.20.0"
   },
   "packageManager": "pnpm@10.17.1",
   "dependencies": {

--- a/tests/dist.test.ts
+++ b/tests/dist.test.ts
@@ -10,7 +10,7 @@ describe('dist build', () => {
     execSync('pnpm build', { cwd: rootDir, stdio: 'pipe' });
 
     // Run the CLI - should exit cleanly with help output
-    const result = execSync('node dist/cli.mjs --help', {
+    const result = execSync('node bin/cli.mjs --help', {
       cwd: rootDir,
       stdio: 'pipe',
       encoding: 'utf-8',


### PR DESCRIPTION
Node.js 18 and 20 are end-of-life, and Node.js 22.20 is the oldest supported release where `path.matchesGlob()` is stable. Test every supported Node.js release line across Linux and Windows.

Corepack is no longer bundled with newer Node.js releases, so install pnpm through the v6.0.9 `pnpm/action-setup` commit. Pin the action because it also runs in write-capable synchronization and publishing workflows.

Keep publishing on the active LTS release, Node.js 24, and exercise public package entrypoint `bin/cli.mjs` in the distribution test.