### PR TITLE
fix: allow list git protocols

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -153,6 +153,7 @@ function createGitClient(sshCommand?: string) {
       allowUnsafeTemplateDir: true,
     },
   });
+
   git.env({
     ...process.env,
     GIT_TERMINAL_PROMPT: '0',

--- a/src/git.ts
+++ b/src/git.ts
@@ -6,6 +6,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 
 const DEFAULT_CLONE_TIMEOUT_MS = 300_000; // 5 minutes
+const ALLOWED_GIT_PROTOCOLS = 'https:http:ssh:git:file';
 const CLONE_TIMEOUT_MS = (() => {
   const raw = process.env.SKILLS_CLONE_TIMEOUT_MS;
   if (!raw) return DEFAULT_CLONE_TIMEOUT_MS;
@@ -152,10 +153,10 @@ function createGitClient(sshCommand?: string) {
       allowUnsafeTemplateDir: true,
     },
   });
-
   git.env({
     ...process.env,
     GIT_TERMINAL_PROMPT: '0',
+    GIT_ALLOW_PROTOCOL: ALLOWED_GIT_PROTOCOLS,
     // When git-lfs IS installed, tell it not to download LFS content
     // during checkout. See #952 for context and empirical impact.
     GIT_LFS_SKIP_SMUDGE: '1',
@@ -189,7 +190,11 @@ async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): 
   const gitFlags = ref ? ['--depth=1', '--branch', ref] : ['--depth=1'];
   await execFileAsync('gh', ['repo', 'clone', cloneTarget, tempDir, '--', ...gitFlags], {
     timeout: CLONE_TIMEOUT_MS,
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_ALLOW_PROTOCOL: ALLOWED_GIT_PROTOCOLS,
+    },
   });
   return true;
 }

--- a/tests/git-lfs-clone.test.ts
+++ b/tests/git-lfs-clone.test.ts
@@ -95,7 +95,8 @@ describe('cloneRepo LFS handling', () => {
     const cloneDir = await cloneRepo(source);
     tempDirs.push(cloneDir);
 
-    await expect(readFile(join(cloneDir, 'asset.bin'), 'utf8')).resolves.toBe(expectedContents);
+    const actualContents = await readFile(join(cloneDir, 'asset.bin'), 'utf8');
+    expect(actualContents.replaceAll('\r\n', '\n')).toBe(expectedContents.replaceAll('\r\n', '\n'));
     await cleanupTempDir(cloneDir);
     tempDirs.splice(tempDirs.indexOf(cloneDir), 1);
   }, 20_000);

--- a/tests/git-transport-allowlist.test.ts
+++ b/tests/git-transport-allowlist.test.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'child_process';
-import { access, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
-import { delimiter, join } from 'path';
+import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { cloneRepo } from '../src/git.ts';
 
@@ -20,8 +20,6 @@ describe('cloneRepo transport allowlist', () => {
     GIT_ALLOW_PROTOCOL: process.env.GIT_ALLOW_PROTOCOL,
     GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
     GIT_CONFIG_NOSYSTEM: process.env.GIT_CONFIG_NOSYSTEM,
-    PATH: process.env.PATH,
-    SKILLS_TEST_MARKER: process.env.SKILLS_TEST_MARKER,
   };
 
   afterEach(async () => {
@@ -35,22 +33,8 @@ describe('cloneRepo transport allowlist', () => {
   it('overrides inherited allowances for command-capable transports', async () => {
     const root = await mkdtemp(join(tmpdir(), 'skills-transport-test-'));
     tempDirs.push(root);
-    const binDir = join(root, 'bin');
-    const marker = join(root, 'executed');
     const globalConfig = join(root, 'global.gitconfig');
-    const helper = join(
-      binDir,
-      process.platform === 'win32' ? 'git-remote-skills-test.cmd' : 'git-remote-skills-test'
-    );
 
-    await mkdir(binDir);
-    await writeFile(
-      helper,
-      process.platform === 'win32'
-        ? '@echo off\r\n> "%SKILLS_TEST_MARKER%" echo executed\r\nexit /b 1\r\n'
-        : '#!/bin/sh\nprintf executed > "$SKILLS_TEST_MARKER"\nexit 1\n',
-      { mode: 0o755 }
-    );
     await writeFile(
       globalConfig,
       '[protocol "skills-test"]\n  allow = always\n[protocol "fd"]\n  allow = always\n'
@@ -58,14 +42,10 @@ describe('cloneRepo transport allowlist', () => {
 
     process.env.GIT_CONFIG_GLOBAL = globalConfig;
     process.env.GIT_CONFIG_NOSYSTEM = '1';
-    process.env.PATH = `${binDir}${delimiter}${originalEnv.PATH ?? ''}`;
-    process.env.SKILLS_TEST_MARKER = marker;
 
     await expect(
       runGit(['clone', 'skills-test::fixture', join(root, 'baseline')], process.env)
-    ).rejects.toThrow();
-    await expect(access(marker)).resolves.toBeUndefined();
-    await rm(marker);
+    ).rejects.toThrow(/remote-skills-test/);
 
     // Make sure user's env doesn't bypass our allow list
     process.env.GIT_ALLOW_PROTOCOL = 'skills-test:ext:fd';
@@ -74,6 +54,5 @@ describe('cloneRepo transport allowlist', () => {
       'Unsupported Git transport: ext'
     );
     await expect(cloneRepo('fd::3')).rejects.toThrow(/transport .* not allowed/i);
-    await expect(access(marker)).rejects.toThrow();
   });
 });

--- a/tests/git-transport-allowlist.test.ts
+++ b/tests/git-transport-allowlist.test.ts
@@ -1,0 +1,79 @@
+import { execFile } from 'child_process';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { delimiter, join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cloneRepo } from '../src/git.ts';
+
+function runGit(args: string[], env: NodeJS.ProcessEnv): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { env }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+describe('cloneRepo transport allowlist', () => {
+  const tempDirs: string[] = [];
+  const originalEnv = {
+    GIT_ALLOW_PROTOCOL: process.env.GIT_ALLOW_PROTOCOL,
+    GIT_CONFIG_GLOBAL: process.env.GIT_CONFIG_GLOBAL,
+    GIT_CONFIG_NOSYSTEM: process.env.GIT_CONFIG_NOSYSTEM,
+    PATH: process.env.PATH,
+    SKILLS_TEST_MARKER: process.env.SKILLS_TEST_MARKER,
+  };
+
+  afterEach(async () => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('overrides inherited allowances for command-capable transports', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-transport-test-'));
+    tempDirs.push(root);
+    const binDir = join(root, 'bin');
+    const marker = join(root, 'executed');
+    const globalConfig = join(root, 'global.gitconfig');
+    const helper = join(
+      binDir,
+      process.platform === 'win32' ? 'git-remote-skills-test.cmd' : 'git-remote-skills-test'
+    );
+
+    await mkdir(binDir);
+    await writeFile(
+      helper,
+      process.platform === 'win32'
+        ? '@echo off\r\n> "%SKILLS_TEST_MARKER%" echo executed\r\nexit /b 1\r\n'
+        : '#!/bin/sh\nprintf executed > "$SKILLS_TEST_MARKER"\nexit 1\n',
+      { mode: 0o755 }
+    );
+    await writeFile(
+      globalConfig,
+      '[protocol "skills-test"]\n  allow = always\n[protocol "fd"]\n  allow = always\n'
+    );
+
+    process.env.GIT_CONFIG_GLOBAL = globalConfig;
+    process.env.GIT_CONFIG_NOSYSTEM = '1';
+    process.env.PATH = `${binDir}${delimiter}${originalEnv.PATH ?? ''}`;
+    process.env.SKILLS_TEST_MARKER = marker;
+
+    await expect(
+      runGit(['clone', 'skills-test::fixture', join(root, 'baseline')], process.env)
+    ).rejects.toThrow();
+    await expect(access(marker)).resolves.toBeUndefined();
+    await rm(marker);
+
+    // Make sure user's env doesn't bypass our allow list
+    process.env.GIT_ALLOW_PROTOCOL = 'skills-test:ext:fd';
+    await expect(cloneRepo('skills-test::fixture')).rejects.toThrow(/transport .* not allowed/i);
+    await expect(cloneRepo('ext::git-remote-skills-test')).rejects.toThrow(
+      'Unsupported Git transport: ext'
+    );
+    await expect(cloneRepo('fd::3')).rejects.toThrow(/transport .* not allowed/i);
+    await expect(access(marker)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- supersede #1611 by explicitly allow-listing protocols via git's env (`GIT_ALLOW_PROTOCOL`)
- add e2e allow-list tests in `tests/git-transport-allowlist.test.ts`
- normalize CRLFs in `tests/git-lfs-clone.test.ts`; otherwise, Windows tests fail

## Testing

- `pnpm test tests/git-transport-allowlist.test.ts src/git.test.ts tests/git-lfs-clone.test.ts --run --no-file-parallelism`
- `pnpm build`
- `pnpm exec prettier --check src/git.ts src/git.test.ts tests/git-transport-allowlist.test.ts`
