### PR TITLE
fix preserve well-known install urls

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -894,6 +894,7 @@ async function handleWellKnownSkills(
       agents: targetAgents.join(','),
       ...(installGlobally && { global: '1' }),
       skillFiles: JSON.stringify(skillFiles),
+      installUrl: url,
       metadata: options.metadata,
       sourceType: 'well-known',
     });

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -8,6 +8,8 @@ interface InstallTelemetryData {
   agents: string;
   global?: '1';
   skillFiles?: string; // JSON stringified { skillName: relativePath }
+  /** User-facing URL that can be passed back to `skills add`. */
+  installUrl?: string;
   /** Caller-provided JSON attached to this install telemetry event. */
   metadata?: string;
   /**

--- a/tests/direct-download-add.test.ts
+++ b/tests/direct-download-add.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { gzipSync } from 'node:zlib';
 
 vi.mock('@clack/prompts', () => {
   const noop = () => {};
@@ -72,12 +74,46 @@ vi.mock('../src/source-parser.ts', async (importActual) => {
 });
 
 import { runAdd } from '../src/add.ts';
+import { track } from '../src/telemetry.ts';
+
+const DISCOVERY_SCHEMA_V2 = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+
+function createTarGz(files: Record<string, string>): Uint8Array {
+  const chunks: Buffer[] = [];
+
+  for (const [name, contents] of Object.entries(files)) {
+    const body = Buffer.from(contents);
+    const header = Buffer.alloc(512);
+    header.write(name, 0, 100, 'utf8');
+    header.write('0000644\0', 100, 8, 'ascii');
+    header.write('0000000\0', 108, 8, 'ascii');
+    header.write('0000000\0', 116, 8, 'ascii');
+    header.write(body.length.toString(8).padStart(11, '0') + '\0', 124, 12, 'ascii');
+    header.write('00000000000\0', 136, 12, 'ascii');
+    header.fill(' ', 148, 156);
+    header[156] = '0'.charCodeAt(0);
+    header.write('ustar\0', 257, 6, 'ascii');
+    header.write('00', 263, 2, 'ascii');
+
+    let checksum = 0;
+    for (const byte of header) checksum += byte;
+    header.write(checksum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'ascii');
+
+    chunks.push(header, body);
+    const padding = (512 - (body.length % 512)) % 512;
+    if (padding) chunks.push(Buffer.alloc(padding));
+  }
+
+  chunks.push(Buffer.alloc(1024));
+  return new Uint8Array(gzipSync(Buffer.concat(chunks)));
+}
 
 describe('direct download add', () => {
   let project: string;
   let originalCwd: string;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     project = await mkdtemp(join(tmpdir(), 'direct-download-add-'));
     originalCwd = process.cwd();
     process.chdir(project);
@@ -117,5 +153,57 @@ describe('direct download add', () => {
       readFile(join(project, '.agents', 'skills', 'direct-skill', 'SKILL.md'), 'utf-8')
     ).resolves.toContain('# Direct skill');
     expect(existsSync(join(project, 'skills-lock.json'))).toBe(false);
+  });
+
+  it('reports the canonical discovery url separately from its archive artifact', async () => {
+    const installUrl = 'https://registry.example.com/publishers/acme/skills/archive-skill';
+    const indexUrl = `${installUrl}/.well-known/agent-skills/index.json`;
+    const artifactUrl = 'https://cdn.example.net/artifacts/archive-skill.tar.gz?version=1.2.5';
+    const skillMd =
+      '---\nname: archive-skill\ndescription: Archive skill\n---\n\n# Archive skill\n';
+    const archive = createTarGz({ 'SKILL.md': skillMd });
+    const digest = `sha256:${createHash('sha256').update(archive).digest('hex')}`;
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const href = String(url);
+      if (href === indexUrl) {
+        return Response.json({
+          $schema: DISCOVERY_SCHEMA_V2,
+          skills: [
+            {
+              name: 'archive-skill',
+              type: 'archive',
+              description: 'Archive skill',
+              url: artifactUrl,
+              digest,
+            },
+          ],
+        });
+      }
+      if (href === artifactUrl) {
+        return new Response(archive, {
+          status: 200,
+          headers: { 'content-type': 'application/gzip' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    });
+
+    await runAdd([installUrl], {
+      yes: true,
+      agent: ['codex'],
+      global: false,
+      copy: true,
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'install',
+        source: 'registry.example.com',
+        installUrl,
+        skillFiles: JSON.stringify({ 'archive-skill': artifactUrl }),
+        sourceType: 'well-known',
+      })
+    );
   });
 });


### PR DESCRIPTION
## summary

- report the original well-known discovery url separately from resolved artifact urls
- keep the existing artifact url map for backend fetching
- cover discovery and artifact hosts with provider-neutral fixtures

## tests

- `pnpm test --run`
- `pnpm type-check`
- `pnpm build`
- `pnpm format:check`

## dependencies

- ingestion: https://github.com/vercel-labs/add-skill-telemetry/pull/17
- display: https://github.com/vercel-labs/skills-leaderboard/pull/212