### PR TITLE
fix(find): show all registry results in non-interactive search

### DIFF
--- a/src/find.test.ts
+++ b/src/find.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { parseFindOptions, searchSkillsAPI } from './find.ts';
+import { parseFindOptions, runFind, searchSkillsAPI } from './find.ts';
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
 });
 
 describe('parseFindOptions', () => {
@@ -46,6 +48,30 @@ describe('searchSkillsAPI', () => {
     expect(url.pathname).toBe('/api/search');
     expect(url.searchParams.get('q')).toBe('react native');
     expect(url.searchParams.get('owner')).toBe('vercel');
-    expect(url.searchParams.get('limit')).toBe('10');
+    expect(url.searchParams.get('limit')).toBe('20');
+  });
+
+  it('prints every result returned for a non-interactive query', async () => {
+    const skills = Array.from({ length: 11 }, (_, index) => ({
+      id: `owner/repo/skill-${index + 1}`,
+      name: `skill-${index + 1}`,
+      installs: 11 - index,
+      source: 'owner/repo',
+    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ skills }),
+      })
+    );
+    vi.stubEnv('DISABLE_TELEMETRY', '1');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runFind(['owner/repo']);
+
+    const output = log.mock.calls.map((args) => args.join(' ')).join('\n');
+    expect(output).toContain('owner/repo@skill-1');
+    expect(output).toContain('owner/repo@skill-11');
   });
 });

--- a/src/find.ts
+++ b/src/find.ts
@@ -15,6 +15,7 @@ const YELLOW = '\x1b[33m';
 
 // API endpoint for skills search
 const SEARCH_API_BASE = process.env.SKILLS_API_URL || 'https://skills.sh';
+const SEARCH_RESULT_LIMIT = '20';
 
 function formatInstalls(count: number): string {
   if (!count || count <= 0) return '';
@@ -85,7 +86,7 @@ export function parseFindOptions(args: string[]): ParseFindOptionsResult {
 // Search via API
 export async function searchSkillsAPI(query: string, owner?: string): Promise<SearchSkill[]> {
   try {
-    const params = new URLSearchParams({ q: query, limit: '10' });
+    const params = new URLSearchParams({ q: query, limit: SEARCH_RESULT_LIMIT });
     if (owner) params.set('owner', owner);
     const url = `${SEARCH_API_BASE}/api/search?${params.toString()}`;
     const res = await fetch(url);
@@ -356,7 +357,7 @@ ${DIM}  2) npx skills add <owner/repo@skill>${RESET}`;
     console.log(`${DIM}Install with${RESET} npx skills add <owner/repo@skill>`);
     console.log();
 
-    for (const skill of results.slice(0, 6)) {
+    for (const skill of results) {
       const pkg = skill.source || skill.slug;
       const installs = formatInstalls(skill.installs);
       console.log(


### PR DESCRIPTION
## Summary

- request up to 20 registry matches instead of 10;
- print every returned match in non-interactive `skills find <query>` output instead of silently truncating at six;
- preserve the interactive prompt's existing eight-row viewport.

## Why

The registry can return a repository's complete skill catalog, but the CLI currently discards matches after the sixth result. For example, `find aictrl-dev/skills` receives eleven valid records while displaying only six, so users cannot see the complete catalog even when ingestion is healthy.

This addresses the CLI display-cap portion of #1688. The separate `--owner` and exact-name ranking behavior originates in the search service response and is intentionally not worked around in this client change.

## Verification

- regression test first reproduced the six-result truncation;
- `pnpm test` on Node 22.20.0 — 47 files, 601 tests passed;
- `pnpm build`;
- `pnpm type-check`;
- `pnpm format:check`;
- live local CLI query against `skills.sh` displayed all 11 `aictrl-dev/skills` records, including all eight launch skills.

## User-visible tradeoff

Broad non-interactive queries may now print up to 20 results instead of six. This is bounded by the request limit and avoids silently hiding valid registry matches.
