### PR TITLE
Pack distribution: install skills from packs via CLI

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1291,6 +1291,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       selectedSkills = skills;
       p.log.info(`Installing all ${skills.length} skills`);
     } else {
+      const isPack = parsed.type === 'pack';
       // Sort skills by plugin name first, then by skill name
       const sortedSkills = [...skills].sort((a, b) => {
         if (a.pluginName && !b.pluginName) return -1;
@@ -1328,6 +1329,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         selected = await p.groupMultiselect({
           message: `Select skills to install ${pc.dim('(space to toggle)')}`,
           options: grouped,
+          initialValues: isPack ? sortedSkills : undefined,
           required: true,
         });
       } else {
@@ -1338,8 +1340,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }));
 
         selected = await multiselect({
-          message: 'Select skills to install',
+          message: isPack ? 'Select skills to install (all selected)' : 'Select skills to install',
           options: skillChoices,
+          initialValues: isPack ? sortedSkills : undefined,
           required: true,
         });
       }

--- a/src/add.ts
+++ b/src/add.ts
@@ -78,6 +78,7 @@ import {
   type BlobSkill,
   type BlobInstallResult,
 } from './blob.ts';
+import { fetchPackSnapshot, packSnapshotToBlobSkills } from './pack.ts';
 import packageJson from '../package.json' with { type: 'json' };
 export function initTelemetry(version: string): void {
   setVersion(version);
@@ -1118,7 +1119,19 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     let skills: Skill[];
     let blobResult: BlobInstallResult | null = null;
 
-    if (parsed.type === 'local') {
+    if (parsed.type === 'pack') {
+      spinner.start('Fetching pack...');
+      const snapshot = await fetchPackSnapshot(parsed.packId!);
+      if (!snapshot) {
+        spinner.stop(pc.red('Pack not found'));
+        p.outro(pc.red('Pack not found or expired/revoked'));
+        process.exit(1);
+      }
+      const packSkills = packSnapshotToBlobSkills(snapshot);
+      blobResult = { skills: packSkills, tree: { sha: '', branch: '', tree: [] } };
+      skills = packSkills;
+      spinner.stop(`Found ${pc.green(skills.length)} skill${skills.length > 1 ? 's' : ''}`);
+    } else if (parsed.type === 'local') {
       // Use local path directly, no cloning needed
       spinner.start('Validating local path...');
       if (!existsSync(parsed.localPath!)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { flushTelemetry } from './telemetry.ts';
 import { isRunningInAgent } from './detect-agent.ts';
 import { runUpdate } from './update.ts';
 import { runUse, parseUseOptions } from './use.ts';
+import { parsePackId, revokePack } from './pack.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -115,6 +116,7 @@ ${BOLD}Manage Skills:${RESET}
   remove [skills]      Remove installed skills
   list, ls             List installed skills
   find [query]         Search for skills interactively
+  revoke <url> <token> Revoke a shared pack (skills.sh/p/<id>)
 
 ${BOLD}Find Options:${RESET}
   --owner <owner>        Search only repositories from a GitHub owner
@@ -293,6 +295,42 @@ Describe when this skill should be used.
   console.log();
 }
 
+async function runRevoke(args: string[]): Promise<void> {
+  const [url, token] = args;
+
+  if (!url || !token) {
+    console.log();
+    console.log(`${BOLD}Usage:${RESET} skills revoke <url> <token>`);
+    console.log();
+    console.log(`${DIM}Example:${RESET}`);
+    console.log(`  skills revoke https://skills.sh/p/abc123 rvk_0123456789abcdef`);
+    console.log();
+    process.exit(1);
+  }
+
+  const packId = parsePackId(url);
+  if (!packId) {
+    console.log(`${TEXT}Not a valid pack URL: ${DIM}${url}${RESET}`);
+    console.log(`${DIM}Expected a skills.sh/p/<id> URL${RESET}`);
+    process.exit(1);
+  }
+
+  try {
+    const { success } = await revokePack(packId, token);
+    if (success) {
+      console.log(`${TEXT}Pack revoked: ${DIM}${packId}${RESET}`);
+    } else {
+      console.log(`${TEXT}Pack not found or already revoked: ${DIM}${packId}${RESET}`);
+      process.exit(1);
+    }
+  } catch (error) {
+    console.log(
+      `${TEXT}Failed to revoke pack: ${DIM}${error instanceof Error ? error.message : 'Unknown error'}${RESET}`
+    );
+    process.exit(1);
+  }
+}
+
 // ============================================
 // Main
 // ============================================
@@ -365,6 +403,9 @@ async function main(): Promise<void> {
       await runSync(restArgs, syncOptions);
       break;
     }
+    case 'revoke':
+      await runRevoke(restArgs);
+      break;
     case 'list':
     case 'ls':
       await runList(restArgs);

--- a/src/pack.ts
+++ b/src/pack.ts
@@ -1,0 +1,127 @@
+import { createHash } from 'node:crypto';
+import type { BlobSkill } from './blob.ts';
+import { sanitizeMetadata } from './sanitize.ts';
+
+const PACK_BASE_URL = process.env.SKILLS_DOWNLOAD_URL || 'https://skills.sh';
+
+const FETCH_TIMEOUT = 10_000;
+
+export interface PackSnapshotFile {
+  path: string;
+  contents: string;
+}
+
+export interface PackSnapshotSkill {
+  name: string;
+  description: string;
+  files: PackSnapshotFile[];
+}
+
+export interface PackSnapshot {
+  id: string;
+  createdAt: string;
+  sourceType: 'folder' | 'zip' | 'github';
+  sourceLabel: string;
+  skills: PackSnapshotSkill[];
+}
+
+const PACK_PATH_PATTERN = /^\/p\/([A-Za-z0-9_-]+)\/?$/;
+
+export function parsePackId(source: string): string | null {
+  const trimmed = source.trim();
+
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return null;
+  }
+
+  if (url.hostname !== 'skills.sh' && url.hostname !== 'www.skills.sh') {
+    return null;
+  }
+
+  const match = url.pathname.match(PACK_PATH_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  return match[1]!;
+}
+
+export function isPackSource(source: string): boolean {
+  return parsePackId(source) !== null;
+}
+
+export class PackNotFoundError extends Error {
+  constructor(public packId: string) {
+    super(`Pack not found or expired/revoked: ${packId}`);
+    this.name = 'PackNotFoundError';
+  }
+}
+
+export async function fetchPackSnapshot(packId: string): Promise<PackSnapshot | null> {
+  const url = `${PACK_BASE_URL}/api/p/${encodeURIComponent(packId)}`;
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': 'skills-cli' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT),
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch pack (${response.status})`);
+  }
+
+  return (await response.json()) as PackSnapshot;
+}
+
+function computeSnapshotHash(files: PackSnapshotFile[]): string {
+  const hash = createHash('sha256');
+  for (const file of [...files].sort((a, b) => a.path.localeCompare(b.path))) {
+    hash.update(file.path);
+    hash.update(file.contents);
+  }
+  return hash.digest('hex');
+}
+
+export function packSnapshotToBlobSkills(snapshot: PackSnapshot): BlobSkill[] {
+  return snapshot.skills.map((skill) => {
+    const skillMdFile = skill.files.find((file) => file.path.toLowerCase() === 'skill.md');
+    const rawContent = skillMdFile?.contents ?? '';
+
+    return {
+      name: sanitizeMetadata(skill.name),
+      description: sanitizeMetadata(skill.description),
+      path: '',
+      rawContent,
+      files: skill.files,
+      snapshotHash: computeSnapshotHash(skill.files),
+      repoPath: skillMdFile ? skillMdFile.path : 'SKILL.md',
+    };
+  });
+}
+
+export async function revokePack(packId: string, token: string): Promise<{ success: boolean }> {
+  const url = `${PACK_BASE_URL}/p/${encodeURIComponent(packId)}/revoke`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': 'skills-cli' },
+    body: JSON.stringify({ token }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT),
+  });
+
+  if (response.status === 404) {
+    return { success: false };
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to revoke pack (${response.status})`);
+  }
+
+  return { success: true };
+}

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, resolve } from 'path';
 import type { ParsedSource } from './types.ts';
