### PR TITLE
fix(remove): keep the lock entry while another agent still uses the skill

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -479,3 +479,76 @@ This is a test skill.
     });
   });
 });
+
+describe('remove -a with a subset of agents', { timeout: 30000 }, () => {
+  let testDir: string;
+  let fakeHome: string;
+
+  // Both agents are detected from directories under HOME, so the test drives
+  // HOME rather than relying on whatever is installed on the host.
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-remove-subset-${Date.now()}`);
+    fakeHome = join(testDir, 'home');
+    mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+    mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the lock entry when another agent still uses the skill', () => {
+    const project = join(testDir, 'project');
+    const skillName = 'shared-skill';
+
+    // Canonical copy — also codex's project skills dir.
+    const canonical = join(project, '.agents', 'skills', skillName);
+    mkdirSync(canonical, { recursive: true });
+    writeFileSync(
+      join(canonical, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: shared between two agents\n---\n`
+    );
+
+    // Claude Code's own copy, the one being removed.
+    const claudeCopy = join(project, '.claude', 'skills', skillName);
+    mkdirSync(claudeCopy, { recursive: true });
+    writeFileSync(
+      join(claudeCopy, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: shared between two agents\n---\n`
+    );
+
+    const lockPath = join(project, 'skills-lock.json');
+    writeFileSync(
+      lockPath,
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            [skillName]: {
+              source: 'owner/repo',
+              sourceType: 'github',
+              computedHash: 'somehash',
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const result = runCli(['remove', skillName, '-a', 'claude-code', '-y'], project, {
+      HOME: fakeHome,
+    });
+
+    expect(result.exitCode).toBe(0);
+    // Claude Code's copy goes, codex keeps working.
+    expect(existsSync(claudeCopy)).toBe(false);
+    expect(existsSync(canonical)).toBe(true);
+
+    // The skill is still installed, so it must still be updatable.
+    const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+    expect(updatedLock.skills[skillName]).toBeDefined();
+  });
+});

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -281,17 +281,24 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
       let effectiveSource = 'local';
       let effectiveSourceType = 'local';
 
+      // The lock entry tracks the canonical path, so it survives for as long as
+      // that path does. Dropping it while another installed agent still links
+      // the skill leaves the skill in place but no longer updatable (#1718).
       if (isGlobal) {
         const lockEntry = await getSkillFromLock(skillName);
         effectiveSource = lockEntry?.source || 'local';
         effectiveSourceType = lockEntry?.sourceType || 'local';
-        await removeSkillFromLock(skillName);
+        if (!isStillUsed) {
+          await removeSkillFromLock(skillName);
+        }
       } else {
         const localLock = await readLocalLock(cwd);
         const lockEntry = localLock.skills[skillName];
         effectiveSource = lockEntry?.source || 'local';
         effectiveSourceType = lockEntry?.sourceType || 'local';
-        await removeSkillFromLocalLock(skillName, cwd);
+        if (!isStillUsed) {
+          await removeSkillFromLocalLock(skillName, cwd);
+        }
       }
 
       results.push({


### PR DESCRIPTION
## Problem

`skills remove -a <subset>` deletes the lock entry even though the skill stays installed for the remaining agents.

The canonical path removal is already guarded — it only runs when no other installed agent still links the skill (#287). The lock removal has no such guard, so the skill stays on disk for every other agent while `skills check` and `skills update` stop seeing it entirely. Getting it back under tracking means reinstalling.

Part 1 of #1718.

## Fix

Reuse the existing `isStillUsed` result for the lock removal, on both the global and project paths.

## Tests

`src/remove.test.ts` gains a case that installs a skill for codex and Claude Code, removes it from Claude Code only, then asserts the Claude Code copy is gone, the canonical copy survives, and the lock entry is retained. It fails on `main` with `expected undefined to be defined` and passes with the change.

Agent detection runs against a test-controlled `HOME`, so the case does not depend on which agents happen to be installed on the host.

## Scope

Part 2 of #1718 — `update` re-invoking `add` without `--agent`, which discards per-agent targeting — is not addressed here. That one needs the lock to record target agents, which is a schema question worth settling first; I'll ask on the issue.