### PR TITLE
fix: dedupe skill writes across agents

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -52,6 +52,7 @@ import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
 import {
   installSkillForAgent,
   installBlobSkillForAgent,
+  createInstallSession,
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
@@ -863,10 +864,12 @@ async function handleWellKnownSkills(
   }[] = [];
 
   for (const skill of selectedSkills) {
+    const session = createInstallSession();
     for (const agent of targetAgents) {
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
+        session,
       });
       results.push({
         skill: skill.installName,
@@ -1706,6 +1709,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }[] = [];
 
     for (const skill of selectedSkills) {
+      const session = createInstallSession();
       for (const target of installTargets) {
         const { agent, subagent } = target;
         let result;
@@ -1715,7 +1719,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode, eveSubagent: subagent }
+            { global: installGlobally, mode: installMode, eveSubagent: subagent, session }
           );
         } else {
           // Disk-based install: copy from cloned/local directory.
@@ -1727,6 +1731,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             global: installGlobally,
             mode: installMode,
             eveSubagent: subagent,
+            session,
           });
         }
         results.push({

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -31,6 +31,24 @@ import { parseSkillMd } from './skills.ts';
 
 export type InstallMode = 'symlink' | 'copy';
 
+/** Coordinates writes while one skill is installed to multiple agent targets. */
+export interface InstallSession {
+  writes: Map<string, Promise<void>>;
+}
+
+export interface InstallOptions {
+  global?: boolean;
+  cwd?: string;
+  mode?: InstallMode;
+  eveSubagent?: string;
+  /** Reuse one session for every target of the same skill. */
+  session?: InstallSession;
+}
+
+export function createInstallSession(): InstallSession {
+  return { writes: new Map() };
+}
+
 interface InstallResult {
   success: boolean;
   path: string;
@@ -169,6 +187,47 @@ async function cleanAndCreateDirectory(path: string): Promise<void> {
   await mkdir(path, { recursive: true });
 }
 
+async function runInstallWriteOnce(
+  path: string,
+  session: InstallSession | undefined,
+  write: () => Promise<void>
+): Promise<void> {
+  if (!session) {
+    await write();
+    return;
+  }
+
+  const key = resolve(path);
+  const existingWrite = session.writes.get(key);
+  if (existingWrite) {
+    await existingWrite;
+    return;
+  }
+
+  const pendingWrite = write();
+  session.writes.set(key, pendingWrite);
+
+  try {
+    await pendingWrite;
+  } catch (error) {
+    if (session.writes.get(key) === pendingWrite) {
+      session.writes.delete(key);
+    }
+    throw error;
+  }
+}
+
+async function replaceInstallDirectoryOnce(
+  path: string,
+  session: InstallSession | undefined,
+  writeFiles: () => Promise<void>
+): Promise<void> {
+  await runInstallWriteOnce(path, session, async () => {
+    await cleanAndCreateDirectory(path);
+    await writeFiles();
+  });
+}
+
 /**
  * Resolve a path's parent directory through symlinks, keeping the final component.
  * This handles the case where a parent directory (e.g., ~/.claude/skills) is a symlink
@@ -265,7 +324,7 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: InstallOptions = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -335,8 +394,9 @@ export async function installSkillForAgent(
 
     // For copy mode, skip canonical directory and copy directly to agent location
     if (installMode === 'copy') {
-      await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir, agentType);
+      await replaceInstallDirectoryOnce(agentDir, options.session, () =>
+        copyDirectory(skill.path, agentDir, agentType)
+      );
 
       return {
         success: true,
@@ -356,8 +416,9 @@ export async function installSkillForAgent(
     }
 
     // Symlink mode: copy to canonical location and symlink to agent location
-    await cleanAndCreateDirectory(canonicalDir);
-    await copyDirectory(skill.path, canonicalDir, agentType);
+    await replaceInstallDirectoryOnce(canonicalDir, options.session, () =>
+      copyDirectory(skill.path, canonicalDir, agentType)
+    );
 
     // For universal agents with global install, the skill is already in the canonical
     // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
@@ -392,8 +453,9 @@ export async function installSkillForAgent(
 
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
-      await cleanAndCreateDirectory(agentDir);
-      await copyDirectory(skill.path, agentDir, agentType);
+      await replaceInstallDirectoryOnce(agentDir, options.session, () =>
+        copyDirectory(skill.path, agentDir, agentType)
+      );
 
       return {
         success: true,
@@ -616,7 +678,7 @@ export function getCanonicalPath(
 export async function installRemoteSkillForAgent(
   skill: RemoteSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: InstallOptions = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -670,15 +732,16 @@ export async function installRemoteSkillForAgent(
   try {
     // For copy mode, write directly to agent location
     if (installMode === 'copy') {
-      await cleanAndCreateDirectory(agentDir);
-      const skillFileName =
-        agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
-      const skillMdPath = join(agentDir, skillFileName);
-      await writeFile(
-        skillMdPath,
-        agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
-        'utf-8'
-      );
+      await replaceInstallDirectoryOnce(agentDir, options.session, async () => {
+        const skillFileName =
+          agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
+        const skillMdPath = join(agentDir, skillFileName);
+        await writeFile(
+          skillMdPath,
+          agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
+          'utf-8'
+        );
+      });
 
       return {
         success: true,
@@ -688,15 +751,16 @@ export async function installRemoteSkillForAgent(
     }
 
     // Symlink mode: write to canonical location and symlink to agent location
-    await cleanAndCreateDirectory(canonicalDir);
-    const skillFileName =
-      agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
-    const skillMdPath = join(canonicalDir, skillFileName);
-    await writeFile(
-      skillMdPath,
-      agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
-      'utf-8'
-    );
+    await replaceInstallDirectoryOnce(canonicalDir, options.session, async () => {
+      const skillFileName =
+        agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
+      const skillMdPath = join(canonicalDir, skillFileName);
+      await writeFile(
+        skillMdPath,
+        agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
+        'utf-8'
+      );
+    });
 
     // For universal agents with global install, skip creating agent-specific symlink
     if (isGlobal && isUniversalAgent(agentType)) {
@@ -712,15 +776,16 @@ export async function installRemoteSkillForAgent(
 
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
-      await cleanAndCreateDirectory(agentDir);
-      const agentSkillFileName =
-        agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
-      const agentSkillMdPath = join(agentDir, agentSkillFileName);
-      await writeFile(
-        agentSkillMdPath,
-        agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
-        'utf-8'
-      );
+      await replaceInstallDirectoryOnce(agentDir, options.session, async () => {
+        const agentSkillFileName =
+          agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
+        const agentSkillMdPath = join(agentDir, agentSkillFileName);
+        await writeFile(
+          agentSkillMdPath,
+          agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
+          'utf-8'
+        );
+      });
 
       return {
         success: true,
@@ -757,7 +822,7 @@ export async function installRemoteSkillForAgent(
 export async function installWellKnownSkillForAgent(
   skill: WellKnownSkill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: InstallOptions = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -839,8 +904,7 @@ export async function installWellKnownSkillForAgent(
   try {
     // For copy mode, write directly to agent location
     if (installMode === 'copy') {
-      await cleanAndCreateDirectory(agentDir);
-      await writeSkillFiles(agentDir);
+      await replaceInstallDirectoryOnce(agentDir, options.session, () => writeSkillFiles(agentDir));
 
       return {
         success: true,
@@ -850,8 +914,9 @@ export async function installWellKnownSkillForAgent(
     }
 
     // Symlink mode: write to canonical location and symlink to agent location
-    await cleanAndCreateDirectory(canonicalDir);
-    await writeSkillFiles(canonicalDir);
+    await replaceInstallDirectoryOnce(canonicalDir, options.session, () =>
+      writeSkillFiles(canonicalDir)
+    );
 
     // For universal agents with global install, skip creating agent-specific symlink
     if (isGlobal && isUniversalAgent(agentType)) {
@@ -867,8 +932,7 @@ export async function installWellKnownSkillForAgent(
 
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
-      await cleanAndCreateDirectory(agentDir);
-      await writeSkillFiles(agentDir);
+      await replaceInstallDirectoryOnce(agentDir, options.session, () => writeSkillFiles(agentDir));
 
       return {
         success: true,
@@ -903,7 +967,7 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: InstallOptions = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -935,9 +999,11 @@ export async function installBlobSkillForAgent(
     }
 
     try {
-      await mkdir(agentBase, { recursive: true });
-      await rm(flatSkillPath, { recursive: true, force: true });
-      await writeFile(flatSkillPath, getEveFlatSkillMarkdown(skill.files), 'utf-8');
+      await runInstallWriteOnce(flatSkillPath, options.session, async () => {
+        await mkdir(agentBase, { recursive: true });
+        await rm(flatSkillPath, { recursive: true, force: true });
+        await writeFile(flatSkillPath, getEveFlatSkillMarkdown(skill.files), 'utf-8');
+      });
       return { success: true, path: flatSkillPath, mode: 'copy' };
     } catch (error) {
       return {
@@ -996,14 +1062,14 @@ export async function installBlobSkillForAgent(
 
   try {
     if (installMode === 'copy') {
-      await cleanAndCreateDirectory(agentDir);
-      await writeSkillFiles(agentDir);
+      await replaceInstallDirectoryOnce(agentDir, options.session, () => writeSkillFiles(agentDir));
       return { success: true, path: agentDir, mode: 'copy' };
     }
 
     // Symlink mode
-    await cleanAndCreateDirectory(canonicalDir);
-    await writeSkillFiles(canonicalDir);
+    await replaceInstallDirectoryOnce(canonicalDir, options.session, () =>
+      writeSkillFiles(canonicalDir)
+    );
 
     if (isGlobal && isUniversalAgent(agentType)) {
       return {
@@ -1034,8 +1100,7 @@ export async function installBlobSkillForAgent(
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
 
     if (!symlinkCreated) {
-      await cleanAndCreateDirectory(agentDir);
-      await writeSkillFiles(agentDir);
+      await replaceInstallDirectoryOnce(agentDir, options.session, () => writeSkillFiles(agentDir));
       return {
         success: true,
         path: agentDir,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4,7 +4,7 @@ import { readdir, stat } from 'fs/promises';
 import { join, sep } from 'path';
 import { homedir } from 'os';
 import { parseSkillMd } from './skills.ts';
-import { installSkillForAgent, getCanonicalPath } from './installer.ts';
+import { createInstallSession, installSkillForAgent, getCanonicalPath } from './installer.ts';
 import {
   detectInstalledAgents,
   agents,
@@ -356,11 +356,13 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   }> = [];
 
   for (const skill of toInstall) {
+    const session = createInstallSession();
     for (const agent of targetAgents) {
       const result = await installSkillForAgent(skill, agent, {
         global: false,
         cwd,
         mode: 'symlink',
+        session,
       });
       results.push({
         skill: skill.name,

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { access, chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installSkillForAgent } from '../src/installer.ts';
+import {
+  createInstallSession,
+  installBlobSkillForAgent,
+  installSkillForAgent,
+} from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
   const dir = join(root, 'source-skill');
@@ -70,6 +74,94 @@ describe('installer copy mode', () => {
       const sourceMode = (await stat(scriptPath)).mode & 0o777;
       const installedMode = (await stat(installedScript)).mode & 0o777;
       expect(installedMode).toBe(sourceMode);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a shared copy destination once per install session', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-once-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'shared-copy-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const skill = { name: skillName, description: 'test', path: skillDir };
+    const session = createInstallSession();
+    const installedDir = join(projectDir, '.agents/skills', skillName);
+    const markerPath = join(installedDir, 'written-once.txt');
+
+    try {
+      const codexResult = await installSkillForAgent(skill, 'codex', {
+        cwd: projectDir,
+        mode: 'copy',
+        global: false,
+        session,
+      });
+      expect(codexResult.success).toBe(true);
+
+      await writeFile(markerPath, 'preserved\n', 'utf-8');
+
+      const cursorResult = await installSkillForAgent(skill, 'cursor', {
+        cwd: projectDir,
+        mode: 'copy',
+        global: false,
+        session,
+      });
+      expect(cursorResult.success).toBe(true);
+      await expect(readFile(markerPath, 'utf-8')).resolves.toBe('preserved\n');
+
+      const freshSessionResult = await installSkillForAgent(skill, 'amp', {
+        cwd: projectDir,
+        mode: 'copy',
+        global: false,
+        session: createInstallSession(),
+      });
+      expect(freshSessionResult.success).toBe(true);
+      await expect(access(markerPath)).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a shared blob destination once per install session', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-blob-copy-once-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'shared-blob-skill';
+    const skill = {
+      installName: skillName,
+      files: [
+        {
+          path: 'SKILL.md',
+          contents: `---\nname: ${skillName}\ndescription: test\n---\n`,
+        },
+      ],
+    };
+    const session = createInstallSession();
+    const installedDir = join(projectDir, '.agents/skills', skillName);
+    const markerPath = join(installedDir, 'written-once.txt');
+
+    try {
+      const codexResult = await installBlobSkillForAgent(skill, 'codex', {
+        cwd: projectDir,
+        mode: 'copy',
+        global: false,
+        session,
+      });
+      expect(codexResult.success).toBe(true);
+
+      await writeFile(markerPath, 'preserved\n', 'utf-8');
+
+      const cursorResult = await installBlobSkillForAgent(skill, 'cursor', {
+        cwd: projectDir,
+        mode: 'copy',
+        global: false,
+        session,
+      });
+      expect(cursorResult.success).toBe(true);
+      await expect(readFile(markerPath, 'utf-8')).resolves.toBe('preserved\n');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -16,7 +16,11 @@ import {
 } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installSkillForAgent, installBlobSkillForAgent } from '../src/installer.ts';
+import {
+  createInstallSession,
+  installSkillForAgent,
+  installBlobSkillForAgent,
+} from '../src/installer.ts';
 
 async function makeSkillSource(root: string, name: string): Promise<string> {
   const dir = join(root, 'source-skill');
@@ -211,6 +215,46 @@ describe('installer symlink regression', () => {
 
       const contents = await readFile(join(claudeSkillDir, 'SKILL.md'), 'utf-8');
       expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('writes a shared canonical directory once per install session', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, '.continue'), { recursive: true });
+
+    const skillName = 'shared-canonical-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    const skill = { name: skillName, description: 'test', path: skillDir };
+    const session = createInstallSession();
+    const canonicalDir = join(projectDir, '.agents/skills', skillName);
+    const markerPath = join(canonicalDir, 'written-once.txt');
+
+    try {
+      const claudeResult = await installSkillForAgent(skill, 'claude-code', {
+        cwd: projectDir,
+        mode: 'symlink',
+        global: false,
+        session,
+      });
+      expect(claudeResult.success).toBe(true);
+
+      await writeFile(markerPath, 'preserved\n', 'utf-8');
+
+      const continueResult = await installSkillForAgent(skill, 'continue', {
+        cwd: projectDir,
+        mode: 'symlink',
+        global: false,
+        session,
+      });
+      expect(continueResult.success).toBe(true);
+
+      await expect(readFile(markerPath, 'utf-8')).resolves.toBe('preserved\n');
+      expect((await lstat(join(projectDir, '.continue/skills', skillName))).isSymbolicLink()).toBe(
+        true
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/root-level-disk-install.test.ts
+++ b/tests/root-level-disk-install.test.ts
@@ -155,4 +155,20 @@ describe('root-level disk install (issue #1603)', () => {
       '# guide\n'
     );
   });
+
+  it('shares one install session across agents for the same skill', async () => {
+    await mkdir(join(project, '.continue'), { recursive: true });
+
+    await runAdd(['someowner/somerepo'], {
+      yes: true,
+      agent: ['claude-code', 'continue'],
+      global: false,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    const firstSession = spy.mock.calls[0]?.[2]?.session;
+    const secondSession = spy.mock.calls[1]?.[2]?.session;
+    expect(firstSession).toBeDefined();
+    expect(secondSession).toBe(firstSession);
+  });
 });


### PR DESCRIPTION
## Summary

- share one install session across all agent targets for each skill
- write canonical and shared copy destinations only once while preserving independent agent and Eve targets
- apply the same deduplication to disk, blob, well-known, remote, and experimental sync installation paths

## Problem

Installing multiple skills for multiple agents rewrote the same canonical directory before every agent link. For 13 skills and 11 agents, this could perform up to 143 full directory copies instead of 13. Universal agents sharing .agents/skills also repeatedly copied over the same destination.

## Tests

- pnpm test (50 files, 678 tests)
- pnpm type-check
- pnpm format:check
- pnpm build