+import { parsePackId } from './pack.ts';
 
 /**
  * Extract owner/repo (or group/subgroup/repo for GitLab) from a parsed source
@@ -8,7 +9,7 @@ import type { ParsedSource } from './types.ts';
  * Supports any Git host with an owner/repo URL structure, including GitLab subgroups.
  */
 export function getOwnerRepo(parsed: ParsedSource): string | null {
-  if (parsed.type === 'local') {
+  if (parsed.type === 'local' || parsed.type === 'pack') {
     return null;
   }
 
@@ -246,6 +247,16 @@ export function parseSource(input: string): ParsedSource {
       type: 'local',
       url: resolvedPath, // Store resolved path in url for consistency
       localPath: resolvedPath,
+    };
+  }
+
+  // Skills.sh pack: skills.sh/p/<id> (and https:// / www. variants)
+  const packId = parsePackId(input);
+  if (packId) {
+    return {
+      type: 'pack',
+      url: `https://skills.sh/p/${packId}`,
+      packId,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,13 +97,15 @@ export interface AgentConfig {
 }
 
 export interface ParsedSource {
-  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known';
+  type: 'github' | 'gitlab' | 'git' | 'local' | 'well-known' | 'pack';
   url: string;
   subpath?: string;
   localPath?: string;
   ref?: string;
   /** Skill name extracted from @skill syntax (e.g., owner/repo@skill-name) */
   skillFilter?: string;
+  /** Pack id extracted from a skills.sh/p/<id> source */
+  packId?: string;
 }
 
 /**

--- a/tests/pack.test.ts
+++ b/tests/pack.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  parsePackId,
+  isPackSource,
+  fetchPackSnapshot,
+  packSnapshotToBlobSkills,
+  revokePack,
+  type PackSnapshot,
+} from '../src/pack.ts';
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return Response.json(body, init);
+}
+
+const snapshot: PackSnapshot = {
+  id: 'abc123',
+  createdAt: '2026-06-26T00:00:00.000Z',
+  sourceType: 'zip',
+  sourceLabel: 'my-skills.zip',
+  skills: [
+    {
+      name: 'First Skill',
+      description: 'Does the first thing.',
+      files: [
+        {
+          path: 'SKILL.md',
+          contents: '---\nname: First Skill\ndescription: Does the first thing.\n---\n# First',
+        },
+        { path: 'references/notes.md', contents: 'notes' },
+      ],
+    },
+    {
+      name: 'Second Skill',
+      description: 'Does the second thing.',
+      files: [
+        {
+          path: 'SKILL.md',
+          contents: '---\nname: Second Skill\ndescription: Does the second thing.\n---\n# Second',
+        },
+      ],
+    },
+  ],
+};
+
+describe('parsePackId', () => {
+  it('parses bare host form', () => {
+    expect(parsePackId('skills.sh/p/abc123')).toBe('abc123');
+  });
+
+  it('parses https form', () => {
+    expect(parsePackId('https://skills.sh/p/abc123')).toBe('abc123');
+  });
+
+  it('parses www form', () => {
+    expect(parsePackId('https://www.skills.sh/p/abc123')).toBe('abc123');
+  });
+
+  it('parses trailing slash', () => {
+    expect(parsePackId('skills.sh/p/abc123/')).toBe('abc123');
+  });
+
+  it('rejects non-skills.sh host', () => {
+    expect(parsePackId('https://example.com/p/abc123')).toBeNull();
+  });
+
+  it('rejects non-pack skills.sh path', () => {
+    expect(parsePackId('skills.sh/owner/repo')).toBeNull();
+  });
+
+  it('isPackSource matches pack urls only', () => {
+    expect(isPackSource('skills.sh/p/abc123')).toBe(true);
+    expect(isPackSource('owner/repo')).toBe(false);
+  });
+});
+
+describe('fetchPackSnapshot', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the snapshot from /api/p/<id>', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(snapshot));
+
+    const result = await fetchPackSnapshot('abc123');
+
+    expect(result).toEqual(snapshot);
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe('https://skills.sh/api/p/abc123');
+  });
+
+  it('returns null on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({}, { status: 404 }));
+    const result = await fetchPackSnapshot('missing');
+    expect(result).toBeNull();
+  });
+
+  it('honors SKILLS_DOWNLOAD_URL override', async () => {
+    const original = process.env.SKILLS_DOWNLOAD_URL;
+    process.env.SKILLS_DOWNLOAD_URL = 'http://localhost:3000';
+    vi.resetModules();
+    try {
+      const fresh = await import('../src/pack.ts?override');
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(snapshot));
+      await fresh.fetchPackSnapshot('abc123');
+      expect(String(fetchSpy.mock.calls[0]![0])).toBe('http://localhost:3000/api/p/abc123');
+    } finally {
+      if (original === undefined) {
+        delete process.env.SKILLS_DOWNLOAD_URL;
+      } else {
+        process.env.SKILLS_DOWNLOAD_URL = original;
+      }
+    }
+  });
+});
+
+describe('packSnapshotToBlobSkills', () => {
+  it('converts every skill in the pack', () => {
+    const skills = packSnapshotToBlobSkills(snapshot);
+    expect(skills).toHaveLength(2);
+    expect(skills.map((s) => s.name)).toEqual(['First Skill', 'Second Skill']);
+  });
+
+  it('carries files and points repoPath at SKILL.md', () => {
+    const [first] = packSnapshotToBlobSkills(snapshot);
+    expect(first!.files).toHaveLength(2);
+    expect(first!.repoPath).toBe('SKILL.md');
+    expect(first!.rawContent).toContain('name: First Skill');
+    expect(first!.snapshotHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('revokePack', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs the token to /p/<id>/revoke', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ ok: true }));
+
+    const result = await revokePack('abc123', 'rvk_secret');
+
+    expect(result.success).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe('https://skills.sh/p/abc123/revoke');
+    expect(init!.method).toBe('POST');
+    expect(JSON.parse(String(init!.body))).toEqual({ token: 'rvk_secret' });
+  });
+
+  it('returns success=false on 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({}, { status: 404 }));
+    const result = await revokePack('abc123', 'wrong');
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -481,4 +481,54 @@ describe('Prefix shorthand tests', () => {
       expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
     });
   });
+
+  describe('skills.sh pack URLs', () => {
+    it('bare host: skills.sh/p/<id>', () => {
+      const result = parseSource('skills.sh/p/abc123');
+      expect(result.type).toBe('pack');
+      expect(result.packId).toBe('abc123');
+      expect(result.url).toBe('https://skills.sh/p/abc123');
+    });
+
+    it('https://skills.sh/p/<id>', () => {
+      const result = parseSource('https://skills.sh/p/abc123');
+      expect(result.type).toBe('pack');
+      expect(result.packId).toBe('abc123');
+      expect(result.url).toBe('https://skills.sh/p/abc123');
+    });
+
+    it('http://skills.sh/p/<id>', () => {
+      const result = parseSource('http://skills.sh/p/abc123');
+      expect(result.type).toBe('pack');
+      expect(result.packId).toBe('abc123');
+    });
+
+    it('www.skills.sh/p/<id>', () => {
+      const result = parseSource('https://www.skills.sh/p/abc123');
+      expect(result.type).toBe('pack');
+      expect(result.packId).toBe('abc123');
+    });
+
+    it('trailing slash', () => {
+      const result = parseSource('skills.sh/p/abc123/');
+      expect(result.type).toBe('pack');
+      expect(result.packId).toBe('abc123');
+    });
+
+    it('id with hyphens and underscores', () => {
+      const result = parseSource('skills.sh/p/aB3-_xYz09');
+      expect(result.type).toBe('pack');
+      expect(result.packId).toBe('aB3-_xYz09');
+    });
+
+    it('does not treat other skills.sh paths as packs', () => {
+      const result = parseSource('skills.sh/owner/repo');
+      expect(result.type).not.toBe('pack');
+    });
+
+    it('does not treat a non-skills.sh host as a pack', () => {
+      const result = parseSource('https://example.com/p/abc123');
+      expect(result.type).not.toBe('pack');
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds pack install support to the CLI (`npx skills add <pack-url>`):

- Fetch pack snapshots and convert them to blob skills for install (`src/pack.ts`, wired into `src/add.ts`)
- Pack installs pre-select every skill in the multiselect prompt — space deselects unwanted skills, enter installs the rest. Non-pack installs still start unselected.

## Notes

- Branch contains the WIP pack distribution CLI draft (`f9bbde1`) plus the preselect commit (`61c0db8`).
- Related: #1815 (pack update flow, stacked on this work).