### PR TITLE
feat: improve grouped skill selection

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1298,47 +1298,33 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Check if any skills have plugin grouping
       const hasGroups = sortedSkills.some((s) => s.pluginName);
 
-      let selected: Skill[] | symbol;
+      const kebabToTitle = (s: string) =>
+        s
+          .split('-')
+          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join(' ');
 
-      if (hasGroups) {
-        // Build grouped options for groupMultiselect
-        const kebabToTitle = (s: string) =>
-          s
-            .split('-')
-            .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-            .join(' ');
+      const skillChoices = sortedSkills.map((s) => ({
+        value: s,
+        label: getSkillDisplayName(s),
+        group: hasGroups ? (s.pluginName ? kebabToTitle(s.pluginName) : 'Other') : undefined,
+        detail: s.description,
+      }));
 
-        const grouped: Record<string, p.Option<Skill>[]> = {};
-        for (const s of sortedSkills) {
-          const groupName = s.pluginName ? kebabToTitle(s.pluginName) : 'Other';
-          if (!grouped[groupName]) grouped[groupName] = [];
-          grouped[groupName]!.push({
-            value: s,
-            label: getSkillDisplayName(s),
-            hint: s.description.length > 60 ? s.description.slice(0, 57) + '…' : s.description,
-          });
-        }
+      const selected = await searchMultiselect({
+        message: hasGroups
+          ? `Select skills to install ${pc.dim('(space to toggle)')}`
+          : 'Select skills to install',
+        items: skillChoices,
+        required: true,
+        maxVisible: 20,
+        searchable: !hasGroups,
+        showDetail: true,
+        showSelectedSummary: false,
+        selectGroups: hasGroups,
+      });
 
-        selected = await p.groupMultiselect({
-          message: `Select skills to install ${pc.dim('(space to toggle)')}`,
-          options: grouped,
-          required: true,
-        });
-      } else {
-        const skillChoices = sortedSkills.map((s) => ({
-          value: s,
-          label: getSkillDisplayName(s),
-          hint: s.description.length > 60 ? s.description.slice(0, 57) + '…' : s.description,
-        }));
-
-        selected = await multiselect({
-          message: 'Select skills to install',
-          options: skillChoices,
-          required: true,
-        });
-      }
-
-      if (p.isCancel(selected)) {
+      if (isCancelled(selected)) {
         p.cancel('Installation cancelled');
         await cleanup(tempDir);
         process.exit(0);

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -14,6 +14,10 @@ export interface SearchItem<T> {
   value: T;
   label: string;
   hint?: string;
+  /** Optional group heading shown before this item. */
+  group?: string;
+  /** Optional detail rendered in a fixed pane for the highlighted item. */
+  detail?: string;
 }
 
 export interface LockedSection<T> {
@@ -31,7 +35,21 @@ export interface SearchMultiselectOptions<T> {
   required?: boolean;
   /** Locked section shown above the searchable list - items are always selected and can't be toggled */
   lockedSection?: LockedSection<T>;
+  /** Whether to render a search input and accept text input. Defaults to true. */
+  searchable?: boolean;
+  /** Whether to render a fixed-height detail pane for the highlighted item. */
+  showDetail?: boolean;
+  /** Number of rows reserved for the detail pane. Defaults to two. */
+  detailLines?: number;
+  /** Whether to display the selected-item summary. Defaults to true. */
+  showSelectedSummary?: boolean;
+  /** Whether group headings are selectable and toggle every item in the group. */
+  selectGroups?: boolean;
 }
+
+export type SearchEntry<T> =
+  | { type: 'item'; item: SearchItem<T> }
+  | { type: 'group'; group: string; items: SearchItem<T>[]; collapsed: boolean };
 
 const S_STEP_ACTIVE = pc.green('◆');
 const S_STEP_CANCEL = pc.red('■');
@@ -127,6 +145,112 @@ export function countVisualRowsForLines(lines: string[], columns: number | undef
   return lines.reduce((sum, line) => sum + visualRowsForLine(line, cols), 0);
 }
 
+function truncateToWidth(text: string, width: number): string {
+  let truncated = '';
+  for (const char of text) {
+    if (approxStringWidth(truncated + char) > width) break;
+    truncated += char;
+  }
+  return truncated;
+}
+
+/**
+ * Wrap description text into a fixed number of terminal-width-safe lines.
+ * Empty lines are appended so changing the highlighted item never changes the
+ * prompt's logical height.
+ */
+export function formatDetailLines(
+  detail: string | undefined,
+  width: number,
+  maxLines: number
+): string[] {
+  const safeWidth = Math.max(1, width);
+  const normalized = detail?.replace(/\s+/g, ' ').trim() ?? '';
+  const lines: string[] = [];
+  let remaining = normalized;
+
+  while (remaining && lines.length < maxLines) {
+    if (approxStringWidth(remaining) <= safeWidth) {
+      lines.push(remaining);
+      remaining = '';
+      break;
+    }
+
+    const candidate = truncateToWidth(remaining, safeWidth);
+    const breakAt = candidate.lastIndexOf(' ');
+    if (breakAt > 0) {
+      lines.push(candidate.slice(0, breakAt).trimEnd());
+      remaining = remaining.slice(breakAt).trimStart();
+    } else {
+      lines.push(candidate);
+      remaining = remaining.slice(candidate.length).trimStart();
+    }
+  }
+
+  if (remaining && lines.length > 0) {
+    const last = lines.length - 1;
+    lines[last] = `${truncateToWidth(lines[last]!, Math.max(0, safeWidth - 1)).trimEnd()}…`;
+  }
+
+  while (lines.length < maxLines) lines.push('');
+  return lines;
+}
+
+/** Build the navigable rows for a prompt, including selectable group headings. */
+export function buildSearchEntries<T>(
+  items: SearchItem<T>[],
+  selectGroups: boolean,
+  collapsedGroups: ReadonlySet<string> = new Set()
+): SearchEntry<T>[] {
+  if (!selectGroups) return items.map((item) => ({ type: 'item', item }));
+
+  const entries: SearchEntry<T>[] = [];
+  let index = 0;
+
+  while (index < items.length) {
+    const item = items[index]!;
+    if (!item.group) {
+      entries.push({ type: 'item', item });
+      index += 1;
+      continue;
+    }
+
+    const groupItems: SearchItem<T>[] = [];
+    while (index < items.length && items[index]!.group === item.group) {
+      groupItems.push(items[index]!);
+      index += 1;
+    }
+
+    const collapsed = collapsedGroups.has(item.group);
+    entries.push({ type: 'group', group: item.group, items: groupItems, collapsed });
+    if (!collapsed) {
+      entries.push(...groupItems.map((groupItem) => ({ type: 'item' as const, item: groupItem })));
+    }
+  }
+
+  return entries;
+}
+
+/** Toggle one item, or every item represented by a selectable group heading. */
+export function toggleSearchEntry<T>(selected: Set<T>, entry: SearchEntry<T> | undefined): void {
+  if (entry?.type === 'group') {
+    const allSelected = entry.items.every((item) => selected.has(item.value));
+    for (const item of entry.items) {
+      if (allSelected) {
+        selected.delete(item.value);
+      } else {
+        selected.add(item.value);
+      }
+    }
+  } else if (entry?.type === 'item') {
+    if (selected.has(entry.item.value)) {
+      selected.delete(entry.item.value);
+    } else {
+      selected.add(entry.item.value);
+    }
+  }
+}
+
 /**
  * Interactive search multiselect prompt.
  * Allows users to filter a long list by typing and select multiple items.
@@ -142,6 +266,11 @@ export async function searchMultiselect<T>(
     initialSelected = [],
     required = false,
     lockedSection,
+    searchable = true,
+    showDetail = false,
+    detailLines = 2,
+    showSelectedSummary = true,
+    selectGroups = false,
   } = options;
 
   return new Promise((resolve) => {
@@ -160,6 +289,7 @@ export async function searchMultiselect<T>(
     let query = '';
     let cursor = 0;
     const selected = new Set<T>(initialSelected);
+    const collapsedGroups = new Set<string>();
     let lastRenderHeight = 0;
 
     // Locked items are always included in the result
@@ -194,6 +324,7 @@ export async function searchMultiselect<T>(
 
       const lines: string[] = [];
       const filtered = getFiltered();
+      const entries = buildSearchEntries(filtered, selectGroups, collapsedGroups);
 
       // Header
       const icon =
@@ -218,42 +349,61 @@ export async function searchMultiselect<T>(
           );
         }
 
-        // Search input
-        const searchLine = `${S_BAR}  ${pc.dim('Search:')} ${query}${pc.inverse(' ')}`;
-        lines.push(searchLine);
-
-        // Hint
-        lines.push(`${S_BAR}  ${pc.dim('↑↓ move, space select, enter confirm')}`);
-        lines.push(`${S_BAR}`);
+        if (searchable) {
+          const searchLine = `${S_BAR}  ${pc.dim('Search:')} ${query}${pc.inverse(' ')}`;
+          lines.push(searchLine);
+          lines.push(`${S_BAR}  ${pc.dim('↑↓ move, space select, enter confirm')}`);
+          lines.push(`${S_BAR}`);
+        }
 
         // Items
         const visibleStart = Math.max(
           0,
-          Math.min(cursor - Math.floor(maxVisible / 2), filtered.length - maxVisible)
+          Math.min(cursor - Math.floor(maxVisible / 2), entries.length - maxVisible)
         );
-        const visibleEnd = Math.min(filtered.length, visibleStart + maxVisible);
-        const visibleItems = filtered.slice(visibleStart, visibleEnd);
+        const visibleEnd = Math.min(entries.length, visibleStart + maxVisible);
+        const visibleEntries = entries.slice(visibleStart, visibleEnd);
 
         if (filtered.length === 0) {
           lines.push(`${S_BAR}  ${pc.dim('No matches found')}`);
         } else {
-          for (let i = 0; i < visibleItems.length; i++) {
-            const item = visibleItems[i]!;
+          for (let i = 0; i < visibleEntries.length; i++) {
+            const entry = visibleEntries[i]!;
             const actualIndex = visibleStart + i;
-            const isSelected = selected.has(item.value);
             const isCursor = actualIndex === cursor;
 
+            if (entry.type === 'group') {
+              const selectedCount = entry.items.filter((item) => selected.has(item.value)).length;
+              const radio =
+                selectedCount === entry.items.length
+                  ? S_RADIO_ACTIVE
+                  : selectedCount > 0
+                    ? pc.yellow('◐')
+                    : S_RADIO_INACTIVE;
+              const label = isCursor ? pc.underline(pc.bold(entry.group)) : pc.bold(entry.group);
+              const prefix = isCursor ? pc.cyan('❯') : ' ';
+              const disclosure = pc.dim(entry.collapsed ? '▸' : '▾');
+              lines.push(`${S_BAR} ${prefix} ${disclosure} ${radio} ${label}`);
+              continue;
+            }
+
+            const item = entry.item;
+            const isSelected = selected.has(item.value);
             const radio = isSelected ? S_RADIO_ACTIVE : S_RADIO_INACTIVE;
             const label = isCursor ? pc.underline(item.label) : item.label;
             const hint = item.hint ? pc.dim(` (${item.hint})`) : '';
 
             const prefix = isCursor ? pc.cyan('❯') : ' ';
-            lines.push(`${S_BAR} ${prefix} ${radio} ${label}${hint}`);
+            const groupItems =
+              selectGroups && item.group ? filtered.filter((i) => i.group === item.group) : [];
+            const isLastInGroup = groupItems.at(-1) === item;
+            const tree = groupItems.length > 0 ? `${pc.dim(isLastInGroup ? '└─' : '├─')} ` : '';
+            lines.push(`${S_BAR} ${prefix} ${tree}${radio} ${label}${hint}`);
           }
 
           // Show count if more items
           const hiddenBefore = visibleStart;
-          const hiddenAfter = filtered.length - visibleEnd;
+          const hiddenAfter = entries.length - visibleEnd;
           if (hiddenBefore > 0 || hiddenAfter > 0) {
             const parts: string[] = [];
             if (hiddenBefore > 0) parts.push(`↑ ${hiddenBefore} more`);
@@ -262,22 +412,47 @@ export async function searchMultiselect<T>(
           }
         }
 
-        // Selected summary (include locked items)
-        lines.push(`${S_BAR}`);
-        const allSelectedLabels = [
-          ...(lockedSection ? lockedSection.items.map((i) => i.label) : []),
-          ...items.filter((item) => selected.has(item.value)).map((item) => item.label),
-        ];
-        if (allSelectedLabels.length === 0) {
-          lines.push(`${S_BAR}  ${pc.dim('Selected: (none)')}`);
-        } else {
-          const summary =
-            allSelectedLabels.length <= 3
-              ? allSelectedLabels.join(', ')
-              : `${allSelectedLabels.slice(0, 3).join(', ')} +${allSelectedLabels.length - 3} more`;
-          lines.push(`${S_BAR}  ${pc.green('Selected:')} ${summary}`);
+        if (showDetail) {
+          const entry = entries[cursor];
+          const detail =
+            entry?.type === 'group'
+              ? `Select all ${entry.items.length} skills in ${entry.group}.`
+              : entry?.item.detail;
+          const columns =
+            process.stdout.columns && process.stdout.columns > 0 ? process.stdout.columns : 80;
+          // Keep a small margin for the left rail and terminal wrapping behavior.
+          const detailWidth = Math.max(1, columns - 5);
+          lines.push(`${S_BAR}`);
+          lines.push(`${S_BAR}  ${pc.dim('Description')}`);
+          for (const line of formatDetailLines(detail, detailWidth, detailLines)) {
+            lines.push(`${S_BAR}  ${pc.dim(line)}`);
+          }
         }
 
+        if (showSelectedSummary) {
+          // Selected summary (include locked items)
+          lines.push(`${S_BAR}`);
+          const allSelectedLabels = [
+            ...(lockedSection ? lockedSection.items.map((i) => i.label) : []),
+            ...items.filter((item) => selected.has(item.value)).map((item) => item.label),
+          ];
+          if (allSelectedLabels.length === 0) {
+            lines.push(`${S_BAR}  ${pc.dim('Selected: (none)')}`);
+          } else {
+            const summary =
+              allSelectedLabels.length <= 3
+                ? allSelectedLabels.join(', ')
+                : `${allSelectedLabels.slice(0, 3).join(', ')} +${allSelectedLabels.length - 3} more`;
+            lines.push(`${S_BAR}  ${pc.green('Selected:')} ${summary}`);
+          }
+        }
+
+        if (!searchable) {
+          lines.push(`${S_BAR}`);
+          lines.push(
+            `${S_BAR}  ${pc.dim('↑↓ move, ←→ collapse/expand, space select, enter confirm')}`
+          );
+        }
         lines.push(`${pc.dim('└')}`);
       } else if (state === 'submit') {
         // Final state - show what was selected (including locked)
@@ -326,7 +501,7 @@ export async function searchMultiselect<T>(
     const keypressHandler = (_str: string, key: readline.Key): void => {
       if (!key) return;
 
-      const filtered = getFiltered();
+      const entries = buildSearchEntries(getFiltered(), selectGroups, collapsedGroups);
 
       if (key.name === 'return') {
         submit();
@@ -345,20 +520,37 @@ export async function searchMultiselect<T>(
       }
 
       if (key.name === 'down') {
-        cursor = Math.min(filtered.length - 1, cursor + 1);
+        cursor = Math.min(entries.length - 1, cursor + 1);
         render();
         return;
       }
 
-      if (key.name === 'space') {
-        const item = filtered[cursor];
-        if (item) {
-          if (selected.has(item.value)) {
-            selected.delete(item.value);
-          } else {
-            selected.add(item.value);
-          }
+      if (selectGroups && key.name === 'right') {
+        const entry = entries[cursor];
+        if (entry?.type === 'group' && entry.collapsed) {
+          collapsedGroups.delete(entry.group);
+          render();
         }
+        return;
+      }
+
+      if (selectGroups && key.name === 'left') {
+        const entry = entries[cursor];
+        const group = entry?.type === 'group' ? entry.group : entry?.item.group;
+        if (group) {
+          collapsedGroups.add(group);
+          const collapsedEntries = buildSearchEntries(getFiltered(), selectGroups, collapsedGroups);
+          cursor = collapsedEntries.findIndex(
+            (collapsedEntry) => collapsedEntry.type === 'group' && collapsedEntry.group === group
+          );
+          render();
+        }
+        return;
+      }
+
+      if (key.name === 'space') {
+        const entry = entries[cursor];
+        toggleSearchEntry(selected, entry);
         render();
         return;
       }
@@ -371,7 +563,7 @@ export async function searchMultiselect<T>(
       }
 
       // Regular character input
-      if (key.sequence && !key.ctrl && !key.meta && key.sequence.length === 1) {
+      if (searchable && key.sequence && !key.ctrl && !key.meta && key.sequence.length === 1) {
         query += key.sequence;
         cursor = 0;
         render();

--- a/tests/search-multiselect-visual-rows.test.ts
+++ b/tests/search-multiselect-visual-rows.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import pc from 'picocolors';
 import {
   approxStringWidth,
+  buildSearchEntries,
   countVisualRowsForLines,
+  formatDetailLines,
+  toggleSearchEntry,
   visualRowsForLine,
 } from '../src/prompts/search-multiselect.ts';
 
@@ -36,5 +39,93 @@ describe('searchMultiselect visual row counting', () => {
   it('matches prior behavior when each line fits in one row', () => {
     const lines = ['a', 'b', 'c'];
     expect(countVisualRowsForLines(lines, 120)).toBe(3);
+  });
+
+  it('reserves a fixed number of detail lines for short descriptions', () => {
+    expect(formatDetailLines('One concise description.', 40, 2)).toEqual([
+      'One concise description.',
+      '',
+    ]);
+  });
+
+  it('wraps and truncates long descriptions inside the reserved detail pane', () => {
+    const lines = formatDetailLines('One two three four five six seven eight nine', 16, 2);
+
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toMatch(/…$/);
+    expect(lines.every((line) => approxStringWidth(line) <= 16)).toBe(true);
+  });
+
+  it('makes group headings navigable and keeps their member skills together', () => {
+    const entries = buildSearchEntries(
+      [
+        { value: 'review', label: 'code-review', group: 'Mattpocock Skills' },
+        { value: 'design', label: 'codebase-design', group: 'Mattpocock Skills' },
+        { value: 'qa', label: 'qa', group: 'General' },
+      ],
+      true
+    );
+
+    expect(entries).toEqual([
+      {
+        type: 'group',
+        group: 'Mattpocock Skills',
+        collapsed: false,
+        items: [
+          { value: 'review', label: 'code-review', group: 'Mattpocock Skills' },
+          { value: 'design', label: 'codebase-design', group: 'Mattpocock Skills' },
+        ],
+      },
+      { type: 'item', item: { value: 'review', label: 'code-review', group: 'Mattpocock Skills' } },
+      {
+        type: 'item',
+        item: { value: 'design', label: 'codebase-design', group: 'Mattpocock Skills' },
+      },
+      {
+        type: 'group',
+        group: 'General',
+        collapsed: false,
+        items: [{ value: 'qa', label: 'qa', group: 'General' }],
+      },
+      { type: 'item', item: { value: 'qa', label: 'qa', group: 'General' } },
+    ]);
+  });
+
+  it('keeps collapsed groups visible while hiding their child skills', () => {
+    const entries = buildSearchEntries(
+      [
+        { value: 'review', label: 'code-review', group: 'Mattpocock Skills' },
+        { value: 'design', label: 'codebase-design', group: 'Mattpocock Skills' },
+        { value: 'qa', label: 'qa', group: 'General' },
+      ],
+      true,
+      new Set(['Mattpocock Skills'])
+    );
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toMatchObject({
+      type: 'group',
+      group: 'Mattpocock Skills',
+      collapsed: true,
+    });
+    expect(entries[1]).toMatchObject({ type: 'group', group: 'General', collapsed: false });
+    expect(entries[2]).toMatchObject({ type: 'item', item: { value: 'qa' } });
+  });
+
+  it('selects every skill from a group heading, then clears them on the next toggle', () => {
+    const entries = buildSearchEntries(
+      [
+        { value: 'review', label: 'code-review', group: 'Mattpocock Skills' },
+        { value: 'design', label: 'codebase-design', group: 'Mattpocock Skills' },
+      ],
+      true
+    );
+    const selected = new Set<string>();
+
+    toggleSearchEntry(selected, entries[0]);
+    expect(selected).toEqual(new Set(['review', 'design']));
+
+    toggleSearchEntry(selected, entries[0]);
+    expect(selected).toEqual(new Set());
   });
 });


### PR DESCRIPTION
## Summary
- move highlighted skill descriptions into a fixed-height detail pane
- make group headers selectable, expandable, and collapsible
- show up to 20 navigable rows in grouped skill selection

## Validation
- `pnpm test src/add.test.ts src/add-prompt.test.ts tests/search-multiselect-visual-rows.test.ts`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`