### PR TITLE
feat(agents): add Grok Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [69 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [70 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -272,6 +272,7 @@ Skills can be installed to any of these agents:
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
+| Grok Build | `grok` | `.agents/skills/` | `~/.grok/skills/` |
 | Hermes Agent | `hermes-agent` | `.hermes/skills/` | `~/.hermes/skills/` |
 | inference.sh | `inference-sh` | `.inferencesh/skills/` | `~/.inferencesh/skills/` |
 | Jazz | `jazz` | `.jazz/skills/` | `~/.jazz/skills/` |

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "gemini-cli",
     "github-copilot",
     "goose",
+    "grok",
     "hermes-agent",
     "inference-sh",
     "jazz",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -11,6 +11,7 @@ const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
+const grokHome = process.env.GROK_HOME?.trim() || join(home, '.grok');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
@@ -339,6 +340,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(configHome, 'goose/skills'),
     detectInstalled: async () => {
       return existsSync(join(configHome, 'goose'));
+    },
+  },
+  grok: {
+    name: 'grok',
+    displayName: 'Grok Build',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(grokHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(grokHome);
     },
   },
   'hermes-agent': {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type AgentType =
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'
+  | 'grok'
   | 'hermes-agent'
   | 'inference-sh'
   | 'iflow-cli'


### PR DESCRIPTION
Adds [Grok Build](https://x.ai/cli), xAI's terminal coding agent, to the agent registry.

## Change

```ts
grok: {
  name: 'grok',
  displayName: 'Grok Build',
  skillsDir: '.agents/skills',
  globalSkillsDir: join(grokHome, 'skills'),
  detectInstalled: async () => {
    return existsSync(grokHome);
  },
},
```

with `const grokHome = process.env.GROK_HOME?.trim() || join(home, '.grok');` alongside the existing `codexHome` / `hermesHome` / `vibeHome` constants, since `GROK_HOME` is documented as the config-directory override.

## Why these paths

From Grok Build's skills documentation:

| Location | Scope |
| :-- | :-- |
| `./.grok/skills/` | Local (CWD) |
| `<repo_root>/.grok/skills/` | Repo |
| `~/.grok/skills/` | **User** |
| `~/.claude/skills/` | User (Claude Code compatibility) |
| `~/.cursor/skills/` | User (Cursor compatibility) |

> Grok deduplicates skills by name — a higher-priority location overrides a lower one. Grok also scans `.agents/skills/` (and `commands/`) at each tier (alongside `.grok/`) and walks every directory between your working directory and the repo root.

- `skillsDir: '.agents/skills'` — Grok scans the shared project directory natively, so it belongs with Codex and Cursor rather than getting its own project folder.
- `globalSkillsDir: ~/.grok/skills` — its documented user tier.

## Steps followed

Per `AGENTS.md` → *Adding a New Agent*:

1. Added the definition to `src/agents.ts` (plus `'grok'` in the `AgentType` union, which the registry's `Record<AgentType, AgentConfig>` requires)
2. `node scripts/validate-agents.ts` → `All agents valid.`
3. `node scripts/sync-agents.ts` → regenerated the README agent table and `package.json` keywords (both included here rather than hand-edited)

Also ran `pnpm format` (no changes) and `pnpm type-check` (clean).

## Test note

`pnpm test` passes 597 tests. The 3 failures in `src/detect-agent.test.ts` reproduce identically on an unmodified checkout of this branch's base — they assert on the ambient agent environment, so they fail when the suite runs inside another coding agent. Unrelated to this change.

## Note on runtime agent detection

Deliberately not touching `src/detect-agent.ts`. Detection is delegated to `@vercel/detect-agent`, so a mapping entry here would be inert until that package recognises Grok. I also couldn't find an environment variable that Grok Build sets for ordinary tool subprocesses — the documented `GROK_HOOK_*` variables are injected only into hook processes — so I have no reliable signal to propose. This PR is limited to the install target.

Closes #1741
