### PR TITLE
fix(update): support full-depth skill updates

### DIFF
--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -128,6 +128,14 @@ describe('update-source', () => {
       expect(result).toBe('git@gitea.example.com:owner/repo.git#main');
     });
 
+    it('does not append skill folder for ssh:// sources without a .git suffix', () => {
+      const result = buildLocalUpdateSource({
+        source: 'ssh://git@gitea.example.com/owner/repo',
+        skillPath: 'skills/my-skill/SKILL.md',
+      });
+      expect(result).toBe('ssh://git@gitea.example.com/owner/repo');
+    });
+
     it('does not append skill folder for self-hosted HTTPS .git URLs', () => {
       const result = buildLocalUpdateSource({
         source: 'https://gitea.example.com/owner/repo.git',
@@ -179,6 +187,16 @@ describe('update-source', () => {
       expect(
         shouldUseFullDepthForUpdate({
           source: 'git@gitea.example.com:owner/repo.git',
+          sourceType: 'git',
+          skillPath: 'plugins/example/skills/deep-skill/SKILL.md',
+        })
+      ).toBe(true);
+    });
+
+    it('returns true for ssh:// sources without a .git suffix', () => {
+      expect(
+        shouldUseFullDepthForUpdate({
+          source: 'ssh://git@gitea.example.com/owner/repo',
           sourceType: 'git',
           skillPath: 'plugins/example/skills/deep-skill/SKILL.md',
         })

--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -3,6 +3,7 @@ import {
   buildLocalUpdateSource,
   buildUpdateInstallSource,
   formatSourceInput,
+  shouldUseFullDepthForUpdate,
 } from './update-source.ts';
 
 describe('update-source', () => {
@@ -170,6 +171,48 @@ describe('update-source', () => {
         skillPath: 'skills/my-skill/SKILL.md',
       });
       expect(result).toBeNull();
+    });
+  });
+
+  describe('shouldUseFullDepthForUpdate', () => {
+    it('returns true for SSH sources that cannot append the locked skill path', () => {
+      expect(
+        shouldUseFullDepthForUpdate({
+          source: 'git@gitea.example.com:owner/repo.git',
+          sourceType: 'git',
+          skillPath: 'plugins/example/skills/deep-skill/SKILL.md',
+        })
+      ).toBe(true);
+    });
+
+    it('returns true for self-hosted .git URLs', () => {
+      expect(
+        shouldUseFullDepthForUpdate({
+          source: 'owner/repo',
+          sourceUrl: 'https://gitea.example.com/owner/repo.git',
+          sourceType: 'git',
+          skillPath: 'plugins/example/skills/deep-skill/SKILL.md',
+        })
+      ).toBe(true);
+    });
+
+    it('returns false for GitHub sources that can append the locked skill path', () => {
+      expect(
+        shouldUseFullDepthForUpdate({
+          source: 'owner/repo',
+          sourceType: 'github',
+          skillPath: 'plugins/example/skills/deep-skill/SKILL.md',
+        })
+      ).toBe(false);
+    });
+
+    it('returns false when no skillPath is recorded', () => {
+      expect(
+        shouldUseFullDepthForUpdate({
+          source: 'git@gitea.example.com:owner/repo.git',
+          sourceType: 'git',
+        })
+      ).toBe(false);
     });
   });
 });

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -42,12 +42,12 @@ function deriveSkillFolder(skillPath: string): string {
  * Whether a skill folder can be safely appended to the given source as a
  * subpath. Only true for sources the source-parser can resolve as a
  * GitHub/GitLab tree URL — owner/repo shorthand or an HTTPS URL on those
- * hosts. Full SSH URLs (`git@host:owner/repo.git`) and generic Git URLs
+ * hosts. Full SSH URLs (`git@host:owner/repo.git` or `ssh://...`) and generic Git URLs
  * (anything ending in `.git`, or hosts other than github.com/gitlab.com)
  * cannot have a subpath appended without producing an unclonable URL.
  */
 function supportsAppendedSubpath(source: string): boolean {
-  if (source.startsWith('git@')) return false;
+  if (source.startsWith('git@') || source.startsWith('ssh://')) return false;
   if (source.endsWith('.git')) return false;
   if (source.startsWith('http://') || source.startsWith('https://')) {
     try {

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -78,6 +78,15 @@ function getLocalSource(entry: LocalUpdateSourceEntry): string | null {
   return entry.source;
 }
 
+export function shouldUseFullDepthForUpdate(entry: LocalUpdateSourceEntry): boolean {
+  if (!entry.skillPath) return false;
+
+  const source =
+    entry.sourceType && entry.sourceType !== 'github' ? getLocalSource(entry) : entry.source;
+
+  return source !== null && !supportsAppendedSubpath(source);
+}
+
 function appendFolderAndRef(source: string, skillPath: string, ref?: string): string {
   if (!supportsAppendedSubpath(source)) {
     return formatSourceInput(source, ref);

--- a/src/update.ts
+++ b/src/update.ts
@@ -14,7 +14,7 @@ import {
 } from './update-source.ts';
 import { cloneRepo, cleanupTempDir } from './git.ts';
 import { discoverSkills } from './skills.ts';
-import { fetchRepoTree, findSkillMdPaths, getSkillFolderHashFromTree } from './blob.ts';
+import { fetchRepoTree, getSkillFolderHashFromTree } from './blob.ts';
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
@@ -347,7 +347,9 @@ export async function updateGlobalSkills(
           continue;
         }
 
-        const discoveredPaths = findSkillMdPaths(tree);
+        const discoveredPaths = tree.tree
+          .filter((entry) => entry.type === 'blob')
+          .map((entry) => entry.path);
 
         const allLockedForSource = Object.entries(lock.skills)
           .filter(([_, entry]) => entry.source === source)
@@ -377,9 +379,11 @@ export async function updateGlobalSkills(
       }
 
       tempDir = await cloneRepo(sourceUrl, firstEntry.ref);
-      const discoveredPaths = (await discoverSkills(tempDir)).map((skill) => {
-        return join(relative(tempDir!, skill.path), 'SKILL.md').split(sep).join('/');
-      });
+      const discoveredPaths = (await discoverSkills(tempDir, undefined, { fullDepth: true })).map(
+        (skill) => {
+          return join(relative(tempDir!, skill.path), 'SKILL.md').split(sep).join('/');
+        }
+      );
 
       const allLockedForSource = Object.entries(lock.skills)
         .filter(([_, entry]) => entry.source === source)
@@ -576,7 +580,7 @@ export async function updateProjectSkills(
 
     try {
       tempDir = await cloneRepo(sourceUrl, ref);
-      const discovered = await discoverSkills(tempDir);
+      const discovered = await discoverSkills(tempDir, undefined, { fullDepth: true });
 
       const discoveredPaths = discovered.map((s) => {
         const relPath = relative(tempDir!, s.path);

--- a/src/update.ts
+++ b/src/update.ts
@@ -11,6 +11,7 @@ import {
   formatSourceInput,
   buildUpdateInstallSource,
   buildLocalUpdateSource,
+  shouldUseFullDepthForUpdate,
 } from './update-source.ts';
 import { cloneRepo, cleanupTempDir } from './git.ts';
 import { discoverSkills } from './skills.ts';
@@ -464,16 +465,21 @@ export async function updateGlobalSkills(
       );
       continue;
     }
-    const result = spawnSync(process.execPath, [cliEntry, 'add', installUrl, '-g', '-y'], {
-      stdio: ['inherit', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-      // Never spawn through a shell. process.execPath is an absolute path to the
-      // node binary, so no shell is needed to resolve it. installUrl is derived
-      // from the lock file (and ref is URL-decoded, so influenceable by whoever
-      // publishes a skill); a shell on Windows would let metacharacters in that
-      // value inject commands. Passing argv directly keeps it inert.
-      shell: false,
-    });
+    const fullDepthArgs = shouldUseFullDepthForUpdate(update.entry) ? ['--full-depth'] : [];
+    const result = spawnSync(
+      process.execPath,
+      [cliEntry, 'add', installUrl, ...fullDepthArgs, '-g', '-y'],
+      {
+        stdio: ['inherit', 'pipe', 'pipe'],
+        encoding: 'utf-8',
+        // Never spawn through a shell. process.execPath is an absolute path to the
+        // node binary, so no shell is needed to resolve it. installUrl is derived
+        // from the lock file (and ref is URL-decoded, so influenceable by whoever
+        // publishes a skill); a shell on Windows would let metacharacters in that
+        // value inject commands. Passing argv directly keeps it inert.
+        shell: false,
+      }
+    );
 
     if (result.status === 0) {
       successCount++;
@@ -622,10 +628,20 @@ export async function updateProjectSkills(
       const subagentArgs = skill.entry.subagents?.length
         ? ['--subagent', ...skill.entry.subagents.map((s) => (s === '' ? 'root' : s))]
         : [];
+      const fullDepthArgs = shouldUseFullDepthForUpdate(skill.entry) ? ['--full-depth'] : [];
 
       const result = spawnSync(
         process.execPath,
-        [cliEntry, 'add', installUrl, '--skill', skill.name, ...subagentArgs, '-y'],
+        [
+          cliEntry,
+          'add',
+          installUrl,
+          '--skill',
+          skill.name,
+          ...subagentArgs,
+          ...fullDepthArgs,
+          '-y',
+        ],
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -457,8 +457,8 @@ describe('Update Cleanup Unit Tests', () => {
         version: 3,
         skills: {
           'skill-a': {
-            source: 'git@github.com:owner/repo.git',
-            sourceUrl: 'git@github.com:owner/repo.git',
+            source: 'ssh://git@github.com/owner/repo',
+            sourceUrl: 'ssh://git@github.com/owner/repo',
             skillPath: 'plugins/example/skills/skill-a/SKILL.md',
             sourceType: 'git',
             skillFolderHash: 'old-hash',
@@ -481,7 +481,7 @@ describe('Update Cleanup Unit Tests', () => {
 
       await updateGlobalSkills({ yes: true });
 
-      expect(git.cloneRepo).toHaveBeenCalledWith('git@github.com:owner/repo.git', undefined);
+      expect(git.cloneRepo).toHaveBeenCalledWith('ssh://git@github.com/owner/repo', undefined);
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
         join('/tmp/repo', 'plugins/example/skills/skill-a')
       );
@@ -490,6 +490,8 @@ describe('Update Cleanup Unit Tests', () => {
         .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
       expect(installCall).toBeDefined();
       const [, argv] = installCall!;
+      expect(argv).toContain('ssh://git@github.com/owner/repo');
+      expect(argv).not.toContain('ssh://git@github.com/owner/repo/plugins/example/skills/skill-a');
       expect(argv).toContain('--full-depth');
     });
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -195,6 +195,41 @@ describe('Update Cleanup Unit Tests', () => {
       expect(remove.removeCommand).not.toHaveBeenCalled();
     });
 
+    it('uses full-depth discovery for project deletion checks', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'help-me-read': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'plugins/help-me-read/skills/help-me-read/SKILL.md',
+            computedHash: 'old-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockImplementation(async (_path, _subpath, options) =>
+        options?.fullDepth
+          ? [
+              {
+                name: 'help-me-read',
+                path: '/tmp/repo/plugins/help-me-read/skills/help-me-read',
+                description: 'Deep skill',
+                rawContent: '',
+              },
+            ]
+          : []
+      );
+
+      await updateProjectSkills();
+
+      expect(skills.discoverSkills).toHaveBeenCalledWith('/tmp/repo', undefined, {
+        fullDepth: true,
+      });
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
+
     it('uses sourceUrl for self-hosted GitLab project updates', async () => {
       vi.mocked(localLock.readLocalLock).mockResolvedValue({
         version: 1,
@@ -296,6 +331,86 @@ describe('Update Cleanup Unit Tests', () => {
         ['skill-b'],
         expect.objectContaining({ yes: true, global: true })
       );
+    });
+
+    it('does not report a locked plugin skill as deleted when it exists in the GitHub tree', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'help-me-read': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            sourceType: 'github',
+            skillPath: 'plugins/help-me-read/skills/help-me-read/SKILL.md',
+            skillFolderHash: 'deep-tree-sha',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          { path: '.claude/skills/shallow/SKILL.md', type: 'blob', sha: 'shallow-blob' },
+          {
+            path: 'plugins/help-me-read/skills/help-me-read/SKILL.md',
+            type: 'blob',
+            sha: 'deep-blob',
+          },
+          {
+            path: 'plugins/help-me-read/skills/help-me-read',
+            type: 'tree',
+            sha: 'deep-tree-sha',
+          },
+        ],
+      });
+      vi.mocked(blob.findSkillMdPaths).mockReturnValue(['.claude/skills/shallow/SKILL.md']);
+      vi.mocked(p.confirm).mockResolvedValue(false);
+
+      await updateGlobalSkills();
+
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
+
+    it('uses full-depth discovery for non-GitHub global deletion checks', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'deep-skill': {
+            source: 'git@gitea.example.com:owner/repo.git',
+            sourceUrl: 'git@gitea.example.com:owner/repo.git',
+            sourceType: 'git',
+            skillPath: 'plugins/example/skills/deep-skill/SKILL.md',
+            skillFolderHash: 'same-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockImplementation(async (_path, _subpath, options) =>
+        options?.fullDepth
+          ? [
+              {
+                name: 'deep-skill',
+                path: '/tmp/repo/plugins/example/skills/deep-skill',
+                description: 'Deep skill',
+                rawContent: '',
+              },
+            ]
+          : []
+      );
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('same-hash');
+
+      await updateGlobalSkills();
+
+      expect(skills.discoverSkills).toHaveBeenCalledWith('/tmp/repo', undefined, {
+        fullDepth: true,
+      });
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
     });
 
     it('should check global non-GitHub git sources by cloning', async () => {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -237,7 +237,7 @@ describe('Update Cleanup Unit Tests', () => {
           'skill-a': {
             source: 'acme/skills',
             sourceUrl: 'https://gitlab.example.com/acme/skills.git',
-            skillPath: 'skills/skill-a/SKILL.md',
+            skillPath: 'plugins/example/skills/skill-a/SKILL.md',
             sourceType: 'git',
             computedHash: 'abc',
           },
@@ -246,7 +246,12 @@ describe('Update Cleanup Unit Tests', () => {
 
       vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
       vi.mocked(skills.discoverSkills).mockResolvedValue([
-        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+        {
+          name: 'skill-a',
+          path: '/tmp/repo/plugins/example/skills/skill-a',
+          description: 'Deep skill',
+          rawContent: '',
+        },
       ]);
 
       await updateProjectSkills({ yes: true });
@@ -264,6 +269,40 @@ describe('Update Cleanup Unit Tests', () => {
         expect.arrayContaining(['add', 'https://gitlab.example.com/acme/skills.git', '--skill'])
       );
       expect(argv).not.toEqual(expect.arrayContaining(['acme/skills']));
+      expect(argv).toContain('--full-depth');
+    });
+
+    it('keeps GitHub project updates path-targeted without full-depth discovery', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'plugins/example/skills/skill-a/SKILL.md',
+            computedHash: 'abc',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'skill-a',
+          path: '/tmp/repo/plugins/example/skills/skill-a',
+          description: 'Deep skill',
+          rawContent: '',
+        },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv] = installCall!;
+      expect(argv).toContain('owner/repo/plugins/example/skills/skill-a');
+      expect(argv).not.toContain('--full-depth');
     });
 
     it('does not reinterpret generic git shorthands as GitHub during project update', async () => {
@@ -420,7 +459,7 @@ describe('Update Cleanup Unit Tests', () => {
           'skill-a': {
             source: 'git@github.com:owner/repo.git',
             sourceUrl: 'git@github.com:owner/repo.git',
-            skillPath: 'skills/skill-a/SKILL.md',
+            skillPath: 'plugins/example/skills/skill-a/SKILL.md',
             sourceType: 'git',
             skillFolderHash: 'old-hash',
             installedAt: '',
@@ -431,7 +470,12 @@ describe('Update Cleanup Unit Tests', () => {
 
       vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
       vi.mocked(skills.discoverSkills).mockResolvedValue([
-        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+        {
+          name: 'skill-a',
+          path: '/tmp/repo/plugins/example/skills/skill-a',
+          description: 'Deep skill',
+          rawContent: '',
+        },
       ]);
       vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
 
@@ -439,8 +483,14 @@ describe('Update Cleanup Unit Tests', () => {
 
       expect(git.cloneRepo).toHaveBeenCalledWith('git@github.com:owner/repo.git', undefined);
       expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
-        join('/tmp/repo', 'skills/skill-a')
+        join('/tmp/repo', 'plugins/example/skills/skill-a')
       );
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv] = installCall!;
+      expect(argv).toContain('--full-depth');
     });
 
     it('uses sourceUrl when updating global non-GitHub sources with host-stripped source', async () => {


### PR DESCRIPTION
## Summary

- compare locked skill paths against the full GitHub tree and use full-depth discovery for cloned update sources
- propagate `--full-depth` when generic Git or SSH sources cannot safely target a nested skill path
- preserve path-targeted GitHub/GitLab updates and direct `shell: false` process spawning

## Test plan

- `pnpm test --run`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`
- temporary `HOME` install/update reproduction with `cuipengfei/prompts` and `help-me-read`

Fixes #1298