### PR TITLE
feat: group project and global skills in the remove picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,17 @@ npx skills init my-skill
 
 Remove installed skills from agents.
 
+The interactive picker lists project and global skills as separate groups, so you
+can see and remove either without knowing up front which scope a skill came from.
+Pass `-p` or `-g` to restrict it to one scope.
+
 ```bash
-# Remove interactively (select from installed skills)
+# Remove interactively (project and global skills, grouped by scope)
 npx skills remove
+
+# Remove interactively from one scope only
+npx skills remove --project
+npx skills remove --global
 
 # Remove specific skill by name
 npx skills remove web-design-guidelines
@@ -214,13 +222,14 @@ npx skills remove my-skill --agent '*'
 npx skills rm my-skill
 ```
 
-| Option         | Description                                      |
-| -------------- | ------------------------------------------------ |
-| `-g, --global` | Remove from global scope (~/) instead of project |
-| `-a, --agent`  | Remove from specific agents (use `'*'` for all)  |
-| `-s, --skill`  | Specify skills to remove (use `'*'` for all)     |
-| `-y, --yes`    | Skip confirmation prompts                        |
-| `--all`        | Shorthand for `--skill '*' --agent '*' -y`       |
+| Option          | Description                                      |
+| --------------- | ------------------------------------------------ |
+| `-g, --global`  | Remove from global scope (~/) instead of project |
+| `-p, --project` | Remove from project scope only                   |
+| `-a, --agent`   | Remove from specific agents (use `'*'` for all)  |
+| `-s, --skill`   | Specify skills to remove (use `'*'` for all)     |
+| `-y, --yes`     | Skip confirmation prompts                        |
+| `--all`         | Shorthand for `--skill '*' --agent '*' -y`       |
 
 ## What are Agent Skills?
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -206,20 +206,23 @@ ${BOLD}Usage:${RESET} skills remove [skills...] [options]
 
 ${BOLD}Description:${RESET}
   Remove installed skills from agents. If no skill names are provided,
-  an interactive selection menu will be shown.
+  an interactive selection menu will be shown, listing project and global
+  skills as separate groups.
 
 ${BOLD}Arguments:${RESET}
   skills            Optional skill names to remove (space-separated)
 
 ${BOLD}Options:${RESET}
   -g, --global       Remove from global scope (~/) instead of project scope
+  -p, --project      Remove from project scope only
   -a, --agent        Remove from specific agents (use '*' for all agents)
   -s, --skill        Specify skills to remove (use '*' for all skills)
   -y, --yes          Skip confirmation prompts
   --all              Shorthand for --skill '*' --agent '*' -y
 
 ${BOLD}Examples:${RESET}
-  ${DIM}$${RESET} skills remove                           ${DIM}# interactive selection${RESET}
+  ${DIM}$${RESET} skills remove                           ${DIM}# interactive selection (project + global)${RESET}
+  ${DIM}$${RESET} skills remove -p                         ${DIM}# interactive selection, project only${RESET}
   ${DIM}$${RESET} skills remove my-skill                   ${DIM}# remove specific skill${RESET}
   ${DIM}$${RESET} skills remove skill1 skill2 -y           ${DIM}# remove multiple skills${RESET}
   ${DIM}$${RESET} skills remove --global my-skill          ${DIM}# remove from global scope${RESET}

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -3,6 +3,7 @@ import { existsSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, runCliWithInput } from './test-utils.js';
+import { buildScopedChoices, resolveRemoveScopes } from './remove.ts';
 
 describe('remove command', { timeout: 30000 }, () => {
   let testDir: string;
@@ -374,6 +375,68 @@ This is a test skill.
     });
   });
 
