### PR TITLE
Add intellectronica/ruler support

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -577,6 +577,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.roo'));
     },
   },
+  ruler: {
+    name: 'ruler',
+    displayName: 'Ruler',
+    skillsDir: '.ruler/skills',
+    globalSkillsDir: join(home, '.ruler/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.ruler'));
+    },
+  },
   'tabnine-cli': {
     name: 'tabnine-cli',
     displayName: 'Tabnine CLI',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -273,6 +273,7 @@ const PRIORITY_PREFIXES = [
   '.pi/skills/',
   '.qoder/skills/',
   '.roo/skills/',
+  '.ruler/skills/',
   '.trae/skills/',
   '.windsurf/skills/',
   '.zcode/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -29,6 +29,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.pi/skills',
   '.qoder/skills',
   '.roo/skills',
+  '.ruler/skills',
   '.trae/skills',
   '.windsurf/skills',
   '.zcode/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export type AgentType =
   | 'reasonix'
   | 'roo'
   | 'rovodev'
+  | 'ruler'
   | 'tabnine-cli'
   | 'terramind'
   | 'tinycloud'


### PR DESCRIPTION
## Summary

This pr adds [ruler](https://github.com/intellectronica/ruler) support in .ruler/skills directory just like others. Ruler is managing ai documentation and skills in a repository, and using it together with "npx skills" conflicts because they both write to agent directories. With this pr, we can write only to ruler's skills directory, and let ruler manage code/file generation without conflicts.

