### PR TITLE
Make skills update work for pack installs

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1118,6 +1118,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     let skills: Skill[];
     let blobResult: BlobInstallResult | null = null;
+    let packRevision: string | undefined;
 
     if (parsed.type === 'pack') {
       spinner.start('Fetching pack...');
@@ -1127,6 +1128,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         p.outro(pc.red('Pack not found or expired/revoked'));
         process.exit(1);
       }
+      packRevision = snapshot.revision ?? '';
       const packSkills = packSnapshotToBlobSkills(snapshot);
       blobResult = { skills: packSkills, tree: { sha: '', branch: '', tree: [] } };
       skills = packSkills;
@@ -1842,7 +1844,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
 
-            if (blobResult && skillPathValue) {
+            if (
+              parsed.type === 'pack' &&
+              'snapshotHash' in skill &&
+              (skill as BlobSkill).snapshotHash
+            ) {
+              skillFolderHash = (skill as BlobSkill).snapshotHash;
+            } else if (blobResult && skillPathValue) {
               const hash = getSkillFolderHashFromTree(blobResult.tree, skillPathValue);
               if (hash) skillFolderHash = hash;
             } else if (parsed.type === 'github' && skillPathValue && cachedTree) {
@@ -1862,6 +1870,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
+              ...(parsed.type === 'pack' && packRevision !== undefined
+                ? { packRevision }
+                : {}),
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -1902,6 +1913,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
                 ...(recordSubagents && { subagents: eveSubagents }),
+                ...(parsed.type === 'pack' && packRevision !== undefined
+                  ? { packRevision }
+                  : {}),
               },
               cwd
             );

--- a/src/add.ts
+++ b/src/add.ts
@@ -1870,9 +1870,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
-              ...(parsed.type === 'pack' && packRevision !== undefined
-                ? { packRevision }
-                : {}),
+              ...(parsed.type === 'pack' && packRevision !== undefined ? { packRevision } : {}),
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -1913,9 +1911,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
                 ...(recordSubagents && { subagents: eveSubagents }),
