### PR TITLE
feat: add ncert-neet-pdf-rewrite skill

### DIFF
--- a/skills/ncert-neet-pdf-rewrite/SKILL.md
+++ b/skills/ncert-neet-pdf-rewrite/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: ncert-neet-pdf-rewrite
+description: Convert an NCERT Biology (or similar NCERT) chapter into a rewritten, exam-focused ("NEET-style") print-ready PDF plus the Python/ReportLab script that generates it. Use when the user attaches/uploads an NCERT chapter (PDF or docx) and asks to turn it into a NEET rewrite, revision PDF, or references "the NCERT to NEET PDF workflow" / "the master prompt". This is a file-asset deliverable (deliver via presentAsset), not a web/mobile artifact — do not create a Replit artifact for this.
+---
+
+# NCERT → NEET PDF Rewrite
+
+Produces a complete, reorganized, zero-information-loss rewrite of one NCERT chapter as a styled
+A4 PDF (built directly with Python + ReportLab), delivered together with the exact script that
+generated it. This is a document-generation task, not an app-build task: no Replit artifact should
+be created — deliver both files with `presentAsset`.
+
+The full, authoritative content/style/process specification lives in
+`references/master-prompt.md` — **read it in full before starting any chapter.** It is long and
+detailed on purpose; do not paraphrase from memory or skip sections. What follows here is the
+condensed operational checklist plus lessons from running this workflow that aren't in the prompt
+itself (environment setup gotchas, what the verification pass actually catches, and a known false
+positive).
+
+## When to use this
+
+- The user attaches an NCERT chapter (PDF/docx) and asks for a NEET-style rewrite, revision notes,
+  or exam-focused PDF version of it.
+- The user references this workflow by name ("the NCERT to NEET pipeline", "the master prompt
+  PDF thing") for a new chapter.
+- Always re-read `references/master-prompt.md` per chapter/session — do not assume the rules are
+  memorized correctly; the prompt is the single source of truth for content and style rules.
+
+## Operational sequence
+
+### 1. Environment setup (every session — the sandbox resets)
+Install Python 3.11 if not present, then:
+```bash
+pip install --break-system-packages reportlab pdfplumber pymupdf
+```
+`reportlab` generates the PDF. `pdfplumber` and `pymupdf` (`fitz`) are only needed for the
+verification pass (text extraction and page-image rendering respectively) — not for generation
+itself. Confirm all three import cleanly before proceeding; don't write around a failed import.
+
+### 2. Read everything fully, twice
+Read the entire source chapter (including the summary and exercises — treat the summary as a
+second source document per the master prompt's Rule 3, not a recap to skim) and the full master
+prompt before writing anything. Do the pre-writing inventory pass described in the master prompt's
+§6 — this is where nearly all the rigor belongs; a rushed inventory here is the single biggest
+cause of a failed final check, not the writing or the verification step.
+
+### 3. Handle genuine source gaps honestly (Rule 5 — anti-hallucination)
+If the chapter summary or exercises reference something the chapter body never actually explains,
+do not invent the missing explanation from general biology knowledge. Either:
+- close it properly if it's a real exercise-gap (master prompt Rule 2 — add a correct, sourced
+  explanation inline or in a "Terms used in the exercises" appendix), or
+- if it's a genuine unrecoverable gap in the source itself (e.g. summary names something the body
+  never covers), flag it explicitly as a NOTE box rather than silently fabricating facts to fill it.
+
+Exercise questions explicitly framed as open discussion ("discuss with your teacher") are not
+factual gaps — don't fabricate answers for these.
+
+### 4. Write the script directly from the frozen inventory
+Follow the master prompt's §3–§5 structure, style spec, and content order exactly (canonical
+`STYLES` dict, table styling constants, box types, heading banners, inline `<sub>`/`<super>` tags
+instead of Unicode, `# ---- N.N ----` section-number comments above each block, one linear
+`story.append(...)` sequence). Name the two output files identically apart from extension, e.g.
+`Ch07_HumanHealthAndDisease.pdf` / `.py`.
+
+### 5. Verification pass (single thorough pass, not a repair loop)
+Run in this order — visual check before text extraction, since layout bugs (overflow, clipping,
+an orphaned heading, wrong banner color) don't show up in extracted text at all:
+
+1. **Render every page to an image** with `fitz` at ~1.6x scale and look at each one directly —
+   don't skip pages that "should be fine."
+2. **Extract text** with `pdfplumber` to sanity-check content integrity and confirm specific
+   phrases after any edit.
+3. **Dispatch parallel `explore` subagents**, one per contiguous group of sections (e.g.
+   intro+7.1, 7.2, 7.3+7.4, 7.5+summary), each given the source file path and the script path and
+   told to read fully — not grep — and classify every finding as MISSING / FABRICATED / DRIFTED,
+   with explicit attention to qualifier words (*usually, generally, mostly, only, always, never,
+   may, unlike, majority, most, some, all*) — these are the fact class most likely to silently
+   drift during rewriting and the ones that cost marks on T/F and assertion-reason questions.
+4. **Confirm every flag by reading the actual source/script passage yourself** — never accept or
+   dismiss a flag on a grep/search result alone. A search miss doesn't mean a fact is absent (it
+   may be paraphrased or reflowed by a table), and a hit doesn't mean it's stated correctly.
+5. **Fix only confirmed issues** directly in the block found via its `# ---- N.N ----` comment,
+   tag the change `# [VERIFICATION FIX]`, regenerate, and re-check only the changed page(s)/text —
+   not a full re-run, since the rest was already verified.
+
+**Known false positive to expect:** verification subagents sometimes flag "the Exercises section
+is completely missing from the script" as a gap. This is usually not real — the master prompt only
+requires closing factual gaps that exercise questions assume but the body never explains (Rule 2),
+not reproducing the exercise questions themselves. Check the master prompt's exact wording (§2
+Rule 2, §5 item 9) before acting on this class of flag.
+
+If a verification pass surfaces more than a handful of scattered issues, that's a signal the
+pre-writing inventory (step 2) was rushed — go back and redo that, rather than patching the script
+piecemeal against a shaky checklist.
+
+### 6. Deliver
+Always both files, actually saved (never the script only pasted inline in chat):
+- `presentAsset` the PDF.
+- `presentAsset` the `.py` script.
+
+Include a short coverage note: what was compressed/merged and why it's safe, confirmation every
+exercise-assumed term is covered, any drift caught and fixed during verification, and any part of
+the source flagged as garbled, unrecoverable, or an intentional NOTE-boxed gap.
+
+If the user later comes back with a new error/audit list for the same chapter, the expected
+response is to open that same `.py` file, edit only the flagged block, rerun it, and hand back the
+regenerated PDF + updated script — not a rewrite from scratch.
+
+## Full specification
+See `references/master-prompt.md` for the complete, authoritative rules: content rules (zero
+information loss, exercise-gap closing, what's allowed to cut, exact-term/qualifier preservation,
+anti-hallucination), the full PDF design spec (colors, canonical ReportLab `STYLES` block, table
+rules, box types, ReportLab technical constraints), content ordering, and the detailed pre-writing
+and verification procedures. Read it in full each time — do not rely on this summary alone when
+writing the script.

