### PR TITLE
fix(check): report updates without modifying installed skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,15 @@ When installing interactively, you can choose:
 
 ## Other Commands
 
-| Command                      | Description                                   |
-| ---------------------------- | --------------------------------------------- |
-| `npx skills use <source>`    | Use one skill without installing              |
-| `npx skills list`            | List installed skills (alias: `ls`)           |
-| `npx skills find [query]`    | Search for skills interactively or by keyword |
-| `npx skills remove [skills]` | Remove installed skills from agents           |
-| `npx skills update [skills]` | Update installed skills to latest versions    |
-| `npx skills init [name]`     | Create a new SKILL.md template                |
+| Command                      | Description                                    |
+| ---------------------------- | ---------------------------------------------- |
+| `npx skills use <source>`    | Use one skill without installing               |
+| `npx skills list`            | List installed skills (alias: `ls`)            |
+| `npx skills find [query]`    | Search for skills interactively or by keyword  |
+| `npx skills remove [skills]` | Remove installed skills from agents            |
+| `npx skills check [skills]`  | Check for available updates without installing |
+| `npx skills update [skills]` | Update installed skills to latest versions     |
+| `npx skills init [name]`     | Create a new SKILL.md template                 |
 
 ### `skills list`
 
@@ -171,9 +172,19 @@ npx skills find typescript
 npx skills find react --owner vercel
 ```
 
-### `skills update`
+### `skills check` / `skills update`
 
 ```bash
+# Check for updates without modifying installed skills
+npx skills check
+
+# Check only global or project skills
+npx skills check -g
+npx skills check -p
+
+# Check both global and project skills
+npx skills check -g -p
+
 # Update all skills (interactive scope prompt)
 npx skills update
 
@@ -193,10 +204,10 @@ npx skills update -y
 
 | Option          | Description                                                               |
 | --------------- | ------------------------------------------------------------------------- |
-| `-g, --global`  | Only update global skills                                                 |
-| `-p, --project` | Only update project skills                                                |
+| `-g, --global`  | Only check or update global skills                                        |
+| `-p, --project` | Only check or update project skills                                       |
 | `-y, --yes`     | Skip scope prompt (auto-detect: project if in a project dir, else global) |
