### PR TITLE
Add Grok Build agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [70 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -272,6 +272,7 @@ Skills can be installed to any of these agents:
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Grok Build | `grok` | `.grok/skills/` | `~/.grok/skills/` |
 | Hermes Agent | `hermes-agent` | `.hermes/skills/` | `~/.hermes/skills/` |
 | inference.sh | `inference-sh` | `.inferencesh/skills/` | `~/.inferencesh/skills/` |
 | Jazz | `jazz` | `.jazz/skills/` | `~/.jazz/skills/` |
@@ -402,6 +403,7 @@ to also discover `SKILL.md` files outside these container directories
 - `agent/skills/`
 - `.forge/skills/`
 - `.goose/skills/`
+- `.grok/skills/`
 - `.hermes/skills/`
 - `.inferencesh/skills/`
 - `.jazz/skills/`

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "gemini-cli",
     "github-copilot",
     "goose",
+    "grok",
     "hermes-agent",
     "inference-sh",
     "jazz",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -12,6 +12,7 @@ const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude'
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
+const grokHome = process.env.GROK_HOME?.trim() || join(home, '.grok');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
 
@@ -339,6 +340,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(configHome, 'goose/skills'),
     detectInstalled: async () => {
       return existsSync(join(configHome, 'goose'));
+    },
+  },
+  grok: {
+    name: 'grok',
+    displayName: 'Grok Build',
+    skillsDir: '.grok/skills',
+    globalSkillsDir: join(grokHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(grokHome);
     },
   },
   'hermes-agent': {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -262,6 +262,7 @@ const PRIORITY_PREFIXES = [
   '.continue/skills/',
   '.github/skills/',
   '.goose/skills/',
+  '.grok/skills/',
   '.iflow/skills/',
   '.junie/skills/',
   '.kilocode/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -18,6 +18,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.continue/skills',
   '.github/skills',
   '.goose/skills',
+  '.grok/skills',
   '.iflow/skills',
   '.junie/skills',
   '.kilocode/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type AgentType =
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'
+  | 'grok'
   | 'hermes-agent'
   | 'inference-sh'
   | 'iflow-cli'

--- a/tests/grok-agent.test.ts
+++ b/tests/grok-agent.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { findSkillMdPaths, type RepoTree } from '../src/blob.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+describe('Grok Build agent support', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses .grok/skills and respects GROK_HOME for global skills', async () => {
+    const grokHome = join(tmpdir(), 'custom-grok-home');
+    vi.stubEnv('GROK_HOME', grokHome);
+
+    const { agents } = await import('../src/agents.ts');
+
+    expect(agents.grok.name).toBe('grok');
+    expect(agents.grok.displayName).toBe('Grok Build');
+    expect(agents.grok.skillsDir).toBe('.grok/skills');
+    expect(agents.grok.globalSkillsDir).toBe(join(grokHome, 'skills'));
+  });
+
+  it('detects Grok Build from its resolved home directory', async () => {
+    const grokHome = join(tmpdir(), `grok-home-${Date.now()}`);
+    mkdirSync(grokHome);
+    vi.stubEnv('GROK_HOME', grokHome);
+
+    try {
+      const { agents } = await import('../src/agents.ts');
+
+      await expect(agents.grok.detectInstalled()).resolves.toBe(true);
+    } finally {
+      rmSync(grokHome, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false when the resolved Grok home does not exist', async () => {
+    const grokHome = join(tmpdir(), `missing-grok-home-${Date.now()}`);
+    vi.stubEnv('GROK_HOME', grokHome);
+
+    const { agents } = await import('../src/agents.ts');
+
+    await expect(agents.grok.detectInstalled()).resolves.toBe(false);
+  });
+
+  it('discovers grouped project skills under .grok/skills', async () => {
+    const projectDir = join(tmpdir(), `grok-project-${Date.now()}`);
+    const skillDir = join(projectDir, '.grok', 'skills', 'team', 'review');
+    const sourceSkillDir = join(projectDir, 'skills', 'source');
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(sourceSkillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: review\ndescription: Review code changes.\n---\n\n# Review\n'
+    );
+    writeFileSync(
+      join(sourceSkillDir, 'SKILL.md'),
+      '---\nname: source\ndescription: Source skill.\n---\n\n# Source\n'
+    );
+
+    try {
+      const skills = await discoverSkills(projectDir);
+
+      expect(skills.map((skill) => skill.name).sort()).toEqual(['review', 'source']);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('discovers grouped Grok project skills from remote repository trees', () => {
+    const tree: RepoTree = {
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: 'skills/source/SKILL.md',
+          type: 'blob',
+          sha: 'source-skill-sha',
+        },
+        {
+          path: '.grok/skills/team/review/SKILL.md',
+          type: 'blob',
+          sha: 'skill-sha',
+        },
+      ],
+    };
+
+    expect(findSkillMdPaths(tree).sort()).toEqual([
+      '.grok/skills/team/review/SKILL.md',
+      'skills/source/SKILL.md',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a grok agent adapter for Grok Build using project .grok/skills and global GROK_HOME/skills paths
- detect Grok Build from its resolved GROK_HOME, defaulting to ~/.grok
- include .grok/skills in local and blob skill discovery, including grouped nested layouts
- update README/package metadata and add focused adapter tests

## Verification

- corepack pnpm test -- --run (46 files, 602 tests passed)
- corepack pnpm type-check
- corepack pnpm format:check
- corepack pnpm exec prettier --check tests/grok-agent.test.ts package.json
- node scripts/validate-agents.ts
- corepack pnpm build
- git diff --check origin/main...HEAD

## References

- https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/08-skills.md
- https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-config/src/paths.rs
