### PR TITLE
feat: remove skills by source

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,13 @@
+# Skills
+
+The domain language for discovering, installing, and removing agent skills from external sources.
+
+## Language
+
+**Skill Source**:
+The exact origin identifier associated with an installed skill. Different identifiers remain distinct even when they refer to the same repository.
+_Avoid_: Repository identity, normalized source
+
+**Unattributed Skill**:
+An installed skill whose source is unknown. It remains independently removable without being attributed to a known Skill Source.
+_Avoid_: Orphaned skill, stale skill

--- a/README.md
+++ b/README.md
@@ -186,8 +186,11 @@ npx skills init my-skill
 Remove installed skills from agents.
 
 ```bash
-# Remove interactively (select from installed skills)
+# Remove interactively (select skills grouped by lock source)
 npx skills remove
+
+# Remove all skills from an exact lock source
+npx skills remove owner/repo
 
 # Remove specific skill by name
 npx skills remove web-design-guidelines

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -255,6 +255,76 @@ This is a test skill.
       expect(existsSync(join(skillsDir, 'skill-one'))).toBe(false);
     });
 
+    it('should remove all skills from an exact lock source', () => {
+      const lockPath = join(testDir, 'skills-lock.json');
+      writeFileSync(
+        lockPath,
+        JSON.stringify({
+          version: 1,
+          skills: {
+            'skill-one': {
+              source: 'mattpocock/skills',
+              sourceType: 'github',
+              computedHash: 'one',
+            },
+            'skill-two': {
+              source: 'mattpocock/skills',
+              ref: 'dev',
+              sourceType: 'github',
+              computedHash: 'two',
+            },
+            'skill-three': {
+              source: 'other/source',
+              sourceType: 'github',
+              computedHash: 'three',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['remove', 'mattpocock/skills', '-y'], testDir);
+
+      expect(result.stdout).toContain('2 skill');
+      expect(existsSync(join(skillsDir, 'skill-one'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'skill-two'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'skill-three'))).toBe(true);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(Object.keys(updatedLock.skills)).toEqual(['skill-three']);
+    });
+
+    it('preserves a shared sanitized directory when removing only one lock identity', () => {
+      createTestSkill('foo-bar');
+      const lockPath = join(testDir, 'skills-lock.json');
+      writeFileSync(
+        lockPath,
+        JSON.stringify({
+          version: 1,
+          skills: {
+            'foo:bar': {
+              source: 'one',
+              sourceType: 'github',
+              computedHash: 'one',
+            },
+            'foo-bar': {
+              source: 'two',
+              sourceType: 'github',
+              computedHash: 'two',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['remove', 'one', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(existsSync(join(skillsDir, 'foo-bar'))).toBe(true);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['foo:bar']).toBeUndefined();
+      expect(updatedLock.skills['foo-bar']).toBeDefined();
+    });
+
     it('should remove only the specified skill and leave others', () => {
       runCli(['remove', 'skill-two', '-y'], testDir);
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -7,6 +7,7 @@ import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
 import { readLocalLock, removeSkillFromLocalLock } from './local-lock.ts';
+import { searchMultiselect, type SearchItem } from './prompts/search-multiselect.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -31,30 +32,107 @@ export interface RemoveOptions {
  * sanitizeName() rewrites — e.g. the ':' in plugin skills such as "ce:review"
  * maps to the folder "ce-review". Matching purely on folder names therefore
  * misses lock-only or name-mismatched skills (and stale lock entries whose
- * folder is already gone). Every candidate is canonicalized by its sanitized
- * name, preferring the lock key, so downstream disk cleanup (which
- * re-sanitizes) and lock removal (which needs the exact key) both target the
- * right thing.
+ * folder is already gone). Removable candidates preserve exact lock keys, including
+ * distinct keys that sanitize to the same folder, while untracked folders are
+ * reconciled with a lock identity where possible. Downstream disk cleanup
+ * re-sanitizes and lock removal needs the exact key, so both target the right thing.
  */
 export function resolveSkillsToRemove(
   requested: string[],
   folderNames: string[],
   lockKeys: string[] = []
 ): string[] {
-  const identityBySanitized = new Map<string, string>();
-  for (const folder of folderNames) {
-    identityBySanitized.set(sanitizeName(folder), folder);
-  }
-  // Lock keys win: they carry the exact key needed for lock removal.
-  for (const key of lockKeys) {
-    identityBySanitized.set(sanitizeName(key), key);
-  }
+  const candidates = getRemovalCandidates(folderNames, lockKeys);
 
   const matched = new Set<string>();
   for (const name of requested) {
-    const hit = identityBySanitized.get(sanitizeName(name));
-    if (hit) matched.add(hit);
+    const sanitizedName = sanitizeName(name);
+    for (const candidate of candidates) {
+      if (sanitizeName(candidate) === sanitizedName) matched.add(candidate);
+    }
   }
+  return Array.from(matched);
+}
+
+type RemoveLockEntry = { source?: string };
+
+function getRemovalCandidates(folderNames: string[], lockKeys: string[]): string[] {
+  const candidates = new Set(lockKeys);
+
+  for (const folder of folderNames) {
+    const sanitizedFolder = sanitizeName(folder);
+    const hasLockIdentity = lockKeys.some((key) => sanitizeName(key) === sanitizedFolder);
+    if (!hasLockIdentity) candidates.add(folder);
+  }
+
+  return Array.from(candidates).sort((a, b) => a.localeCompare(b));
+}
+
+/** Build the grouped choices used by the interactive remove selector. */
+export function buildRemoveChoices(
+  folderNames: string[],
+  lockEntries: Record<string, RemoveLockEntry>
+): SearchItem<string>[] {
+  const lockKeys = Object.keys(lockEntries);
+  const groups = new Map<string, SearchItem<string>[]>();
+
+  for (const skill of getRemovalCandidates(folderNames, lockKeys)) {
+    const group = lockEntries[skill]?.source ?? 'Unknown source';
+    const choices = groups.get(group) || [];
+    choices.push({ value: skill, label: skill, group });
+    groups.set(group, choices);
+  }
+
+  return Array.from(groups.values()).flat();
+}
+
+/** Resolve skill names first, then exact lock-entry source strings. */
+export function resolveRemoveTargets(
+  requested: string[],
+  folderNames: string[],
+  lockEntries: Record<string, RemoveLockEntry>
+): string[] {
+  const lockKeys = Object.keys(lockEntries);
+  const candidates = getRemovalCandidates(folderNames, lockKeys);
+  const identityByName = new Map<string, string>();
+
+  for (const folder of folderNames) {
+    const sanitizedFolder = sanitizeName(folder);
+    const lockKey = lockKeys.find((key) => sanitizeName(key) === sanitizedFolder);
+    identityByName.set(folder.toLowerCase(), lockKey || folder);
+  }
+  // Exact lock keys must retain their own identity, even when another key
+  // sanitizes to the same on-disk folder name.
+  for (const key of lockKeys) {
+    identityByName.set(key.toLowerCase(), key);
+  }
+  for (const candidate of candidates) {
+    identityByName.set(candidate.toLowerCase(), candidate);
+  }
+
+  const matched = new Set<string>();
+  for (const request of requested) {
+    const nameMatch = identityByName.get(request.toLowerCase());
+    if (nameMatch) {
+      matched.add(nameMatch);
+      continue;
+    }
+
+    const sourceMatches = candidates.filter(
+      (candidate) => lockEntries[candidate]?.source === request
+    );
+    if (sourceMatches.length > 0) {
+      for (const candidate of sourceMatches) matched.add(candidate);
+      continue;
+    }
+
+    // Keep the historical sanitized-name fallback for plugin skill names such
+    // as `ce:review` and their on-disk `ce-review` folder.
+    for (const candidate of resolveSkillsToRemove([request], folderNames, lockKeys)) {
+      matched.add(candidate);
+    }
+  }
+
   return Array.from(matched);
 }
 
@@ -114,20 +192,15 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   const installedSkills = Array.from(skillNamesSet).sort();
   spinner.stop(`Found ${installedSkills.length} unique installed skill(s)`);
 
-  // Read lock file keys up front. These are needed both to decide whether there is
-  // anything to remove (a skill may be missing from disk but still leave a stale lock
-  // entry) and to clean up those stale entries below.
-  const lockSkillsKeys = isGlobal
-    ? Object.keys((await readSkillLock()).skills)
-    : Object.keys((await readLocalLock(cwd)).skills);
-
-  const requestedSkills = options.all ? [...installedSkills, ...lockSkillsKeys] : skillNames;
+  // Read the relevant lock file once. Its keys represent stale skills as well as
+  // skills that are still present on disk.
+  const lockEntries = (isGlobal ? await readSkillLock() : await readLocalLock(cwd)).skills;
+  const lockSkillsKeys = Object.keys(lockEntries);
+  const removableSkills = getRemovalCandidates(installedSkills, lockSkillsKeys);
   const resolvedRequestedSkills =
-    options.all || skillNames.length > 0
-      ? resolveSkillsToRemove(requestedSkills, installedSkills, lockSkillsKeys)
-      : [];
+    skillNames.length > 0 ? resolveRemoveTargets(skillNames, installedSkills, lockEntries) : [];
 
-  if (installedSkills.length === 0 && resolvedRequestedSkills.length === 0) {
+  if (removableSkills.length === 0) {
     p.outro(pc.yellow('No skills found to remove.'));
     return;
   }
@@ -147,7 +220,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   let selectedSkills: string[] = [];
 
   if (options.all) {
-    selectedSkills = resolvedRequestedSkills;
+    selectedSkills = removableSkills;
   } else if (skillNames.length > 0) {
     selectedSkills = resolvedRequestedSkills;
 
@@ -156,23 +229,19 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
       return;
     }
   } else {
-    const choices = installedSkills.map((s) => ({
-      value: s,
-      label: s,
-    }));
-
-    const selected = await p.multiselect({
+    const selected = await searchMultiselect({
       message: `Select skills to remove ${pc.dim('(space to toggle)')}`,
-      options: choices,
+      items: buildRemoveChoices(installedSkills, lockEntries),
       required: true,
+      selectGroups: true,
     });
 
-    if (p.isCancel(selected)) {
+    if (typeof selected === 'symbol') {
       p.cancel('Removal cancelled');
       process.exit(0);
     }
 
-    selectedSkills = resolveSkillsToRemove(selected as string[], installedSkills, lockSkillsKeys);
+    selectedSkills = selected as string[];
   }
 
   let targetAgents: AgentType[];
@@ -216,6 +285,12 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   for (const skillName of selectedSkills) {
     try {
       const canonicalPath = getCanonicalPath(skillName, { global: isGlobal, cwd });
+      const sharesPathWithUnselectedSkill = removableSkills.some(
+        (candidate) =>
+          candidate !== skillName &&
+          !selectedSkills.includes(candidate) &&
+          sanitizeName(candidate) === sanitizeName(skillName)
+      );
 
       for (const agentKey of targetAgents) {
         const agent = agents[agentKey];
@@ -239,6 +314,10 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         }
 
         for (const pathToCleanup of pathsToCleanup) {
+          // A shared sanitized path belongs to an unselected lock identity too.
+          if (sharesPathWithUnselectedSkill) {
+            continue;
+          }
           // Skip if this is the canonical path - we'll handle that after checking all agents
           if (pathToCleanup === canonicalPath) {
             continue;
@@ -274,7 +353,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         }
       }
 
-      if (!isStillUsed) {
+      if (!sharesPathWithUnselectedSkill && !isStillUsed) {
         await rm(canonicalPath, { recursive: true, force: true });
       }
 

--- a/tests/resolve-skills-to-remove.test.ts
+++ b/tests/resolve-skills-to-remove.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolveSkillsToRemove } from '../src/remove.ts';
+import { buildRemoveChoices, resolveRemoveTargets, resolveSkillsToRemove } from '../src/remove.ts';
 
 describe('resolveSkillsToRemove', () => {
   it('matches a plugin lock key against its sanitized on-disk folder', () => {
@@ -71,5 +71,81 @@ describe('resolveSkillsToRemove', () => {
     const lockKeys = ['ce:review', 'my-skill'];
     const result = resolveSkillsToRemove([...installed, ...lockKeys], installed, lockKeys);
     expect(new Set(result)).toEqual(new Set(['ce:review', 'my-skill']));
+  });
+
+  it('groups installed and stale skills by their exact lock source', () => {
+    expect(
+      buildRemoveChoices(['beta', 'untracked'], {
+        alpha: { source: 'mattpocock/skills', ref: 'main' },
+        beta: { source: 'mattpocock/skills', ref: 'other-ref' },
+        stale: { source: 'https://github.com/mattpocock/skills' },
+      })
+    ).toEqual([
+      { value: 'alpha', label: 'alpha', group: 'mattpocock/skills' },
+      { value: 'beta', label: 'beta', group: 'mattpocock/skills' },
+      { value: 'stale', label: 'stale', group: 'https://github.com/mattpocock/skills' },
+      { value: 'untracked', label: 'untracked', group: 'Unknown source' },
+    ]);
+  });
+
+  it('expands an exact source argument to every matching lock entry', () => {
+    expect(
+      resolveRemoveTargets(['mattpocock/skills'], ['review', 'design'], {
+        review: { source: 'mattpocock/skills' },
+        design: { source: 'mattpocock/skills', ref: 'dev' },
+        other: { source: 'MATTPOCOCK/SKILLS' },
+      })
+    ).toEqual(['design', 'review']);
+  });
+
+  it('preserves lock entries whose names sanitize to the same folder', () => {
+    const lockEntries = {
+      'foo:bar': { source: 'one' },
+      'foo-bar': { source: 'two' },
+    };
+    const choices = buildRemoveChoices(['foo-bar'], lockEntries);
+
+    expect(choices).toHaveLength(2);
+    expect(choices).toEqual(
+      expect.arrayContaining([
+        { value: 'foo:bar', label: 'foo:bar', group: 'one' },
+        { value: 'foo-bar', label: 'foo-bar', group: 'two' },
+      ])
+    );
+    expect(resolveRemoveTargets(['one'], ['foo-bar'], lockEntries)).toEqual(['foo:bar']);
+    expect(resolveRemoveTargets(['foo-bar'], ['foo-bar'], lockEntries)).toEqual(['foo-bar']);
+  });
+
+  it('gives an exact case-insensitive skill name precedence over a source', () => {
+    expect(
+      resolveRemoveTargets(['review'], ['review', 'other'], {
+        review: { source: 'review' },
+        other: { source: 'review' },
+      })
+    ).toEqual(['review']);
+  });
+
+  it('matches an exact source without normalizing shorthand or URL forms', () => {
+    expect(
+      resolveRemoveTargets(['https://github.com/mattpocock/skills'], [], {
+        shorthand: { source: 'mattpocock/skills' },
+        https: { source: 'https://github.com/mattpocock/skills' },
+      })
+    ).toEqual(['https']);
+  });
+
+  it('does not normalize a source that resembles a skill name', () => {
+    expect(
+      resolveRemoveTargets(['owner/repo'], ['owner-repo'], {
+        'owner-repo': { source: 'other/source' },
+        fromRepo: { source: 'owner/repo' },
+      })
+    ).toEqual(['fromRepo']);
+  });
+
+  it('assigns lock entries without a source to Unknown source', () => {
+    expect(buildRemoveChoices([], { unattributed: {} })).toEqual([
+      { value: 'unattributed', label: 'unattributed', group: 'Unknown source' },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- group the interactive remove selector by each skill's exact lock-file source
- allow `skills remove owner/repo` to remove every skill from that source while preserving exact skill-name precedence
- include unattributed and stale lock-only skills, with safe handling for plugin names that share a sanitized path
- document the new removal workflow and domain terminology

## Testing

- `pnpm test src/remove.test.ts tests/resolve-skills-to-remove.test.ts` (48 passed)
- `pnpm build`
- `pnpm format:check`
- full suite: 682 passed; the Git LFS fixture fails locally because `git-lfs` is unavailable

Closes #1034