-| `[skills...]`   | Update specific skills by name instead of all                             |
+| `[skills...]`   | Check or update specific skills by name instead of all                    |
 
 ### `skills init`
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -12,6 +12,7 @@ describe('skills CLI', () => {
       expect(output).toContain('init [name]');
       expect(output).toContain('add <package>');
       expect(output).toContain('use <package>@<skill>');
+      expect(output).toContain('check [skills...]');
       expect(output).toContain('update');
       expect(output).toContain('Add Options:');
       expect(output).toContain('Use Options:');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,11 +120,12 @@ ${BOLD}Find Options:${RESET}
   --owner <owner>        Search only repositories from a GitHub owner
 
 ${BOLD}Updates:${RESET}
+  check [skills...]    Check for available skill updates without installing them
   update [skills...]   Update skills to latest versions (alias: upgrade)
 
-${BOLD}Update Options:${RESET}
-  -g, --global           Update global skills only
-  -p, --project          Update project skills only
+${BOLD}Check/Update Options:${RESET}
+  -g, --global           Use global skills only
+  -p, --project          Use project skills only
   -y, --yes              Skip scope prompt (auto-detect: project if in a project, else global)
 
 ${BOLD}Project:${RESET}
@@ -391,6 +392,8 @@ async function main(): Promise<void> {
       await runList(restArgs);
       break;
     case 'check':
+      await runUpdate(restArgs, 'check');
+      break;
     case 'update':
     case 'upgrade':
       await runUpdate(restArgs);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -429,7 +429,7 @@ const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
   return false;
 };
 
-function stripIgnoredEveFrontmatter(raw: string): string {
+export function stripIgnoredEveFrontmatter(raw: string): string {
   const { data, content } = parseFrontmatter(raw);
   const eveData: Record<string, unknown> = {};
 

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -142,9 +142,17 @@ function getPortableLocalSource(source: string, lockDir: string): string {
  * Reads all files recursively, sorts them by relative path for determinism,
  * and produces a single hash from their concatenated contents.
  */
-export async function computeSkillFolderHash(skillDir: string): Promise<string> {
+export interface SkillFolderHashOptions {
+  exclude?: (name: string, isDirectory: boolean) => boolean;
+  transform?: (relativePath: string, content: Buffer) => Buffer;
+}
+
+export async function computeSkillFolderHash(
+  skillDir: string,
+  options: SkillFolderHashOptions = {}
+): Promise<string> {
   const files: Array<{ relativePath: string; content: Buffer }> = [];
-  await collectFiles(skillDir, skillDir, files);
+  await collectFiles(skillDir, skillDir, files, options);
 
   // Sort by relative path for deterministic hashing
   files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
@@ -153,7 +161,7 @@ export async function computeSkillFolderHash(skillDir: string): Promise<string> 
   for (const file of files) {
     // Include the path in the hash so renames are detected
     hash.update(file.relativePath);
-    hash.update(file.content);
+    hash.update(options.transform?.(file.relativePath, file.content) ?? file.content);
   }
 
   return hash.digest('hex');
@@ -162,18 +170,21 @@ export async function computeSkillFolderHash(skillDir: string): Promise<string> 
 async function collectFiles(
   baseDir: string,
   currentDir: string,
-  results: Array<{ relativePath: string; content: Buffer }>
+  results: Array<{ relativePath: string; content: Buffer }>,
+  options: SkillFolderHashOptions
 ): Promise<void> {
   const entries = await readdir(currentDir, { withFileTypes: true });
 
   await Promise.all(
     entries.map(async (entry) => {
+      if (options.exclude?.(entry.name, entry.isDirectory())) return;
+
       const fullPath = join(currentDir, entry.name);
 
       if (entry.isDirectory()) {
         // Skip .git and node_modules within skill dirs
         if (entry.name === '.git' || entry.name === 'node_modules') return;
-        await collectFiles(baseDir, fullPath, results);
+        await collectFiles(baseDir, fullPath, results, options);
       } else if (entry.isFile()) {
         const content = await readFile(fullPath);
         const relativePath = relative(baseDir, fullPath).split('\\').join('/');

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -38,6 +38,13 @@ interface UpdateTelemetryData {
   failCount: string;
 }
 
+interface CheckTelemetryData {
+  event: 'check';
+  scope?: string;
+  skillCount: string;
+  updatesAvailable: string;
+}
+
 interface FindTelemetryData {
   event: 'find';
   query: string;
@@ -55,6 +62,7 @@ interface SyncTelemetryData {
 type TelemetryData =
   | InstallTelemetryData
   | RemoveTelemetryData
+  | CheckTelemetryData
   | UpdateTelemetryData
   | FindTelemetryData
   | SyncTelemetryData;

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
-import { join, dirname, relative, sep } from 'path';
+import { join, dirname, relative, sep, basename } from 'path';
 import { fileURLToPath } from 'url';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
@@ -21,7 +21,8 @@ import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/inde
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
-import { agents, isUniversalAgent } from './agents.ts';
+import { getEveSubagentSkillsDir, sanitizeName, stripIgnoredEveFrontmatter } from './installer.ts';
+import { agents, getEveSubagents, isUniversalAgent } from './agents.ts';
 import type { AgentType } from './types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -41,6 +42,7 @@ export interface UpdateCheckOptions {
   global?: boolean;
   project?: boolean;
   yes?: boolean;
+  checkOnly?: boolean;
   /** Optional skill name(s) to filter on (positional args) */
   skills?: string[];
 }
@@ -115,15 +117,16 @@ export function hasProjectSkills(cwd?: string): boolean {
  * Determine the update/check scope via interactive prompt or auto-detection.
  */
 export async function resolveUpdateScope(options: UpdateCheckOptions): Promise<UpdateScope> {
+  if (options.global && options.project) {
+    return 'both';
+  }
+
   if (options.skills && options.skills.length > 0) {
     if (options.global) return 'global';
     if (options.project) return 'project';
     return 'both';
   }
 
-  if (options.global && options.project) {
-    return 'both';
-  }
   if (options.global) {
     return 'global';
   }
@@ -135,23 +138,24 @@ export async function resolveUpdateScope(options: UpdateCheckOptions): Promise<U
     return hasProjectSkills() ? 'project' : 'global';
   }
 
+  const action = options.checkOnly ? 'Check' : 'Update';
   const scope = await p.select({
-    message: 'Update scope',
+    message: `${action} scope`,
     options: [
       {
         value: 'project' as UpdateScope,
         label: 'Project',
-        hint: 'Update skills in current directory',
+        hint: `${action} skills in current directory`,
       },
       {
         value: 'global' as UpdateScope,
         label: 'Global',
-        hint: 'Update skills in home directory',
+        hint: `${action} skills in home directory`,
       },
       {
         value: 'both' as UpdateScope,
         label: 'Both',
-        hint: 'Update all skills',
+        hint: `${action} all skills`,
       },
     ],
   });
@@ -168,6 +172,62 @@ export function matchesSkillFilter(name: string, filter?: string[]): boolean {
   if (!filter || filter.length === 0) return true;
   const lower = name.toLowerCase();
   return filter.some((f) => f.toLowerCase() === lower);
+}
+
+function sourceRefKey(source: string, ref?: string): string {
+  return JSON.stringify([source, ref ?? null]);
+}
+
+function sameRef(left?: string, right?: string): boolean {
+  return (left ?? null) === (right ?? null);
+}
+
+function getInstalledProjectSkillPaths(
+  skillName: string,
+  entry: LocalSkillLockEntry,
+  cwd: string
+): Array<{ path: string; eve: boolean }> {
+  const sanitized = sanitizeName(skillName);
+  const candidates = new Map<string, { path: string; eve: boolean }>();
+
+  const add = (base: string, eve: boolean) => {
+    const path = join(base, sanitized);
+    if (existsSync(path)) {
+      candidates.set(path, { path, eve });
+    }
+  };
+
+  add(join(cwd, '.agents', 'skills'), false);
+
+  for (const [agentType, config] of Object.entries(agents)) {
+    add(join(cwd, config.skillsDir), agentType === 'eve');
+  }
+
+  const eveSubagents = new Set([
+    ...getEveSubagents(cwd),
+    ...(entry.subagents ?? []).filter((name) => name !== ''),
+  ]);
+  for (const subagent of eveSubagents) {
+    add(getEveSubagentSkillsDir(subagent, cwd), true);
+  }
+
+  return [...candidates.values()];
+}
+
+const INSTALLED_SKILL_EXCLUDES = new Set(['metadata.json']);
+const INSTALLED_SKILL_DIR_EXCLUDES = new Set(['.git', '__pycache__', '__pypackages__']);
+
+function expectedInstalledHashOptions(eve: boolean) {
+  return {
+    exclude: (name: string, isDirectory: boolean) =>
+      INSTALLED_SKILL_EXCLUDES.has(name) || (isDirectory && INSTALLED_SKILL_DIR_EXCLUDES.has(name)),
+    transform: eve
+      ? (relativePath: string, content: Buffer) =>
+          basename(relativePath).toLowerCase() === 'skill.md'
+            ? Buffer.from(stripIgnoredEveFrontmatter(content.toString('utf-8')))
+            : content
+      : undefined,
+  };
 }
 
 export interface SkippedSkill {
@@ -268,6 +328,8 @@ export async function promptDeletions(
   for (const s of deletedSkills) {
     console.log(`  ${DIM}•${RESET} ${s}`);
   }
+
+  if (options.checkOnly) return;
 
   const isNonInteractive = options.yes || !process.stdin.isTTY;
 
@@ -397,10 +459,11 @@ export async function processWellKnownUpdates(
   groups: Map<string, WellKnownUpdateItem[]>,
   isGlobal: boolean,
   options: UpdateCheckOptions
-): Promise<{ successCount: number; failCount: number; changed: boolean }> {
+): Promise<{ successCount: number; failCount: number; changed: boolean; updateCount: number }> {
   let successCount = 0;
   let failCount = 0;
   let changed = false;
+  let updateCount = 0;
 
   for (const [baseUrl, items] of groups) {
     process.stdout.write(`\r${DIM}Checking skills from source: ${baseUrl}${RESET}\x1b[K\n`);
@@ -409,6 +472,7 @@ export async function processWellKnownUpdates(
 
     if (result.status === 'error') {
       console.log(`  ${DIM}✗ Failed to check skills from ${baseUrl}${RESET}`);
+      if (options.checkOnly) failCount += items.length;
       continue;
     }
 
@@ -423,6 +487,18 @@ export async function processWellKnownUpdates(
     printNewSkills(baseUrl, result.newSkills, isGlobal);
 
     if (result.changedSkills.length === 0) continue;
+    updateCount += result.changedSkills.length;
+
+    if (options.checkOnly) {
+      console.log(
+        `${TEXT}${result.changedSkills.length} ${isGlobal ? 'global' : 'project'} update(s) available:${RESET}`
+      );
+      for (const name of result.changedSkills) {
+        console.log(`  ${TEXT}↑${RESET} ${sanitizeMetadata(name)}`);
+        console.log(`    ${DIM}source: ${sanitizeMetadata(baseUrl)}${RESET}`);
+      }
+      continue;
+    }
 
     const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
     if (!existsSync(cliEntry)) {
@@ -472,23 +548,27 @@ export async function processWellKnownUpdates(
     }
   }
 
-  return { successCount, failCount, changed };
+  return { successCount, failCount, changed, updateCount };
 }
 
-export async function updateGlobalSkills(
-  options: UpdateCheckOptions = {}
-): Promise<{ successCount: number; failCount: number; checkedCount: number }> {
+export async function updateGlobalSkills(options: UpdateCheckOptions = {}): Promise<{
+  successCount: number;
+  failCount: number;
+  checkedCount: number;
+  updateCount: number;
+}> {
   const lock = await readSkillLock();
   const skillNames = Object.keys(lock.skills);
   let successCount = 0;
   let failCount = 0;
+  let deletedCount = 0;
 
   if (skillNames.length === 0) {
     if (!options.skills) {
       console.log(`${DIM}No global skills tracked in lock file.${RESET}`);
       console.log(`${DIM}Install skills with${RESET} ${TEXT}npx skills add <package> -g${RESET}`);
     }
-    return { successCount, failCount, checkedCount: 0 };
+    return { successCount, failCount, checkedCount: 0, updateCount: 0 };
   }
 
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
@@ -531,19 +611,21 @@ export async function updateGlobalSkills(
     successCount: wkSuccessCount,
     failCount: wkFailCount,
     changed: wkChanged,
+    updateCount: wkUpdateCount,
   } = await processWellKnownUpdates(wellKnownGroups, true, options);
   successCount += wkSuccessCount;
   failCount += wkFailCount;
 
-  const bySource = new Map<string, typeof checkable>();
+  const bySource = new Map<string, { source: string; ref?: string; items: typeof checkable }>();
   for (const item of checkable) {
     const source = item.entry.source;
-    const existing = bySource.get(source) || [];
-    existing.push(item);
-    bySource.set(source, existing);
+    const key = sourceRefKey(source, item.entry.ref);
+    const group = bySource.get(key) || { source, ref: item.entry.ref, items: [] };
+    group.items.push(item);
+    bySource.set(key, group);
   }
 
-  for (const [source, itemsForSource] of bySource) {
+  for (const { source, ref, items: itemsForSource } of bySource.values()) {
     const firstEntry = itemsForSource[0]!.entry;
     const sourceUrl = firstEntry.sourceUrl || firstEntry.source;
     let tempDir: string | null = null;
@@ -562,7 +644,7 @@ export async function updateGlobalSkills(
             .map((entry) => entry.path);
 
           const allLockedForSource = Object.entries(lock.skills)
-            .filter(([_, entry]) => entry.source === source)
+            .filter(([_, entry]) => entry.source === source && sameRef(entry.ref, ref))
             .map(([name, _]) => name);
 
           const deletedSkills = await checkAndPromptForDeletions(
@@ -573,6 +655,7 @@ export async function updateGlobalSkills(
             options,
             discoveredPaths
           );
+          deletedCount += deletedSkills.length;
 
           const deletedSkillSet = new Set(deletedSkills);
 
@@ -599,7 +682,7 @@ export async function updateGlobalSkills(
       );
 
       const allLockedForSource = Object.entries(lock.skills)
-        .filter(([_, entry]) => entry.source === source)
+        .filter(([_, entry]) => entry.source === source && sameRef(entry.ref, ref))
         .map(([name, _]) => name);
 
       const deletedSkills = await checkAndPromptForDeletions(
@@ -610,6 +693,7 @@ export async function updateGlobalSkills(
         options,
         discoveredPaths
       );
+      deletedCount += deletedSkills.length;
 
       const deletedSkillSet = new Set(deletedSkills);
 
@@ -629,6 +713,9 @@ export async function updateGlobalSkills(
       }
     } catch (error) {
       console.log(`  ${DIM}✗ Failed to check skills from ${source}${RESET}`);
+      if (options.checkOnly) {
+        failCount += itemsForSource.length;
+      }
     } finally {
       if (tempDir) await cleanupTempDir(tempDir);
     }
@@ -644,26 +731,44 @@ export async function updateGlobalSkills(
     if (!options.skills) {
       console.log(`${DIM}No global skills to check.${RESET}`);
     }
-    return { successCount, failCount, checkedCount: 0 };
+    return { successCount, failCount, checkedCount: 0, updateCount: 0 };
   }
 
   if (checkable.length === 0 && skipped.length === 0) {
-    if (!wkChanged) {
+    if (!wkChanged && (!options.checkOnly || failCount === 0)) {
       console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
     }
-    return { successCount, failCount, checkedCount };
+    return { successCount, failCount, checkedCount, updateCount: wkUpdateCount };
   }
 
   if (checkable.length === 0 && skipped.length > 0) {
     printSkippedSkills(skipped);
-    return { successCount, failCount, checkedCount };
+    return { successCount, failCount, checkedCount, updateCount: wkUpdateCount };
   }
 
   if (updates.length === 0) {
-    if (!wkChanged) {
+    if (!wkChanged && (!options.checkOnly || (failCount === 0 && deletedCount === 0))) {
       console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
     }
-    return { successCount, failCount, checkedCount };
+    if (options.checkOnly) {
+      printSkippedSkills(skipped);
+    }
+    return { successCount, failCount, checkedCount, updateCount: wkUpdateCount };
+  }
+
+  if (options.checkOnly) {
+    console.log(`${TEXT}${updates.length} global update(s) available:${RESET}`);
+    for (const update of updates) {
+      console.log(`  ${TEXT}↑${RESET} ${sanitizeMetadata(update.name)}`);
+      console.log(`    ${DIM}source: ${sanitizeMetadata(update.source)}${RESET}`);
+    }
+    printSkippedSkills(skipped);
+    return {
+      successCount,
+      failCount,
+      checkedCount,
+      updateCount: updates.length + wkUpdateCount,
+    };
   }
 
   console.log(`${TEXT}Found ${updates.length} global update(s)${RESET}`);
@@ -716,24 +821,34 @@ export async function updateGlobalSkills(
   }
 
   printSkippedSkills(skipped);
-  return { successCount, failCount, checkedCount };
+  return {
+    successCount,
+    failCount,
+    checkedCount,
+    updateCount: updates.length + wkUpdateCount,
+  };
 }
 
-export async function updateProjectSkills(
-  options: UpdateCheckOptions = {}
-): Promise<{ successCount: number; failCount: number; foundCount: number }> {
+export async function updateProjectSkills(options: UpdateCheckOptions = {}): Promise<{
+  successCount: number;
+  failCount: number;
+  foundCount: number;
+  updateCount: number;
+}> {
   const projectSkills = await getProjectSkillsForUpdate(options.skills);
   let successCount = 0;
   let failCount = 0;
+  let deletedCount = 0;
+  const updates: Array<{ name: string; source: string }> = [];
 
   if (projectSkills.length === 0) {
     if (!options.skills) {
-      console.log(`${DIM}No project skills to update.${RESET}`);
+      console.log(`${DIM}No project skills to ${options.checkOnly ? 'check' : 'update'}.${RESET}`);
       console.log(
         `${DIM}Install project skills with${RESET} ${TEXT}npx skills add <package>${RESET}`
       );
     }
-    return { successCount, failCount, foundCount: 0 };
+    return { successCount, failCount, foundCount: 0, updateCount: 0 };
   }
 
   const wellKnownGroups = new Map<string, WellKnownUpdateItem[]>();
@@ -763,7 +878,7 @@ export async function updateProjectSkills(
   if (updatable.length === 0 && wellKnownCount === 0) {
     console.log(`${DIM}No project skills can be updated in place.${RESET}`);
     printLegacyProjectSkills(legacy);
-    return { successCount, failCount, foundCount: projectSkills.length };
+    return { successCount, failCount, foundCount: projectSkills.length, updateCount: 0 };
   }
 
   const cwd = process.cwd();
@@ -787,48 +902,54 @@ export async function updateProjectSkills(
   if (hasUniversal) targetParts.push('Universal');
   targetParts.push(...targetAgentNames);
 
-  if (targetParts.length > 0) {
+  if (!options.checkOnly && targetParts.length > 0) {
     console.log(`${TEXT}Updating for: ${targetParts.join(', ')}${RESET}`);
   }
 
-  console.log(`${TEXT}Refreshing ${updatable.length + wellKnownCount} skill(s)…${RESET}`);
-  console.log();
+  if (!options.checkOnly) {
+    console.log(`${TEXT}Refreshing ${updatable.length + wellKnownCount} skill(s)…${RESET}`);
+    console.log();
+  }
 
-  const { successCount: wkSuccessCount, failCount: wkFailCount } = await processWellKnownUpdates(
-    wellKnownGroups,
-    false,
-    options
-  );
+  const {
+    successCount: wkSuccessCount,
+    failCount: wkFailCount,
+    changed: wkChanged,
+    updateCount: wkUpdateCount,
+  } = await processWellKnownUpdates(wellKnownGroups, false, options);
   successCount += wkSuccessCount;
   failCount += wkFailCount;
 
-  const bySource = new Map<string, typeof updatable>();
+  const bySource = new Map<string, { source: string; ref?: string; items: typeof updatable }>();
   for (const skill of updatable) {
     const source = skill.entry.sourceUrl || skill.entry.source;
-    const existing = bySource.get(source) || [];
-    existing.push(skill);
-    bySource.set(source, existing);
+    const key = sourceRefKey(source, skill.entry.ref);
+    const group = bySource.get(key) || { source, ref: skill.entry.ref, items: [] };
+    group.items.push(skill);
+    bySource.set(key, group);
   }
 
   const localLock = await readLocalLock();
   const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
 
-  if (updatable.length > 0 && !existsSync(cliEntry)) {
+  if (!options.checkOnly && updatable.length > 0 && !existsSync(cliEntry)) {
     console.log(`${DIM}✗ CLI entrypoint not found at ${cliEntry}${RESET}`);
     return {
       successCount,
       failCount: failCount + updatable.length,
       foundCount: projectSkills.length,
+      updateCount: wkUpdateCount,
     };
   }
 
-  for (const [source, skillsForSource] of bySource) {
+  for (const { source, ref, items: skillsForSource } of bySource.values()) {
     const firstEntry = skillsForSource[0]!.entry;
     const cloneSource = buildLocalCloneSource(firstEntry);
-    const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)
-      .filter(([_, entry]) => (entry.sourceUrl || entry.source) === source)
+      .filter(
+        ([_, entry]) => (entry.sourceUrl || entry.source) === source && sameRef(entry.ref, ref)
+      )
       .map(([name, _]) => name);
 
     let tempDir: string | null = null;
@@ -837,7 +958,7 @@ export async function updateProjectSkills(
     if (cloneSource === null) {
       failCount += skillsForSource.length;
       console.log(
-        `${DIM}✗ Cannot update ${source}: skills-lock.json is missing sourceUrl for this generic Git source${RESET}`
+        `${DIM}✗ Cannot ${options.checkOnly ? 'check' : 'update'} ${source}: skills-lock.json is missing sourceUrl for this generic Git source${RESET}`
       );
       continue;
     }
@@ -859,13 +980,68 @@ export async function updateProjectSkills(
         options,
         discoveredPaths
       );
+      deletedCount += deletedSkills.length;
+
+      if (options.checkOnly) {
+        const remainingSkills = skillsForSource.filter(
+          (skill) => !deletedSkills.includes(skill.name)
+        );
+        for (const skill of remainingSkills) {
+          try {
+            const skillPath = skill.entry.skillPath!;
+            if (!discoveredPaths.includes(skillPath)) continue;
+
+            const installedPaths = getInstalledProjectSkillPaths(skill.name, skill.entry, cwd);
+            if (installedPaths.length === 0) {
+              failCount++;
+              console.log(
+                `  ${DIM}✗ Cannot check ${sanitizeMetadata(skill.name)}: no installed copy found${RESET}`
+              );
+              continue;
+            }
+
+            const expectedHashes = new Map<boolean, string>();
+            let changed = false;
+            for (const installed of installedPaths) {
+              let expectedHash = expectedHashes.get(installed.eve);
+              if (!expectedHash) {
+                expectedHash = await computeSkillFolderHash(
+                  join(tempDir, dirname(skillPath)),
+                  expectedInstalledHashOptions(installed.eve)
+                );
+                expectedHashes.set(installed.eve, expectedHash);
+              }
+              const installedHash = await computeSkillFolderHash(installed.path);
+              if (expectedHash !== installedHash) {
+                changed = true;
+                break;
+              }
+            }
+            if (changed) {
+              updates.push({ name: skill.name, source });
+            }
+          } catch {
+            failCount++;
+            console.log(`  ${DIM}✗ Failed to check ${sanitizeMetadata(skill.name)}${RESET}`);
+          }
+        }
+      }
     } catch (error) {
-      console.log(`${DIM}✗ Failed to check for deleted skills from ${source}${RESET}`);
+      console.log(
+        `${DIM}✗ ${
+          options.checkOnly ? 'Failed to check skills' : 'Failed to check for deleted skills'
+        } from ${source}${RESET}`
+      );
+      if (options.checkOnly) {
+        failCount += skillsForSource.length;
+      }
     } finally {
       if (tempDir) {
         await cleanupTempDir(tempDir);
       }
     }
+
+    if (options.checkOnly) continue;
 
     const remainingSkills = skillsForSource.filter((s) => !deletedSkills.includes(s.name));
 
@@ -922,8 +1098,26 @@ export async function updateProjectSkills(
     }
   }
 
+  if (options.checkOnly) {
+    const totalUpdateCount = updates.length + wkUpdateCount;
+    if (!wkChanged && totalUpdateCount === 0 && failCount === 0 && deletedCount === 0) {
+      console.log(`${TEXT}✓ All project skills are up to date${RESET}`);
+    } else if (updates.length > 0) {
+      console.log(`${TEXT}${updates.length} project update(s) available:${RESET}`);
+      for (const update of updates) {
+        console.log(`  ${TEXT}↑${RESET} ${sanitizeMetadata(update.name)}`);
+        console.log(`    ${DIM}source: ${sanitizeMetadata(update.source)}${RESET}`);
+      }
+    }
+  }
+
   printLegacyProjectSkills(legacy);
-  return { successCount, failCount, foundCount: projectSkills.length };
+  return {
+    successCount,
+    failCount,
+    foundCount: projectSkills.length,
+    updateCount: updates.length + wkUpdateCount,
+  };
 }
 
 export function printLegacyProjectSkills(
@@ -947,11 +1141,16 @@ export function printLegacyProjectSkills(
   }
 }
 
-export async function runUpdate(args: string[] = []): Promise<void> {
-  const options = parseUpdateOptions(args);
+export async function runUpdate(
+  args: string[] = [],
+  mode: 'check' | 'update' = 'update'
+): Promise<void> {
+  const options = { ...parseUpdateOptions(args), checkOnly: mode === 'check' };
   const scope = await resolveUpdateScope(options);
 
-  if (options.skills) {
+  if (options.checkOnly) {
+    console.log(`${TEXT}Checking for skill updates…${RESET}`);
+  } else if (options.skills) {
     console.log(`${TEXT}Updating ${options.skills.join(', ')}…${RESET}`);
   } else {
     console.log(`${TEXT}Checking for skill updates…${RESET}`);
@@ -961,15 +1160,18 @@ export async function runUpdate(args: string[] = []): Promise<void> {
   let totalSuccess = 0;
   let totalFail = 0;
   let totalFound = 0;
+  let totalUpdates = 0;
 
   if (scope === 'global' || scope === 'both') {
     if (scope === 'both' && !options.skills) {
       console.log(`${BOLD}Global Skills${RESET}`);
     }
-    const { successCount, failCount, checkedCount } = await updateGlobalSkills(options);
+    const { successCount, failCount, checkedCount, updateCount } =
+      await updateGlobalSkills(options);
     totalSuccess += successCount;
     totalFail += failCount;
     totalFound += checkedCount;
+    totalUpdates += updateCount;
     if (scope === 'both' && !options.skills) {
       console.log();
     }
@@ -979,10 +1181,11 @@ export async function runUpdate(args: string[] = []): Promise<void> {
     if (scope === 'both' && !options.skills) {
       console.log(`${BOLD}Project Skills${RESET}`);
     }
-    const { successCount, failCount, foundCount } = await updateProjectSkills(options);
+    const { successCount, failCount, foundCount, updateCount } = await updateProjectSkills(options);
     totalSuccess += successCount;
     totalFail += failCount;
     totalFound += foundCount;
+    totalUpdates += updateCount;
   }
 
   if (options.skills && totalFound === 0) {
@@ -994,17 +1197,28 @@ export async function runUpdate(args: string[] = []): Promise<void> {
     console.log(`${TEXT}✓ Updated ${totalSuccess} skill(s)${RESET}`);
   }
   if (totalFail > 0) {
-    console.log(`${DIM}Failed to update ${totalFail} skill(s)${RESET}`);
+    console.log(
+      `${DIM}Failed to ${options.checkOnly ? 'check' : 'update'} ${totalFail} skill(s)${RESET}`
+    );
     process.exitCode = 1;
   }
 
-  track({
-    event: 'update',
-    scope,
-    skillCount: String(totalSuccess + totalFail),
-    successCount: String(totalSuccess),
-    failCount: String(totalFail),
-  });
+  if (options.checkOnly) {
+    track({
+      event: 'check',
+      scope,
+      skillCount: String(totalFound),
+      updatesAvailable: String(totalUpdates),
+    });
+  } else {
+    track({
+      event: 'update',
+      scope,
+      skillCount: String(totalSuccess + totalFail),
+      successCount: String(totalSuccess),
+      failCount: String(totalFail),
+    });
+  }
 
   console.log();
 }

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -387,6 +387,30 @@ describe('local-lock', () => {
       }
     });
 
+    it('can hash the representation written by an installer', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        const sourceDir = join(dir, 'source');
+        const installedDir = join(dir, 'installed');
+        await mkdir(sourceDir, { recursive: true });
+        await mkdir(installedDir, { recursive: true });
+        await writeFile(join(sourceDir, 'SKILL.md'), 'source content', 'utf-8');
+        await writeFile(join(sourceDir, 'metadata.json'), '{}', 'utf-8');
+        await writeFile(join(installedDir, 'SKILL.md'), 'installed content', 'utf-8');
+
+        const sourceHash = await computeSkillFolderHash(sourceDir, {
+          exclude: (name) => name === 'metadata.json',
+          transform: (path, content) =>
+            path === 'SKILL.md' ? Buffer.from('installed content') : content,
+        });
+        const installedHash = await computeSkillFolderHash(installedDir);
+
+        expect(sourceHash).toBe(installedHash);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
     it('changes when a file is added', async () => {
       const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
       try {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,14 +1,20 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'child_process';
-import { updateProjectSkills, updateGlobalSkills, runUpdate } from '../src/update.ts';
+import {
+  resolveUpdateScope,
+  updateProjectSkills,
+  updateGlobalSkills,
+  runUpdate,
+} from '../src/update.ts';
 import * as git from '../src/git.ts';
 import * as skills from '../src/skills.ts';
 import * as blob from '../src/blob.ts';
 import * as localLock from '../src/local-lock.ts';
 import * as skillLock from '../src/skill-lock.ts';
 import * as remove from '../src/remove.ts';
+import * as installer from '../src/installer.ts';
 import * as p from '@clack/prompts';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 // Mock dependencies
@@ -18,6 +24,7 @@ vi.mock('../src/blob.ts');
 vi.mock('../src/local-lock.ts');
 vi.mock('../src/skill-lock.ts');
 vi.mock('../src/remove.ts');
+vi.mock('../src/installer.ts');
 vi.mock('@clack/prompts');
 
 // Mock fs to prevent actual file checks during test
@@ -74,6 +81,9 @@ describe('Update Cleanup Unit Tests', () => {
     vi.clearAllMocks();
     process.exitCode = undefined;
     process.env.DISABLE_TELEMETRY = '1';
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(installer.sanitizeName).mockImplementation((name) => name);
+    vi.mocked(installer.stripIgnoredEveFrontmatter).mockImplementation((content) => content);
     // Default mock for isTTY
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
@@ -86,6 +96,122 @@ describe('Update Cleanup Unit Tests', () => {
   });
 
   describe('updateProjectSkills', () => {
+    it('reports project updates without reinstalling skills in check mode', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'old-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash)
+        .mockResolvedValueOnce('new-hash')
+        .mockResolvedValueOnce('old-hash');
+
+      const result = await updateProjectSkills({ checkOnly: true, yes: true });
+
+      expect(result.updateCount).toBe(1);
+      expect(git.cloneRepo).toHaveBeenCalledWith('https://github.com/owner/repo.git', undefined);
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
+        join('/tmp/repo', 'skills/skill-a'),
+        expect.any(Object)
+      );
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
+        join(process.cwd(), '.agents/skills/skill-a')
+      );
+      expect(spawnSync).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+
+      vi.mocked(localLock.computeSkillFolderHash).mockReset().mockResolvedValue('same-hash');
+      const upToDateResult = await updateProjectSkills({ checkOnly: true, yes: true });
+      expect(upToDateResult.updateCount).toBe(0);
+    });
+
+    it('checks every copied project installation', async () => {
+      const canonicalPath = join(process.cwd(), '.agents/skills/skill-a');
+      const claudePath = join(process.cwd(), '.claude/skills/skill-a');
+      vi.mocked(existsSync).mockImplementation(
+        (path) =>
+          path === canonicalPath ||
+          path === claudePath ||
+          (typeof path === 'string' && path.endsWith('/bin/cli.mjs'))
+      );
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'installed-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash)
+        .mockResolvedValueOnce('remote-hash')
+        .mockResolvedValueOnce('remote-hash')
+        .mockResolvedValueOnce('changed-copy-hash');
+
+      const result = await updateProjectSkills({ checkOnly: true, yes: true });
+
+      expect(result.updateCount).toBe(1);
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(canonicalPath);
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(claudePath);
+    });
+
+    it('checks separate refs from the same project source independently', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            ref: 'main',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'same-hash',
+          },
+          'skill-b': {
+            source: 'owner/repo',
+            ref: 'beta',
+            skillPath: 'skills/skill-b/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'same-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockImplementation(async (_source, ref) => `/tmp/repo-${ref}`);
+      vi.mocked(skills.discoverSkills).mockImplementation(async (path) => {
+        const name = path.endsWith('main') ? 'skill-a' : 'skill-b';
+        return [
+          {
+            name,
+            path: join(path, 'skills', name),
+            description: name,
+            rawContent: '',
+          },
+        ];
+      });
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('same-hash');
+
+      const result = await updateProjectSkills({ checkOnly: true, yes: true });
+
+      expect(result.updateCount).toBe(0);
+      expect(git.cloneRepo).toHaveBeenCalledWith('https://github.com/owner/repo.git', 'main');
+      expect(git.cloneRepo).toHaveBeenCalledWith('https://github.com/owner/repo.git', 'beta');
+    });
+
     it('should prompt to remove deleted skill on update', async () => {
       // Mock local lock with 2 skills from same source
       vi.mocked(localLock.readLocalLock).mockResolvedValue({
@@ -364,6 +490,146 @@ describe('Update Cleanup Unit Tests', () => {
   });
 
   describe('updateGlobalSkills', () => {
+    it('checks separate refs from the same global source independently', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            ref: 'main',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'hash-a',
+            installedAt: '',
+            updatedAt: '',
+          },
+          'skill-b': {
+            source: 'owner/repo',
+            ref: 'beta',
+            skillPath: 'skills/skill-b/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'hash-b',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockImplementation(async (_source, ref) => {
+        const name = ref === 'main' ? 'skill-a' : 'skill-b';
+        return {
+          sha: `root-${ref}`,
+          branch: ref!,
+          tree: [
+            { path: `skills/${name}/SKILL.md`, type: 'blob', sha: `blob-${ref}` },
+            { path: `skills/${name}`, type: 'tree', sha: `hash-${name.slice(-1)}` },
+          ],
+        };
+      });
+      vi.mocked(blob.getSkillFolderHashFromTree).mockImplementation((_tree, skillPath) =>
+        skillPath.includes('skill-a') ? 'hash-a' : 'hash-b'
+      );
+
+      const result = await updateGlobalSkills({ checkOnly: true, yes: true });
+
+      expect(result.updateCount).toBe(0);
+      expect(blob.fetchRepoTree).toHaveBeenCalledWith(
+        'owner/repo',
+        'main',
+        skillLock.getGitHubToken
+      );
+      expect(blob.fetchRepoTree).toHaveBeenCalledWith(
+        'owner/repo',
+        'beta',
+        skillLock.getGitHubToken
+      );
+    });
+
+    it('reports global updates without reinstalling skills in check mode', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          { path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'skill-md-sha' },
+          { path: 'skills/skill-a', type: 'tree', sha: 'new-hash' },
+        ],
+      });
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-hash');
+
+      const result = await updateGlobalSkills({ checkOnly: true, yes: true });
+
+      expect(result.updateCount).toBe(1);
+      expect(spawnSync).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
+
+    it('does not remove skills deleted upstream in check mode', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [],
+      });
+      vi.mocked(p.confirm).mockResolvedValue(true);
+
+      await updateGlobalSkills({ checkOnly: true });
+
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed remote check when the API and clone fallback both fail', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue(null);
+      vi.mocked(git.cloneRepo).mockRejectedValueOnce(new Error('clone failed'));
+
+      const result = await updateGlobalSkills({ checkOnly: true, yes: true });
+
+      expect(result.failCount).toBe(1);
+      expect(result.updateCount).toBe(0);
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+
     it('should prompt to remove deleted skill on global update', async () => {
       // Mock readSkillLock
       vi.mocked(skillLock.readSkillLock).mockResolvedValue({
@@ -787,6 +1053,16 @@ describe('Update Cleanup Unit Tests', () => {
   });
 
   describe('runUpdate exit status', () => {
+    it('respects both explicit scopes when filtering by skill name', async () => {
+      await expect(
+        resolveUpdateScope({
+          global: true,
+          project: true,
+          skills: ['skill-a'],
+        })
+      ).resolves.toBe('both');
+    });
+
     beforeEach(() => {
       vi.mocked(localLock.readLocalLock).mockResolvedValue({
         version: 1,
@@ -819,6 +1095,68 @@ describe('Update Cleanup Unit Tests', () => {
 
       await runUpdate(['--project', '--yes']);
 
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('checks both project and global scopes without applying updates', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'global-skill': {
+            source: 'owner/global',
+            sourceUrl: 'https://github.com/owner/global.git',
+            skillPath: 'skills/global-skill/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-global-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'project-skill': {
+            source: 'owner/project',
+            skillPath: 'skills/project-skill/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'old-project-hash',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          {
+            path: 'skills/global-skill/SKILL.md',
+            type: 'blob',
+            sha: 'global-skill-md-sha',
+          },
+          { path: 'skills/global-skill', type: 'tree', sha: 'new-global-hash' },
+        ],
+      });
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-global-hash');
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/project-repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'project-skill',
+          path: '/tmp/project-repo/skills/project-skill',
+          description: 'Project skill',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash)
+        .mockResolvedValueOnce('new-project-hash')
+        .mockResolvedValueOnce('old-project-hash');
+
+      await runUpdate(['--global', '--project', '--yes'], 'check');
+
+      expect(skillLock.readSkillLock).toHaveBeenCalled();
+      expect(localLock.readLocalLock).toHaveBeenCalled();
+      expect(spawnSync).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+      expect(p.confirm).not.toHaveBeenCalled();
       expect(process.exitCode).toBeUndefined();
     });
   });

--- a/tests/wellknown-update.test.ts
+++ b/tests/wellknown-update.test.ts
@@ -1,10 +1,35 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { checkWellKnownForUpdates, type WellKnownUpdateItem } from '../src/update.ts';
+import { spawnSync } from 'child_process';
+import {
+  checkWellKnownForUpdates,
+  processWellKnownUpdates,
+  updateProjectSkills,
+  type WellKnownUpdateItem,
+} from '../src/update.ts';
+import * as localLock from '../src/local-lock.ts';
+import * as remove from '../src/remove.ts';
+import * as p from '@clack/prompts';
 import {
   computeWellKnownSkillDigest,
   wellKnownProvider,
   type WellKnownSkill,
 } from '../src/providers/index.ts';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, spawnSync: vi.fn() };
+});
+
+vi.mock('../src/local-lock.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/local-lock.ts')>();
+  return { ...actual, readLocalLock: vi.fn() };
+});
+
+vi.mock('../src/remove.ts');
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@clack/prompts')>();
+  return { ...actual, confirm: vi.fn() };
+});
 
 const BASE_URL = 'https://skills.example.com/p/testpack';
 
@@ -76,6 +101,8 @@ async function digestOf(name: string, contents = V1_CONTENTS): Promise<string> {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -254,5 +281,45 @@ describe('checkWellKnownForUpdates', () => {
       .map((call) => String(call[0]))
       .filter((url) => url.endsWith('/SKILL.md'));
     expect(fileCalls).toEqual([`${BASE_URL}/.well-known/skills/alpha-skill/SKILL.md`]);
+  });
+});
+
+describe('processWellKnownUpdates', () => {
+  it('reports updates without installing in check mode', async () => {
+    stubWellKnownServer(v2Index([{ name: 'alpha-skill', digest: DIGEST_A }]));
+
+    const result = await processWellKnownUpdates(
+      new Map([[BASE_URL, [{ name: 'alpha-skill', digest: DIGEST_STALE }]]]),
+      true,
+      { checkOnly: true, yes: true }
+    );
+
+    expect(result.updateCount).toBe(1);
+    expect(result.successCount).toBe(0);
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('warns about removed project skills without mutating or reporting them as current', async () => {
+    vi.mocked(localLock.readLocalLock).mockResolvedValue({
+      version: 1,
+      skills: {
+        'alpha-skill': {
+          source: 'wellknown/skills.example.com',
+          sourceUrl: BASE_URL,
+          sourceType: 'well-known',
+          wellKnownDigest: DIGEST_A,
+        },
+      },
+    });
+    stubWellKnownServer(v2Index([]));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await updateProjectSkills({ checkOnly: true });
+
+    expect(result.updateCount).toBe(0);
+    expect(log.mock.calls.flat().join('\n')).not.toContain('All project skills are up to date');
+    expect(p.confirm).not.toHaveBeenCalled();
+    expect(remove.removeCommand).not.toHaveBeenCalled();
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- restore `skills check` as a read-only operation for project, global, or both scopes
- report available updates and upstream deletions without reinstalling or removing skills
- compare project sources against every installed copy, including Eve-specific normalization
- keep source checks isolated by git ref while preserving `update` / `upgrade` behavior

## What this code does

`check` now shares update discovery but stops before every persistent mutation path. Global checks compare the remote GitHub tree with the global lock. Project checks fetch the selected source into a temporary directory, compare it with each installed target, report differences, and remove the temporary directory. `update` remains the command that applies changes.

Supported scopes:

- `skills check -g`: global skills
- `skills check -p`: project skills
- `skills check -g -p`: both scopes
- positional skill names continue to filter the selected scope(s)

## Validation

- `pnpm format:check`
- `pnpm type-check`
- `pnpm test` (50 files, 684 tests)
- `pnpm build`
- isolated project E2E: fresh multi-agent copy reported up to date; modifying only the secondary copy reported an update; lock and installed-file checksums stayed unchanged
- isolated global E2E: a stale lock hash reported an update; the lock checksum stayed unchanged
- independent QA gate: PASS

Fixes #954