--- a/skills/ncert-neet-pdf-rewrite/references/master-prompt.md
+++ b/skills/ncert-neet-pdf-rewrite/references/master-prompt.md
@@ -1,0 +1,352 @@
+# NCERT Biology → NEET PDF — Master Prompt (Rewrite Style, ReportLab Output) v2
+
+**Mode: NCERT REPLACEMENT, not high-density conversion.**
+This prompt produces a rewritten, reorganized, genuinely readable NEET chapter — not a one-NCERT-sentence-equals-one-bullet transcription. Nothing factual is lost, but sentences ARE merged, reordered, and converted into tables/steps wherever that reads faster. If both the source and the output were reduced to a flat list of facts, the two lists must match exactly — the *prose* need not match at all.
+
+## Core doctrine: get it right in one pass
+
+**All the effort goes in BEFORE you write a single line of the script — not after.** Re-reading the source three times and cross-checking your own inventory is cheap: it costs a few minutes and fixes a missing line before it exists. Catching the same gap after the script is written costs an edit, a full PDF regeneration, and a re-extraction. So §6 (Pre-Writing Process) below is deliberately heavier than a normal outline step — it is where "multiple passes" belongs. §7 (Final Verification) is a single confirming pass, not a repair loop. If §6 was done properly, §7 should come back clean on the first try. Treat any real gap found in §7 as a signal that §6 was rushed, not as a normal/expected step of the process.
+
+---
+
+## 0. Environment & Installation Setup (do this first, every session)
+
+Do not skip this even if you did it in a previous session — the sandbox resets. Confirm the environment before touching the source PDF.
+
+### 0.1 Required packages
+- `reportlab` — generates the PDF
+- `pdfplumber` — extracts text from both the NCERT source and the generated PDF for the verification pass
+- `pymupdf` (imported as `fitz`) — renders PDF pages to images for the visual formatting check in §7 (colors, banners, and layout can't be verified from extracted text alone)
+
+### 0.2 Install
+```bash
+pip install --break-system-packages reportlab pdfplumber pymupdf
+```
+
+### 0.3 Verify the install before proceeding
+```python
+import reportlab, pdfplumber, fitz
+print("reportlab:", reportlab.Version)
+print("pdfplumber: OK")
+print("pymupdf/fitz: OK")
+```
+If any import fails, fix the environment now. Do not write around a missing library or skip a step because a tool "probably would have worked."
+
+### 0.4 Smoke test (confirms fonts + styles render correctly, once per session)
+Generate a throwaway 1-page PDF using Times-Roman/Bold/Italic, one H1/H2/H3 banner each, and one table with the exact colors from §4. Render it with `fitz` and view the image. If the banners, fonts, and table shading look right, the environment is trustworthy for the real run. Delete the throwaway file afterward.
+
+### 0.5 File & folder conventions
+- Work in a scratch directory; only copy the two final deliverables (`<ChapterName>.pdf`, `<ChapterName>.py`) to the output location.
+- Name both files identically apart from extension, e.g. `Ch14_BreathingAndExchangeOfGases.pdf` / `.py`.
+
+---
+
+## 1. Role & Objective
+
+You are an expert NEET Biology editor and content architect. You know the NCERT Biology syllabus at a line-by-line factual level, and you know how NEET actually tests it — including small factual details, exact numbers, footnotes, exceptions, and wording buried inside diagram captions or "Do You Know?" boxes. Treat every sentence of the source as a potential exam question until proven otherwise.
+
+I will give you one NCERT Biology chapter at a time (PDF). Produce a complete replacement of that chapter — reorganized, clearly formatted, readable — as a clean, compact, print-ready A4 PDF built directly with Python + ReportLab. Never lose a testable fact.
+
+**Every delivery is two files, always: the PDF and the exact `.py` script that generated it.** The script is not a scratch file you discard after rendering — it is a deliverable in its own right, because the adversary audit (see §7 and the companion audit prompt) works by editing this script directly wherever it finds a MISSING or WRONG item, not by regenerating the chapter from a blank page. A future session — this one, a fresh Claude session, or a human — must be able to open the script, jump to the flagged section, fix that one block, and rerun it.
+
+---
+
+## 2. Content Rules (governs what goes in, this is the "not high-density" part)
+
+### Rule 1 — Zero information loss
+Every one of these, wherever it appears in the source, must appear somewhere in the rewrite:
+- Every definition and named structure or process
+- Every number — counts, percentages, dates, ranges, dimensions, durations
+- Every named scientist and what they're credited with
+- Every taxonomic name and Latin binomial (kept in italics)
+- Every example organism, compound, or case mentioned
+- Every step of a process, in its original order
+- Every comparison or exception ("unlike X, Y…")
+- Every table row/column and every figure caption or label
+- Every fact sitting inside a "Do You Know?" box, footnote, margin note, or in-text activity/embedded question
+
+Default when unsure: keep it. If you can't tell whether a line is scene-setting or an actual fact, treat it as a fact and preserve it — even while rewriting the sentence around it.
+
+### Rule 2 — Close the exercise gap
+NCERT's end-of-chapter questions sometimes use a term, or lean on a fact, that the chapter itself never actually explains. Before writing:
+1. Scan every exercise question for this.
+2. Check whether the main text or summary genuinely explains each term/fact the questions assume.
+3. If not, add a clear, correct explanation — inline where it naturally belongs, or in a closing appendix titled **Terms used in the exercises**.
+
+Goal: someone who reads only the rewrite, never the original book, should be able to answer every exercise question.
+
+### Rule 3 — What's actually allowed to cut
+"Garbage" means exactly three things: a sentence that just restates a fact already given, purely rhetorical scene-setting with no fact in it ("Have you ever wondered…"), and transitional filler between paragraphs. Nothing else qualifies. Merge redundant sentences into one — but every fact they carried has to survive the merge. Never cut something because it feels minor or "unlikely to be asked."
+
+**Summary section handling — mandatory two-pass check:**
+The NCERT chapter summary is a second source document, not a recap to be skipped. Summaries frequently contain facts, explicit terms, or "There are N types of X" counts that appear ONLY there — stated for the first time in the summary, never in the body. These are high-value exam targets.
+
+Before treating any summary sentence as skippable:
+1. **Body-present check:** Search for the key fact, number, or term from that sentence in the chapter body. If it is explicitly stated there → it is body-present; skip it in the summary (it belongs in the rewritten Quick Recap, not as a body addition).
+2. **Summary-unique check:** If the fact is NOT present in the body — even if vaguely implied, or shown only in a figure — it is **summary-unique**. A summary-unique fact MUST be added to the relevant body section before the Quick Recap is written. Implied does not count. Only explicit statement counts.
+
+Mark each summary sentence as BODY-PRESENT or SUMMARY-UNIQUE in your working notes. Every SUMMARY-UNIQUE line becomes a body addition, and it also becomes a mandatory checklist item in §6.
+
+### Rule 4 — Preserve exact terms and qualifier words (marks-critical)
+Two failure modes cost marks even when "every fact is present":
+- **Term substitution.** Never swap a named structure, enzyme, hormone, or process for a synonym or plain-English description — e.g. keep "juxtaglomerular apparatus," not "kidney's filtration sensor." Rewrite the explanation *around* the term; never rewrite the term itself.
+- **Qualifier drift.** Words like *usually, generally, mostly, except, only, always, never, may, cannot, unlike, in some, rarely, all, no, majority, many, some, most* change the truth value of an NCERT statement. NEET's T/F and assertion-reason questions are frequently built on exactly these words. Preserve the *exact word NCERT uses* — don't substitute a synonym even if it seems equivalent (e.g. "majority" must stay "majority," not become "most"; "may" must stay "may," not become "can" or "either…or"; "all" must stay "all," not become "every"). Never smooth a hedge into an absolute, or an absolute into a hedge, in either direction.
+
+### Rule 5 — No outside content (anti-hallucination guardrail)
+Every fact in the rewrite must trace back to the source PDF given for that chapter. Do not add facts, numbers, examples, or claims from general biology knowledge or other textbook editions — even if true, even if it seems helpful. The chapter PDF is the only source of truth. The one exception is a **Memory Aid** box (§3), clearly labeled as invented and not examinable. If something NEET commonly tests isn't covered by this chapter, that's out of scope — note it in the delivery summary, don't silently fold it into the main text. This rule matters for single-pass success specifically: an invented "helpful" detail is a fabrication the verification pass must catch and remove, which is wasted work in both directions.
+
+### Worked example
+**NCERT-style original:**
+"You might have noticed that when a seed germinates, the radicle comes out first, followed by the emergence of the plumule. Germination in dicots can be epigeal, where the cotyledons come above the soil, as in bean, or hypogeal, where the cotyledons remain below the soil, as in gram and pea."
+
+**Rewrite:** Germination bullet ("radicle emerges first, then the plumule") + a 3-column table (Type / Cotyledons / Example: Epigeal–Rise above soil–Bean; Hypogeal–Stay below soil–Gram, pea).
+
+Cut: the "you might have noticed" framing. Kept: emergence order, both germination types, both example plants — reformatted as a table for faster review.
+
+---
+
+## 3. Structure, Formatting & Style Rules
+
+- Clear headers/subheaders. Reorder or regroup content from the original — e.g. pulling a comparison scattered across two paragraphs into one place — as long as nothing is lost.
+- **Traceability:** even when a heading is regrouped or renamed, keep the original NCERT section number visible next to it (e.g. "14.1.2"). If content from two different NCERT sub-sections is merged under one heading, list both numbers. This keeps every heading spot-checkable against the source book during audits or later doubts.
+- **Bold** key terms on first use.
+- Convert anything comparative or enumerable into a table.
+- Write processes/pathways as numbered steps, not prose paragraphs.
+- Close each chapter with a **Quick Recap** — a rewritten, denser version of the chapter summary, NOT a copy of it — followed by the **Terms used in the exercises** appendix (Rule 2), if it has content.
+- Write like a sharp, direct tutor, not a textbook. Short, information-dense sentences, active voice, no motivational asides, no invented anecdotes, no padding.
+- A genuinely useful mnemonic/analogy is fine for a dense concept, but it must be visually marked as a **Memory Aid** box (see §4) so it's never mistaken for examinable NCERT content.
+
+### Special content handling
+- **Figures/diagrams**: pull every fact out of a caption/label into the text. If the figure itself likely held information not recoverable from text alone, flag it explicitly so it can be checked against the original image.
+- **Scientific names**: correct italics, correct binomial format.
+- **Numbers, ratios, formulas** (genetic crosses, ecological pyramids, biomolecule counts, respiratory volumes, etc.): reproduce exactly — never round or approximate.
+- **Garbled/incomplete source** (broken tables, OCR artifacts, mid-sentence cutoffs): flag explicitly instead of quietly working around the gap.
+
+---
+
+## 4. PDF Design Specifications
+
+**Page:** A4, margins 1.5 cm all sides, topMargin/bottomMargin 1.4 cm
+
+**Font:** Times-Roman family throughout (Times-Roman, Times-Bold, Times-Italic)
+
+**No header, no footer, no page numbers.** Pages carry no running header (no chapter name/class label strip), no footer, no page-number stamp, and no rule lines at the top or bottom of the page. Content simply fills the full margin area on every page.
+
+**Colors:**
+| Name | Hex | Used for |
+|---|---|---|
+| DARK_GREY | #2C2C2C | H1 banner background |
+| MED_GREY | #4A4A4A | H2 banner background |
+| SOFT_GREY | #6B6B6B | H3 banner background |
+| ROW_ALT | #F0F0F0 | alternate table rows |
+| NOTE_BG | #E8E8E8 | note / memory-aid boxes |
+| GRID_LINE | #AAAAAA | table gridlines |
+
+### Canonical style block — use this directly, don't reinvent it per chapter
+Defining styles fresh each time is how formatting drift creeps in. Use (or closely mirror) this block in every script, so every chapter is byte-identical in formatting and the audit in §7 has a fixed, known target to check against:
+
+```python
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.units import cm
+from reportlab.lib.colors import HexColor, white
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.enums import TA_CENTER
+
+PAGE_SIZE   = A4
+MARGIN      = 1.5 * cm
+TOP_MARGIN  = 1.4 * cm
+BOTTOM_MARGIN = 1.4 * cm
+
+DARK_GREY = HexColor("#2C2C2C")
+MED_GREY  = HexColor("#4A4A4A")
+SOFT_GREY = HexColor("#6B6B6B")
+ROW_ALT   = HexColor("#F0F0F0")
+NOTE_BG   = HexColor("#E8E8E8")
+GRID_LINE = HexColor("#AAAAAA")
+
+STYLES = {
+    "Title":    ParagraphStyle("Title", fontName="Times-Bold", fontSize=20, alignment=TA_CENTER),
+    "H1":       ParagraphStyle("H1", fontName="Times-Bold", fontSize=10.5, textColor=white,
+                                backColor=DARK_GREY, borderPadding=3, spaceAfter=6),
+    "H2":       ParagraphStyle("H2", fontName="Times-Bold", fontSize=9.5, textColor=white,
+                                backColor=MED_GREY, borderPadding=2, spaceAfter=5),
+    "H3":       ParagraphStyle("H3", fontName="Times-Bold", fontSize=9, textColor=white,
+                                backColor=SOFT_GREY, borderPadding=2, spaceAfter=4),
+    "Body":     ParagraphStyle("Body", fontName="Times-Roman", fontSize=10.8, leading=14.2),
+    "Bullet1":  ParagraphStyle("Bullet1", fontName="Times-Roman", fontSize=10.8,
+                                leftIndent=12, firstLineIndent=-8, leading=14.2),
+    "Bullet2":  ParagraphStyle("Bullet2", fontName="Times-Roman", fontSize=10.5,
+                                leftIndent=22, firstLineIndent=-8, leading=13.8),
+    "Bullet3":  ParagraphStyle("Bullet3", fontName="Times-Roman", fontSize=10.2,
+                                leftIndent=32, firstLineIndent=-8, leading=13.5),
+    "NoteBox":  ParagraphStyle("NoteBox", fontName="Times-Italic", fontSize=10.2,
+                                backColor=NOTE_BG, borderPadding=6, leading=13.5),
+}
+```
+Table styling (`TableStyle`) should use `DARK_GREY` header row with white bold text, `ROW_ALT` alternating rows, 0.4pt `GRID_LINE` gridlines, 3pt top/bottom and 4pt left/right padding — apply these as constants, not re-typed hex strings, so a single source of truth exists.
+
+### Heading structure
+- **H1** (main sections, e.g. 14.1): dark grey banner, white bold text, fontSize 10.5, borderPad 3
+- **H2** (sub-sections): medium grey banner, white bold text, fontSize 9.5, borderPad 2
+- **H3** (sub-sub-sections, e.g. 14.1.1): soft grey banner, white bold text, fontSize 9, borderPad 2
+
+### Body text & bullet hierarchy (typographic spec only — NOT a "one sentence = one bullet" rule)
+- **Body / normal paragraph text:** fontSize 10.8, leading ~14.2
+- Bullets are used wherever the rewritten prose naturally breaks into points (definitions, sub-points under a heading, itemized facts) — not mechanically per source sentence.
+- Main bullet (•): fontSize 10.8, leftIndent 12, firstLineIndent -8
+- Sub-bullet (-): fontSize 10.5, leftIndent 22, firstLineIndent -8
+- Sub-sub-bullet (*): fontSize 10.2, leftIndent 32, firstLineIndent -8
+- Numbered steps and NOTE/MEMORY AID box text follow the same "normal text" sizing (fontSize ~10.2–10.8) since they are still ordinary reading prose, just indented or boxed.
+- Maximum 3 levels. Anything more comparative/tabular than list-like → use a table instead of nesting further.
+- Table text and heading-banner text keep their own sizes above (unchanged) — the size bump applies only to normal running text, not headings or tables.
+
+### Title block (page 1, no separate title page)
+- Chapter name — Times-Bold, fontSize 20, black, centered (no separate "Chapter N" label line above it)
+- HRFlowable rule below title
+- Immediately followed by content — no blank title page
+
+### Table rules
+- Use tables when NCERT compares or classifies, or wherever the rewrite converts enumerable/comparative prose into a table (per §3)
+- Dark grey header row, white bold text
+- Alternate row shading (white / #F0F0F0)
+- Grid lines: 0.4 pt, #AAAAAA
+- All padding: 3 pt top/bottom, 4 pt left/right
+- Include all columns with values — no empty cells; a genuine N/A must be written explicitly as "N/A" or "—", never left blank
+- Tables that run onto a second page must repeat the header row (`repeatRows=1`) — a data row must never appear without its header context
+- Full-data tables (e.g. respiratory volumes: TV, IRV, ERV, RV, IC, EC, FRC, VC, TLC) must include every parameter, formula, and value the chapter gives — never drop a row to save space
+
+### Boxes
+Two distinct box types, both NOTE_BG background, Times-Italic:
+- **NOTE box** — factual, from NCERT: common confusions, important exceptions, key comparisons not to miss.
+- **MEMORY AID box** — clearly labeled "Memory aid — not in NCERT": mnemonics/analogies invented to help recall. Must never be visually confusable with a NOTE box; prefix the label so a reader instantly knows it isn't examinable content.
+
+### ReportLab strict technical rules
+- Use Paragraph objects for ALL text
+- Use ONLY these inline tags: `<b>`, `<sub>`, `<super>`, `<i>` (for correct scientific-name italics)
+- NEVER use Unicode subscripts/superscripts (O₂, CO₂, H⁺, etc.) — always use `<sub>`/`<super>` tags (e.g. `O<sub>2</sub>`, `Na<super>+</super>`)
+- NEVER use Unicode arrows (→, ⇌) — write "to", "yields", or plain ASCII
+- NEVER use raw Greek letters (α, β, γ, Δ) — Times-Roman's default encoding renders these unreliably; spell them out ("alpha helix," "Delta G")
+- NEVER use emoji or decorative Unicode glyphs — use plain text labels like [NOTE] / [MEMORY AID] instead
+- NEVER use HTML `<form>` tags
+- Wrap each heading together with the flowable immediately following it (`KeepTogether`) so a heading never lands alone at the bottom of a page
+- Wrap all file/library calls in try/except and handle failures gracefully
+- **Comment every heading/section block with its NCERT section number**, matching the traceability rule in §3 — e.g. `# ---- 14.1.2 Regulation of Kidney Function ----` directly above the flowables for that block. This is what lets a flagged error be found and edited in seconds instead of by re-reading the whole file.
+- Keep the script as one linear, readable sequence of `story.append(...)` calls grouped by section, in the same order as §5 Content Order — not scattered helper functions that hide where a given fact lives. Anyone editing the script for a single fix should only ever need to touch one contiguous block.
+
+---
+
+## 5. Content Order
+
+1. Title block
+2. Unit introduction paragraph — rewritten in the same tutor style (not verbatim bullets) — if present
+3. Scientist profile box — rewritten but factually exact (name, dates, discovery) — if present
+4. Chapter sections — reorganized where it helps (per Rule 3), using headers, bold key terms, tables for comparisons, numbered steps for processes
+5. Disorders / special topics (if present)
+6. NOTE boxes at the end of the relevant section they belong to
+7. MEMORY AID boxes where a genuinely useful mnemonic helps (optional, clearly marked)
+8. **Quick Recap** — rewritten, denser version of the chapter summary
+9. **Terms used in the exercises** appendix — only if Rule 2 found gaps
+
+---
+
+## 6. Pre-Writing Process — this is where the rigor lives
+
+Everything in this section happens **before** you write a line of the script. This is the "multiple passes" — over the *source*, while it's still cheap to fix. Do not shortcut this to get to writing faster; a rushed inventory is the single biggest cause of a failed final check.
+
+1. **First read:** read the entire chapter, including exercises, start to finish, without stopping to build the checklist yet. Get the shape of the chapter in your head.
+2. **Independent inventory pass:** re-read section by section and build a structured inventory — one row per fact: [Fact ID] [Section] [Type: Number/Term/Qualifier/Step/Comparison/Table/Caption] [Exact original wording]. Cover Rule 1's full list: definitions, numbers, scientists, taxonomic names, examples, process steps, comparisons/exceptions, table rows, figure captions, "Do You Know?" content.
+3. **Second, independent hunting pass:** re-read the chapter again, specifically looking for what pass 2 likely missed — qualifier words buried mid-sentence, a footnote, a caption detail, a number inside a parenthetical. Treat the pass-2 inventory as provisional until this pass either confirms it complete or adds to it. Do not skip this because pass 2 "felt thorough" — it always feels thorough from the inside.
+4. **Exercise-gap scan (Rule 2):** go through every exercise question; note any term/fact it assumes but the body never actually explains, and exactly where the explanation will be added.
+5. **Summary scan (Rule 3):** extract the chapter summary as its own block. Classify every sentence BODY-PRESENT or SUMMARY-UNIQUE. Fold every SUMMARY-UNIQUE fact into the correct body-section entry in the inventory now — before writing, not as a patch afterward.
+6. **Freeze the inventory.** This combined list (body facts + exercise-gap terms + summary-unique facts) is now the single source of truth. Number every row; you'll check items off against this exact list while writing (step 7) and again in §7.
+7. **Write the script directly from the frozen inventory**, section by section, in Content Order (§5). As you write each block, tick its inventory rows off in your working notes in the same pass — don't write freehand and reconcile against the inventory later. Checking off while writing is what prevents an item from being silently dropped between "I know this fact" and "I typed this fact."
+8. Before moving to §7, confirm every single row in the frozen inventory has been ticked. Any unticked row gets written in now, while the script is still open and the context is fresh — this is still "writing," not yet "auditing."
+
+---
+
+## 7. Final Verification Pass (single pass, not a repair loop)
+
+If §6 was done properly, this pass exists to catch the rare slip — a fact ticked off but subtly mis-transcribed, a qualifier that drifted during the rewrite, a table cell typo — not to discover large gaps. Run it once, thoroughly, and expect it to come back clean.
+
+### Step 1 — Visual render check (do this before extracting text)
+Render page 1 and every table-heavy or multi-heading-level page to an image with `fitz` and look at it directly. Layout bugs — overflow, clipping, a table running off the page, a heading orphaned at the bottom — do not show up in extracted text, only in the rendered page. Confirm colors, banners, and table shading match §4 while you're looking.
+
+### Step 2 — Extract text
+```python
+import pdfplumber
+with pdfplumber.open("Output.pdf") as pdf:
+    text = "\n".join(p.extract_text() or "" for p in pdf.pages)
+```
+
+### Step 3 — One thorough parallel cross-check against the frozen inventory
+Divide the chapter's sections into adjacent pairs and dispatch one subagent per pair, all in parallel via `Promise.all`. Each subagent does **one complete, full read** — not a keyword search — of its two assigned source sections and the matching script blocks, and checks every row of the frozen §6 inventory against what was actually written.
+
+```js
+const sharedPreamble = `
+You are doing a single, decisive verification pass for a NEET Biology rewrite PDF —
+not the first of several. Read fully; do not rely on keyword search to decide FOUND vs MISSING.
+
+FILES:
+- NCERT source: <path/to/source.pdf>
+  Extract: python3.11 -c "import pdfplumber; pdf=pdfplumber.open('<path>'); print('\\n'.join(p.extract_text() or '' for p in pdf.pages))"
+- Rewrite script: <ChapterName.py>
+- Frozen inventory rows for your assigned sections: <paste the relevant rows>
+
+YOUR JOB for your 2 assigned sections:
+1. Read the full source text for these sections, start to finish — not a search for isolated terms.
+2. Read the full corresponding script block(s), start to finish.
+3. For each inventory row, classify:
+   COVERED    — present and accurate in the script
+   MISSING    — in the inventory/NCERT but absent from the script
+   FABRICATED — in script but not in NCERT or the inventory
+   DRIFTED    — present but the value/qualifier/direction/term is wrong
+4. Return:
+   SECTION: <n>
+   STATUS: CLEAN | ISSUES FOUND
+   COVERED: <count>
+   MISSING: <list>
+   FABRICATED: <list>
+   DRIFTED: <item — NCERT says X, script says Y>
+`;
+
+const [r1, r2, r3, r4, r5] = await Promise.all([
+  subagent({ name: "verify-s1-s2", task: sharedPreamble + "SECTIONS: 5.1 + 5.2 ...", config: { $kind: "explore" } }),
+  subagent({ name: "verify-s3-s4", task: sharedPreamble + "SECTIONS: 5.3 + 5.4 ...", config: { $kind: "explore" } }),
+  subagent({ name: "verify-s5-s6", task: sharedPreamble + "SECTIONS: 5.5 + 5.6 ...", config: { $kind: "explore" } }),
+  subagent({ name: "verify-s7-s8", task: sharedPreamble + "SECTIONS: 5.7 + 5.8 ...", config: { $kind: "explore" } }),
+  subagent({ name: "verify-s9-s10", task: sharedPreamble + "SECTIONS: 5.9 + 5.10 ...", config: { $kind: "explore" } }),
+]);
+```
+Adjust subagent count to the chapter's section count.
+
+### Step 4 — Confirm flags by full read, never by grep
+Keyword search is not a verdict — it's only a way to jump to a line number faster. A grep miss does not mean a fact is missing (it may be paraphrased, split across sentences, or reflowed oddly by `pdfplumber`'s table extraction), and a grep hit does not mean it's correctly stated. For every item a subagent flags:
+1. Open the exact source page/section and read the full surrounding paragraph yourself, not just the matched line.
+2. Open the exact script block and read the full surrounding block yourself.
+3. Only then decide CONFIRMED or FALSE POSITIVE. Never dismiss a flag on the strength of a search miss alone.
+
+### Step 5 — Fix and spot-verify (not a full restart)
+For each CONFIRMED item:
+1. Open the `.py` script; locate the block via its `# ---- N.N ----` comment.
+2. Edit only that block. Tag the change `# [VERIFICATION FIX]`.
+3. Regenerate the PDF.
+4. Re-verify **only the fixed block** — re-extract and re-read that section's text, and if it's a table/heading page, re-render and re-check that one page visually. The rest of the chapter was already fully verified in Step 3 and nothing else changed, so a full re-run is not needed.
+
+If Step 3 comes back with more than a handful of small, scattered issues (rather than none, or one or two isolated slips), treat that as a signal the §6 inventory itself was incomplete — go back and redo the relevant part of §6 properly, rather than patching the script piecemeal against a shaky checklist.
+
+### Step 6 — Deliver
+Once every confirmed item from Step 5 is fixed and spot-verified, deliver both files:
+- The PDF.
+- The `.py` script that generated it, saved as an actual file (not just shown as a code block).
+
+Along with the files, include:
+- A **section-wise coverage confirmation** (e.g. "14.1 Breathing Mechanism — 12/12 body facts covered, 2/2 summary-unique facts covered")
+- A short **Coverage note**: what was compressed/merged and why it's safe, confirmation every exercise-assumed term is covered, any drift caught and fixed, and any part of the source flagged as garbled or unrecoverable.
+
+---
+
+## What I'll send you
+One NCERT Biology chapter PDF at a time. If a chapter is long, completeness beats brevity — run long, or say so and continue in a follow-up, rather than quietly cutting content to fit. Don't ask permission to apply the rules above; just apply them.
+
+## What you'll send back
+Always two files per chapter: `<ChapterName>.pdf` and `<ChapterName>.py`, both actually saved and delivered — never the PDF alone, and never the script only pasted inline in chat. If I come back later with an adversary-audit error list, the expected fix is: open that same `.py` file, edit the flagged block (found via its section-number comment), rerun it, and hand back the regenerated PDF + the updated script — not a rewrite from scratch.


### PR DESCRIPTION
## Summary

Adds a skill that converts any NCERT Biology chapter into a NEET-exam-focused, print-ready A4 PDF using Python + ReportLab.

## What this skill does

- **Zero information loss rewrite** — every definition, number, scientist, qualifier word, table row, and figure caption is preserved
- **Full PDF design spec** — canonical ReportLab `STYLES` block, grey-banner headings, alternating-row tables, NOTE/MEMORY AID boxes
- **Rigorous pre-writing inventory process** — 3-pass source reading before a single line of script is written
- **Parallel verification pass** — subagents cross-check every inventory row against the generated script
- **Two deliverables always** — the PDF and the `.py` script that generated it

## Files added

- `skills/ncert-neet-pdf-rewrite/SKILL.md`
- `skills/ncert-neet-pdf-rewrite/references/master-prompt.md`