### PR TITLE
fix(agents): tighten AstrBot detection to avoid generic data/ folders

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -67,6 +67,24 @@ export function isMiniMaxCodeInstalled(
   return pathExists(join(homeDir, '.minimax')) || pathExists('/Applications/MiniMax Code.app');
 }
 
+export function isAstrBotInstalled(
+  cwd = process.cwd(),
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  if (process.env.ASTRBOT_ROOT?.trim()) {
+    return true;
+  }
+  if (pathExists(join(homeDir, '.astrbot'))) {
+    return true;
+  }
+  // AstrBot source checkout or initialized instance — not a generic data/ folder.
+  if (pathExists(join(cwd, 'astrbot'))) {
+    return true;
+  }
+  return pathExists(join(cwd, 'data', 'plugins'));
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   'aider-desk': {
     name: 'aider-desk',
@@ -110,7 +128,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     skillsDir: 'data/skills',
     globalSkillsDir: join(home, '.astrbot/data/skills'),
     detectInstalled: async () => {
-      return existsSync(join(process.cwd(), 'data/skills')) || existsSync(join(home, '.astrbot'));
+      return isAstrBotInstalled();
     },
   },
   'autohand-code': {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -67,6 +67,17 @@ export function isMiniMaxCodeInstalled(
   return pathExists(join(homeDir, '.minimax')) || pathExists('/Applications/MiniMax Code.app');
 }
 
+export function isAstrBotProjectInstalled(
+  cwd = process.cwd(),
+  pathExists: (path: string) => boolean = existsSync
+) {
+  // Project-local markers only — not ASTRBOT_ROOT, ~/.astrbot, or bare data/.
+  if (pathExists(join(cwd, 'astrbot'))) {
+    return true;
+  }
+  return pathExists(join(cwd, 'data', 'plugins'));
+}
+
 export function isAstrBotInstalled(
   cwd = process.cwd(),
   homeDir = home,
@@ -78,11 +89,7 @@ export function isAstrBotInstalled(
   if (pathExists(join(homeDir, '.astrbot'))) {
     return true;
   }
-  // AstrBot source checkout or initialized instance — not a generic data/ folder.
-  if (pathExists(join(cwd, 'astrbot'))) {
-    return true;
-  }
-  return pathExists(join(cwd, 'data', 'plugins'));
+  return isAstrBotProjectInstalled(cwd, pathExists);
 }
 
 export const agents: Record<AgentType, AgentConfig> = {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -21,7 +21,7 @@ import type { WellKnownSkill } from './providers/wellknown.ts';
 import {
   agents,
   detectInstalledAgents,
-  isAstrBotInstalled,
+  isAstrBotProjectInstalled,
   isUniversalAgent,
   getEveSubagents,
   EVE_SUBAGENTS_DIR,
@@ -47,7 +47,7 @@ function shouldSkipProjectAgentInstall(agentType: AgentType, cwd: string): boole
     return false;
   }
   if (agentType === 'astrbot') {
-    return !isAstrBotInstalled(cwd);
+    return !isAstrBotProjectInstalled(cwd);
   }
   const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
   return !existsSync(agentRootDir);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -21,6 +21,7 @@ import type { WellKnownSkill } from './providers/wellknown.ts';
 import {
   agents,
   detectInstalledAgents,
+  isAstrBotInstalled,
   isUniversalAgent,
   getEveSubagents,
   EVE_SUBAGENTS_DIR,
@@ -39,6 +40,17 @@ interface InstallResult {
   symlinkFailed?: boolean;
   skipped?: boolean;
   error?: string;
+}
+
+function shouldSkipProjectAgentInstall(agentType: AgentType, cwd: string): boolean {
+  if (agentType === 'claude-code') {
+    return false;
+  }
+  if (agentType === 'astrbot') {
+    return !isAstrBotInstalled(cwd);
+  }
+  const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
+  return !existsSync(agentRootDir);
 }
 
 /**
@@ -335,6 +347,18 @@ export async function installSkillForAgent(
 
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
+      if (
+        !isGlobal &&
+        !isUniversalAgent(agentType) &&
+        shouldSkipProjectAgentInstall(agentType, cwd)
+      ) {
+        return {
+          success: true,
+          path: agentDir,
+          mode: 'copy',
+          skipped: true,
+        };
+      }
       await cleanAndCreateDirectory(agentDir);
       await copyDirectory(skill.path, agentDir, agentType);
 
@@ -375,17 +399,18 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
+    if (
+      !isGlobal &&
+      !isUniversalAgent(agentType) &&
+      shouldSkipProjectAgentInstall(agentType, cwd)
+    ) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
+      };
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
@@ -996,6 +1021,18 @@ export async function installBlobSkillForAgent(
 
   try {
     if (installMode === 'copy') {
+      if (
+        !isGlobal &&
+        !isUniversalAgent(agentType) &&
+        shouldSkipProjectAgentInstall(agentType, cwd)
+      ) {
+        return {
+          success: true,
+          path: agentDir,
+          mode: 'copy',
+          skipped: true,
+        };
+      }
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
       return { success: true, path: agentDir, mode: 'copy' };
@@ -1015,20 +1052,19 @@ export async function installBlobSkillForAgent(
     }
 
     // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. Claude Code is
-    // exempted since it can be explicitly selected as the install target even when
-    // .claude/ doesn't exist yet (see installSkillForAgent for the same exemption).
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
+    // whose config directory doesn't already exist in the project.
+    if (
+      !isGlobal &&
+      !isUniversalAgent(agentType) &&
+      shouldSkipProjectAgentInstall(agentType, cwd)
+    ) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
+      };
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);

--- a/tests/astrbot-agent.test.ts
+++ b/tests/astrbot-agent.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { describe, expect, it } from 'vitest';
-import { isAstrBotInstalled } from '../src/agents.ts';
+import { isAstrBotInstalled, isAstrBotProjectInstalled } from '../src/agents.ts';
 
 describe('AstrBot agent detection', () => {
   it('does not treat a bare project data/ directory as AstrBot', () => {
@@ -48,5 +48,46 @@ describe('AstrBot agent detection', () => {
     const exists = (path: string) => path === join(cwd, 'data', 'plugins');
 
     expect(isAstrBotInstalled(cwd, '/tmp/home', exists)).toBe(true);
+  });
+});
+
+describe('AstrBot project-local markers', () => {
+  it('does not treat bare data/ as a project marker', () => {
+    const cwd = '/tmp/project';
+    const exists = (path: string) => path === join(cwd, 'data');
+
+    expect(isAstrBotProjectInstalled(cwd, exists)).toBe(false);
+  });
+
+  it('does not treat ASTRBOT_ROOT as a project marker', () => {
+    const prev = process.env.ASTRBOT_ROOT;
+    process.env.ASTRBOT_ROOT = '/opt/astrbot';
+    try {
+      expect(isAstrBotProjectInstalled('/tmp/project', () => false)).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.ASTRBOT_ROOT;
+      else process.env.ASTRBOT_ROOT = prev;
+    }
+  });
+
+  it('does not treat ~/.astrbot as a project marker', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.astrbot');
+
+    expect(isAstrBotProjectInstalled('/tmp/project', exists)).toBe(false);
+  });
+
+  it('detects cwd/astrbot as a project marker', () => {
+    const cwd = '/tmp/astrbot-project';
+    const exists = (path: string) => path === join(cwd, 'astrbot');
+
+    expect(isAstrBotProjectInstalled(cwd, exists)).toBe(true);
+  });
+
+  it('detects data/plugins as a project marker', () => {
+    const cwd = '/tmp/astrbot-project';
+    const exists = (path: string) => path === join(cwd, 'data', 'plugins');
+
+    expect(isAstrBotProjectInstalled(cwd, exists)).toBe(true);
   });
 });

--- a/tests/astrbot-agent.test.ts
+++ b/tests/astrbot-agent.test.ts
@@ -11,11 +11,36 @@ describe('AstrBot agent detection', () => {
     expect(isAstrBotInstalled(cwd, '/tmp/home', exists)).toBe(false);
   });
 
+  it('does not treat data/skills alone as AstrBot', () => {
+    const cwd = '/tmp/project';
+    const exists = (path: string) => path === join(cwd, 'data', 'skills');
+
+    expect(isAstrBotInstalled(cwd, '/tmp/home', exists)).toBe(false);
+  });
+
+  it('detects AstrBot from ASTRBOT_ROOT', () => {
+    const prev = process.env.ASTRBOT_ROOT;
+    process.env.ASTRBOT_ROOT = '/opt/astrbot';
+    try {
+      expect(isAstrBotInstalled('/tmp/project', '/tmp/home', () => false)).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.ASTRBOT_ROOT;
+      else process.env.ASTRBOT_ROOT = prev;
+    }
+  });
+
   it('detects AstrBot from ~/.astrbot', () => {
     const home = '/tmp/home';
     const exists = (path: string) => path === join(home, '.astrbot');
 
     expect(isAstrBotInstalled('/tmp/project', home, exists)).toBe(true);
+  });
+
+  it('detects AstrBot from cwd/astrbot', () => {
+    const cwd = '/tmp/astrbot-project';
+    const exists = (path: string) => path === join(cwd, 'astrbot');
+
+    expect(isAstrBotInstalled(cwd, '/tmp/home', exists)).toBe(true);
   });
 
   it('detects AstrBot from data/plugins', () => {

--- a/tests/astrbot-agent.test.ts
+++ b/tests/astrbot-agent.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { isAstrBotInstalled } from '../src/agents.ts';
+
+describe('AstrBot agent detection', () => {
+  it('does not treat a bare project data/ directory as AstrBot', () => {
+    const cwd = '/tmp/project';
+    const exists = (path: string) =>
+      path === join(cwd, 'data') || path === join(cwd, 'data', '.gitkeep');
+
+    expect(isAstrBotInstalled(cwd, '/tmp/home', exists)).toBe(false);
+  });
+
+  it('detects AstrBot from ~/.astrbot', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.astrbot');
+
+    expect(isAstrBotInstalled('/tmp/project', home, exists)).toBe(true);
+  });
+
+  it('detects AstrBot from data/plugins', () => {
+    const cwd = '/tmp/astrbot-project';
+    const exists = (path: string) => path === join(cwd, 'data', 'plugins');
+
+    expect(isAstrBotInstalled(cwd, '/tmp/home', exists)).toBe(true);
+  });
+});

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -297,4 +297,52 @@ describe('installer symlink regression', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('does not install AstrBot skills into bare data/ without AstrBot markers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, 'data'), { recursive: true });
+
+    const skillName = 'astrbot-generic-data-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'astrbot',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      await expect(lstat(join(projectDir, 'data', 'skills', skillName))).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('installs AstrBot skills when data/plugins marks an AstrBot project', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, 'data', 'plugins'), { recursive: true });
+
+    const skillName = 'astrbot-marked-project-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'astrbot',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+
+      const astrbotSkillDir = join(projectDir, 'data', 'skills', skillName);
+      expect((await lstat(astrbotSkillDir)).isSymbolicLink()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -321,6 +321,58 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('still skips AstrBot project install when only global AstrBot is present', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, 'data'), { recursive: true });
+
+    const skillName = 'astrbot-global-only-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const prev = process.env.ASTRBOT_ROOT;
+    process.env.ASTRBOT_ROOT = '/opt/astrbot';
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'astrbot',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      await expect(lstat(join(projectDir, 'data', 'skills', skillName))).rejects.toThrow();
+    } finally {
+      if (prev === undefined) delete process.env.ASTRBOT_ROOT;
+      else process.env.ASTRBOT_ROOT = prev;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('installs AstrBot skills when cwd/astrbot marks an AstrBot project', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, 'astrbot'), { recursive: true });
+
+    const skillName = 'astrbot-source-project-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'astrbot',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+
+      const astrbotSkillDir = join(projectDir, 'data', 'skills', skillName);
+      expect((await lstat(astrbotSkillDir)).isSymbolicLink()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('installs AstrBot skills when data/plugins marks an AstrBot project', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
     const projectDir = join(root, 'project');
@@ -342,6 +394,40 @@ describe('installer symlink regression', () => {
       const astrbotSkillDir = join(projectDir, 'data', 'skills', skillName);
       expect((await lstat(astrbotSkillDir)).isSymbolicLink()).toBe(true);
     } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips AstrBot blob install into bare data/ even when ASTRBOT_ROOT is set', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, 'data'), { recursive: true });
+
+    const skillName = 'astrbot-blob-bare-data-skill';
+    const prev = process.env.ASTRBOT_ROOT;
+    process.env.ASTRBOT_ROOT = '/opt/astrbot';
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            {
+              path: 'SKILL.md',
+              contents: `---\nname: ${skillName}\ndescription: test\n---\n`,
+            },
+          ],
+        },
+        'astrbot',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      await expect(lstat(join(projectDir, 'data', 'skills', skillName))).rejects.toThrow();
+    } finally {
+      if (prev === undefined) delete process.env.ASTRBOT_ROOT;
+      else process.env.ASTRBOT_ROOT = prev;
       await rm(root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- Fixes false-positive AstrBot installs when a project has a generic `data/` folder (issue #1356 repro: `mkdir data && npx skills add … --all`)
- `--all` bypasses `detectInstalledAgents`; the installer was treating bare `data/` as an AstrBot root via `skillsDir.split('/')[0]`. Project installs now require `isAstrBotInstalled(cwd)` before writing to `data/skills`
- Keeps tightened `detectInstalled` signals: `ASTRBOT_ROOT`, `~/.astrbot`, `cwd/astrbot`, or `data/plugins` (not bare `data/` or `data/skills` alone)

Fixes #1356

## Test plan

- [x] `npm test -- tests/astrbot-agent.test.ts tests/zcode-agent.test.ts tests/eve-agent.test.ts tests/xdg-config-paths.test.ts src/detect-agent.test.ts tests/installer-symlink.test.ts tests/installer-copy.test.ts --run` (48/48 passed)