### PR TITLE
feat(agents): add Polytoken agent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ package-lock.json
 .gemini/
 .github/skills/
 .opencode/
+.polytoken/
 .qoder/
 .qwen/
 .trae/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [70 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -291,6 +291,7 @@ Skills can be installed to any of these agents:
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
+| Polytoken | `polytoken` | `.polytoken/skills/` | `~/.polytoken/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
@@ -422,6 +423,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.openhands/skills/`
 - `.ona/skills/`
 - `.pi/skills/`
+- `.polytoken/skills/`
 - `.qoder/skills/`
 - `.qwen/skills/`
 - `.reasonix/skills/`

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Skills can be installed to any of these agents:
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
-| Polytoken | `polytoken` | `.polytoken/skills/` | `~/.polytoken/skills/` |
+| Polytoken | `polytoken` | `.polytoken/skills/` | `~/.config/polytoken/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "openhands",
     "ona",
     "pi",
+    "polytoken",
     "qoder",
     "qoder-cn",
     "qwen-code",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -539,6 +539,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.pi/agent'));
     },
   },
+  polytoken: {
+    name: 'polytoken',
+    displayName: 'Polytoken',
+    skillsDir: '.polytoken/skills',
+    globalSkillsDir: join(home, '.polytoken/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.polytoken')) || existsSync(join(process.cwd(), '.polytoken'));
+    },
+  },
   qoder: {
     name: 'qoder',
     displayName: 'Qoder',

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -559,9 +559,11 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'polytoken',
     displayName: 'Polytoken',
     skillsDir: '.polytoken/skills',
-    globalSkillsDir: join(home, '.polytoken/skills'),
+    globalSkillsDir: join(configHome, 'polytoken/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.polytoken')) || existsSync(join(process.cwd(), '.polytoken'));
+      return (
+        existsSync(join(configHome, 'polytoken')) || existsSync(join(process.cwd(), '.polytoken'))
+      );
     },
   },
   qoder: {

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -51,6 +51,7 @@ const agentNameToType: Record<string, AgentType> = {
   'augment-cli': 'augment',
   opencode: 'opencode',
   'github-copilot': 'github-copilot',
+  polytoken: 'polytoken',
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type AgentType =
   | 'openhands'
   | 'ona'
   | 'pi'
+  | 'polytoken'
   | 'qoder'
   | 'qoder-cn'
   | 'qwen-code'

--- a/tests/polytoken-detection.test.ts
+++ b/tests/polytoken-detection.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
+import { detectInstalledAgents } from '../src/agents.ts';
+
+describe('polytoken detection', () => {
+  let originalHome: string | undefined;
+  let originalCwd: string | undefined;
+  let tempHome: string | undefined;
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    originalCwd = process.cwd();
+    tempHome = await mkdtemp(join(tmpdir(), 'skills-polytoken-home-'));
+    process.env.HOME = tempHome;
+    process.chdir(tempHome);
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    if (originalCwd) process.chdir(originalCwd);
+    process.env.HOME = originalHome;
+    if (tempHome) {
+      await rm(tempHome, { recursive: true, force: true });
+    }
+    vi.unstubAllEnvs();
+  });
+
+  it('detects Polytoken when ~/.polytoken exists', async () => {
+    await mkdir(join(tempHome!, '.polytoken'), { recursive: true });
+    const { detectInstalledAgents: detect } = await import('../src/agents.ts');
+    const installed = await detect();
+    expect(installed).toContain('polytoken');
+  });
+
+  it('does not detect Polytoken when ~/.polytoken is absent', async () => {
+    const { detectInstalledAgents: detect } = await import('../src/agents.ts');
+    const installed = await detect();
+    expect(installed).not.toContain('polytoken');
+  });
+});

--- a/tests/polytoken-detection.test.ts
+++ b/tests/polytoken-detection.test.ts
@@ -27,14 +27,14 @@ describe('polytoken detection', () => {
     vi.unstubAllEnvs();
   });
 
-  it('detects Polytoken when ~/.polytoken exists', async () => {
-    await mkdir(join(tempHome!, '.polytoken'), { recursive: true });
+  it('detects Polytoken when ~/.config/polytoken exists', async () => {
+    await mkdir(join(tempHome!, '.config', 'polytoken'), { recursive: true });
     const { detectInstalledAgents: detect } = await import('../src/agents.ts');
     const installed = await detect();
     expect(installed).toContain('polytoken');
   });
 
-  it('does not detect Polytoken when ~/.polytoken is absent', async () => {
+  it('does not detect Polytoken when ~/.config/polytoken is absent', async () => {
     const { detectInstalledAgents: detect } = await import('../src/agents.ts');
     const installed = await detect();
     expect(installed).not.toContain('polytoken');

--- a/tests/polytoken-paths.test.ts
+++ b/tests/polytoken-paths.test.ts
@@ -14,8 +14,8 @@ describe('polytoken paths', () => {
     expect(getAgentConfig('polytoken').skillsDir).toBe('.polytoken/skills');
   });
 
-  it('uses ~/.polytoken/skills for global skills', () => {
-    const expected = join(home, '.polytoken', 'skills');
+  it('uses ~/.config/polytoken/skills for global skills', () => {
+    const expected = join(home, '.config', 'polytoken', 'skills');
     expect(getAgentConfig('polytoken').globalSkillsDir).toBe(expected);
   });
 

--- a/tests/polytoken-paths.test.ts
+++ b/tests/polytoken-paths.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'path';
+import { homedir } from 'os';
+import { agents, getAgentConfig } from '../src/agents.ts';
+
+describe('polytoken paths', () => {
+  const home = homedir();
+
+  it('is registered as an agent', () => {
+    expect('polytoken' in agents).toBe(true);
+  });
+
+  it('uses .polytoken/skills for project skills', () => {
+    expect(getAgentConfig('polytoken').skillsDir).toBe('.polytoken/skills');
+  });
+
+  it('uses ~/.polytoken/skills for global skills', () => {
+    const expected = join(home, '.polytoken', 'skills');
+    expect(getAgentConfig('polytoken').globalSkillsDir).toBe(expected);
+  });
+
+  it('does not share the universal .agents/skills directory', () => {
+    expect(getAgentConfig('polytoken').skillsDir).not.toBe('.agents/skills');
+  });
+});

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -104,6 +104,19 @@ describe('XDG config paths', () => {
     });
   });
 
+  describe('Polytoken', () => {
+    it('uses ~/.config/polytoken/skills for global skills', () => {
+      const expected = join(home, '.config', 'polytoken', 'skills');
+      expect(agents.polytoken.globalSkillsDir).toBe(expected);
+    });
+
+    it('does NOT use platform-specific paths', () => {
+      expect(agents.polytoken.globalSkillsDir).not.toContain('Library');
+      expect(agents.polytoken.globalSkillsDir).not.toContain('Preferences');
+      expect(agents.polytoken.globalSkillsDir).not.toContain('AppData');
+    });
+  });
+
   describe('non-XDG agents', () => {
     it('cursor uses ~/.cursor/skills (home-based, not XDG)', () => {
       const expected = join(home, '.cursor', 'skills');


### PR DESCRIPTION
## Summary

- add Polytoken agent detection and native project/global skill directories
- install skills into `.polytoken/skills` (project) and `$XDG_CONFIG_HOME/polytoken/skills/` (fallback: `~/.config/polytoken/skills/` (global)
- detect Polytoken from `$XDG_CONFIG_HOME/polytoken/skills/` (global config marker) or `.polytoken` in the current working directory
- add defensive `polytoken: 'polytoken'` mapping in `agentNameToType` for future `@vercel/detect-agent` support
- generate supported-agent documentation and package metadata via `scripts/sync-agents.ts`
- add focused tests for path configuration and installation detection (positive + negative)

Polytoken is a discrete, non-universal agent target. Skills install to the primary `.polytoken/skills` directory — Polytoken also loads skills from `.agents/skills` via its own fallback mechanism, so no universal-group installation is needed. Detection uses the `.polytoken` marker directory, which is namespaced and unlikely to collide with generic project folders.

## References

- Polytoken documentation: https://docs.polytoken.dev/
- Polytoken skills documentation: https://docs.polytoken.dev/harness-engineering/skills/

## Verification

- `pnpm test --run tests/polytoken-paths.test.ts tests/polytoken-detection.test.ts`
- `node scripts/validate-agents.ts`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm test --run`
- `pnpm build`
- `git diff --check origin/main...HEAD`
- smoke test: `skills add vercel-labs/agent-skills --agent polytoken --global --yes`
- rerun `scripts/sync-agents.ts` and verify generated files are unchanged
