### PR TITLE
feat: add Raven agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Skills can be installed to any of these agents:
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
+| Raven | `raven` | `skills/` | `~/.raven/workspace/skills/` |
 | Reasonix | `reasonix` | `.reasonix/skills/` | `~/.reasonix/skills/` |
 | Rovo Dev | `rovodev` | `.rovodev/skills/` | `~/.rovodev/skills/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "qoder",
     "qoder-cn",
     "qwen-code",
+    "raven",
     "replit",
     "reasonix",
     "rovodev",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -60,6 +60,13 @@ export function isKimchiInstalled(
   return pathExists(join(homeDir, '.config', 'kimchi'));
 }
 
+export function isRavenInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  return pathExists(join(homeDir, '.raven'));
+}
+
 export function isMiniMaxCodeInstalled(
   homeDir = home,
   pathExists: (path: string) => boolean = existsSync
@@ -580,6 +587,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.qwen/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.qwen'));
+    },
+  },
+  raven: {
+    name: 'raven',
+    displayName: 'Raven',
+    skillsDir: 'skills',
+    globalSkillsDir: join(home, '.raven', 'workspace', 'skills'),
+    detectInstalled: async () => {
+      return isRavenInstalled();
     },
   },
   replit: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type AgentType =
   | 'qoder'
   | 'qoder-cn'
   | 'qwen-code'
+  | 'raven'
   | 'replit'
   | 'reasonix'
   | 'roo'

--- a/tests/raven-agent.test.ts
+++ b/tests/raven-agent.test.ts
@@ -1,0 +1,58 @@
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { agents, isRavenInstalled } from '../src/agents.ts';
+import { installSkillForAgent } from '../src/installer.ts';
+
+describe('Raven agent support', () => {
+  it('uses the Raven workspace skill directories', () => {
+    expect(agents.raven.name).toBe('raven');
+    expect(agents.raven.displayName).toBe('Raven');
+    expect(agents.raven.skillsDir).toBe('skills');
+    expect(agents.raven.globalSkillsDir).toBe(join(homedir(), '.raven', 'workspace', 'skills'));
+  });
+
+  it('detects Raven from its home directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.raven');
+
+    expect(isRavenInstalled(home, exists)).toBe(true);
+  });
+
+  it('returns false when the Raven home directory is absent', () => {
+    expect(isRavenInstalled('/tmp/home', () => false)).toBe(false);
+  });
+
+  it('copies project skills into the Raven workspace skills directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'raven-agent-'));
+    const workspace = join(root, 'workspace');
+    const source = join(root, 'source');
+    await mkdir(workspace, { recursive: true });
+    await mkdir(source, { recursive: true });
+    await writeFile(
+      join(source, 'SKILL.md'),
+      '---\nname: example\ndescription: Raven test skill\n---\n',
+      'utf-8'
+    );
+
+    try {
+      const result = await installSkillForAgent(
+        { name: 'example', description: 'Raven test skill', path: source },
+        'raven',
+        { cwd: workspace, mode: 'copy' }
+      );
+
+      expect(result).toMatchObject({
+        success: true,
+        path: join(workspace, 'skills', 'example'),
+        mode: 'copy',
+      });
+      await expect(
+        access(join(workspace, 'skills', 'example', 'SKILL.md'))
+      ).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- register [Raven](https://github.com/EverMind-AI/Raven) as a supported agent target
- install project skills into `skills/` and global skills into Raven's default `~/.raven/workspace/skills/`
- detect Raven installations through `~/.raven`
- sync the supported-agent documentation and package keywords
- add coverage for target paths, installation detection, and copy-mode installation

## What this enables

Raven users can install any compatible Agent Skill through the `skills` CLI:

```bash
npx -y skills add tt-a1i/archify \
  --skill archify \
  --agent raven \
  --global \
  --copy \
  --yes
```

The generic CLI source pipeline also supports GitHub/GitLab repositories, arbitrary Git URLs, local paths, well-known skill endpoints, direct `SKILL.md` URLs, and zip/tar archives. Installed files land in Raven's default workspace and are discovered by Raven's existing SkillForge registry.

Users with a custom Raven workspace can run a project-level install from that workspace root:

```bash
cd /path/to/custom-raven-workspace
npx -y skills add <source> --agent raven --copy --yes
```

## Why

Raven discovers file-based skills from `<workspace>/skills/**/SKILL.md`, with `~/.raven/workspace` as its default workspace. Adding a native target lets the generic `skills add` pipeline install directly into the locations Raven already watches, without a Raven-specific downloader.

## Testing

- `vitest run tests/raven-agent.test.ts tests/direct-download-add.test.ts` — 2 files, 6 tests passed
- `tsc --noEmit`
- `node scripts/validate-agents.ts`
- `node scripts/sync-agents.ts`
- `pnpm format:check`
- `pnpm build` with the repository-pinned pnpm version
- isolated-home end-to-end install of Archify into Raven
  - Raven `skill list` and `skill get` discovered the installed skill
  - Archify `doctor` passed
  - Archify generated a working demo HTML
  - uninstall completed and Raven reported no remaining workspace skills

The complete test suite was also exercised after rebasing onto the latest `main`: 753 of 755 tests passed. The two remaining failures are environment-only: `git-lfs` is unavailable while preparing its fixture, and the dist test's nested `pnpm build` resolves a system pnpm version that differs from the repository-pinned version. Running the build directly with the pinned pnpm version succeeds.
