### PR TITLE
Track successful skills use downloads

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -52,12 +52,23 @@ interface SyncTelemetryData {
   agents: string;
 }
 
+export interface UseTelemetryData {
+  event: 'use';
+  source: string;
+  skills: string;
+  agents?: string;
+  sourceType: string;
+  downloadMethod: 'blob' | 'git' | 'well-known' | 'download';
+  mode: 'prompt' | 'agent';
+}
+
 type TelemetryData =
   | InstallTelemetryData
   | RemoveTelemetryData
   | UpdateTelemetryData
   | FindTelemetryData
-  | SyncTelemetryData;
+  | SyncTelemetryData
+  | UseTelemetryData;
 
 let cliVersion: string | null = null;
 let detectedAgentName: string | null = null;

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -14,6 +14,7 @@ import {
   type AgentProcess,
   type AgentSpawn,
   type UseSkill,
+  type UseTelemetryTracker,
 } from './use.ts';
 
 describe('use command', () => {
@@ -29,6 +30,7 @@ describe('use command', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     for (const dir of cleanupDirs.splice(0)) {
       if (existsSync(dir)) {
         rmSync(dir, { recursive: true, force: true });
@@ -226,6 +228,58 @@ describe('use command', () => {
   });
 
   describe('CLI behavior', () => {
+    it('tracks a successful well-known skill download as a use event', async () => {
+      const sourceUrl = 'https://example.com/docs';
+      const telemetryEvents: Parameters<UseTelemetryTracker>[0][] = [];
+
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === 'https://example.com/docs/.well-known/agent-skills/index.json') {
+          return Response.json({
+            skills: [
+              {
+                name: 'example-skill',
+                description: 'Example skill.',
+                files: ['SKILL.md', 'reference.md'],
+              },
+            ],
+          });
+        }
+        if (href === 'https://example.com/docs/.well-known/agent-skills/example-skill/SKILL.md') {
+          return new Response(
+            '---\nname: example-skill\ndescription: Example skill.\n---\n# Example'
+          );
+        }
+        if (
+          href === 'https://example.com/docs/.well-known/agent-skills/example-skill/reference.md'
+        ) {
+          return new Response('Reference');
+        }
+        return new Response('not found', { status: 404 });
+      });
+
+      const writes: string[] = [];
+      vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+        writes.push(String(chunk));
+        return true;
+      }) as typeof process.stdout.write);
+
+      await runUse([sourceUrl], {}, [], (event) => telemetryEvents.push(event));
+
+      const supportDir = extractSupportDir(writes.join(''));
+      if (supportDir) cleanupDirs.push(join(supportDir, '..'));
+      expect(telemetryEvents).toEqual([
+        {
+          event: 'use',
+          source: 'example.com',
+          skills: 'example-skill',
+          sourceType: 'well-known',
+          downloadMethod: 'well-known',
+          mode: 'prompt',
+        },
+      ]);
+    });
+
     it('uses a direct archive when well-known discovery misses', async () => {
       const archiveRoot = join(testDir, 'direct-archive');
       writeSkill(archiveRoot, 'direct-skill', 'Direct archive body.');
@@ -256,14 +310,16 @@ describe('use command', () => {
       vi.spyOn(process, 'exit').mockImplementation((() => {
         throw new Error('process.exit called');
       }) as never);
+      const trackUse = vi.fn<UseTelemetryTracker>();
 
-      await runUse([directUrl]);
+      await runUse([directUrl], {}, [], trackUse);
 
       const stdout = writes.join('');
       const supportDir = extractSupportDir(stdout);
       if (supportDir) cleanupDirs.push(join(supportDir, '..'));
       expect(stdout).toContain('Direct archive body.');
       expect(supportDir).toBeTruthy();
+      expect(trackUse).not.toHaveBeenCalled();
     });
 
     it('prints only the generated prompt for a single local skill', () => {

--- a/src/use.ts
+++ b/src/use.ts
@@ -9,8 +9,9 @@ import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { sanitizeName } from './installer.ts';
 import { getGitHubToken } from './skill-lock.ts';
 import { discoverSkills, filterSkills, getSkillDisplayName } from './skills.ts';
-import { getOwnerRepo, parseSource } from './source-parser.ts';
-import type { AgentType, Skill } from './types.ts';
+import { getOwnerRepo, isRepoPrivate, parseOwnerRepo, parseSource } from './source-parser.ts';
+import { track, type UseTelemetryData } from './telemetry.ts';
+import type { AgentType, ParsedSource, Skill } from './types.ts';
 import { downloadSource } from './download-source.ts';
 import {
   wellKnownProvider,
@@ -71,6 +72,8 @@ export type AgentSpawn = (
   args: string[],
   options: { stdio: 'inherit' }
 ) => AgentProcess;
+
+export type UseTelemetryTracker = (data: UseTelemetryData) => void;
 
 interface UseAgentConfig {
   command: string;
@@ -185,7 +188,8 @@ export async function materializeUseSkill(skill: UseSkill): Promise<Materialized
 export async function runUse(
   sourceArgs: string[],
   options: UseOptions = {},
-  parseErrors: string[] = []
+  parseErrors: string[] = [],
+  trackUse: UseTelemetryTracker = track
 ): Promise<void> {
   let cloneTempDir: string | null = null;
 
@@ -227,6 +231,7 @@ export async function runUse(
       );
     }
 
+    const repoPrivacyPromise = getUseRepoPrivacy(parsed, ownerRepoRaw);
     const selector = resolveSelector(parsed.skillFilter, options.skill);
     const includeInternal = selector !== undefined;
 
@@ -331,6 +336,20 @@ export async function runUse(
       hasSupportingFiles: materialized.hasSupportingFiles,
     });
 
+    const telemetrySource = getUseTelemetrySource(parsed, ownerRepoRaw, selectedSkill);
+    const canTrackSource = parsed.type !== 'github' || (await repoPrivacyPromise) === false;
+    if (telemetrySource && canTrackSource) {
+      trackUse({
+        event: 'use',
+        source: telemetrySource,
+        skills: selectedSkill.directoryName,
+        ...(useAgent && { agents: useAgent }),
+        sourceType: parsed.type,
+        downloadMethod: getUseDownloadMethod(parsed, selectedSkill),
+        mode: useAgent ? 'agent' : 'prompt',
+      });
+    }
+
     if (useAgent) {
       const exitCode = await launchAgentInteractively(useAgent, prompt);
       if (exitCode !== 0) {
@@ -350,6 +369,53 @@ export async function runUse(
     }
     fail(error instanceof Error ? error.message : 'Unknown error');
   }
+}
+
+function getUseRepoPrivacy(
+  parsed: ParsedSource,
+  ownerRepo: string | null
+): Promise<boolean | null> {
+  if (parsed.type !== 'github' || !ownerRepo) {
+    return Promise.resolve(null);
+  }
+
+  const parsedOwnerRepo = parseOwnerRepo(ownerRepo);
+  if (!parsedOwnerRepo) {
+    return Promise.resolve(null);
+  }
+
+  return isRepoPrivate(parsedOwnerRepo.owner, parsedOwnerRepo.repo).catch(() => null);
+}
+
+function getUseTelemetrySource(
+  parsed: ParsedSource,
+  ownerRepo: string | null,
+  skill: UseSkill
+): string | null {
+  if (parsed.type === 'local' || parsed.type === 'download') {
+    return null;
+  }
+
+  if (parsed.type === 'well-known') {
+    // Arbitrary HTTP URLs use the well-known parser first, then fall back to
+    // a direct archive/SKILL.md download. Only the public discovery path is
+    // safe to identify in telemetry; direct URLs may be private or signed.
+    if (skill.kind !== 'well-known') return null;
+    const source = wellKnownProvider.getSourceIdentifier(parsed.url);
+    return source === 'unknown' ? null : source;
+  }
+
+  return ownerRepo;
+}
+
+function getUseDownloadMethod(
+  parsed: ParsedSource,
+  skill: UseSkill
+): UseTelemetryData['downloadMethod'] {
+  if (skill.kind === 'blob') return 'blob';
+  if (skill.kind === 'well-known') return 'well-known';
+  if (parsed.type === 'well-known' || parsed.type === 'download') return 'download';
+  return 'git';
 }
 
 export async function launchAgentInteractively(


### PR DESCRIPTION
## Summary

- emit a use telemetry event after a remote skill is successfully resolved and materialized
- include the source, selected skill, source type, download method, output mode, and optional launched agent
- skip local paths, direct or signed download URLs, private GitHub repositories, and repositories whose privacy cannot be verified
- add coverage for public well-known downloads and direct URL exclusion

## Deployment order

Deploy vercel-labs/add-skill-telemetry#18 before publishing this CLI change so use events cannot enter install aggregates.

## Testing

- pnpm test (714 tests)
- pnpm type-check
- pnpm format:check