### PR TITLE
refactor: share zip extraction without yauzl

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "@clack/prompts": "^1.2.0",
     "@types/bun": "latest",
     "@types/node": "^22.10.0",
-    "@types/yauzl": "^3.4.0",
     "@vercel/detect-agent": "^1.2.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
@@ -144,7 +143,6 @@
   "packageManager": "pnpm@10.17.1",
   "dependencies": {
     "tar": "^7.5.20",
-    "yaml": "^2.8.3",
-    "yauzl": "^3.4.0"
+    "yaml": "^2.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.9.0
-      yauzl:
-        specifier: ^3.4.0
-        version: 3.4.0
     devDependencies:
       '@clack/prompts':
         specifier: ^1.2.0
@@ -27,9 +24,6 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.20.1
-      '@types/yauzl':
-        specifier: ^3.4.0
-        version: 3.4.0
       '@vercel/detect-agent':
         specifier: ^1.2.1
         version: 1.2.3
@@ -260,9 +254,6 @@ packages:
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
-
-  '@types/yauzl@3.4.0':
-    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
 
   '@vercel/detect-agent@1.2.3':
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
@@ -597,9 +588,6 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -839,10 +827,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yauzl@3.4.0:
-    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
-    engines: {node: '>=12'}
-
 snapshots:
 
   '@babel/generator@8.0.0':
@@ -1012,10 +996,6 @@ snapshots:
   '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/yauzl@3.4.0':
-    dependencies:
-      '@types/node': 22.20.1
 
   '@vercel/detect-agent@1.2.3': {}
 
@@ -1295,8 +1275,6 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pend@1.2.0: {}
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
@@ -1496,7 +1474,3 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.9.0: {}
-
-  yauzl@3.4.0:
-    dependencies:
-      pend: 1.2.0

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,0 +1,401 @@
+import { crc32, inflateRawSync } from 'node:zlib';
+
+const ZIP_LOCAL_FILE_HEADER = 0x04034b50;
+const ZIP_CENTRAL_DIRECTORY_HEADER = 0x02014b50;
+const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50;
+const ZIP64_END_OF_CENTRAL_DIRECTORY = 0x06064b50;
+const ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR = 0x07064b50;
+const ZIP_END_MIN_SIZE = 22;
+const ZIP_MAX_COMMENT_SIZE = 0xffff;
+const CP437_HIGH_BYTES = [
+  'ÇüéâäàåçêëèïîìÄÅ',
+  'ÉæÆôöòûùÿÖÜ¢£¥₧ƒ',
+  'áíóúñÑªº¿⌐¬½¼¡«»',
+  '░▒▓│┤╡╢╖╕╣║╗╝╜╛┐',
+  '└┴┬├─┼╞╟╚╔╩╦╠═╬╧',
+  '╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀',
+  'αßΓπΣσµτΦΘΩδ∞φε∩',
+  '≡±≥≤⌠⌡÷≈°∙·√ⁿ²■\u00a0',
+].join('');
+
+export interface ArchiveLimits {
+  maxExtractedBytes: number;
+  maxEntries: number;
+}
+
+export class ArchiveValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArchiveValidationError';
+  }
+}
+
+function ensureRange(buffer: Buffer, offset: number, length: number, label: string): void {
+  if (
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(length) ||
+    offset < 0 ||
+    length < 0 ||
+    offset + length > buffer.length
+  ) {
+    throw new Error(`Invalid zip archive: ${label} is out of bounds`);
+  }
+}
+
+function findEndOfCentralDirectory(buffer: Buffer): number {
+  const minOffset = Math.max(0, buffer.length - ZIP_MAX_COMMENT_SIZE - ZIP_END_MIN_SIZE);
+  for (let offset = buffer.length - ZIP_END_MIN_SIZE; offset >= minOffset; offset--) {
+    if (buffer.readUInt32LE(offset) !== ZIP_END_OF_CENTRAL_DIRECTORY) continue;
+
+    const commentLength = buffer.readUInt16LE(offset + 20);
+    if (offset + ZIP_END_MIN_SIZE + commentLength === buffer.length) {
+      return offset;
+    }
+  }
+  return -1;
+}
+
+function readUInt64AsNumber(buffer: Buffer, offset: number, label: string): number {
+  ensureRange(buffer, offset, 8, label);
+  const value = buffer.readBigUInt64LE(offset);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`Invalid zip archive: ${label} exceeds the safe integer range`);
+  }
+  return Number(value);
+}
+
+function readCentralDirectory(
+  buffer: Buffer,
+  endOffset: number
+): {
+  entries: number;
+  offset: number;
+  size: number;
+  trailerOffset: number;
+} {
+  const diskNumber = buffer.readUInt16LE(endOffset + 4);
+  const centralDirectoryDisk = buffer.readUInt16LE(endOffset + 6);
+  const entriesOnDisk = buffer.readUInt16LE(endOffset + 8);
+  const totalEntries = buffer.readUInt16LE(endOffset + 10);
+  const size = buffer.readUInt32LE(endOffset + 12);
+  const offset = buffer.readUInt32LE(endOffset + 16);
+  const usesZip64 =
+    entriesOnDisk === 0xffff ||
+    totalEntries === 0xffff ||
+    size === 0xffffffff ||
+    offset === 0xffffffff;
+
+  if (!usesZip64) {
+    if (diskNumber !== 0 || centralDirectoryDisk !== 0 || entriesOnDisk !== totalEntries) {
+      throw new Error('Multi-disk zip archives are not supported');
+    }
+    return { entries: totalEntries, offset, size, trailerOffset: endOffset };
+  }
+
+  if (diskNumber !== 0 || centralDirectoryDisk !== 0) {
+    throw new Error('Multi-disk zip archives are not supported');
+  }
+
+  const locatorOffset = endOffset - 20;
+  ensureRange(buffer, locatorOffset, 20, 'zip64 locator');
+  if (buffer.readUInt32LE(locatorOffset) !== ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR) {
+    throw new Error('Invalid zip64 locator');
+  }
+  if (
+    buffer.readUInt32LE(locatorOffset + 4) !== 0 ||
+    buffer.readUInt32LE(locatorOffset + 16) !== 1
+  ) {
+    throw new Error('Multi-disk zip archives are not supported');
+  }
+
+  const zip64EndOffset = readUInt64AsNumber(buffer, locatorOffset + 8, 'zip64 end offset');
+  ensureRange(buffer, zip64EndOffset, 56, 'zip64 end of central directory');
+  if (buffer.readUInt32LE(zip64EndOffset) !== ZIP64_END_OF_CENTRAL_DIRECTORY) {
+    throw new Error('Invalid zip64 end of central directory');
+  }
+
+  const recordSize = readUInt64AsNumber(buffer, zip64EndOffset + 4, 'zip64 end size');
+  if (recordSize < 44) {
+    throw new Error('Invalid zip64 end of central directory');
+  }
+  ensureRange(buffer, zip64EndOffset, recordSize + 12, 'zip64 end of central directory');
+  if (zip64EndOffset + recordSize + 12 !== locatorOffset) {
+    throw new Error('Invalid zip64 end of central directory');
+  }
+  if (
+    buffer.readUInt32LE(zip64EndOffset + 16) !== 0 ||
+    buffer.readUInt32LE(zip64EndOffset + 20) !== 0
+  ) {
+    throw new Error('Multi-disk zip archives are not supported');
+  }
+
+  const zip64EntriesOnDisk = readUInt64AsNumber(
+    buffer,
+    zip64EndOffset + 24,
+    'zip64 entries on disk'
+  );
+  const zip64TotalEntries = readUInt64AsNumber(buffer, zip64EndOffset + 32, 'zip64 total entries');
+  if (zip64EntriesOnDisk !== zip64TotalEntries) {
+    throw new Error('Multi-disk zip archives are not supported');
+  }
+
+  return {
+    entries: zip64TotalEntries,
+    size: readUInt64AsNumber(buffer, zip64EndOffset + 40, 'zip64 central directory size'),
+    offset: readUInt64AsNumber(buffer, zip64EndOffset + 48, 'zip64 central directory offset'),
+    trailerOffset: zip64EndOffset,
+  };
+}
+
+function normalizeArchivePath(rawPath: string): string | null {
+  if (!rawPath || rawPath.includes('\0')) return null;
+
+  const path = rawPath.replace(/\\/g, '/');
+  if (path.startsWith('/') || /^[A-Za-z]:/.test(path)) return null;
+
+  const parts = path.split('/');
+  if (parts.some((part) => part === '..')) return null;
+
+  const normalized = parts.filter((part) => part && part !== '.').join('/');
+  if (!normalized && !path.endsWith('/')) return null;
+  return path.endsWith('/') && normalized ? `${normalized}/` : normalized;
+}
+
+function findExtraField(
+  buffer: Buffer,
+  extraOffset: number,
+  extraLength: number,
+  targetId: number
+): Buffer | null {
+  const extraEnd = extraOffset + extraLength;
+  let offset = extraOffset;
+  while (offset < extraEnd) {
+    if (offset + 4 > extraEnd) throw new Error('Invalid zip extra field');
+
+    const id = buffer.readUInt16LE(offset);
+    const size = buffer.readUInt16LE(offset + 2);
+    const dataOffset = offset + 4;
+    ensureRange(buffer, dataOffset, size, 'zip extra field');
+    if (dataOffset + size > extraEnd) throw new Error('Invalid zip extra field');
+    if (id === targetId) return buffer.subarray(dataOffset, dataOffset + size);
+
+    offset = dataOffset + size;
+  }
+  return null;
+}
+
+function decodeFileName(bytes: Buffer, isUtf8: boolean, unicodePathExtra: Buffer | null): string {
+  if (isUtf8) {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  }
+
+  if (
+    unicodePathExtra &&
+    unicodePathExtra.length >= 5 &&
+    unicodePathExtra[0] === 1 &&
+    unicodePathExtra.readUInt32LE(1) === crc32(bytes)
+  ) {
+    return new TextDecoder('utf-8', { fatal: true }).decode(unicodePathExtra.subarray(5));
+  }
+
+  let result = '';
+  for (const byte of bytes) {
+    result += byte < 0x80 ? String.fromCharCode(byte) : CP437_HIGH_BYTES[byte - 0x80]!;
+  }
+  return result;
+}
+
+function readZip64EntryValues(
+  buffer: Buffer,
+  extraOffset: number,
+  extraLength: number,
+  values: {
+    compressedSize: number;
+    diskStart: number;
+    localHeaderOffset: number;
+    uncompressedSize: number;
+  }
+): typeof values {
+  const needsZip64 =
+    values.uncompressedSize === 0xffffffff ||
+    values.compressedSize === 0xffffffff ||
+    values.localHeaderOffset === 0xffffffff ||
+    values.diskStart === 0xffff;
+
+  if (!needsZip64) {
+    if (values.diskStart !== 0) throw new Error('Multi-disk zip archives are not supported');
+    return values;
+  }
+
+  const zip64Extra = findExtraField(buffer, extraOffset, extraLength, 0x0001);
+  if (!zip64Extra) throw new Error('Invalid zip64 extra field');
+
+  let valueOffset = 0;
+  const readNextUInt64 = (label: string): number => {
+    if (valueOffset + 8 > zip64Extra.length) {
+      throw new Error(`Invalid zip64 extra field: missing ${label}`);
+    }
+    const value = readUInt64AsNumber(zip64Extra, valueOffset, `zip64 ${label}`);
+    valueOffset += 8;
+    return value;
+  };
+
+  const resolved = { ...values };
+  if (resolved.uncompressedSize === 0xffffffff) {
+    resolved.uncompressedSize = readNextUInt64('uncompressed size');
+  }
+  if (resolved.compressedSize === 0xffffffff) {
+    resolved.compressedSize = readNextUInt64('compressed size');
+  }
+  if (resolved.localHeaderOffset === 0xffffffff) {
+    resolved.localHeaderOffset = readNextUInt64('local header offset');
+  }
+  if (resolved.diskStart === 0xffff) {
+    if (valueOffset + 4 > zip64Extra.length) {
+      throw new Error('Invalid zip64 extra field: missing disk start');
+    }
+    resolved.diskStart = zip64Extra.readUInt32LE(valueOffset);
+  }
+  if (resolved.diskStart !== 0) {
+    throw new Error('Multi-disk zip archives are not supported');
+  }
+  return resolved;
+}
+
+export function readZipArchive(bytes: Uint8Array, limits: ArchiveLimits): Map<string, Uint8Array> {
+  const buffer = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const endOffset = findEndOfCentralDirectory(buffer);
+  if (endOffset < 0) throw new Error('Invalid zip archive');
+
+  const centralDirectory = readCentralDirectory(buffer, endOffset);
+  const totalEntries = centralDirectory.entries;
+  if (totalEntries > limits.maxEntries) {
+    throw new ArchiveValidationError(
+      `Archive contains too many files (${totalEntries}). Maximum is ${limits.maxEntries}.`
+    );
+  }
+
+  ensureRange(buffer, centralDirectory.offset, centralDirectory.size, 'central directory');
+  if (centralDirectory.offset + centralDirectory.size > centralDirectory.trailerOffset) {
+    throw new Error('Invalid zip archive: central directory overlaps archive trailer');
+  }
+
+  const files = new Map<string, Uint8Array>();
+  let extractedBytes = 0;
+  let offset = centralDirectory.offset;
+
+  for (let index = 0; index < totalEntries; index++) {
+    ensureRange(buffer, offset, 46, 'central directory entry');
+    if (buffer.readUInt32LE(offset) !== ZIP_CENTRAL_DIRECTORY_HEADER) {
+      throw new Error('Invalid zip central directory entry');
+    }
+
+    const flags = buffer.readUInt16LE(offset + 8);
+    const method = buffer.readUInt16LE(offset + 10);
+    const expectedChecksum = buffer.readUInt32LE(offset + 16);
+    let compressedSize = buffer.readUInt32LE(offset + 20);
+    let uncompressedSize = buffer.readUInt32LE(offset + 24);
+    const fileNameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    let diskStart = buffer.readUInt16LE(offset + 34);
+    const externalAttributes = buffer.readUInt32LE(offset + 38);
+    let localHeaderOffset = buffer.readUInt32LE(offset + 42);
+    const variableSize = fileNameLength + extraLength + commentLength;
+    ensureRange(buffer, offset + 46, variableSize, 'central directory entry data');
+
+    const nameStart = offset + 46;
+    const extraOffset = nameStart + fileNameLength;
+    ({ compressedSize, diskStart, localHeaderOffset, uncompressedSize } = readZip64EntryValues(
+      buffer,
+      extraOffset,
+      extraLength,
+      {
+        compressedSize,
+        diskStart,
+        localHeaderOffset,
+        uncompressedSize,
+      }
+    ));
+    const centralFileName = buffer.subarray(nameStart, nameStart + fileNameLength);
+    const rawFileName = decodeFileName(
+      centralFileName,
+      Boolean(flags & 0x800),
+      findExtraField(buffer, extraOffset, extraLength, 0x7075)
+    );
+    const fileName = normalizeArchivePath(rawFileName);
+    if (fileName === null) {
+      throw new ArchiveValidationError(`Archive contains unsafe path: ${rawFileName}`);
+    }
+    if (flags & 0x1) {
+      throw new ArchiveValidationError('Encrypted zip entries are not supported');
+    }
+    const fileType = (externalAttributes >>> 16) & 0o170000;
+    if (fileType !== 0 && fileType !== 0o100000 && fileType !== 0o040000) {
+      throw new ArchiveValidationError('Archive links are not supported');
+    }
+    const isDirectory = rawFileName.replace(/\\/g, '/').endsWith('/') || fileType === 0o040000;
+    offset += 46 + variableSize;
+
+    extractedBytes += uncompressedSize;
+    if (extractedBytes > limits.maxExtractedBytes) {
+      throw new ArchiveValidationError(
+        `Archive extracts to more than ${limits.maxExtractedBytes} bytes.`
+      );
+    }
+    if (isDirectory) continue;
+
+    ensureRange(buffer, localHeaderOffset, 30, 'local file header');
+    if (buffer.readUInt32LE(localHeaderOffset) !== ZIP_LOCAL_FILE_HEADER) {
+      throw new Error('Invalid zip local file header');
+    }
+
+    const localFlags = buffer.readUInt16LE(localHeaderOffset + 6);
+    const localMethod = buffer.readUInt16LE(localHeaderOffset + 8);
+    const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
+    const localNameOffset = localHeaderOffset + 30;
+    ensureRange(
+      buffer,
+      localNameOffset,
+      localFileNameLength + localExtraLength,
+      'local file header data'
+    );
+    const localFileName = buffer.subarray(localNameOffset, localNameOffset + localFileNameLength);
+    if (localFlags !== flags || localMethod !== method || !localFileName.equals(centralFileName)) {
+      throw new Error('Zip local header does not match central directory');
+    }
+
+    const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+    ensureRange(buffer, dataOffset, compressedSize, 'file data');
+    if (dataOffset + compressedSize > centralDirectory.offset) {
+      throw new Error('Invalid zip archive: file data overlaps central directory');
+    }
+
+    const compressed = buffer.subarray(dataOffset, dataOffset + compressedSize);
+    let contents: Buffer;
+    if (method === 0) {
+      contents = compressed;
+    } else if (method === 8) {
+      contents = inflateRawSync(compressed, {
+        maxOutputLength: uncompressedSize + 1,
+      });
+    } else {
+      throw new Error(`Unsupported zip compression method: ${method}`);
+    }
+
+    if (contents.byteLength !== uncompressedSize) {
+      throw new Error('Zip entry size mismatch');
+    }
+    if (crc32(contents) !== expectedChecksum) {
+      throw new Error('Zip entry checksum mismatch');
+    }
+    files.set(fileName, new Uint8Array(contents));
+  }
+
+  if (offset !== centralDirectory.offset + centralDirectory.size) {
+    throw new Error('Invalid zip central directory size');
+  }
+
+  return files;
+}

