### PR TITLE
feat: add Kimchi agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [70 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -278,6 +278,7 @@ Skills can be installed to any of these agents:
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
 | Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
+| Kimchi | `kimchi` | `.kimchi/skills/` | `~/.config/kimchi/harness/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
 | Lingma | `lingma` | `.lingma/skills/` | `~/.lingma/skills/` |
@@ -408,6 +409,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.junie/skills/`
 - `.iflow/skills/`
 - `.kilocode/skills/`
+- `.kimchi/skills/`
 - `.kiro/skills/`
 - `.kode/skills/`
 - `.lingma/skills/`

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "junie",
     "iflow-cli",
     "kilo",
+    "kimchi",
     "kimi-code-cli",
     "kiro-cli",
     "kode",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -52,6 +52,13 @@ export function isZCodeInstalled(
   return pathExists(join(homeDir, '.zcode')) || pathExists('/Applications/ZCode.app');
 }
 
+export function isKimchiInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  return pathExists(join(homeDir, '.config', 'kimchi'));
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   'aider-desk': {
     name: 'aider-desk',
@@ -393,6 +400,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.kilocode/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.kilocode'));
+    },
+  },
+  kimchi: {
+    name: 'kimchi',
+    displayName: 'Kimchi',
+    skillsDir: '.kimchi/skills',
+    globalSkillsDir: join(home, '.config', 'kimchi', 'harness', 'skills'),
+    detectInstalled: async () => {
+      return isKimchiInstalled();
     },
   },
   'kimi-code-cli': {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -265,6 +265,7 @@ const PRIORITY_PREFIXES = [
   '.iflow/skills/',
   '.junie/skills/',
   '.kilocode/skills/',
+  '.kimchi/skills/',
   '.kiro/skills/',
   '.mux/skills/',
   '.neovate/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -21,6 +21,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.iflow/skills',
   '.junie/skills',
   '.kilocode/skills',
+  '.kimchi/skills',
   '.kiro/skills',
   '.mux/skills',
   '.neovate/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type AgentType =
   | 'jazz'
   | 'junie'
   | 'kilo'
+  | 'kimchi'
   | 'kimi-code-cli'
   | 'kiro-cli'
   | 'kode'

--- a/tests/kimchi-agent.test.ts
+++ b/tests/kimchi-agent.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { agents, isKimchiInstalled } from '../src/agents.ts';
+import { findSkillMdPaths } from '../src/blob.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+const skillFile = (name: string) => `---
+name: ${name}
+description: ${name} test skill
+---
+
+# ${name}
+`;
+
+describe('Kimchi agent support', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'skills-kimchi-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('uses the documented project and global skill directories', () => {
+    expect(agents.kimchi.name).toBe('kimchi');
+    expect(agents.kimchi.displayName).toBe('Kimchi');
+    expect(agents.kimchi.skillsDir).toBe('.kimchi/skills');
+    expect(agents.kimchi.globalSkillsDir).toBe(
+      join(homedir(), '.config', 'kimchi', 'harness', 'skills')
+    );
+  });
+
+  it('detects Kimchi from its documented config directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.config', 'kimchi');
+
+    expect(isKimchiInstalled(home, exists)).toBe(true);
+  });
+
+  it('returns false when the Kimchi config directory is absent', () => {
+    expect(isKimchiInstalled('/tmp/home', () => false)).toBe(false);
+  });
+
+  it('discovers project skills from .kimchi/skills alongside other priority skills', async () => {
+    const kimchiSkillDir = join(testDir, '.kimchi', 'skills', 'kimchi-skill');
+    const standardSkillDir = join(testDir, 'skills', 'standard-skill');
+    mkdirSync(kimchiSkillDir, { recursive: true });
+    mkdirSync(standardSkillDir, { recursive: true });
+    writeFileSync(join(kimchiSkillDir, 'SKILL.md'), skillFile('kimchi-skill'));
+    writeFileSync(join(standardSkillDir, 'SKILL.md'), skillFile('standard-skill'));
+
+    const discovered = await discoverSkills(testDir);
+
+    expect(discovered.map((skill) => skill.name).sort()).toEqual([
+      'kimchi-skill',
+      'standard-skill',
+    ]);
+  });
+
+  it('discovers .kimchi/skills through the GitHub tree fast path', () => {
+    const discovered = findSkillMdPaths({
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: '.claude/skills/standard-skill/SKILL.md',
+          type: 'blob',
+          sha: 'standard-sha',
+        },
+        {
+          path: '.kimchi/skills/kimchi-skill/SKILL.md',
+          type: 'blob',
+          sha: 'kimchi-sha',
+        },
+      ],
+    });
+
+    expect(discovered).toContain('.kimchi/skills/kimchi-skill/SKILL.md');
+  });
+});


### PR DESCRIPTION
## Summary

- add Kimchi agent detection and native project/global skill directories
- discover `.kimchi/skills` through both filesystem and GitHub tree paths
- generate supported-agent documentation and package metadata

Kimchi skills documentation: https://docs.kimchi.dev/docs/coding-skills

## Test plan

- `pnpm test --run tests/kimchi-agent.test.ts`
- `node scripts/validate-agents.ts`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm test --run`
- `pnpm build`
- rerun `scripts/sync-agents.ts` and verify generated files are unchanged

Fixes #1684