+  describe('interactive scope grouping', () => {
+    let testHome: string;
+
+    beforeEach(() => {
+      testHome = join(testDir, 'home');
+      createTestSkill('project-skill', 'A project skill');
+      createTestSkill('global-skill', 'A global skill', join(testHome, '.agents', 'skills'));
+    });
+
+    // Piped stdin cannot drive a clack multiselect to submit, so these assert
+    // what the picker offers. Sending a carriage return ends the prompt with
+    // nothing selected once the first frame has rendered.
+    const showPicker = ' \r';
+
+    it('lists project and global skills as separate groups', () => {
+      const result = runCliWithInput(['remove'], showPicker, testDir, { HOME: testHome });
+
+      expect(result.stdout).toContain('Select skills to remove');
+      expect(result.stdout).toContain('Project');
+      expect(result.stdout).toContain('Global');
+      expect(result.stdout).toContain('project-skill');
+      expect(result.stdout).toContain('global-skill');
+    });
+
+    it('restricts the picker to project skills with -p', () => {
+      const result = runCliWithInput(['remove', '-p'], showPicker, testDir, { HOME: testHome });
+
+      expect(result.stdout).toContain('project-skill');
+      expect(result.stdout).not.toContain('global-skill');
+    });
+
+    it('restricts the picker to global skills with -g', () => {
+      const result = runCliWithInput(['remove', '-g'], showPicker, testDir, { HOME: testHome });
+
+      expect(result.stdout).toContain('global-skill');
+      expect(result.stdout).not.toContain('project-skill');
+    });
+
+    it('removes a name from both scopes when -g and -p are combined', () => {
+      createTestSkill('shared-skill', 'In both scopes');
+      createTestSkill('shared-skill', 'In both scopes', join(testHome, '.agents', 'skills'));
+
+      const result = runCli(['remove', 'shared-skill', '-g', '-p', '-y'], testDir, {
+        HOME: testHome,
+      });
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.stdout).toContain('2 skill');
+      expect(existsSync(join(skillsDir, 'shared-skill'))).toBe(false);
+      expect(existsSync(join(testHome, '.agents', 'skills', 'shared-skill'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'project-skill'))).toBe(true);
+      expect(existsSync(join(testHome, '.agents', 'skills', 'global-skill'))).toBe(true);
+    });
+
+    it('leaves global skills alone when removing by name', () => {
+      const result = runCli(['remove', 'global-skill', '-y'], testDir, { HOME: testHome });
+
+      expect(result.stdout).toContain('No matching skills');
+      expect(existsSync(join(testHome, '.agents', 'skills', 'global-skill'))).toBe(true);
+    });
+  });
+
   describe('command aliases', () => {
     beforeEach(() => {
       createTestSkill('alias-test-skill');
@@ -446,6 +509,51 @@ This is a test skill.
       const result = runCli(['remove', '-h'], testDir);
       expect(result.stdout).toContain('Usage');
       expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('resolveRemoveScopes', () => {
+    it('browses both scopes for an interactive selection', () => {
+      expect(resolveRemoveScopes({}, false)).toEqual([{ global: false }, { global: true }]);
+    });
+
+    it('stays project-scoped for named skills and --all', () => {
+      expect(resolveRemoveScopes({}, true)).toEqual([{ global: false }]);
+      expect(resolveRemoveScopes({ all: true }, false)).toEqual([{ global: false }]);
+    });
+
+    it('honours explicit scope flags', () => {
+      expect(resolveRemoveScopes({ global: true }, false)).toEqual([{ global: true }]);
+      expect(resolveRemoveScopes({ project: true }, false)).toEqual([{ global: false }]);
+      expect(resolveRemoveScopes({ global: true, project: true }, true)).toEqual([
+        { global: false },
+        { global: true },
+      ]);
+    });
+  });
+
+  describe('buildScopedChoices', () => {
+    it('keeps same-named skills in both scopes as distinct entries', () => {
+      const groups = buildScopedChoices([
+        { global: false, names: ['shared'], dir: './.agents/skills' },
+        { global: true, names: ['shared'], dir: '~/.agents/skills' },
+      ]);
+
+      const [projectGroup, globalGroup] = Object.keys(groups);
+      expect(projectGroup).toContain('Project');
+      expect(globalGroup).toContain('Global');
+      expect(groups[projectGroup!]![0]!.value).toEqual({ name: 'shared', global: false });
+      expect(groups[globalGroup!]![0]!.value).toEqual({ name: 'shared', global: true });
+    });
+
+    it('omits empty scopes', () => {
+      const groups = buildScopedChoices([
+        { global: false, names: ['only-project'], dir: './.agents/skills' },
+        { global: true, names: [], dir: '~/.agents/skills' },
+      ]);
+
+      expect(Object.keys(groups)).toHaveLength(1);
+      expect(Object.keys(groups)[0]).toContain('Project');
     });
   });
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -1,7 +1,8 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
-import { join } from 'path';
+import { join, sep } from 'path';
+import { homedir } from 'os';
 import { agents, detectInstalledAgents, getEveSubagents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
@@ -18,9 +19,77 @@ import {
 
 export interface RemoveOptions {
   global?: boolean;
+  project?: boolean;
   agent?: string[];
   yes?: boolean;
   all?: boolean;
+}
+
+/** A skill to remove, paired with the scope it is installed in. */
+export interface RemovalTarget {
+  name: string;
+  global: boolean;
+}
+
+export function scopeLabel(global: boolean): string {
+  return global ? 'Global' : 'Project';
+}
+
+/**
+ * Shortens a path for display: replaces homedir with ~ and cwd with .
+ */
+function shortenPath(fullPath: string, cwd: string): string {
+  const home = homedir();
+  if (fullPath === home || fullPath.startsWith(home + sep)) {
+    return '~' + fullPath.slice(home.length);
+  }
+  if (fullPath === cwd || fullPath.startsWith(cwd + sep)) {
+    return '.' + fullPath.slice(cwd.length);
+  }
+  return fullPath;
+}
+
+/**
+ * Decide which scopes a remove run touches.
+ *
+ * Explicit flags always win. Otherwise only the interactive picker looks at
+ * both scopes — named skills and --all stay project-scoped so that existing
+ * non-interactive invocations keep removing exactly what they removed before.
+ */
+export function resolveRemoveScopes(
+  options: RemoveOptions,
+  hasSkillNames: boolean
+): Array<{ global: boolean }> {
+  const project = { global: false };
+  const global = { global: true };
+
+  if (options.global && options.project) return [project, global];
+  if (options.global) return [global];
+  if (options.project) return [project];
+
+  const isInteractiveSelection = !options.all && !hasSkillNames;
+  return isInteractiveSelection ? [project, global] : [project];
+}
+
+/**
+ * Build the grouped option list for the interactive picker, one group per
+ * scope. Values carry their scope so a name installed both globally and in the
+ * project stays two distinct, independently selectable entries.
+ */
+export function buildScopedChoices(
+  skillsByScope: Array<{ global: boolean; names: string[]; dir: string }>
+): Record<string, Array<{ value: RemovalTarget; label: string }>> {
+  const groups: Record<string, Array<{ value: RemovalTarget; label: string }>> = {};
+
+  for (const { global, names, dir } of skillsByScope) {
+    if (names.length === 0) continue;
+    groups[`${scopeLabel(global)} ${pc.dim(`(${dir})`)}`] = names.map((name) => ({
+      value: { name, global },
+      label: name,
+    }));
+  }
+
+  return groups;
 }
 
 /**
@@ -70,64 +139,83 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     );
   }
 
-  const isGlobal = options.global ?? false;
   const cwd = process.cwd();
+  const scopes = resolveRemoveScopes(options, skillNames.length > 0);
 
   const spinner = p.spinner();
 
   spinner.start('Scanning for installed skills…');
-  const skillNamesSet = new Set<string>();
 
-  const scanDir = async (dir: string) => {
-    try {
-      const entries = await readdir(dir, { withFileTypes: true });
-      for (const entry of entries) {
-        if (entry.isDirectory()) {
-          skillNamesSet.add(entry.name);
+  const scanScope = async (isGlobal: boolean): Promise<string[]> => {
+    const skillNamesSet = new Set<string>();
+
+    const scanDir = async (dir: string) => {
+      try {
+        const entries = await readdir(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            skillNamesSet.add(entry.name);
+          }
+        }
+      } catch (err) {
+        if (err instanceof Error && (err as { code?: string }).code !== 'ENOENT') {
+          p.log.warn(`Could not scan directory ${dir}: ${err.message}`);
         }
       }
-    } catch (err) {
-      if (err instanceof Error && (err as { code?: string }).code !== 'ENOENT') {
-        p.log.warn(`Could not scan directory ${dir}: ${err.message}`);
+    };
+
+    if (isGlobal) {
+      await scanDir(getCanonicalSkillsDir(true, cwd));
+      for (const agent of Object.values(agents)) {
+        if (agent.globalSkillsDir !== undefined) {
+          await scanDir(agent.globalSkillsDir);
+        }
+      }
+    } else {
+      await scanDir(getCanonicalSkillsDir(false, cwd));
+      for (const agent of Object.values(agents)) {
+        await scanDir(join(cwd, agent.skillsDir));
+      }
+      // Eve subagents keep their skills under agent/subagents/<name>/skills.
+      for (const subagent of getEveSubagents(cwd)) {
+        await scanDir(getEveSubagentSkillsDir(subagent, cwd));
       }
     }
+
+    return Array.from(skillNamesSet).sort();
   };
-
-  if (isGlobal) {
-    await scanDir(getCanonicalSkillsDir(true, cwd));
-    for (const agent of Object.values(agents)) {
-      if (agent.globalSkillsDir !== undefined) {
-        await scanDir(agent.globalSkillsDir);
-      }
-    }
-  } else {
-    await scanDir(getCanonicalSkillsDir(false, cwd));
-    for (const agent of Object.values(agents)) {
-      await scanDir(join(cwd, agent.skillsDir));
-    }
-    // Eve subagents keep their skills under agent/subagents/<name>/skills.
-    for (const subagent of getEveSubagents(cwd)) {
-      await scanDir(getEveSubagentSkillsDir(subagent, cwd));
-    }
-  }
-
-  const installedSkills = Array.from(skillNamesSet).sort();
-  spinner.stop(`Found ${installedSkills.length} unique installed skill(s)`);
 
   // Read lock file keys up front. These are needed both to decide whether there is
   // anything to remove (a skill may be missing from disk but still leave a stale lock
   // entry) and to clean up those stale entries below.
-  const lockSkillsKeys = isGlobal
-    ? Object.keys((await readSkillLock()).skills)
-    : Object.keys((await readLocalLock(cwd)).skills);
+  const readLockKeys = async (isGlobal: boolean): Promise<string[]> =>
+    isGlobal
+      ? Object.keys((await readSkillLock()).skills)
+      : Object.keys((await readLocalLock(cwd)).skills);
 
-  const requestedSkills = options.all ? [...installedSkills, ...lockSkillsKeys] : skillNames;
-  const resolvedRequestedSkills =
-    options.all || skillNames.length > 0
-      ? resolveSkillsToRemove(requestedSkills, installedSkills, lockSkillsKeys)
-      : [];
+  const scanned: Array<{ global: boolean; names: string[]; lockKeys: string[] }> = [];
+  for (const { global } of scopes) {
+    scanned.push({
+      global,
+      names: await scanScope(global),
+      lockKeys: await readLockKeys(global),
+    });
+  }
 
-  if (installedSkills.length === 0 && resolvedRequestedSkills.length === 0) {
+  const installedCount = scanned.reduce((total, scope) => total + scope.names.length, 0);
+  spinner.stop(`Found ${installedCount} unique installed skill(s)`);
+
+  const resolvedRequestedTargets: RemovalTarget[] = [];
+  if (options.all || skillNames.length > 0) {
+    for (const scope of scanned) {
+      const requested = options.all ? [...scope.names, ...scope.lockKeys] : skillNames;
+      for (const name of resolveSkillsToRemove(requested, scope.names, scope.lockKeys)) {
+        resolvedRequestedTargets.push({ name, global: scope.global });
+      }
+    }
+  }
+
+  if (installedCount === 0 && resolvedRequestedTargets.length === 0) {
     p.outro(pc.yellow('No skills found to remove.'));
     return;
   }
@@ -144,36 +232,67 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
   }
 
-  let selectedSkills: string[] = [];
+  let selectedTargets: RemovalTarget[] = [];
 
   if (options.all) {
-    selectedSkills = resolvedRequestedSkills;
+    selectedTargets = resolvedRequestedTargets;
   } else if (skillNames.length > 0) {
-    selectedSkills = resolvedRequestedSkills;
+    selectedTargets = resolvedRequestedTargets;
 
-    if (selectedSkills.length === 0) {
+    if (selectedTargets.length === 0) {
       p.log.error(`No matching skills found for: ${skillNames.join(', ')}`);
       return;
     }
   } else {
-    const choices = installedSkills.map((s) => ({
-      value: s,
-      label: s,
-    }));
+    const message = `Select skills to remove ${pc.dim('(space to toggle)')}`;
+    let selected: RemovalTarget[] | symbol;
 
-    const selected = await p.multiselect({
-      message: `Select skills to remove ${pc.dim('(space to toggle)')}`,
-      options: choices,
-      required: true,
-    });
+    if (scanned.length > 1) {
+      // Both scopes are in play: group them so it is obvious which copy of a
+      // skill is about to be removed.
+      selected = await p.groupMultiselect<RemovalTarget>({
+        message,
+        options: buildScopedChoices(
+          scanned.map((scope) => ({
+            global: scope.global,
+            names: scope.names,
+            dir: shortenPath(getCanonicalSkillsDir(scope.global, cwd), cwd),
+          }))
+        ),
+        required: true,
+        selectableGroups: true,
+      });
+    } else {
+      const scope = scanned[0]!;
+      const picked = await p.multiselect({
+        message,
+        options: scope.names.map((name) => ({ value: name, label: name })),
+        required: true,
+      });
+      selected = p.isCancel(picked)
+        ? picked
+        : (picked as string[]).map((name) => ({ name, global: scope.global }));
+    }
 
     if (p.isCancel(selected)) {
       p.cancel('Removal cancelled');
       process.exit(0);
     }
 
-    selectedSkills = resolveSkillsToRemove(selected as string[], installedSkills, lockSkillsKeys);
+    // Re-resolve per scope so lock-only keys (e.g. "ce:review" behind the
+    // "ce-review" folder) are removed under their exact key.
+    for (const scope of scanned) {
+      const namesInScope = (selected as RemovalTarget[])
+        .filter((target) => target.global === scope.global)
+        .map((target) => target.name);
+      if (namesInScope.length === 0) continue;
+      for (const name of resolveSkillsToRemove(namesInScope, scope.names, scope.lockKeys)) {
+        selectedTargets.push({ name, global: scope.global });
+      }
+    }
   }
+
+  const spansScopes = new Set(selectedTargets.map((target) => target.global)).size > 1;
 
   let targetAgents: AgentType[];
   if (options.agent && options.agent.length > 0) {
@@ -188,13 +307,16 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   if (!options.yes) {
     console.log();
     p.log.info('Skills to remove:');
-    for (const skill of selectedSkills) {
-      p.log.message(`  ${pc.red('•')} ${skill}`);
+    for (const target of selectedTargets) {
+      const scopeTag = spansScopes
+        ? ` ${pc.dim(`(${scopeLabel(target.global).toLowerCase()})`)}`
+        : '';
+      p.log.message(`  ${pc.red('•')} ${target.name}${scopeTag}`);
     }
     console.log();
 
     const confirmed = await p.confirm({
-      message: `Are you sure you want to uninstall ${selectedSkills.length} skill(s)?`,
+      message: `Are you sure you want to uninstall ${selectedTargets.length} skill(s)?`,
     });
 
     if (p.isCancel(confirmed) || !confirmed) {
@@ -207,13 +329,14 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
   const results: {
     skill: string;
+    global: boolean;
     success: boolean;
     source?: string;
     sourceType?: string;
     error?: string;
   }[] = [];
 
-  for (const skillName of selectedSkills) {
+  for (const { name: skillName, global: isGlobal } of selectedTargets) {
     try {
       const canonicalPath = getCanonicalPath(skillName, { global: isGlobal, cwd });
 
@@ -296,6 +419,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       results.push({
         skill: skillName,
+        global: isGlobal,
         success: true,
         source: effectiveSource,
         sourceType: effectiveSourceType,
@@ -303,6 +427,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     } catch (err) {
       results.push({
         skill: skillName,
+        global: isGlobal,
         success: false,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -314,25 +439,29 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   const successful = results.filter((r) => r.success);
   const failed = results.filter((r) => !r.success);
 
-  // Track removal (grouped by source)
+  // Track removal (grouped by scope, then source)
   if (successful.length > 0) {
-    const bySource = new Map<string, { skills: string[]; sourceType?: string }>();
+    const byScopeAndSource = new Map<
+      string,
+      { global: boolean; source: string; skills: string[]; sourceType?: string }
+    >();
 
     for (const r of successful) {
       const source = r.source || 'local';
-      const existing = bySource.get(source) || { skills: [] };
+      const key = `${r.global ? 'global' : 'project'} ${source}`;
+      const existing = byScopeAndSource.get(key) || { global: r.global, source, skills: [] };
       existing.skills.push(r.skill);
       existing.sourceType = r.sourceType;
-      bySource.set(source, existing);
+      byScopeAndSource.set(key, existing);
     }
 
-    for (const [source, data] of bySource) {
+    for (const data of byScopeAndSource.values()) {
       track({
         event: 'remove',
-        source,
+        source: data.source,
         skills: data.skills.join(','),
         agents: targetAgents.join(','),
-        ...(isGlobal && { global: '1' }),
+        ...(data.global && { global: '1' }),
         sourceType: data.sourceType,
       });
     }
@@ -366,6 +495,8 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
 
     if (arg === '-g' || arg === '--global') {
       options.global = true;
+    } else if (arg === '-p' || arg === '--project') {
+      options.project = true;
     } else if (arg === '-y' || arg === '--yes') {
       options.yes = true;
     } else if (arg === '--all') {


### PR DESCRIPTION
## Problem

`skills remove` scans one scope at a time. Run it in a project directory and the
interactive picker only lists project skills; globally installed skills are
invisible unless you already know to re-run with `-g`. There is no way to see, or
remove, both from one prompt — and nothing in the picker tells you which scope a
listed skill belongs to.

## Change

The interactive picker now scans both scopes and renders them as separate groups,
each labelled with its canonical directory:

```
◆  Select skills to remove (space to toggle)
│  ◻ Project (./.agents/skills)
│  └ ◻ project-skill
│  ◻ Global (~/.agents/skills)
│  └ ◻ global-skill
│  ↑/↓ to navigate • Space: select • Enter: confirm
└
```

- Selections carry their scope, so a skill installed both globally and in the
  project stays two independently selectable entries, and each removal targets
  the matching canonical path and lock file (`skills-lock.json` vs
  `~/.agents/.skill-lock.json`).
- The confirmation list tags each skill with its scope when a selection spans
  both.
- Removal telemetry is grouped by scope as well as source, so a mixed removal no
  longer reports every skill under one `global` flag.

## Scope flags

- Named skills and `--all` are **unchanged**: still project-scoped unless `-g` is
  passed. Only the interactive picker looks at both scopes, so existing
  non-interactive invocations remove exactly what they removed before.
- New `-p, --project` restricts the picker to project skills, mirroring the
  existing flag on `skills update`.
- `-g -p` together operate on both scopes, again matching `skills update`.

## Tests

Added to `src/remove.test.ts`:

- the picker lists project and global skills as separate groups
- `-p` / `-g` restrict it to a single scope
- `remove <name> -g -p -y` removes the name from both scopes and leaves other
  skills alone
- unit coverage for `resolveRemoveScopes` (flag precedence, interactive-only
  widening) and `buildScopedChoices` (same name in both scopes stays distinct,
  empty scopes omitted)

`pnpm exec vitest run src/remove.test.ts` — 39 passed. `pnpm type-check` and
`pnpm format` are clean.

Note: the picker assertions check what the prompt renders rather than driving it
to submit — piped stdin can't submit a clack multiselect (same on `main`).

Eight tests in `src/detect-agent.test.ts`, `tests/installer-symlink.test.ts` and
`tests/list-installed.test.ts` fail on my Windows machine on unmodified `main`
too (symlink privileges and agent env-var detection), so they're unrelated to
this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyCgvyorhdVZX8f8qf4MEq