-                ...(parsed.type === 'pack' && packRevision !== undefined
-                  ? { packRevision }
-                  : {}),
+                ...(parsed.type === 'pack' && packRevision !== undefined ? { packRevision } : {}),
               },
               cwd
             );

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -40,6 +40,7 @@ export interface LocalSkillLockEntry {
    * non-Eve installs and for plain Eve root installs (treated as `['']`).
    */
   subagents?: string[];
+  packRevision?: string;
 }
 
 /**

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -60,8 +60,11 @@ export function isPackSource(source: string): boolean {
 }
 
 export class PackNotFoundError extends Error {
-  constructor(public packId: string) {
+  packId: string;
+
+  constructor(packId: string) {
     super(`Pack not found or expired/revoked: ${packId}`);
+    this.packId = packId;
     this.name = 'PackNotFoundError';
   }
 }

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -20,6 +20,10 @@ export interface PackSnapshotSkill {
 export interface PackSnapshot {
   id: string;
   createdAt: string;
+  updatedAt?: string;
+  revision?: string;
+  name?: string;
+  description?: string;
   sourceType: 'folder' | 'zip' | 'github';
   sourceLabel: string;
   skills: PackSnapshotSkill[];

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -35,6 +35,7 @@ export interface SkillLockEntry {
   updatedAt: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  packRevision?: string;
 }
 
 /**

--- a/src/update.ts
+++ b/src/update.ts
@@ -15,6 +15,12 @@ import {
 import { cloneRepo, cleanupTempDir } from './git.ts';
 import { discoverSkills } from './skills.ts';
 import { fetchRepoTree, findSkillMdPaths, getSkillFolderHashFromTree } from './blob.ts';
+import {
+  fetchPackSnapshot,
+  packSnapshotToBlobSkills,
+  parsePackId,
+  type PackSnapshot,
+} from './pack.ts';
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
@@ -173,6 +179,9 @@ export function getSkipReason(entry: SkillLockEntry): string {
   if (entry.sourceType === 'well-known') {
     return 'Well-known skill';
   }
+  if (entry.sourceType === 'pack') {
+    return 'Pack snapshot';
+  }
   if (!entry.skillFolderHash) {
     return 'Private or deleted repo';
   }
@@ -238,6 +247,39 @@ export async function getProjectSkillsForUpdate(
   return skills;
 }
 
+export async function promptForDeletions(
+  deletedSkills: string[],
+  isGlobal: boolean,
+  options: UpdateCheckOptions,
+  header: string
+): Promise<void> {
+  if (deletedSkills.length === 0) return;
+
+  console.log();
+  console.log(header);
+  for (const s of deletedSkills) {
+    console.log(`  ${DIM}•${RESET} ${s}`);
+  }
+
+  const isNonInteractive = options.yes || !process.stdin.isTTY;
+
+  if (isNonInteractive) {
+    console.log(`${DIM}Skipping deletion in non-interactive mode.${RESET}`);
+    return;
+  }
+
+  const confirmed = await p.confirm({
+    message: `Would you like to remove the local copies of these deleted skills?`,
+  });
+
+  if (confirmed && !p.isCancel(confirmed)) {
+    for (const s of deletedSkills) {
+      console.log(`${DIM}Removing${RESET} ${s}...`);
+      await removeCommand([s], { yes: true, global: isGlobal });
+    }
+  }
+}
+
 export async function checkAndPromptForDeletions(
   source: string,
   allLockedForSource: string[],
@@ -252,33 +294,190 @@ export async function checkAndPromptForDeletions(
     return !discoveredPaths.includes(entry.skillPath);
   });
 
-  if (deletedSkills.length > 0) {
-    console.log();
-    console.log(
-      `${DIM}Warning:${RESET} The following skills from ${DIM}${source}${RESET} appear to have been deleted upstream:`
-    );
-    for (const s of deletedSkills) {
-      console.log(`  ${DIM}•${RESET} ${s}`);
-    }
+  await promptForDeletions(
+    deletedSkills,
+    isGlobal,
+    options,
+    `${DIM}Warning:${RESET} The following skills from ${DIM}${source}${RESET} appear to have been deleted upstream:`
+  );
+  return deletedSkills;
+}
 
-    const isNonInteractive = options.yes || !process.stdin.isTTY;
+export interface PackUpdateItem {
+  name: string;
+  hash: string;
+  packRevision?: string;
+  subagents?: string[];
+}
 
-    if (isNonInteractive) {
-      console.log(`${DIM}Skipping deletion in non-interactive mode.${RESET}`);
-    } else {
-      const confirmed = await p.confirm({
-        message: `Would you like to remove the local copies of these deleted skills?`,
-      });
+export type PackCheckResult =
+  | { status: 'error' }
+  | { status: 'not-found' }
+  | { status: 'current' }
+  | {
+      status: 'changed';
+      snapshot: PackSnapshot;
+      changedSkills: string[];
+      newSkills: string[];
+      removedSkills: string[];
+    };
 
-      if (confirmed && !p.isCancel(confirmed)) {
-        for (const s of deletedSkills) {
-          console.log(`${DIM}Removing${RESET} ${s}...`);
-          await removeCommand([s], { yes: true, global: isGlobal });
-        }
-      }
+export async function checkPackForUpdates(
+  packId: string,
+  items: PackUpdateItem[]
+): Promise<PackCheckResult> {
+  let snapshot: PackSnapshot | null;
+  try {
+    snapshot = await fetchPackSnapshot(packId);
+  } catch {
+    return { status: 'error' };
+  }
+  if (!snapshot) return { status: 'not-found' };
+
+  const lockRevisions = new Set(items.map((item) => item.packRevision || ''));
+  if (
+    snapshot.revision &&
+    lockRevisions.size === 1 &&
+    lockRevisions.has(snapshot.revision)
+  ) {
+    return { status: 'current' };
+  }
+
+  const remoteSkills = packSnapshotToBlobSkills(snapshot);
+  const remoteByName = new Map(remoteSkills.map((skill) => [skill.name, skill]));
+  const localNames = new Set(items.map((item) => item.name));
+
+  const changedSkills: string[] = [];
+  const newSkills: string[] = [];
+  const removedSkills: string[] = [];
+
+  for (const item of items) {
+    const remote = remoteByName.get(item.name);
+    if (!remote) {
+      removedSkills.push(item.name);
+    } else if (!item.hash || remote.snapshotHash !== item.hash) {
+      changedSkills.push(item.name);
     }
   }
-  return deletedSkills;
+  for (const remote of remoteSkills) {
+    if (!localNames.has(remote.name)) {
+      newSkills.push(remote.name);
+    }
+  }
+
+  if (changedSkills.length + newSkills.length + removedSkills.length === 0) {
+    return { status: 'current' };
+  }
+
+  return { status: 'changed', snapshot, changedSkills, newSkills, removedSkills };
+}
+
+export function groupPackItems(
+  entries: Array<{ sourceUrl: string; item: PackUpdateItem }>
+): Map<string, PackUpdateItem[]> {
+  const groups = new Map<string, PackUpdateItem[]>();
+  for (const entry of entries) {
+    const packId = parsePackId(entry.sourceUrl);
+    if (!packId) continue;
+    const group = groups.get(packId) || [];
+    group.push(entry.item);
+    groups.set(packId, group);
+  }
+  return groups;
+}
+
+export async function processPackUpdates(
+  packGroups: Map<string, PackUpdateItem[]>,
+  isGlobal: boolean,
+  options: UpdateCheckOptions
+): Promise<{ successCount: number; failCount: number; changed: boolean }> {
+  let successCount = 0;
+  let failCount = 0;
+  let changed = false;
+
+  for (const [packId, items] of packGroups) {
+    const packUrl = `https://skills.sh/p/${packId}`;
+    process.stdout.write(`\r${DIM}Checking pack: ${packId}${RESET}\x1b[K\n`);
+
+    const result = await checkPackForUpdates(packId, items);
+
+    if (result.status === 'error') {
+      console.log(`  ${DIM}✗ Failed to check pack ${packId}${RESET}`);
+      continue;
+    }
+
+    if (result.status === 'not-found') {
+      changed = true;
+      await promptForDeletions(
+        items.map((item) => item.name),
+        isGlobal,
+        options,
+        `${DIM}Warning:${RESET} Pack ${DIM}${packUrl}${RESET} was revoked or deleted upstream. Locally installed skills from it:`
+      );
+      continue;
+    }
+
+    if (result.status === 'current') continue;
+
+    changed = true;
+
+    await promptForDeletions(
+      result.removedSkills,
+      isGlobal,
+      options,
+      `${DIM}Warning:${RESET} The following skills were removed from pack ${DIM}${packUrl}${RESET}:`
+    );
+
+    const installNames = [...result.changedSkills, ...result.newSkills];
+    if (installNames.length === 0) continue;
+
+    console.log(
+      `${TEXT}Updating pack ${packId} (${installNames.map(sanitizeMetadata).join(', ')})...${RESET}`
+    );
+
+    const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
+    if (!existsSync(cliEntry)) {
+      failCount += installNames.length;
+      console.log(
+        `  ${DIM}✗ Failed to update pack ${packId}: CLI entrypoint not found at ${cliEntry}${RESET}`
+      );
+      continue;
+    }
+
+    const subagentTargets = Array.from(
+      new Set(items.flatMap((item) => item.subagents ?? []))
+    );
+    const subagentArgs =
+      !isGlobal && subagentTargets.length > 0
+        ? ['--subagent', ...subagentTargets.map((s) => (s === '' ? 'root' : s))]
+        : [];
+
+    const spawnArgs = [
+      cliEntry,
+      'add',
+      packUrl,
+      ...(isGlobal ? ['-g'] : []),
+      ...subagentArgs,
+      '-y',
+    ];
+    const spawnResult = spawnSync(process.execPath, spawnArgs, {
+      stdio: ['inherit', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+      shell: process.platform === 'win32',
+    });
+
+    if (spawnResult.status === 0) {
+      successCount += installNames.length;
+      for (const name of installNames) {
+        console.log(`  ${TEXT}✓${RESET} Updated ${sanitizeMetadata(name)}`);
+      }
+    } else {
+      failCount += installNames.length;
+      console.log(`  ${DIM}✗ Failed to update pack ${packId}${RESET}`);
+    }
+  }
+
+  return { successCount, failCount, changed };
 }
 
 export async function updateGlobalSkills(
@@ -300,12 +499,28 @@ export async function updateGlobalSkills(
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
   const checkable: Array<{ name: string; entry: SkillLockEntry }> = [];
+  const packEntries: Array<{ sourceUrl: string; item: PackUpdateItem }> = [];
 
   for (const skillName of skillNames) {
     if (!matchesSkillFilter(skillName, options.skills)) continue;
 
     const entry = lock.skills[skillName];
     if (!entry) continue;
+
+    if (
+      entry.sourceType === 'pack' &&
+      parsePackId(entry.sourceUrl || entry.source)
+    ) {
+      packEntries.push({
+        sourceUrl: entry.sourceUrl || entry.source,
+        item: {
+          name: skillName,
+          hash: entry.skillFolderHash,
+          packRevision: entry.packRevision,
+        },
+      });
+      continue;
+    }
 
     if (!entry.skillFolderHash || !entry.skillPath) {
       skipped.push({
@@ -320,6 +535,15 @@ export async function updateGlobalSkills(
 
     checkable.push({ name: skillName, entry });
   }
+
+  const packGroups = groupPackItems(packEntries);
+  const {
+    successCount: packSuccessCount,
+    failCount: packFailCount,
+    changed: packChanged,
+  } = await processPackUpdates(packGroups, true, options);
+  successCount += packSuccessCount;
+  failCount += packFailCount;
 
   const bySource = new Map<string, typeof checkable>();
   for (const item of checkable) {
@@ -418,22 +642,28 @@ export async function updateGlobalSkills(
     process.stdout.write('\r\x1b[K');
   }
 
-  const checkedCount = checkable.length + skipped.length;
+  const checkedCount = checkable.length + skipped.length + packEntries.length;
 
-  if (checkable.length === 0 && skipped.length === 0) {
+  if (checkable.length === 0 && skipped.length === 0 && packEntries.length === 0) {
     if (!options.skills) {
       console.log(`${DIM}No global skills to check.${RESET}`);
     }
     return { successCount, failCount, checkedCount: 0 };
   }
 
-  if (checkable.length === 0 && skipped.length > 0) {
+  if (checkable.length === 0 && updates.length === 0) {
+    if (!packChanged && packEntries.length > 0 && skipped.length === 0) {
+      console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    }
     printSkippedSkills(skipped);
     return { successCount, failCount, checkedCount };
   }
 
   if (updates.length === 0) {
-    console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    if (!packChanged) {
+      console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    }
+    printSkippedSkills(skipped);
     return { successCount, failCount, checkedCount };
   }
 
@@ -489,10 +719,16 @@ export async function updateProjectSkills(
     return { successCount, failCount, foundCount: 0 };
   }
 
-  const updatable = projectSkills.filter((s) => s.entry.skillPath);
-  const legacy = projectSkills.filter((s) => !s.entry.skillPath);
+  const packProjectSkills = projectSkills.filter(
+    (s) => s.entry.sourceType === 'pack' && parsePackId(s.entry.source)
+  );
+  const packProjectNames = new Set(packProjectSkills.map((s) => s.name));
+  const nonPackSkills = projectSkills.filter((s) => !packProjectNames.has(s.name));
 
-  if (updatable.length === 0) {
+  const updatable = nonPackSkills.filter((s) => s.entry.skillPath);
+  const legacy = nonPackSkills.filter((s) => !s.entry.skillPath);
+
+  if (updatable.length === 0 && packProjectSkills.length === 0) {
     console.log(`${DIM}No project skills can be updated in place.${RESET}`);
     printLegacyProjectSkills(legacy);
     return { successCount, failCount, foundCount: projectSkills.length };
@@ -523,8 +759,28 @@ export async function updateProjectSkills(
     console.log(`${TEXT}Updating for: ${targetParts.join(', ')}${RESET}`);
   }
 
-  console.log(`${TEXT}Refreshing ${updatable.length} skill(s)...${RESET}`);
+  console.log(
+    `${TEXT}Refreshing ${updatable.length + packProjectSkills.length} skill(s)...${RESET}`
+  );
   console.log();
+
+  const packGroups = groupPackItems(
+    packProjectSkills.map((s) => ({
+      sourceUrl: s.entry.source,
+      item: {
+        name: s.name,
+        hash: s.entry.computedHash,
+        packRevision: s.entry.packRevision,
+        subagents: s.entry.subagents,
+      },
+    }))
+  );
+  const {
+    successCount: packSuccessCount,
+    failCount: packFailCount,
+  } = await processPackUpdates(packGroups, false, options);
+  successCount += packSuccessCount;
+  failCount += packFailCount;
 
   const bySource = new Map<string, typeof updatable>();
   for (const skill of updatable) {
@@ -537,9 +793,13 @@ export async function updateProjectSkills(
   const localLock = await readLocalLock();
   const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
 
-  if (!existsSync(cliEntry)) {
+  if (updatable.length > 0 && !existsSync(cliEntry)) {
     console.log(`${DIM}✗ CLI entrypoint not found at ${cliEntry}${RESET}`);
-    return { successCount, failCount: updatable.length, foundCount: projectSkills.length };
+    return {
+      successCount,
+      failCount: failCount + updatable.length,
+      foundCount: projectSkills.length,
+    };
   }
 
   for (const [source, skillsForSource] of bySource) {

--- a/src/update.ts
+++ b/src/update.ts
@@ -335,11 +335,7 @@ export async function checkPackForUpdates(
   if (!snapshot) return { status: 'not-found' };
 
   const lockRevisions = new Set(items.map((item) => item.packRevision || ''));
-  if (
-    snapshot.revision &&
-    lockRevisions.size === 1 &&
-    lockRevisions.has(snapshot.revision)
-  ) {
+  if (snapshot.revision && lockRevisions.size === 1 && lockRevisions.has(snapshot.revision)) {
     return { status: 'current' };
   }
 
@@ -444,9 +440,7 @@ export async function processPackUpdates(
       continue;
     }
 
-    const subagentTargets = Array.from(
-      new Set(items.flatMap((item) => item.subagents ?? []))
-    );
+    const subagentTargets = Array.from(new Set(items.flatMap((item) => item.subagents ?? [])));
     const subagentArgs =
       !isGlobal && subagentTargets.length > 0
         ? ['--subagent', ...subagentTargets.map((s) => (s === '' ? 'root' : s))]
@@ -507,10 +501,7 @@ export async function updateGlobalSkills(
     const entry = lock.skills[skillName];
     if (!entry) continue;
 
-    if (
-      entry.sourceType === 'pack' &&
-      parsePackId(entry.sourceUrl || entry.source)
-    ) {
+    if (entry.sourceType === 'pack' && parsePackId(entry.sourceUrl || entry.source)) {
       packEntries.push({
         sourceUrl: entry.sourceUrl || entry.source,
         item: {
@@ -775,10 +766,11 @@ export async function updateProjectSkills(
       },
     }))
   );
-  const {
-    successCount: packSuccessCount,
-    failCount: packFailCount,
-  } = await processPackUpdates(packGroups, false, options);
+  const { successCount: packSuccessCount, failCount: packFailCount } = await processPackUpdates(
+    packGroups,
+    false,
+    options
+  );
   successCount += packSuccessCount;
   failCount += packFailCount;
 

--- a/tests/pack-update.test.ts
+++ b/tests/pack-update.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  checkPackForUpdates,
+  getSkipReason,
+  groupPackItems,
+  type PackUpdateItem,
+} from '../src/update.ts';
+import { packSnapshotToBlobSkills, type PackSnapshot } from '../src/pack.ts';
+import type { SkillLockEntry } from '../src/skill-lock.ts';
+
+const snapshot: PackSnapshot = {
+  id: 'abc123',
+  createdAt: '2026-06-26T00:00:00.000Z',
+  revision: 'rev-1',
+  sourceType: 'zip',
+  sourceLabel: 'my-skills.zip',
+  skills: [
+    {
+      name: 'first-skill',
+      description: 'Does the first thing.',
+      files: [
+        { path: 'SKILL.md', contents: '# First' },
+        { path: 'references/notes.md', contents: 'notes' },
+      ],
+    },
+    {
+      name: 'second-skill',
+      description: 'Does the second thing.',
+      files: [{ path: 'SKILL.md', contents: '# Second' }],
+    },
+  ],
+};
+
+const snapshotHashes = new Map(
+  packSnapshotToBlobSkills(snapshot).map((skill) => [skill.name, skill.snapshotHash])
+);
+
+function lockItems(
+  overrides?: Partial<Record<string, Partial<PackUpdateItem>>>
+): PackUpdateItem[] {
+  return [...snapshotHashes.entries()].map(([name, hash]) => ({
+    name,
+    hash,
+    packRevision: 'rev-1',
+    ...overrides?.[name],
+  }));
+}
+
+function stubFetch(response: Response | Error): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      if (response instanceof Error) throw response;
+      return response;
+    })
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('groupPackItems', () => {
+  it('groups items by pack id', () => {
+    const item = (name: string): PackUpdateItem => ({ name, hash: 'h' });
+    const groups = groupPackItems([
+      { sourceUrl: 'https://skills.sh/p/aaa', item: item('one') },
+      { sourceUrl: 'https://skills.sh/p/aaa', item: item('two') },
+      { sourceUrl: 'https://skills.sh/p/bbb', item: item('three') },
+    ]);
+    expect([...groups.keys()].sort()).toEqual(['aaa', 'bbb']);
+    expect(groups.get('aaa')!.map((i) => i.name)).toEqual(['one', 'two']);
+  });
+
+  it('skips entries whose source is not a pack url', () => {
+    const groups = groupPackItems([
+      { sourceUrl: 'https://github.com/owner/repo', item: { name: 'x', hash: 'h' } },
+    ]);
+    expect(groups.size).toBe(0);
+  });
+});
+
+describe('checkPackForUpdates', () => {
+  it('returns not-found on 404', async () => {
+    stubFetch(new Response(null, { status: 404 }));
+    const result = await checkPackForUpdates('abc123', lockItems());
+    expect(result.status).toBe('not-found');
+  });
+
+  it('returns error when the fetch fails', async () => {
+    stubFetch(new Error('network down'));
+    const result = await checkPackForUpdates('abc123', lockItems());
+    expect(result.status).toBe('error');
+  });
+
+  it('returns current when all lock entries match the served revision', async () => {
+    stubFetch(Response.json(snapshot));
+    const result = await checkPackForUpdates(
+      'abc123',
+      lockItems({ 'first-skill': { hash: 'stale' } })
+    );
+    expect(result.status).toBe('current');
+  });
+
+  it('returns current when revisions are absent but skill hashes match', async () => {
+    stubFetch(Response.json({ ...snapshot, revision: undefined }));
+    const result = await checkPackForUpdates(
+      'abc123',
+      lockItems({
+        'first-skill': { packRevision: undefined },
+        'second-skill': { packRevision: undefined },
+      })
+    );
+    expect(result.status).toBe('current');
+  });
+
+  it('classifies changed skills when the revision differs', async () => {
+    stubFetch(Response.json({ ...snapshot, revision: 'rev-2' }));
+    const result = await checkPackForUpdates(
+      'abc123',
+      lockItems({ 'first-skill': { hash: 'stale' } })
+    );
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills).toEqual(['first-skill']);
+    expect(result.newSkills).toEqual([]);
+    expect(result.removedSkills).toEqual([]);
+  });
+
+  it('classifies skills added to and removed from the pack', async () => {
+    stubFetch(Response.json({ ...snapshot, revision: 'rev-2' }));
+    const items = lockItems().filter((item) => item.name !== 'second-skill');
+    items.push({ name: 'retired-skill', hash: 'gone', packRevision: 'rev-1' });
+    const result = await checkPackForUpdates('abc123', items);
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills).toEqual([]);
+    expect(result.newSkills).toEqual(['second-skill']);
+    expect(result.removedSkills).toEqual(['retired-skill']);
+  });
+
+  it('treats entries with empty hashes and no revision as changed', async () => {
+    stubFetch(Response.json({ ...snapshot, revision: 'rev-2' }));
+    const result = await checkPackForUpdates(
+      'abc123',
+      lockItems({
+        'first-skill': { hash: '', packRevision: undefined },
+        'second-skill': { hash: '', packRevision: undefined },
+      })
+    );
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills.sort()).toEqual(['first-skill', 'second-skill']);
+  });
+});
+
+describe('getSkipReason for pack entries', () => {
+  it('labels pack entries as pack snapshots', () => {
+    const entry: SkillLockEntry = {
+      source: 'https://skills.sh/p/abc123',
+      sourceType: 'pack',
+      sourceUrl: 'https://skills.sh/p/abc123',
+      skillFolderHash: '',
+      installedAt: '2026-06-26T00:00:00.000Z',
+      updatedAt: '2026-06-26T00:00:00.000Z',
+    };
+    expect(getSkipReason(entry)).toBe('Pack snapshot');
+  });
+});


### PR DESCRIPTION
## Why

`npx skills update` silently no-ops for skills installed from packs (`skills add https://skills.sh/p/<id>`):

- Global installs record an empty `skillFolderHash` (the pack path fabricates an empty tree), so update skips them with a misleading **"Private or deleted repo"** reason.
- Project installs attempt `git clone https://skills.sh/p/<id>` (always fails), then respawn a per-skill re-add and print **✓ Updated** even when nothing changed.

Packs are becoming mutable behind a stable id (skills.sh pack editing, [skills-leaderboard#183](https://github.com/vercel-labs/skills-leaderboard/pull/183)), so consumer-side pack updates are now meaningful.

## What

- **Lock entries**: pack installs store the per-skill snapshot hash and a new optional `packRevision` (the content revision served by skills.sh) in both the global and project locks.
- **`skills update`** (both scopes): pack entries are partitioned out, grouped by pack id, and checked with one snapshot fetch per pack:
  - served revision matches lock → up to date, nothing else runs
  - content changed → prompt for skills removed from the pack (existing deletion-prompt UX), then a single `add <packUrl> -y` respawn pulls changed + newly added skills (full sync)
  - 404 → "revoked or deleted upstream", offers to remove local copies
- No more clone attempts against skills.sh URLs and no fake ✓ output. `getSkipReason` gains a `'pack'` case as a safety net.
- Lock entries written by earlier builds (empty hash, no revision) heal on their first update via the re-add path.

## Server dependency

Revision compare needs `GET /api/p/<id>` to serve `revision` — added in the paired leaderboard PR. Until that deploys, update falls back to per-skill snapshot-hash comparison against the fetched snapshot, which yields the same sync behavior.

Pack install analytics (`pack_install_events.pack_revision`) has no CLI sender yet; when one lands it should use `snapshot.revision`.

## Testing

- `vitest run`: 490 passed / 87 failed — identical 87 failures on the base commit f9bbde1 (pre-existing in the WIP branch), zero regressions, +10 new tests covering revision short-circuit, hash fallback, changed/new/removed classification, 404, and skip-reason labeling.
- `tsc --noEmit`: no errors in touched files (pre-existing errors in `src/git.ts`/`src/skills.ts` on base).

Stacked on `pack-distribution`.