### PR TITLE
Preselect all skills when installing a skills.sh pack

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -556,6 +556,16 @@ export interface AddOptions {
  * Discovers skills from /.well-known/agent-skills/index.json (preferred)
  * or /.well-known/skills/index.json (legacy fallback).
  */
+function isSkillsShPackUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.replace(/^www\./, '');
+    return hostname === 'skills.sh' && /^\/p\/[^/]+/.test(parsed.pathname);
+  } catch {
+    return false;
+  }
+}
+
 async function handleWellKnownSkills(
   source: string,
   url: string,
@@ -640,6 +650,7 @@ async function handleWellKnownSkills(
     const selected = await multiselect({
       message: 'Select skills to install',
       options: skillChoices,
+      initialValues: isSkillsShPackUrl(url) ? skills : undefined,
       required: true,
     });
 


### PR DESCRIPTION
## What

When installing from a skills.sh pack URL (`skills.sh/p/<id>`), the skill multiselect now starts with every skill checked — space deselects unwanted skills, enter installs the rest.

Packs install through the well-known skills endpoint, so this gates on the URL in `handleWellKnownSkills`. Non-pack installs are unchanged (start unselected).

## Why

A pack is a curated set — the default intent is "install the whole pack", with opt-out rather than opt-in.