### PR TITLE
fix: don't discard custom-layout SKILL.md paths when a known prefix also matches

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -356,8 +356,43 @@ export function findSkillMdPaths(tree: RepoTree, subpath?: string): string[] {
     }
   }
 
-  // If we found skills in priority dirs, return those
-  if (priorityResults.length > 0) return priorityResults;
+  // A recognized container name (e.g. "skills/") can also appear at a
+  // directory boundary deeper than the repo/subpath root, when a custom
+  // layout wraps it (e.g. "plugins/<name>/skills/<skill>/SKILL.md"). The
+  // loop above only ever anchors at `prefix`, so it misses these; find them
+  // too instead of silently dropping them, using the same direct/1-level
+  // rules as above.
+  const nestedResults: string[] = [];
+  for (const skillMd of filtered) {
+    if (seen.has(skillMd)) continue;
+
+    for (const priorityPrefix of PRIORITY_PREFIXES) {
+      if (priorityPrefix === '') continue; // root anchor already handled above
+      const anchor = skillMd.indexOf('/' + priorityPrefix);
+      if (anchor < 0) continue; // not present at a nested directory boundary
+
+      const rest = skillMd.slice(anchor + 1 + priorityPrefix.length);
+
+      if (rest.toLowerCase() === 'skill.md') {
+        nestedResults.push(skillMd);
+        seen.add(skillMd);
+        break;
+      }
+
+      const parts = rest.split('/');
+      if (parts.length === 2 && parts[1]!.toLowerCase() === 'skill.md') {
+        nestedResults.push(skillMd);
+        seen.add(skillMd);
+        break;
+      }
+    }
+  }
+
+  // Union priority-dir matches with nested-container matches instead of
+  // discarding the latter whenever the former is non-empty.
+  if (priorityResults.length > 0 || nestedResults.length > 0) {
+    return [...priorityResults, ...nestedResults];
+  }
 
   // Fallback: return all SKILL.md files found (limited to 5 levels deep)
   return filtered.filter((p) => {

--- a/tests/nested-container-discovery.test.ts
+++ b/tests/nested-container-discovery.test.ts
@@ -217,4 +217,16 @@ describe('findSkillMdPaths — bounded depth-2 inside skill container prefixes',
 
     expect(findSkillMdPaths(tree, 'skills')).toEqual(['skills/category/in-scope/SKILL.md']);
   });
+
+  it('returns paths from an unrecognized custom container alongside a known-prefix path', () => {
+    const tree = makeTree([
+      '.claude/skills/agent-quality/SKILL.md',
+      'plugins/tfso-bank/skills/bank-account/SKILL.md',
+    ]);
+
+    expect(findSkillMdPaths(tree).sort()).toEqual([
+      '.claude/skills/agent-quality/SKILL.md',
+      'plugins/tfso-bank/skills/bank-account/SKILL.md',
+    ]);
+  });
 });


### PR DESCRIPTION
## Problem

`npx skills update -g` can report that **all** skills from a source repo were "deleted upstream" when they were not. Answering "yes" at that prompt deletes local skill copies that still exist upstream — data loss for the user.

This happens for a repo that mixes a recognized top-level skills prefix with a custom/nested layout, e.g.:

```
.claude/skills/agent-quality/SKILL.md
plugins/tfso-bank/skills/bank-account/SKILL.md
```

(This is the actual shape of an internal project used by the author, which is how the bug was found.)

## Root cause

`findSkillMdPaths()` in `src/blob.ts` (used by `update`'s deleted-upstream check) walks a `PRIORITY_PREFIXES` list (`skills/`, `.claude/skills/`, `.agents/skills/`, etc.) and, as soon as it finds **any** match under one of those root-anchored prefixes, returns early:

```ts
if (priorityResults.length > 0) return priorityResults;
```

Any `SKILL.md` living under a layout the priority loop doesn't recognize — e.g. wrapped inside a custom path like `plugins/<plugin>/skills/<skill>/SKILL.md` — is silently dropped from the result whenever *any other* skill in the same repo happens to live under a recognized prefix. `update`'s deleted-upstream check then treats every dropped path as no-longer-existing upstream.

Note: `discoverSkills()` in `src/skills.ts` (used by `skills add`) does not have this bug; this fix is isolated to `src/blob.ts`.

## Fix

Add a second pass that recognizes a `PRIORITY_PREFIXES` entry occurring at *any* directory boundary in the path (not only at the subpath root), so a nested container like `.../plugins/tfso-bank/skills/bank-account/SKILL.md` is found using the same direct/one-level matching rules already used for root-anchored prefixes. Union these "nested-container" matches with the existing `priorityResults` instead of discarding them:

```ts
if (priorityResults.length > 0 || nestedResults.length > 0) {
  return [...priorityResults, ...nestedResults];
}
```

The existing root-anchored loop, the depth-`<=6` fallback, and `discoverSkills()`/`src/skills.ts` are untouched — this is additive only.

Known, small limitation (flagging proactively): the nested pass does not replicate the "don't descend past a SKILL.md already found one level up" shadow-exclusion that the root-anchored loop applies for depth-2 matches. That shadow case wasn't part of the reported bug or its regression test, so it's left out of scope for this fix.

## Test

Added a regression case to `tests/nested-container-discovery.test.ts` covering exactly the reported shape — a known-prefix path alongside an unrecognized custom-container path — asserting both are returned. Confirmed it fails before the fix (only the `.claude/skills/...` path returned, the `plugins/...` path silently dropped) and passes after.

## Testing done

- `pnpm test tests/nested-container-discovery.test.ts` — 18/18 pass (17 pre-existing + 1 new)
- `pnpm test` (full suite) — 598/601 pass; the only failures are 3 pre-existing/environmental cases in `src/detect-agent.test.ts` (Cursor-agent env-var detection getting confused by the fact that this sandbox itself runs inside a Claude Code agent process). Confirmed identical on a clean, unmodified `upstream/main` checkout via `git stash`, so unrelated to this change.
- `pnpm type-check` — clean
- `pnpm format` — no changes (already formatted); diff is limited to the two touched files

## Related issues

While reading around `update`'s deleted-upstream logic, #1298 looks like a related (not identical) symptom: a `--full-depth`-added nested skill gets reported as "deleted upstream" because the shallower discovery pass used by the deleted-skills check doesn't see it — same broad class of bug (discovery-path blind spots causing false "deleted upstream" positives), different specific code path. #1376 is also in the same feature area (the deleted-skills check failing outright for shorthand-form lockfile sources) but is unrelated to this fix's root cause. Not claiming either as a duplicate — just flagging as related context in case it's useful when triaging.