--- a/src/download-source.ts
+++ b/src/download-source.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, normalize, resolve, sep } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import * as tar from 'tar';
-import yauzl from 'yauzl';
+import { ArchiveValidationError, readZipArchive } from './archive.ts';
 import { parseFrontmatter } from './frontmatter.ts';
 
 const DEFAULT_DOWNLOAD_MAX_BYTES = 10 * 1024 * 1024;
@@ -21,13 +21,6 @@ interface DownloadLimits {
 interface ExtractState {
   bytes: number;
   entries: number;
-}
-
-class ArchiveValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ArchiveValidationError';
-  }
 }
 
 export interface DownloadedSource {
@@ -138,90 +131,24 @@ async function isValidSkillMarkdown(filePath: string): Promise<boolean> {
   }
 }
 
-function openZip(filePath: string): Promise<yauzl.ZipFile> {
-  return new Promise((resolvePromise, reject) => {
-    yauzl.open(filePath, { lazyEntries: true, validateEntrySizes: true }, (error, zipFile) => {
-      if (error || !zipFile) {
-        reject(error ?? new Error('Invalid zip archive'));
-        return;
-      }
-      resolvePromise(zipFile);
-    });
-  });
-}
-
-function isZipPathValidationError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return /invalid (?:relative|absolute) path/i.test(error.message);
-}
-
-function openZipReadStream(
-  zipFile: yauzl.ZipFile,
-  entry: yauzl.Entry
-): Promise<NodeJS.ReadableStream> {
-  return new Promise((resolvePromise, reject) => {
-    zipFile.openReadStream(entry, (error, readStream) => {
-      if (error || !readStream) {
-        reject(error ?? new Error('Failed to read zip entry'));
-        return;
-      }
-      resolvePromise(readStream);
-    });
-  });
-}
-
 async function extractZip(
   filePath: string,
   extractDir: string,
   limits: DownloadLimits
 ): Promise<void> {
-  const zipFile = await openZip(filePath);
-  const state: ExtractState = { bytes: 0, entries: 0 };
+  const files = readZipArchive(await readFile(filePath), {
+    maxExtractedBytes: limits.extractMaxBytes,
+    maxEntries: limits.extractMaxFiles,
+  });
 
-  try {
-    await new Promise<void>((resolvePromise, reject) => {
-      zipFile.on('error', (error) => {
-        reject(
-          isZipPathValidationError(error)
-            ? new ArchiveValidationError(`Archive contains unsafe path: ${error.message}`)
-            : error
-        );
-      });
-      zipFile.on('end', resolvePromise);
-      zipFile.on('entry', (entry: yauzl.Entry) => {
-        void (async () => {
-          const safePath = validateArchivePath(entry.fileName);
-          if (safePath === null) {
-            throw new ArchiveValidationError(`Archive contains unsafe path: ${entry.fileName}`);
-          }
+  for (const [path, contents] of files) {
+    const targetPath = join(extractDir, path);
+    if (!isPathSafe(extractDir, targetPath)) {
+      throw new ArchiveValidationError(`Archive contains unsafe path: ${path}`);
+    }
 
-          incrementEntry(state, entry.uncompressedSize, limits);
-
-          if (!safePath || /\/$/.test(safePath)) {
-            zipFile.readEntry();
-            return;
-          }
-
-          if (/\/$/.test(entry.fileName)) {
-            zipFile.readEntry();
-            return;
-          }
-
-          const targetPath = join(extractDir, safePath);
-          if (!isPathSafe(extractDir, targetPath)) {
-            throw new ArchiveValidationError(`Archive contains unsafe path: ${entry.fileName}`);
-          }
-
-          await mkdir(dirname(targetPath), { recursive: true });
-          const readStream = await openZipReadStream(zipFile, entry);
-          await pipeline(readStream, createWriteStream(targetPath));
-          zipFile.readEntry();
-        })().catch(reject);
-      });
-      zipFile.readEntry();
-    });
-  } finally {
-    zipFile.close();
+    await mkdir(dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, contents);
   }
 }
 

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
-import { gunzipSync, inflateRawSync } from 'node:zlib';
+import { gunzipSync } from 'node:zlib';
+import { readZipArchive } from '../archive.ts';
 import { parseFrontmatter } from '../frontmatter.ts';
 import { sanitizeMetadata } from '../sanitize.ts';
 import type { HostProvider, ProviderMatch, RemoteSkill } from './types.ts';
@@ -572,7 +573,12 @@ export class WellKnownProvider implements HostProvider {
     contentType: string
   ): Map<string, WellKnownFileContent> {
     if (this.isZipArchive(bytes, artifactUrl, contentType)) {
-      return this.extractZip(bytes);
+      return new Map<string, WellKnownFileContent>(
+        readZipArchive(bytes, {
+          maxExtractedBytes: MAX_ARCHIVE_UNPACKED_BYTES,
+          maxEntries: MAX_ARCHIVE_FILES,
+        })
+      );
     }
 
     if (this.isTarGzArchive(bytes, artifactUrl, contentType)) {
@@ -676,83 +682,6 @@ export class WellKnownProvider implements HostProvider {
     const slice = buffer.subarray(offset, offset + length);
     const nul = slice.indexOf(0);
     return new TextDecoder().decode(nul >= 0 ? slice.subarray(0, nul) : slice);
-  }
-
-  private extractZip(bytes: Uint8Array): Map<string, WellKnownFileContent> {
-    const buffer = Buffer.from(bytes);
-    const eocdOffset = this.findZipEndOfCentralDirectory(buffer);
-    if (eocdOffset < 0) throw new Error('Invalid zip archive');
-
-    const totalEntries = buffer.readUInt16LE(eocdOffset + 10);
-    const centralDirectoryOffset = buffer.readUInt32LE(eocdOffset + 16);
-    const files = new Map<string, WellKnownFileContent>();
-    const runningTotal = { bytes: 0 };
-    let offset = centralDirectoryOffset;
-
-    for (let i = 0; i < totalEntries; i++) {
-      if (buffer.readUInt32LE(offset) !== 0x02014b50) throw new Error('Invalid zip directory');
-
-      const flags = buffer.readUInt16LE(offset + 8);
-      const method = buffer.readUInt16LE(offset + 10);
-      const compressedSize = buffer.readUInt32LE(offset + 20);
-      const uncompressedSize = buffer.readUInt32LE(offset + 24);
-      const fileNameLength = buffer.readUInt16LE(offset + 28);
-      const extraLength = buffer.readUInt16LE(offset + 30);
-      const commentLength = buffer.readUInt16LE(offset + 32);
-      const externalAttributes = buffer.readUInt32LE(offset + 38);
-      const localHeaderOffset = buffer.readUInt32LE(offset + 42);
-      const nameStart = offset + 46;
-      const rawName = buffer.subarray(nameStart, nameStart + fileNameLength);
-      const fileName = new TextDecoder(flags & 0x800 ? 'utf-8' : undefined).decode(rawName);
-
-      offset = nameStart + fileNameLength + extraLength + commentLength;
-
-      // Directories are allowed but not installed as files.
-      if (fileName.endsWith('/')) continue;
-
-      // Reject encrypted entries, symlinks, and hard links. ZIP external attributes store
-      // POSIX mode bits in the upper 16 bits for common UNIX-producing tools.
-      if (flags & 0x1) throw new Error('Encrypted zip entries are not supported');
-      const unixMode = externalAttributes >>> 16;
-      const fileType = unixMode & 0o170000;
-      if (fileType === 0o120000 || fileType === 0o10000) {
-        throw new Error('Archive links are not supported');
-      }
-
-      if (buffer.readUInt32LE(localHeaderOffset) !== 0x04034b50) {
-        throw new Error('Invalid zip local header');
-      }
-      const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
-      const localExtraLength = buffer.readUInt16LE(localHeaderOffset + 28);
-      const dataStart = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
-      const compressed = buffer.subarray(dataStart, dataStart + compressedSize);
-
-      let content: Buffer;
-      if (method === 0) {
-        content = compressed;
-      } else if (method === 8) {
-        content = inflateRawSync(compressed);
-      } else {
-        throw new Error(`Unsupported zip compression method: ${method}`);
-      }
-
-      if (content.byteLength !== uncompressedSize) {
-        throw new Error('Zip entry size mismatch');
-      }
-
-      this.addArchiveFile(files, fileName, new Uint8Array(content), runningTotal);
-    }
-
-    if (!files.has('SKILL.md')) throw new Error('Archive missing root SKILL.md');
-    return files;
-  }
-
-  private findZipEndOfCentralDirectory(buffer: Buffer): number {
-    const minOffset = Math.max(0, buffer.length - 0xffff - 22);
-    for (let offset = buffer.length - 22; offset >= minOffset; offset--) {
-      if (buffer.readUInt32LE(offset) === 0x06054b50) return offset;
-    }
-    return -1;
   }
 
   /**

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from 'vitest';
+import { ArchiveValidationError, readZipArchive } from '../src/archive.ts';
+import { createZip } from './fixtures/zip.ts';
+
+function convertToZip64(archive: Buffer): Buffer {
+  const endOffset = archive.length - 22;
+  const entries = archive.readUInt16LE(endOffset + 10);
+  const centralDirectorySize = archive.readUInt32LE(endOffset + 12);
+  const centralDirectoryOffset = archive.readUInt32LE(endOffset + 16);
+  const prefix = archive.subarray(0, endOffset);
+
+  const zip64End = Buffer.alloc(56);
+  zip64End.writeUInt32LE(0x06064b50, 0);
+  zip64End.writeBigUInt64LE(44n, 4);
+  zip64End.writeUInt16LE(45, 12);
+  zip64End.writeUInt16LE(45, 14);
+  zip64End.writeBigUInt64LE(BigInt(entries), 24);
+  zip64End.writeBigUInt64LE(BigInt(entries), 32);
+  zip64End.writeBigUInt64LE(BigInt(centralDirectorySize), 40);
+  zip64End.writeBigUInt64LE(BigInt(centralDirectoryOffset), 48);
+
+  const locator = Buffer.alloc(20);
+  locator.writeUInt32LE(0x07064b50, 0);
+  locator.writeBigUInt64LE(BigInt(prefix.length), 8);
+  locator.writeUInt32LE(1, 16);
+
+  const end = Buffer.from(archive.subarray(endOffset));
+  end.writeUInt16LE(0xffff, 8);
+  end.writeUInt16LE(0xffff, 10);
+  end.writeUInt32LE(0xffffffff, 12);
+  end.writeUInt32LE(0xffffffff, 16);
+
+  return Buffer.concat([prefix, zip64End, locator, end]);
+}
+
+describe('readZipArchive', () => {
+  it('returns files from a stored zip archive', () => {
+    const archive = createZip([
+      { path: 'SKILL.md', contents: '# skill' },
+      { path: 'references/README.md', contents: 'reference' },
+    ]);
+
+    const files = readZipArchive(archive, {
+      maxExtractedBytes: 1024,
+      maxEntries: 10,
+    });
+
+    expect(Buffer.from(files.get('SKILL.md')!)).toEqual(Buffer.from('# skill'));
+    expect(Buffer.from(files.get('references/README.md')!)).toEqual(Buffer.from('reference'));
+  });
+
+  it('inflates deflated entries', () => {
+    const archive = createZip([
+      {
+        path: 'SKILL.md',
+        contents: '# compressed skill',
+        method: 'deflate',
+      },
+    ]);
+
+    const files = readZipArchive(archive, {
+      maxExtractedBytes: 1024,
+      maxEntries: 10,
+    });
+
+    expect(Buffer.from(files.get('SKILL.md')!)).toEqual(Buffer.from('# compressed skill'));
+  });
+
+  it('rejects paths that escape the extraction root', () => {
+    const archive = createZip([{ path: '../SKILL.md', contents: '# unsafe' }]);
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 10,
+      })
+    ).toThrow('Archive contains unsafe path');
+  });
+
+  it('rejects drive-prefixed paths', () => {
+    const archive = createZip([{ path: 'C:SKILL.md', contents: '# unsafe' }]);
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 10,
+      })
+    ).toThrow('Archive contains unsafe path');
+  });
+
+  it('rejects encrypted entries', () => {
+    const archive = createZip([
+      {
+        path: 'SKILL.md',
+        contents: '# encrypted',
+        encrypted: true,
+      },
+    ]);
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 10,
+      })
+    ).toThrow('Encrypted zip entries are not supported');
+  });
+
+  it('rejects symbolic links', () => {
+    const archive = createZip([
+      {
+        path: 'SKILL.md',
+        contents: 'target',
+        unixMode: 0o120777,
+      },
+    ]);
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 10,
+      })
+    ).toThrow('Archive links are not supported');
+  });
+
+  it('counts directory entries toward the archive entry limit', () => {
+    const archive = createZip([
+      {
+        path: 'skill/',
+        contents: '',
+        unixMode: 0o040755,
+      },
+      {
+        path: 'skill/SKILL.md',
+        contents: '# skill',
+      },
+    ]);
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 1,
+      })
+    ).toThrow(ArchiveValidationError);
+  });
+
+  it('omits directory entries after normalizing dot segments', () => {
+    const archive = createZip([
+      {
+        path: './',
+        contents: '',
+        unixMode: 0o040755,
+      },
+      {
+        path: './SKILL.md',
+        contents: '# skill',
+      },
+    ]);
+
+    const files = readZipArchive(archive, {
+      maxExtractedBytes: 1024,
+      maxEntries: 10,
+    });
+
+    expect([...files.keys()]).toEqual(['SKILL.md']);
+  });
+
+  it('rejects entries whose contents do not match their checksum', () => {
+    const archive = createZip([{ path: 'SKILL.md', contents: '# skill' }]);
+    const contentsOffset = archive.indexOf(Buffer.from('# skill'));
+    archive[contentsOffset] ^= 0xff;
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 10,
+      })
+    ).toThrow('Zip entry checksum mismatch');
+  });
+
+  it('decodes legacy cp437 file names', () => {
+    const archive = createZip([
+      {
+        path: Buffer.from([
+          0x63, 0x61, 0x66, 0x82, 0x2f, 0x53, 0x4b, 0x49, 0x4c, 0x4c, 0x2e, 0x6d, 0x64,
+        ]),
+        contents: '# skill',
+      },
+    ]);
+
+    const files = readZipArchive(archive, {
+      maxExtractedBytes: 1024,
+      maxEntries: 10,
+    });
+
+    expect(Buffer.from(files.get('café/SKILL.md')!)).toEqual(Buffer.from('# skill'));
+  });
+
+  it('reads zip64 central directory metadata', () => {
+    const archive = convertToZip64(createZip([{ path: 'SKILL.md', contents: '# zip64 skill' }]));
+
+    const files = readZipArchive(archive, {
+      maxExtractedBytes: 1024,
+      maxEntries: 10,
+    });
+
+    expect(Buffer.from(files.get('SKILL.md')!)).toEqual(Buffer.from('# zip64 skill'));
+  });
+
+  it('uses a valid info-zip unicode path', () => {
+    const archive = createZip([
+      {
+        path: 'cafe/SKILL.md',
+        unicodePath: 'café/SKILL.md',
+        contents: '# unicode skill',
+      },
+    ]);
+
+    const files = readZipArchive(archive, {
+      maxExtractedBytes: 1024,
+      maxEntries: 10,
+    });
+
+    expect(Buffer.from(files.get('café/SKILL.md')!)).toEqual(Buffer.from('# unicode skill'));
+  });
+
+  it('reads zip64 entry sizes and offsets', () => {
+    const archive = createZip([
+      {
+        path: 'SKILL.md',
+        contents: '# zip64 entry',
+        zip64Entry: true,
+      },
+    ]);
+
+    const files = readZipArchive(archive, {
+      maxExtractedBytes: 1024,
+      maxEntries: 10,
+    });
+
+    expect(Buffer.from(files.get('SKILL.md')!)).toEqual(Buffer.from('# zip64 entry'));
+  });
+
+  it('rejects mismatched local and central directory headers', () => {
+    const archive = createZip([{ path: 'SKILL.md', contents: '# skill' }]);
+    archive[30] = 'X'.charCodeAt(0);
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 10,
+      })
+    ).toThrow('Zip local header does not match central directory');
+  });
+
+  it('rejects inconsistent central directory metadata', () => {
+    const archive = createZip([{ path: 'SKILL.md', contents: '# skill' }]);
+    const endOffset = archive.length - 22;
+    archive.writeUInt32LE(archive.readUInt32LE(endOffset + 12) + 1, endOffset + 12);
+
+    expect(() =>
+      readZipArchive(archive, {
+        maxExtractedBytes: 1024,
+        maxEntries: 10,
+      })
+    ).toThrow('Invalid zip');
+  });
+});

--- a/tests/download-source.test.ts
+++ b/tests/download-source.test.ts
@@ -5,6 +5,7 @@ import * as tar from 'tar';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadSource } from '../src/download-source.ts';
 import { discoverSkills } from '../src/skills.ts';
+import { createZip } from './fixtures/zip.ts';
 
 function mockFetchFile(filePath: string): void {
   vi.stubGlobal(
@@ -17,79 +18,6 @@ function mockFetchFile(filePath: string): void {
       });
     })
   );
-}
-
-function crc32(buffer: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of buffer) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit++) {
-      crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
-
-function createStoredZip(entries: Array<{ path: string; contents: string }>): Buffer {
-  const localParts: Buffer[] = [];
-  const centralParts: Buffer[] = [];
-  let offset = 0;
-
-  for (const entry of entries) {
-    const name = Buffer.from(entry.path);
-    const contents = Buffer.from(entry.contents);
-    const checksum = crc32(contents);
-
-    const localHeader = Buffer.alloc(30);
-    localHeader.writeUInt32LE(0x04034b50, 0);
-    localHeader.writeUInt16LE(20, 4);
-    localHeader.writeUInt16LE(0, 6);
-    localHeader.writeUInt16LE(0, 8);
-    localHeader.writeUInt16LE(0, 10);
-    localHeader.writeUInt16LE(0, 12);
-    localHeader.writeUInt32LE(checksum, 14);
-    localHeader.writeUInt32LE(contents.length, 18);
-    localHeader.writeUInt32LE(contents.length, 22);
-    localHeader.writeUInt16LE(name.length, 26);
-    localHeader.writeUInt16LE(0, 28);
-
-    localParts.push(localHeader, name, contents);
-
-    const centralHeader = Buffer.alloc(46);
-    centralHeader.writeUInt32LE(0x02014b50, 0);
-    centralHeader.writeUInt16LE(20, 4);
-    centralHeader.writeUInt16LE(20, 6);
-    centralHeader.writeUInt16LE(0, 8);
-    centralHeader.writeUInt16LE(0, 10);
-    centralHeader.writeUInt16LE(0, 12);
-    centralHeader.writeUInt16LE(0, 14);
-    centralHeader.writeUInt32LE(checksum, 16);
-    centralHeader.writeUInt32LE(contents.length, 20);
-    centralHeader.writeUInt32LE(contents.length, 24);
-    centralHeader.writeUInt16LE(name.length, 28);
-    centralHeader.writeUInt16LE(0, 30);
-    centralHeader.writeUInt16LE(0, 32);
-    centralHeader.writeUInt16LE(0, 34);
-    centralHeader.writeUInt16LE(0, 36);
-    centralHeader.writeUInt32LE(0, 38);
-    centralHeader.writeUInt32LE(offset, 42);
-    centralParts.push(centralHeader, name);
-
-    offset += localHeader.length + name.length + contents.length;
-  }
-
-  const centralDirectory = Buffer.concat(centralParts);
-  const end = Buffer.alloc(22);
-  end.writeUInt32LE(0x06054b50, 0);
-  end.writeUInt16LE(0, 4);
-  end.writeUInt16LE(0, 6);
-  end.writeUInt16LE(entries.length, 8);
-  end.writeUInt16LE(entries.length, 10);
-  end.writeUInt32LE(centralDirectory.length, 12);
-  end.writeUInt32LE(offset, 16);
-  end.writeUInt16LE(0, 20);
-
-  return Buffer.concat([...localParts, centralDirectory, end]);
 }
 
 describe('downloadSource', () => {
@@ -168,7 +96,7 @@ description: A skill served from an archive
     const zipPath = join(testDir, 'payload.zip');
     writeFileSync(
       zipPath,
-      createStoredZip([
+      createZip([
         {
           path: 'repo-main/skills/zip-url-skill/SKILL.md',
           contents: `---
@@ -197,7 +125,7 @@ description: A skill served from a zip archive
     const zipPath = join(testDir, 'unsafe.zip');
     writeFileSync(
       zipPath,
-      createStoredZip([
+      createZip([
         {
           path: '../SKILL.md',
           contents: `---
@@ -219,7 +147,7 @@ description: Unsafe archive path
     const zipPath = join(testDir, 'too-many-files.zip');
     writeFileSync(
       zipPath,
-      createStoredZip([
+      createZip([
         {
           path: 'repo-main/skills/limited/SKILL.md',
           contents: '---\nname: limited\ndescription: Limited\n---\n',

--- a/tests/fixtures/zip.ts
+++ b/tests/fixtures/zip.ts
@@ -1,0 +1,87 @@
+import { crc32, deflateRawSync } from 'node:zlib';
+
+export interface ZipFixtureEntry {
+  path: string | Buffer;
+  contents: string;
+  method?: 'store' | 'deflate';
+  encrypted?: boolean;
+  unicodePath?: string;
+  unixMode?: number;
+  zip64Entry?: boolean;
+}
+
+export function createZip(entries: ZipFixtureEntry[]): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.isBuffer(entry.path) ? entry.path : Buffer.from(entry.path);
+    const contents = Buffer.from(entry.contents);
+    const method = entry.method === 'deflate' ? 8 : 0;
+    const flags = entry.encrypted ? 0x1 : 0;
+    const compressed = method === 8 ? deflateRawSync(contents) : contents;
+    const checksum = crc32(contents);
+    const extraParts: Buffer[] = [];
+
+    if (entry.zip64Entry) {
+      const zip64Extra = Buffer.alloc(28);
+      zip64Extra.writeUInt16LE(0x0001, 0);
+      zip64Extra.writeUInt16LE(24, 2);
+      zip64Extra.writeBigUInt64LE(BigInt(contents.length), 4);
+      zip64Extra.writeBigUInt64LE(BigInt(compressed.length), 12);
+      zip64Extra.writeBigUInt64LE(BigInt(offset), 20);
+      extraParts.push(zip64Extra);
+    }
+
+    if (entry.unicodePath) {
+      const unicodeName = Buffer.from(entry.unicodePath);
+      const unicodeExtra = Buffer.alloc(9 + unicodeName.length);
+      unicodeExtra.writeUInt16LE(0x7075, 0);
+      unicodeExtra.writeUInt16LE(5 + unicodeName.length, 2);
+      unicodeExtra[4] = 1;
+      unicodeExtra.writeUInt32LE(crc32(name), 5);
+      unicodeName.copy(unicodeExtra, 9);
+      extraParts.push(unicodeExtra);
+    }
+
+    const centralExtra = Buffer.concat(extraParts);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(flags, 6);
+    localHeader.writeUInt16LE(method, 8);
+    localHeader.writeUInt32LE(checksum, 14);
+    localHeader.writeUInt32LE(compressed.length, 18);
+    localHeader.writeUInt32LE(contents.length, 22);
+    localHeader.writeUInt16LE(name.length, 26);
+    localParts.push(localHeader, name, compressed);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE((3 << 8) | 20, 4);
+    centralHeader.writeUInt16LE(entry.zip64Entry ? 45 : 20, 6);
+    centralHeader.writeUInt16LE(flags, 8);
+    centralHeader.writeUInt16LE(method, 10);
+    centralHeader.writeUInt32LE(checksum, 16);
+    centralHeader.writeUInt32LE(entry.zip64Entry ? 0xffffffff : compressed.length, 20);
+    centralHeader.writeUInt32LE(entry.zip64Entry ? 0xffffffff : contents.length, 24);
+    centralHeader.writeUInt16LE(name.length, 28);
+    centralHeader.writeUInt16LE(centralExtra.length, 30);
+    centralHeader.writeUInt32LE((entry.unixMode ?? 0o100644) * 0x10000, 38);
+    centralHeader.writeUInt32LE(entry.zip64Entry ? 0xffffffff : offset, 42);
+    centralParts.push(centralHeader, name, centralExtra);
+
+    offset += localHeader.length + name.length + compressed.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(offset, 16);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { gzipSync } from 'node:zlib';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { WellKnownProvider } from '../src/providers/wellknown.ts';
+import { createZip } from './fixtures/zip.ts';
 
 const SCHEMA_V2 = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 
@@ -327,6 +328,47 @@ describe('WellKnownProvider', () => {
       const skills = await provider.fetchAllSkills('https://example.com');
       expect(skills).toHaveLength(1);
       expect(skills[0]!.installName).toBe('archive-skill');
+      expect(skills[0]!.files.has('SKILL.md')).toBe(true);
+      expect(skills[0]!.files.has('references/README.md')).toBe(true);
+    });
+
+    it('supports v0.2.0 zip archive entries through the shared archive reader', async () => {
+      const archive = createZip([
+        {
+          path: 'SKILL.md',
+          contents: '---\nname: zip-skill\ndescription: Zip skill.\n---\n# Zip',
+        },
+        {
+          path: 'references/README.md',
+          contents: 'Reference',
+        },
+      ]);
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === 'https://example.com/.well-known/agent-skills/index.json') {
+          return response({
+            $schema: SCHEMA_V2,
+            skills: [
+              {
+                name: 'zip-skill',
+                type: 'archive',
+                description: 'Zip skill.',
+                url: '/downloads/zip-skill.zip',
+                digest: digest(archive),
+              },
+            ],
+          });
+        }
+        if (href === 'https://example.com/downloads/zip-skill.zip') {
+          return response(archive, { headers: { 'content-type': 'application/zip' } });
+        }
+        return response('not found', { status: 404 });
+      });
+
+      const skills = await provider.fetchAllSkills('https://example.com');
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.installName).toBe('zip-skill');
       expect(skills[0]!.files.has('SKILL.md')).toBe(true);
       expect(skills[0]!.files.has('references/README.md')).toBe(true);
     });


### PR DESCRIPTION
follows #1671.

## summary

- replace yauzl with one shared zip reader for direct downloads and well-known artifacts
- preserve zip64, stored/deflate, cp437/utf-8 paths, and checksum validation
- remove yauzl, @types/yauzl, and pend

## validation

- 706 tests pass
- type-check, formatting, build, and dist test pass