### PR TITLE
fix: avoid flicker when redrawing prompts

### DIFF
--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -308,20 +308,7 @@ export async function searchMultiselect<T>(
       return items.filter((item) => filter(item, query));
     };
 
-    const clearRender = (): void => {
-      if (lastRenderHeight > 0) {
-        // Move up and clear each line
-        process.stdout.write(`\x1b[${lastRenderHeight}A`);
-        for (let i = 0; i < lastRenderHeight; i++) {
-          process.stdout.write('\x1b[2K\x1b[1B');
-        }
-        process.stdout.write(`\x1b[${lastRenderHeight}A`);
-      }
-    };
-
     const render = (state: 'active' | 'submit' | 'cancel' = 'active'): void => {
-      clearRender();
-
       const lines: string[] = [];
       const filtered = getFiltered();
       const entries = buildSearchEntries(filtered, selectGroups, collapsedGroups);
@@ -465,10 +452,13 @@ export async function searchMultiselect<T>(
         lines.push(`${S_BAR}  ${pc.strikethrough(pc.dim('Cancelled'))}`);
       }
 
-      process.stdout.write(lines.join('\n') + '\n');
+      // Write the clear sequence and next frame together. Clearing individual rows first
+      // makes larger prompts visibly flash between redraws in some terminals.
+      const clearPreviousFrame = lastRenderHeight > 0 ? `\x1b[${lastRenderHeight}A\x1b[J` : '';
+      process.stdout.write(clearPreviousFrame + lines.join('\n') + '\n');
       // Use wrapped row count: logical lines can span multiple terminal rows when hints
-      // or labels exceed column width. Using lines.length alone under-counts and breaks
-      // clearRender(), causing the prompt to re-print hundreds of times on each redraw.
+      // or labels exceed column width. Using lines.length alone under-counts and fails to
+      // clear the full previous frame, causing the prompt to re-print stale rows on redraw.
       lastRenderHeight = countVisualRowsForLines(lines, process.stdout.columns);
     };
 

--- a/tests/search-multiselect-render.test.ts
+++ b/tests/search-multiselect-render.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cancelSymbol, searchMultiselect } from '../src/prompts/search-multiselect.ts';
+
+describe('searchMultiselect rendering', () => {
+  it('redraws the prompt in one terminal write after navigation', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const prompt = searchMultiselect({
+      message: 'Select skills',
+      items: [
+        { value: 'one', label: 'one' },
+        { value: 'two', label: 'two' },
+      ],
+    });
+
+    write.mockClear();
+    process.stdin.emit('keypress', '', { name: 'down' });
+
+    expect(write).toHaveBeenCalledTimes(1);
+
+    process.stdin.emit('keypress', '', { name: 'escape' });
+    await expect(prompt).resolves.toBe(cancelSymbol);
+    write.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- render prompt redraws as one atomic terminal write
- remove the per-line erase loop that visibly blanked larger prompts
- add a regression test for arrow-key navigation redraws

## Validation
- `pnpm test src/add.test.ts src/add-prompt.test.ts tests/search-multiselect-render.test.ts tests/search-multiselect-visual-rows.test.ts`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`