### PR TITLE
fix: avoid removing undetected agent skill dirs

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -185,6 +185,26 @@ This is a test skill.
       expect(existsSync(join(skillsDir, 'skill-three'))).toBe(false);
     });
 
+    it('should not remove a repo-owned skills directory for an undetected agent with --all', () => {
+      const repoSkillDir = createTestSkill(
+        'source-skill',
+        'A repository-owned source skill',
+        join(testDir, 'skills')
+      );
+
+      const result = runCli(['remove', '--all', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(skillsDir, 'skill-one'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'skill-two'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'skill-three'))).toBe(false);
+      expect(existsSync(repoSkillDir)).toBe(true);
+      expect(readFileSync(join(repoSkillDir, 'SKILL.md'), 'utf-8')).toContain(
+        'A repository-owned source skill'
+      );
+    });
+
     it('should show error for non-existent skill name when skills exist', () => {
       const result = runCli(['remove', 'non-existent', '-y'], testDir);
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -73,6 +73,22 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   const isGlobal = options.global ?? false;
   const cwd = process.cwd();
 
+  // Validate agent options BEFORE prompting for skill selection
+  if (options.agent && options.agent.length > 0) {
+    const validAgents = Object.keys(agents);
+    const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
+
+    if (invalidAgents.length > 0) {
+      p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
+      p.log.info(`Valid agents: ${validAgents.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
+  const explicitlyTargetedAgents = options.agent as AgentType[] | undefined;
+  const installedAgents = await detectInstalledAgents();
+  const installedAgentSet = new Set(installedAgents);
+
   const spinner = p.spinner();
 
   spinner.start('Scanning for installed skills…');
@@ -102,12 +118,15 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     }
   } else {
     await scanDir(getCanonicalSkillsDir(false, cwd));
-    for (const agent of Object.values(agents)) {
-      await scanDir(join(cwd, agent.skillsDir));
+    const agentsToScan = explicitlyTargetedAgents ?? installedAgents;
+    for (const agentKey of agentsToScan) {
+      await scanDir(join(cwd, agents[agentKey].skillsDir));
     }
     // Eve subagents keep their skills under agent/subagents/<name>/skills.
-    for (const subagent of getEveSubagents(cwd)) {
-      await scanDir(getEveSubagentSkillsDir(subagent, cwd));
+    if (explicitlyTargetedAgents?.includes('eve') || installedAgentSet.has('eve')) {
+      for (const subagent of getEveSubagents(cwd)) {
+        await scanDir(getEveSubagentSkillsDir(subagent, cwd));
+      }
     }
   }
 
@@ -130,18 +149,6 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   if (installedSkills.length === 0 && resolvedRequestedSkills.length === 0) {
     p.outro(pc.yellow('No skills found to remove.'));
     return;
-  }
-
-  // Validate agent options BEFORE prompting for skill selection
-  if (options.agent && options.agent.length > 0) {
-    const validAgents = Object.keys(agents);
-    const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
-
-    if (invalidAgents.length > 0) {
-      p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
-      p.log.info(`Valid agents: ${validAgents.join(', ')}`);
-      process.exit(1);
-    }
   }
 
   let selectedSkills: string[] = [];
@@ -247,6 +254,14 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
           try {
             const stats = await lstat(pathToCleanup).catch(() => null);
             if (stats) {
+              if (
+                !isGlobal &&
+                !explicitlyTargetedAgents &&
+                !installedAgentSet.has(agentKey) &&
+                !stats.isSymbolicLink()
+              ) {
+                continue;
+              }
               await rm(pathToCleanup, { recursive: true, force: true });
             }
           } catch (err) {
@@ -261,7 +276,6 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 
       // Only remove the canonical path if no other installed agents are using it.
       // This prevents breaking other agents when uninstalling from a specific agent (#287).
-      const installedAgents = await detectInstalledAgents();
       const remainingAgents = installedAgents.filter((a) => !targetAgents.includes(a));
 
       let isStillUsed = false;


### PR DESCRIPTION
Fixes #1771.

## Summary
- limit local `remove --all` discovery to the canonical skills dir plus explicitly targeted or detected agents
- preserve cleanup of stale symlinks for undetected agents, but skip real directories so `skills/` source trees are not treated as OpenClaw installs
- add a regression test for a repo-owned `skills/source-skill/SKILL.md` directory

## Verification
```text
npx pnpm@10.17.1 exec vitest run src/remove.test.ts
Test Files  1 passed (1)
Tests  30 passed (30)
```

```text
npx pnpm@10.17.1 exec prettier --check src/remove.ts src/remove.test.ts
Checking formatting...
All matched files use Prettier code style!
```

```text
npx pnpm@10.17.1 exec tsc --noEmit
# exited 0
```