### PR TITLE
fix: preserve source skills during remove --all

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -185,6 +185,23 @@ This is a test skill.
       expect(existsSync(join(skillsDir, 'skill-three'))).toBe(false);
     });
 
+    it('should not delete source skills from an undetected agent directory with --all', () => {
+      const sourceSkillsDir = join(testDir, 'skills');
+      const sourceSkillDir = createTestSkill(
+        'source-skill',
+        'An authored source skill',
+        sourceSkillsDir
+      );
+
+      const result = runCli(['remove', '--all', '-y'], testDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(sourceSkillDir)).toBe(true);
+      expect(readFileSync(join(sourceSkillDir, 'SKILL.md'), 'utf-8')).toContain(
+        'An authored source skill'
+      );
+    });
+
     it('should show error for non-existent skill name when skills exist', () => {
       const result = runCli(['remove', 'non-existent', '-y'], testDir);
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -176,6 +176,8 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   }
 
   let targetAgents: AgentType[];
+  const installedAgents = await detectInstalledAgents();
+  const explicitlyTargetedAgents = new Set(options.agent as AgentType[] | undefined);
   if (options.agent && options.agent.length > 0) {
     targetAgents = options.agent as AgentType[];
   } else {
@@ -247,6 +249,18 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
           try {
             const stats = await lstat(pathToCleanup).catch(() => null);
             if (stats) {
+              // Project-relative agent directories can overlap with source trees
+              // (notably OpenClaw's bare "skills" directory). For agents that
+              // are not installed, only remove symlinks left by a previous
+              // installation. A real directory is not known to be managed and
+              // may contain the user's source files (#1771).
+              const canRemoveRealDirectory =
+                isGlobal ||
+                installedAgents.includes(agentKey) ||
+                explicitlyTargetedAgents.has(agentKey);
+              if (!stats.isSymbolicLink() && !canRemoveRealDirectory) {
+                continue;
+              }
               await rm(pathToCleanup, { recursive: true, force: true });
             }
           } catch (err) {
@@ -261,7 +275,6 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       // Only remove the canonical path if no other installed agents are using it.
       // This prevents breaking other agents when uninstalling from a specific agent (#287).
-      const installedAgents = await detectInstalledAgents();
       const remainingAgents = installedAgents.filter((a) => !targetAgents.includes(a));
 
       let isStillUsed = false;


### PR DESCRIPTION
## Summary

- protect real project directories belonging to undetected agents during removal
- continue cleaning stale symlinks for agents that are no longer detected
- add a regression test for a top-level `skills/` source tree

## Root cause

Without an explicit `--agent`, removal targets every known agent so it can clean up stale links. OpenClaw uses the project-relative `skills/` directory, which can overlap a repository's authored source tree. The cleanup loop treated any matching real directory as managed and recursively deleted it even when OpenClaw was not installed.

The cleanup now removes real project-relative agent directories only when that agent is detected or explicitly targeted. Symlinks remain safe to remove for undetected agents, preserving the existing stale-link cleanup behavior.

## Validation

- `pnpm test` (50 files, 675 tests)
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`

Closes #1771
