### PR TITLE
fix: include description in filterSkills search 

### DIFF
--- a/src/skills.ts
+++ b/src/skills.ts
@@ -332,14 +332,32 @@ export function getSkillDisplayName(skill: Skill): string {
 /**
  * Filter skills based on user input (case-insensitive direct matching).
  * Multi-word skill names must be quoted on the command line.
+ *
+ * When `includeDescription` is true and no name matches are found,
+ * falls back to searching inside the skill description field.
  */
-export function filterSkills(skills: Skill[], inputNames: string[]): Skill[] {
+export function filterSkills(
+  skills: Skill[],
+  inputNames: string[],
+  options?: { includeDescription?: boolean }
+): Skill[] {
   const normalizedInputs = inputNames.map((n) => n.toLowerCase());
 
-  return skills.filter((skill) => {
+  // Try to match by name first
+  const nameMatches = skills.filter((skill) => {
     const name = skill.name.toLowerCase();
     const displayName = getSkillDisplayName(skill).toLowerCase();
-
     return normalizedInputs.some((input) => input === name || input === displayName);
+  });
+
+  // If we found name matches, return them immediately
+  if (nameMatches.length > 0 || !options?.includeDescription) {
+    return nameMatches;
+  }
+
+  // No name matches found — search inside descriptions as fallback
+  return skills.filter((skill) => {
+    const desc = (skill.description || '').toLowerCase();
+    return normalizedInputs.some((input) => desc.includes(input));
   });
 }

--- a/tests/skill-matching.test.ts
+++ b/tests/skill-matching.test.ts
@@ -93,6 +93,67 @@ describe('filterSkills', () => {
       expect(result.length).toBe(0);
     });
   });
+  describe('description search (includeDescription: true)', () => {
+    // Set up some fake skills for testing
+    // These skills have short/generic names but rich descriptions
+    const skillsWithDescriptions: Skill[] = [
+      {
+        name: 'medical-checker',
+        description:
+          'Supports STROBE, CONSORT, and QUADAS reporting standards for medical research',
+        path: '/tmp/medical-checker',
+      },
+      {
+        name: 'prisma-orm',
+        description: 'Best practices for the Prisma ORM database toolkit',
+        path: '/tmp/prisma-orm',
+      },
+      {
+        name: 'foo',
+        description: 'A simple skill for foo operations',
+        path: '/tmp/foo',
+      },
+    ];
+
+    it('finds a skill by description keyword when no name matches', () => {
+      const result = filterSkills(skillsWithDescriptions, ['STROBE'], { includeDescription: true });
+      expect(result.length).toBe(1);
+      expect(result[0].name).toBe('medical-checker');
+    });
+
+    it('description search is case-insensitive', () => {
+      const result = filterSkills(skillsWithDescriptions, ['strobe'], { includeDescription: true });
+      expect(result.length).toBe(1);
+      expect(result[0].name).toBe('medical-checker');
+    });
+
+    it('name match takes priority over description match', () => {
+      const result = filterSkills(skillsWithDescriptions, ['foo'], { includeDescription: true });
+      expect(result.length).toBe(1);
+      expect(result[0].name).toBe('foo');
+    });
+
+    it('does not search descriptions when includeDescription is false', () => {
+      // By default (no options), description search is disabled
+      const result = filterSkills(skillsWithDescriptions, ['STROBE']);
+      expect(result.length).toBe(0);
+    });
+
+    it('does not search descriptions when includeDescription is explicitly false', () => {
+      const result = filterSkills(skillsWithDescriptions, ['STROBE'], {
+        includeDescription: false,
+      });
+      expect(result.length).toBe(0);
+    });
+
+    it('returns multiple skills when multiple descriptions match', () => {
+      const result = filterSkills(skillsWithDescriptions, ['research'], {
+        includeDescription: true,
+      });
+      expect(result.length).toBe(1);
+      expect(result[0].name).toBe('medical-checker');
+    });
+  });
 });
 
 describe('parseSkillMd with non-string frontmatter values', () => {


### PR DESCRIPTION
Fixes #1761

### Changes Included
- Updated `filterSkills()` in `src/skills.ts` to support fallback search matching against skill `description` when `includeDescription: true` is passed.
- Added comprehensive unit test cases in `tests/skill-matching.test.ts` covering description search, case insensitivity, and name-match priority.

### Note for Maintainers (Backend API Update Needed)
Please update the `/api/search` backend endpoint on `skills.sh` to include `description` field in full-text search (ranked below `name` and `source`). This will help users find indexed skills even when the search terms only appear in the skill description.