### PR TITLE
feat: support --agent and --copy in experimental_install

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, lstatSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, stripAnsi } from './test-utils.ts';
@@ -257,6 +257,48 @@ description: Test
   it('should restore from lock file with experimental_install', () => {
     const result = runCli(['experimental_install'], testDir);
     expect(result.stdout).toContain('No project skills found in skills-lock.json');
+  });
+
+  it('should restore to selected agents using copy mode with experimental_install', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'restore-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: restore-skill
+description: Restore test skill
+---
+
+# Restore Skill
+`
+    );
+    writeFileSync(
+      join(testDir, 'skills-lock.json'),
+      JSON.stringify({
+        version: 1,
+        skills: {
+          'restore-skill': {
+            source: sourceDir,
+            sourceType: 'local',
+            computedHash: 'test',
+          },
+        },
+      })
+    );
+    const result = runCli(
+      ['experimental_install', '--agent', 'claude-code', 'openclaw', '--copy'],
+      testDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    for (const agentDir of [
+      join(testDir, '.claude', 'skills', 'restore-skill'),
+      join(testDir, 'skills', 'restore-skill'),
+    ]) {
+      expect(existsSync(join(agentDir, 'SKILL.md'))).toBe(true);
+      expect(lstatSync(agentDir).isSymbolicLink()).toBe(false);
+    }
   });
 
   describe('internal skills', () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -15,6 +15,8 @@ describe('skills CLI', () => {
       expect(output).toContain('update');
       expect(output).toContain('Add Options:');
       expect(output).toContain('Use Options:');
+      expect(output).toContain('Experimental Install Options:');
+      expect(output).toContain('--copy');
       expect(output).toContain('-g, --global');
       expect(output).toContain('-a, --agent');
       expect(output).toContain('-s, --skill');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,6 +132,10 @@ ${BOLD}Project:${RESET}
   init [name]          Initialize a skill (creates <name>/SKILL.md or ./SKILL.md)
   experimental_sync    Sync skills from node_modules into agent directories
 
+${BOLD}Experimental Install Options:${RESET}
+  -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
+  --copy                 Copy files instead of symlinking to agent directories
+
 ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readLocalLock } from './local-lock.ts';
-import { runAdd } from './add.ts';
+import { parseAddOptions, runAdd } from './add.ts';
 import { runSync, parseSyncOptions } from './sync.ts';
 import { getUniversalAgents } from './agents.ts';
 import { buildLocalUpdateSource } from './update-source.ts';
@@ -10,12 +10,13 @@ import { buildLocalUpdateSource } from './update-source.ts';
  * Install all skills from the local skills-lock.json.
  * Groups skills by source and calls `runAdd` for each group.
  *
- * Only installs to .agents/skills/ (universal agents) -- the canonical
- * project-level location. Does not install to agent-specific directories.
+ * Defaults to .agents/skills/ (universal agents), unless --agent is provided.
+ * Supports the same --agent and --copy options as skills add.
  *
  * node_modules skills are handled via experimental_sync.
  */
 export async function runInstallFromLock(args: string[]): Promise<void> {
+  const { options } = parseAddOptions(args);
   const cwd = process.cwd();
   const lock = await readLocalLock(cwd);
   const skillEntries = Object.entries(lock.skills);
@@ -28,8 +29,8 @@ export async function runInstallFromLock(args: string[]): Promise<void> {
     return;
   }
 
-  // Only install to .agents/skills/ (universal agents)
-  const universalAgentNames = getUniversalAgents();
+  // Default to universal agents, matching the previous restore behavior.
+  const targetAgents = options.agent ?? getUniversalAgents();
 
   // Separate node_modules skills from remote skills
   const nodeModuleSkills: string[] = [];
@@ -71,7 +72,8 @@ export async function runInstallFromLock(args: string[]): Promise<void> {
     try {
       await runAdd([source], {
         skill: skills,
-        agent: universalAgentNames,
+        agent: targetAgents,
+        copy: options.copy,
         yes: true,
       });
     } catch (error) {
@@ -88,7 +90,12 @@ export async function runInstallFromLock(args: string[]): Promise<void> {
     );
     try {
       const { options: syncOptions } = parseSyncOptions(args);
-      await runSync(args, { ...syncOptions, yes: true, agent: universalAgentNames });
+      await runSync(args, {
+        ...syncOptions,
+        yes: true,
+        agent: targetAgents,
+        copy: options.copy,
+      });
     } catch (error) {
       p.log.error(
         `Failed to sync node_modules skills: ${error instanceof Error ? error.message : 'Unknown error'}`

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -24,6 +24,7 @@ export interface SyncOptions {
   agent?: string[];
   yes?: boolean;
   force?: boolean;
+  copy?: boolean;
 }
 
 /**
@@ -342,7 +343,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
     }
   }
 
-  // 5. Install skills (always project-scoped, always symlink)
+  // 5. Install skills (always project-scoped)
   spinner.start('Syncing skills…');
 
   const results: Array<{
@@ -360,7 +361,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
       const result = await installSkillForAgent(skill, agent, {
         global: false,
         cwd,
-        mode: 'symlink',
+        mode: options.copy ? 'copy' : 'symlink',
       });
       results.push({
         skill: skill.name,

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -4,7 +4,10 @@ import * as localLock from '../src/local-lock.ts';
 import * as add from '../src/add.ts';
 
 vi.mock('../src/local-lock.ts');
-vi.mock('../src/add.ts');
+vi.mock('../src/add.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/add.ts')>('../src/add.ts');
+  return { ...actual, runAdd: vi.fn() };
+});
 vi.mock('../src/sync.ts', () => ({
   runSync: vi.fn(),
   parseSyncOptions: vi.fn().mockReturnValue({ options: {} }),

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { existsSync, lstatSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from '../src/test-utils.ts';
@@ -120,6 +120,48 @@ Instructions.
       expect(lock.skills['lock-test-skill'].source).toBe('my-pkg');
       expect(lock.skills['lock-test-skill'].sourceType).toBe('node_modules');
       expect(lock.skills['lock-test-skill'].computedHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should restore node_modules skills to selected agents using copy mode', () => {
+      const pkgDir = join(testDir, 'node_modules', 'restore-pkg');
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, 'SKILL.md'),
+        `---
+name: restored-node-skill
+description: Restored node_modules skill
+---
+
+# Restored Node Skill
+`
+      );
+      writeFileSync(
+        join(testDir, 'skills-lock.json'),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            'restored-node-skill': {
+              source: 'restore-pkg',
+              sourceType: 'node_modules',
+              computedHash: 'stale',
+            },
+          },
+        })
+      );
+
+      const result = runCli(
+        ['experimental_install', '--agent', 'claude-code', 'openclaw', '--copy'],
+        testDir
+      );
+
+      expect(result.exitCode).toBe(0);
+      for (const agentDir of [
+        join(testDir, '.claude', 'skills', 'restored-node-skill'),
+        join(testDir, 'skills', 'restored-node-skill'),
+      ]) {
+        expect(existsSync(join(agentDir, 'SKILL.md'))).toBe(true);
+        expect(lstatSync(agentDir).isSymbolicLink()).toBe(false);
+      }
     });
 
     it('should not have timestamps in lock entries', () => {


### PR DESCRIPTION
## Summary
- add --agent and --copy support to experimental_install
- forward options for both lock-file and node_modules restore paths
- cover help text and both restore paths with tests

## Testing
- pnpm exec vitest run src/add.test.ts src/cli.test.ts tests/install.test.ts tests/sync.test.ts
- pnpm exec prettier --check src/add.test.ts src/cli.test.ts src/cli.ts src/install.ts src/sync.ts tests/install.test.ts tests/sync.test.ts

Closes #1805
