### PR TITLE
add nanobot agent type

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -721,6 +721,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.adal'));
     },
   },
+  nanobot: {
+    name: 'nanobot',
+    displayName: 'Nanobot',
+    skillsDir: '.nanobot/workspace/skills',
+    globalSkillsDir: join(home, '.nanobot/workspace/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.nanobot/config.json'));
+    },
+  },
   universal: {
     name: 'universal',
     displayName: 'Universal',

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -39,6 +39,7 @@ function refineAgentResult(result: AgentResult): AgentResult {
  * Only includes agents that exist in both systems.
  */
 const agentNameToType: Record<string, AgentType> = {
+  nanobot: 'nanobot',
   cursor: 'cursor',
   'cursor-cli': 'cursor',
   claude: 'claude-code',

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export type AgentType =
   | 'pochi'
   | 'promptscript'
   | 'adal'
+  | 'nanobot'
   | 'universal';
 
 export interface Skill {


### PR DESCRIPTION
- nanobot: agent for Nanobot runtime
- skillsDir: .nanobot/workspace/skills (project)
- globalSkillsDir: ~/.nanobot/workspace/skills (global)
- detect: ~/.nanobot/config.json

rel: #852