### PR TITLE
Add MiniMax Code agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [70 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -289,6 +289,7 @@ Skills can be installed to any of these agents:
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
 | Lingma | `lingma` | `.lingma/skills/` | `~/.lingma/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
+| MiniMax Code | `minimax-code` | `.minimax/skills/` | `~/.minimax/skills/` |
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Moxby | `moxby` | `.moxby/skills/` | `~/.moxby/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
@@ -421,6 +422,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.kode/skills/`
 - `.lingma/skills/`
 - `.mcpjam/skills/`
+- `.minimax/skills/`
 - `.vibe/skills/`
 - `.moxby/skills/`
 - `.mux/skills/`

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lingma",
     "loaf",
     "mcpjam",
+    "minimax-code",
     "mistral-vibe",
     "moxby",
     "mux",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -60,6 +60,13 @@ export function isKimchiInstalled(
   return pathExists(join(homeDir, '.config', 'kimchi'));
 }
 
+export function isMiniMaxCodeInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  return pathExists(join(homeDir, '.minimax')) || pathExists('/Applications/MiniMax Code.app');
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   'aider-desk': {
     name: 'aider-desk',
@@ -474,6 +481,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.mcpjam/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.mcpjam'));
+    },
+  },
+  'minimax-code': {
+    name: 'minimax-code',
+    displayName: 'MiniMax Code',
+    skillsDir: '.minimax/skills',
+    globalSkillsDir: join(home, '.minimax/skills'),
+    detectInstalled: async () => {
+      return isMiniMaxCodeInstalled();
     },
   },
   'mistral-vibe': {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -268,6 +268,7 @@ const PRIORITY_PREFIXES = [
   '.kilocode/skills/',
   '.kimchi/skills/',
   '.kiro/skills/',
+  '.minimax/skills/',
   '.mux/skills/',
   '.neovate/skills/',
   '.opencode/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -24,6 +24,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.kilocode/skills',
   '.kimchi/skills',
   '.kiro/skills',
+  '.minimax/skills',
   '.mux/skills',
   '.neovate/skills',
   '.opencode/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export type AgentType =
   | 'lingma'
   | 'loaf'
   | 'mcpjam'
+  | 'minimax-code'
   | 'mistral-vibe'
   | 'moxby'
   | 'mux'

--- a/tests/minimax-code-agent.test.ts
+++ b/tests/minimax-code-agent.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as agentModule from '../src/agents.ts';
+import { findSkillMdPaths } from '../src/blob.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+type InstallationDetector = (homeDir?: string, pathExists?: (path: string) => boolean) => boolean;
+
+function getDetector(): InstallationDetector | undefined {
+  return Reflect.get(agentModule, 'isMiniMaxCodeInstalled') as InstallationDetector | undefined;
+}
+
+const skillFile = (name: string) => `---
+name: ${name}
+description: ${name} test skill
+---
+
+# ${name}
+`;
+
+describe('MiniMax Code agent support', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'skills-minimax-code-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('uses the documented project and global skill directories', () => {
+    const agent = Reflect.get(agentModule.agents, 'minimax-code');
+
+    expect(agent?.name).toBe('minimax-code');
+    expect(agent?.displayName).toBe('MiniMax Code');
+    expect(agent?.skillsDir).toBe('.minimax/skills');
+    expect(agent?.globalSkillsDir).toBe(join(homedir(), '.minimax', 'skills'));
+  });
+
+  it('detects MiniMax Code from its home directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.minimax');
+
+    expect(getDetector()?.(home, exists)).toBe(true);
+  });
+
+  it('detects MiniMax Code from the macOS app bundle', () => {
+    const exists = (path: string) => path === '/Applications/MiniMax Code.app';
+
+    expect(getDetector()?.('/tmp/home', exists)).toBe(true);
+  });
+
+  it('returns false when no known MiniMax Code path exists', () => {
+    expect(getDetector()?.('/tmp/home', () => false)).toBe(false);
+  });
+
+  it('discovers project skills from .minimax/skills alongside standard skills', async () => {
+    const minimaxSkillDir = join(testDir, '.minimax', 'skills', 'minimax-skill');
+    const standardSkillDir = join(testDir, 'skills', 'standard-skill');
+    mkdirSync(minimaxSkillDir, { recursive: true });
+    mkdirSync(standardSkillDir, { recursive: true });
+    writeFileSync(join(minimaxSkillDir, 'SKILL.md'), skillFile('minimax-skill'));
+    writeFileSync(join(standardSkillDir, 'SKILL.md'), skillFile('standard-skill'));
+
+    const discovered = await discoverSkills(testDir);
+
+    expect(discovered.map((skill) => skill.name).sort()).toEqual([
+      'minimax-skill',
+      'standard-skill',
+    ]);
+  });
+
+  it('discovers .minimax/skills through the GitHub tree fast path', () => {
+    const discovered = findSkillMdPaths({
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: '.claude/skills/standard-skill/SKILL.md',
+          type: 'blob',
+          sha: 'standard-sha',
+        },
+        {
+          path: '.minimax/skills/minimax-skill/SKILL.md',
+          type: 'blob',
+          sha: 'minimax-sha',
+        },
+      ],
+    });
+
+    expect(discovered).toContain('.minimax/skills/minimax-skill/SKILL.md');
+  });
+});


### PR DESCRIPTION
## Summary

- add a `minimax-code` agent adapter using `.minimax/skills` for project installs and `~/.minimax/skills` for global installs
- detect MiniMax Code from `~/.minimax` or the macOS app bundle at `/Applications/MiniMax Code.app`
- include `.minimax/skills` in local and GitHub-tree skill discovery
- update generated README/package metadata and add focused adapter tests

## Compatibility note

The project install path intentionally uses the MiniMax product namespace. MiniMax Code needs the corresponding `.minimax/skills` workspace root for end-to-end project discovery; global installs already align with its canonical `~/.minimax/skills` directory.

The generated README count moves from 70 to 72 additional agents because `upstream/main` was already one agent behind the registry before MiniMax Code was added.

## Verification

- `npx --yes corepack@latest pnpm exec vitest run tests/minimax-code-agent.test.ts`
- `node scripts/validate-agents.ts`
- `npx --yes corepack@latest pnpm format:check`
- `npx --yes corepack@latest pnpm exec prettier --check tests/minimax-code-agent.test.ts`
- `npx --yes corepack@latest pnpm type-check`
- `npx --yes corepack@latest pnpm exec vitest run`
- `npx --yes corepack@latest pnpm build`
