### PR TITLE
fix: install Antigravity global skills into ~/.gemini/config/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [70 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [71 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -244,8 +244,7 @@ Skills can be installed to any of these agents:
 |-------|-----------|--------------|-------------|
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
-| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
-| Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~/.gemini/antigravity-cli/skills/` |
+| Antigravity, Antigravity CLI | `antigravity`, `antigravity-cli` | `.agents/skills/` | `~/.gemini/config/skills/` |
 | AstrBot | `astrbot` | `data/skills/` | `~/.astrbot/data/skills/` |
 | Autohand Code CLI | `autohand-code` | `.autohand/skills/` | `~/.autohand/skills/` |
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -79,11 +79,16 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(configHome, 'amp'));
     },
   },
+  // Antigravity products read workspace skills from `.agents/skills` but are
+  // global-installed into the shared `~/.gemini/config/skills`, so they are not
+  // universal. The per-product `~/.gemini/<product>` paths remain valid presence
+  // probes for detection.
   antigravity: {
     name: 'antigravity',
     displayName: 'Antigravity',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity/skills'),
+    globalSkillsDir: join(home, '.gemini/config/skills'),
+    universal: false,
     detectInstalled: async () => {
       return existsSync(join(home, '.gemini/antigravity'));
     },
@@ -92,7 +97,8 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'antigravity-cli',
     displayName: 'Antigravity CLI',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity-cli/skills'),
+    globalSkillsDir: join(home, '.gemini/config/skills'),
+    universal: false,
     detectInstalled: async () => {
       return existsSync(join(home, '.gemini/antigravity-cli'));
     },
@@ -808,9 +814,7 @@ export function getEveSubagents(cwd: string = process.cwd()): string[] {
  */
 export function getUniversalAgents(): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
-    .filter(
-      ([_, config]) => config.skillsDir === '.agents/skills' && config.showInUniversalList !== false
-    )
+    .filter(([type, config]) => isUniversalAgent(type) && config.showInUniversalList !== false)
     .map(([type]) => type);
 }
 
@@ -821,8 +825,8 @@ export function getUniversalAgents(): AgentType[] {
 export function getVisibleUniversalAgents(): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
     .filter(
-      ([_, config]) =>
-        config.skillsDir === '.agents/skills' &&
+      ([type, config]) =>
+        isUniversalAgent(type) &&
         config.showInUniversalList !== false &&
         config.showInUniversalPrompt !== false
     )
@@ -835,13 +839,15 @@ export function getVisibleUniversalAgents(): AgentType[] {
  */
 export function getNonUniversalAgents(): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
-    .filter(([_, config]) => config.skillsDir !== '.agents/skills')
+    .filter(([type]) => !isUniversalAgent(type))
     .map(([type]) => type);
 }
 
 /**
  * Check if an agent uses the universal .agents/skills directory.
+ * An explicit `universal` flag wins; otherwise it is inferred from skillsDir.
  */
 export function isUniversalAgent(type: AgentType): boolean {
-  return agents[type].skillsDir === '.agents/skills';
+  const config = agents[type];
+  return config.universal ?? config.skillsDir === '.agents/skills';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,16 @@ export interface AgentConfig {
   showInUniversalList?: boolean;
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
+  /**
+   * Whether this agent shares the canonical `.agents/skills` directory for both
+   * workspace and global installs. Defaults to true when `skillsDir` is
+   * `.agents/skills`. Set to `false` for agents that read workspace skills from
+   * `.agents/skills` but keep their own global skills directory (e.g. Antigravity,
+   * which is global-installed into `~/.gemini/config/skills`). Such agents are
+   * symlinked like other non-universal agents instead of sharing the canonical
+   * global directory.
+   */
+  universal?: boolean;
 }
 
 export interface ParsedSource {

--- a/tests/antigravity-agent.test.ts
+++ b/tests/antigravity-agent.test.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { describe, expect, it } from 'vitest';
+import {
+  agents,
+  getNonUniversalAgents,
+  getUniversalAgents,
+  isUniversalAgent,
+} from '../src/agents.ts';
+
+const home = homedir();
+
+describe('Antigravity agent paths', () => {
+  it('installs globally into the shared ~/.gemini/config/skills', () => {
+    expect(agents.antigravity.globalSkillsDir).toBe(join(home, '.gemini/config/skills'));
+    expect(agents['antigravity-cli'].globalSkillsDir).toBe(join(home, '.gemini/config/skills'));
+  });
+
+  it('keeps .agents/skills as the workspace directory', () => {
+    expect(agents.antigravity.skillsDir).toBe('.agents/skills');
+    expect(agents['antigravity-cli'].skillsDir).toBe('.agents/skills');
+  });
+
+  it('is not universal even though it shares the .agents/skills workspace dir', () => {
+    expect(isUniversalAgent('antigravity')).toBe(false);
+    expect(isUniversalAgent('antigravity-cli')).toBe(false);
+    expect(getUniversalAgents()).not.toContain('antigravity');
+    expect(getUniversalAgents()).not.toContain('antigravity-cli');
+    expect(getNonUniversalAgents()).toContain('antigravity');
+    expect(getNonUniversalAgents()).toContain('antigravity-cli');
+  });
+
+  it('still detects each product from its own directory', async () => {
+    const probe = join(tmpdir(), `antigravity-probe-${Date.now()}`);
+    mkdirSync(probe, { recursive: true });
+    try {
+      // detectInstalled reads the real home, so only assert it resolves to a boolean
+      // without throwing; the per-product probe paths are asserted below.
+      await expect(agents.antigravity.detectInstalled()).resolves.toBeTypeOf('boolean');
+      await expect(agents['antigravity-cli'].detectInstalled()).resolves.toBeTypeOf('boolean');
+    } finally {
+      rmSync(probe, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isUniversalAgent', () => {
+  it('still infers universality from skillsDir when no flag is set', () => {
+    expect(agents.codex.universal).toBeUndefined();
+    expect(agents.codex.skillsDir).toBe('.agents/skills');
+    expect(isUniversalAgent('codex')).toBe(true);
+  });
+
+  it('treats agents with their own workspace dir as non-universal', () => {
+    expect(isUniversalAgent('claude-code')).toBe(false);
+  });
+});

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -73,14 +73,18 @@ describe('XDG config paths', () => {
   });
 
   describe('Antigravity CLI', () => {
-    it('uses ~/.gemini/antigravity-cli/skills for global skills', () => {
-      const expected = join(home, '.gemini', 'antigravity-cli', 'skills');
+    it('uses ~/.gemini/config/skills for global skills', () => {
+      const expected = join(home, '.gemini', 'config', 'skills');
       expect(agents['antigravity-cli'].globalSkillsDir).toBe(expected);
     });
 
-    it('uses a distinct global directory from the Antigravity IDE', () => {
+    it('shares the global directory with the other Antigravity products', () => {
+      expect(agents['antigravity-cli'].globalSkillsDir).toBe(agents.antigravity.globalSkillsDir);
+    });
+
+    it('does not use the per-product directory, which nothing reads', () => {
       expect(agents['antigravity-cli'].globalSkillsDir).not.toBe(
-        agents.antigravity.globalSkillsDir
+        join(home, '.gemini', 'antigravity-cli', 'skills')
       );
     });
   });


### PR DESCRIPTION
Fixes Antigravity global installs, which currently land in per-product directories that no Antigravity surface reads. Skills installed with `-g` are invisible to the agent.

This is the same bug as #1483. That PR has been open since June 21, is now conflicting with `main`, and fixes only the `antigravity` entry — `antigravity-cli` still points at `~/.gemini/antigravity-cli/skills` there, so `agy` stays broken after it. I verified that on the branch and left the details in #1483. This PR rebases the idea onto current `main` and covers both entries. Credit for the diagnosis and the `universal` flag approach goes to @tahatariq19 in #1483; happy to close this if that one gets rebased and extended instead.

## What was wrong

**1. Wrong global directory.** The three Antigravity products consolidated on a shared customization root. The global skills directory is `~/.gemini/config/skills`, not the per-product paths.

Evidence from the Antigravity CLI binary (`agy` 1.1.7), which embeds its customization docs:

```
3.  **Global Configuration** (Machine-Local):
    *   Path: `~/.gemini/config/`
    *   Applies to all projects and workspaces run on your machine.
```

```
   - Location: "skills/<skill_name>/" (relative to the customization root).
```

String counts over that binary:

```
gemini/config            5 hits
antigravity-cli/skills   0 hits
antigravity/skills       0 hits
.agents/skills           8 hits    (workspace root — matches skillsDir, unchanged here)
```

The per-product directories appear nowhere in the binary. This matches the reports in #1470 for Antigravity 2.0 and the IDE.

**2. Misclassified as universal.** `isUniversalAgent` inferred universality from `skillsDir === '.agents/skills'`. Antigravity uses that directory for *workspace* skills but keeps its own *global* directory, so it was treated as universal — and universal agents skip `globalSkillsDir` entirely, dumping everything into `~/.agents/skills`.

## Changes

- `antigravity` and `antigravity-cli` install globally into `~/.gemini/config/skills`.
- New optional `universal` flag on `AgentConfig`. It defaults to the previous inference (`skillsDir === '.agents/skills'`), so every other agent behaves exactly as before; only Antigravity opts out.
- `getUniversalAgents`, `getVisibleUniversalAgents` and `getNonUniversalAgents` now route through `isUniversalAgent` instead of re-deriving the rule, so the flag is honored everywhere.
- `detectInstalled` is unchanged — `~/.gemini/antigravity` and `~/.gemini/antigravity-cli` remain valid presence probes; only the install target moved.
- README agent table regenerated with `scripts/sync-agents.ts` (the two rows merge, since they now share a path).

## Verification

```
pnpm type-check                       clean
pnpm test --run                       678 passed
node scripts/validate-agents.ts       All agents valid.
```

`src/detect-agent.test.ts` reports 3 failures in my environment, but those reproduce on a clean checkout of `main` — they are unrelated to this change (the harness I ran in is itself detected as an agent).

New `tests/antigravity-agent.test.ts` covers the paths, the non-universal classification, and that inference still holds for agents without the flag. `tests/xdg-config-paths.test.ts` had two assertions encoding the old per-product path; they are updated to the shared path, plus one asserting the old directory is no longer used.

End-to-end with an isolated `HOME` containing both `~/.gemini/antigravity/` and `~/.gemini/antigravity-cli/`:

```bash
HOME=/tmp/fh node src/cli.ts add <owner>/<repo> -a antigravity     -s '*' -g -y
HOME=/tmp/fh node src/cli.ts add <owner>/<repo> -a antigravity-cli -s '*' -g -y
```

| agent | before | after |
| --- | --- | --- |
| `antigravity` | `~/.gemini/antigravity/skills/<skill>` | `~/.gemini/config/skills/<skill>` |
| `antigravity-cli` | `~/.gemini/antigravity-cli/skills/<skill>` | `~/.gemini/config/skills/<skill>` |

## Out of scope

#1483 also adds a new `antigravity-ide` agent entry. I left that out: I do not run the IDE and could not verify it. @tahatariq19 reported in #1470 that on Windows the IDE also responds to `~/.gemini/config/skills/`, which would make a separate entry either unnecessary or a third alias for the same directory. Worth settling with someone who can test the IDE before adding it.

Refs #1470
