### PR TITLE
fix: honor GH_HOST for GitHub Enterprise shorthand

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1097,6 +1097,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // telemetry gating — it should never block user-visible output.
     const ownerRepoRaw = getOwnerRepo(parsed);
     const repoPrivacyPromise: Promise<boolean | null> = (() => {
+      // The privacy endpoint below is GitHub.com-specific. In particular, do
+      // not send GitHub Enterprise repository names to the public API.
+      if (parsed.type !== 'github') return Promise.resolve(null);
       if (!ownerRepoRaw) return Promise.resolve(null);
       const ownerRepo = parseOwnerRepo(ownerRepoRaw);
       if (!ownerRepo) return Promise.resolve(null);

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -81,6 +81,18 @@ describe('git clone fallbacks', () => {
     });
   });
 
+  it('recognizes the configured GitHub Enterprise host', () => {
+    vi.stubEnv('GH_HOST', 'github.example.com');
+
+    expect(parseGitHubRepoUrl('https://github.example.com/acme/agent-skills.git')).toEqual({
+      owner: 'acme',
+      repo: 'agent-skills',
+      slug: 'acme/agent-skills',
+      sshUrl: 'git@github.example.com:acme/agent-skills.git',
+    });
+    expect(isGitHubHttpsCloneUrl('https://github.example.com/acme/agent-skills.git')).toBe(true);
+  });
+
   it('detects GitHub SAML SSO clone failures', () => {
     expect(
       isGitHubSsoAuthError("remote: The 'Giphy' organization has enabled or enforced SAML SSO.")
@@ -177,6 +189,33 @@ describe('git clone fallbacks', () => {
       2,
       'gh',
       ['repo', 'clone', 'Giphy/giphy-codex-skills', tempDir, '--', '--depth=1'],
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  it('uses the enterprise host for gh authentication fallback', async () => {
+    vi.stubEnv('GH_HOST', 'github.example.com');
+    const primaryClone = vi.fn().mockRejectedValue(new Error('fatal: Authentication failed'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+    mockExecFileSuccess('Git operations protocol: https\n');
+    mockExecFileSuccess();
+
+    const tempDir = await cloneRepo('https://github.example.com/acme/agent-skills.git');
+    createdDirs.push(tempDir);
+
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      1,
+      'gh',
+      ['auth', 'status', '-h', 'github.example.com'],
+      expect.any(Object),
+      expect.any(Function)
+    );
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'gh',
+      ['repo', 'clone', 'acme/agent-skills', tempDir, '--', '--depth=1'],
       expect.any(Object),
       expect.any(Function)
     );

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { isGitHubHost } from './github-host.ts';
 
 const DEFAULT_CLONE_TIMEOUT_MS = 300_000; // 5 minutes
 const ALLOWED_GIT_PROTOCOLS = 'https:http:ssh:git:file';
@@ -37,21 +38,22 @@ export class GitCloneError extends Error {
 }
 
 export function parseGitHubRepoUrl(url: string): GitHubRepoInfo | null {
-  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i);
-  if (sshMatch) {
-    const owner = sshMatch[1]!;
-    const repo = sshMatch[2]!;
+  const sshMatch = url.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  if (sshMatch && isGitHubHost(sshMatch[1]!)) {
+    const host = sshMatch[1]!;
+    const owner = sshMatch[2]!;
+    const repo = sshMatch[3]!;
     return {
       owner,
       repo,
       slug: `${owner}/${repo}`,
-      sshUrl: `git@github.com:${owner}/${repo}.git`,
+      sshUrl: `git@${host}:${owner}/${repo}.git`,
     };
   }
 
   try {
     const parsed = new URL(url);
-    if (parsed.hostname !== 'github.com') return null;
+    if (!isGitHubHost(parsed.host)) return null;
 
     const match = parsed.pathname.match(/^\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/);
     if (!match) return null;
@@ -62,7 +64,7 @@ export function parseGitHubRepoUrl(url: string): GitHubRepoInfo | null {
       owner,
       repo,
       slug: `${owner}/${repo}`,
-      sshUrl: `git@github.com:${owner}/${repo}.git`,
+      sshUrl: `git@${parsed.host}:${owner}/${repo}.git`,
     };
   } catch {
     return null;
@@ -72,7 +74,7 @@ export function parseGitHubRepoUrl(url: string): GitHubRepoInfo | null {
 export function isGitHubHttpsCloneUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === 'https:' && parsed.hostname === 'github.com';
+    return parsed.protocol === 'https:' && isGitHubHost(parsed.host);
   } catch {
     return false;
   }
@@ -174,9 +176,10 @@ async function resetTempDir(dir: string): Promise<void> {
 
 async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): Promise<boolean> {
   let cloneTarget = repo.slug;
+  const host = repo.sshUrl.match(/^git@([^:]+):/)?.[1] || 'github.com';
 
   try {
-    const { stdout, stderr } = await execFileAsync('gh', ['auth', 'status', '-h', 'github.com'], {
+    const { stdout, stderr } = await execFileAsync('gh', ['auth', 'status', '-h', host], {
       timeout: 5000,
       env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
     });
@@ -201,13 +204,14 @@ async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): 
 }
 
 function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message: string): string {
+  const host = repo?.sshUrl.match(/^git@([^:]+):/)?.[1] || 'github.com';
   if (repo && isGitHubSsoAuthError(message)) {
     return (
       `GitHub blocked HTTPS access to ${url} because the organization enforces SAML SSO.\n` +
       `  skills tried your existing git credentials and available fallbacks, but none succeeded.\n` +
       `  - Re-authorize your GitHub credentials/app for that org's SSO policy\n` +
       `  - Or rerun with SSH: npx skills add ${repo.sshUrl}\n` +
-      `  - Verify access with: gh auth status -h github.com or ssh -T git@github.com`
+      `  - Verify access with: gh auth status -h ${host} or ssh -T git@${host}`
     );
   }
 
@@ -216,7 +220,7 @@ function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message:
       `Authentication failed for ${url}.\n` +
       `  - For private repos, ensure you have access\n` +
       `  - Retry with SSH: npx skills add ${repo.sshUrl}\n` +
-      `  - Check access with: gh auth status -h github.com or ssh -T git@github.com`
+      `  - Check access with: gh auth status -h ${host} or ssh -T git@${host}`
     );
   }
 

--- a/src/github-host.ts
+++ b/src/github-host.ts
@@ -1,0 +1,38 @@
+const DEFAULT_GITHUB_HOST = 'github.com';
+
+/**
+ * Return the GitHub host selected by the GitHub CLI.
+ *
+ * GH_HOST is expected to be a hostname, not a URL.
+ * Invalid values fall back to github.com instead of being interpolated into
+ * clone URLs.
+ */
+export function getGitHubHost(): string {
+  const configuredHost = process.env.GH_HOST?.trim();
+  if (!configuredHost) {
+    return DEFAULT_GITHUB_HOST;
+  }
+
+  try {
+    const parsed = new URL(`https://${configuredHost}`);
+    if (
+      parsed.username ||
+      parsed.password ||
+      parsed.port ||
+      parsed.pathname !== '/' ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return DEFAULT_GITHUB_HOST;
+    }
+    return parsed.hostname;
+  } catch {
+    return DEFAULT_GITHUB_HOST;
+  }
+}
+
+/** Whether a host is GitHub.com or the configured GitHub Enterprise host. */
+export function isGitHubHost(host: string): boolean {
+  const normalizedHost = host.toLowerCase();
+  return normalizedHost === DEFAULT_GITHUB_HOST || normalizedHost === getGitHubHost().toLowerCase();
+}

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { parseSource } from './source-parser.js';
 
 describe('source-parser', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe('GitLab Custom Domains & Subgroups', () => {
     it('parses custom gitlab domain with deep subgroup paths', () => {
       const result = parseSource('https://git.corp.com/group/subgroup/project/-/tree/main/src');
@@ -125,6 +129,48 @@ describe('source-parser', () => {
         type: 'git',
         url: 'git@github.com:owner/repo.git',
         ref: 'feature/install',
+      });
+    });
+
+    it('uses GH_HOST for shorthand GitHub Enterprise sources', () => {
+      vi.stubEnv('GH_HOST', 'github.example.com');
+
+      expect(parseSource('acme/agent-skills')).toEqual({
+        type: 'git',
+        url: 'https://github.example.com/acme/agent-skills.git',
+        subpath: undefined,
+      });
+    });
+
+    it('uses GH_HOST for github: prefixed sources', () => {
+      vi.stubEnv('GH_HOST', 'github.example.com');
+
+      expect(parseSource('github:acme/agent-skills@review')).toEqual({
+        type: 'git',
+        url: 'https://github.example.com/acme/agent-skills.git',
+        skillFilter: 'review',
+      });
+    });
+
+    it('parses explicit GitHub Enterprise tree URLs', () => {
+      vi.stubEnv('GH_HOST', 'github.example.com');
+
+      expect(
+        parseSource('https://github.example.com/acme/agent-skills/tree/main/skills/review')
+      ).toEqual({
+        type: 'git',
+        url: 'https://github.example.com/acme/agent-skills.git',
+        ref: 'main',
+        subpath: 'skills/review',
+      });
+    });
+
+    it('does not override explicit github.com URLs with GH_HOST', () => {
+      vi.stubEnv('GH_HOST', 'github.example.com');
+
+      expect(parseSource('https://github.com/owner/repo')).toEqual({
+        type: 'github',
+        url: 'https://github.com/owner/repo.git',
       });
     });
   });

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, resolve } from 'path';
 import type { ParsedSource } from './types.ts';
+import { getGitHubHost, isGitHubHost } from './github-host.ts';
 
 /**
  * Extract owner/repo (or group/subgroup/repo for GitLab) from a parsed source
@@ -174,7 +175,7 @@ function looksLikeGitSource(input: string): boolean {
       const pathname = parsed.pathname;
 
       // Only treat GitHub fragments as refs for repo/tree URLs.
-      if (parsed.hostname === 'github.com') {
+      if (isGitHubHost(parsed.host)) {
         return /^\/[^/]+\/[^/]+(?:\.git)?(?:\/tree\/[^/]+(?:\/.*)?)?\/?$/.test(pathname);
       }
 
@@ -282,6 +283,32 @@ export function parseSource(input: string): ParsedSource {
     );
   }
 
+  // Explicit GitHub Enterprise URL. Use generic git handling for cloning and
+  // updates because the GitHub.com API/blob fast paths target the public host.
+  if (getGitHubHost() !== 'github.com' && /^https?:\/\//.test(input)) {
+    try {
+      const parsedUrl = new URL(input);
+      if (isGitHubHost(parsedUrl.host) && parsedUrl.host !== 'github.com') {
+        const segments = parsedUrl.pathname.split('/').filter(Boolean);
+        const [owner, rawRepo, marker, ref, ...subpathSegments] = segments;
+        if (owner && rawRepo) {
+          const repo = rawRepo.replace(/\.git$/, '');
+          const isTreeUrl = marker === 'tree' && ref;
+          return {
+            type: 'git',
+            url: `${parsedUrl.protocol}//${parsedUrl.host}/${owner}/${repo}.git`,
+            ...(isTreeUrl ? { ref } : fragmentRef ? { ref: fragmentRef } : {}),
+            ...(isTreeUrl && subpathSegments.length > 0
+              ? { subpath: sanitizeSubpath(subpathSegments.join('/')) }
+              : {}),
+          };
+        }
+      }
+    } catch {
+      // Fall through to the remaining source formats.
+    }
+  }
+
   // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
   const githubTreeWithPathMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/);
   if (githubTreeWithPathMatch) {
@@ -366,13 +393,19 @@ export function parseSource(input: string): ParsedSource {
 
   // GitHub shorthand: owner/repo, owner/repo/path/to/skill, or owner/repo@skill-name
   // Exclude paths that start with . or / to avoid matching local paths
+  // GH_HOST selects a GitHub Enterprise host for shorthand inputs. Enterprise
+  // sources use the generic git path because GitHub.com API optimizations do
+  // not apply to them.
+  const githubHost = getGitHubHost();
+  const shorthandSourceType = githubHost === 'github.com' ? 'github' : 'git';
+
   // First check for @skill syntax: owner/repo@skill-name
   const atSkillMatch = input.match(/^([^/]+)\/([^/@]+)@(.+)$/);
   if (atSkillMatch && !input.includes(':') && !input.startsWith('.') && !input.startsWith('/')) {
     const [, owner, repo, skillFilter] = atSkillMatch;
     return {
-      type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      type: shorthandSourceType,
+      url: `https://${githubHost}/${owner}/${repo}.git`,
       ...(fragmentRef ? { ref: fragmentRef } : {}),
       skillFilter: fragmentSkillFilter || skillFilter,
     };
@@ -382,8 +415,8 @@ export function parseSource(input: string): ParsedSource {
   if (shorthandMatch && !input.includes(':') && !input.startsWith('.') && !input.startsWith('/')) {
     const [, owner, repo, subpath] = shorthandMatch;
     return {
-      type: 'github',
-      url: `https://github.com/${owner}/${repo}.git`,
+      type: shorthandSourceType,
+      url: `https://${githubHost}/${owner}/${repo}.git`,
       ...(fragmentRef ? { ref: fragmentRef } : {}),
       subpath: subpath ? sanitizeSubpath(subpath) : subpath,
       ...(fragmentSkillFilter ? { skillFilter: fragmentSkillFilter } : {}),


### PR DESCRIPTION
## Summary
- Fixes #1751 by resolving `owner/repo` / `github:` shorthand against `GH_HOST` instead of always expanding to `github.com`
- Persists the enterprise clone URL in `skills-lock.json` as a generic `git` source so restore/update keep the correct host
- Keeps github.com API/blob fast paths and explicit github.com URLs unchanged, and uses the enterprise host for `gh` auth/SSH fallbacks

## Test plan
- [x] `pnpm test`
- [x] `pnpm type-check`
- [x] `pnpm format:check`
- [x] Manual: `GH_HOST=<enterprise-host> npx skills add owner/repo` shows the enterprise URL and writes it into `skills-lock.json`
- [x] Manual: without `GH_HOST`, `owner/repo` still resolves to `https://github.com/owner/repo.git`