### PR TITLE
Make skills update work for well-known installs (incl. skills.sh packs)

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -33,7 +33,11 @@ import {
   type PartnerAudit,
 } from './telemetry.ts';
 import { detectAgent, getAgentType } from './detect-agent.ts';
-import { wellKnownProvider, type WellKnownSkill } from './providers/index.ts';
+import {
+  wellKnownProvider,
+  computeWellKnownSkillDigest,
+  type WellKnownSkill,
+} from './providers/index.ts';
 import { downloadSource } from './download-source.ts';
 import {
   addSkillToLock,
@@ -921,7 +925,9 @@ async function handleWellKnownSkills(
             source: sourceIdentifier,
             sourceType: 'well-known',
             sourceUrl: skill.sourceUrl,
-            skillFolderHash: '', // Well-known skills don't have a folder hash
+            skillFolderHash: '',
+            sourceBaseUrl: url,
+            wellKnownDigest: computeWellKnownSkillDigest(skill),
           });
         } catch {
           // Don't fail installation if lock file update fails
@@ -944,8 +950,10 @@ async function handleWellKnownSkills(
               skill.installName,
               {
                 source: sourceIdentifier,
+                sourceUrl: url,
                 sourceType: 'well-known',
                 computedHash,
+                wellKnownDigest: computeWellKnownSkillDigest(skill),
               },
               cwd
             );

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -42,6 +42,7 @@ export interface LocalSkillLockEntry {
    * non-Eve installs and for plain Eve root installs (treated as `['']`).
    */
   subagents?: string[];
+  wellKnownDigest?: string;
 }
 
 /**

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -8,6 +8,8 @@ export { registry, registerProvider, findProvider, getProviders } from './regist
 export {
   WellKnownProvider,
   wellKnownProvider,
+  computeWellKnownSkillDigest,
+  type NormalizedWellKnownEntry,
   type WellKnownIndex,
   type WellKnownSkillEntry,
   type WellKnownSkill,

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -53,7 +53,7 @@ export type WellKnownIndex = WellKnownIndexV1 | WellKnownIndexV2;
 export type WellKnownSkillEntry = WellKnownSkillEntryV1 | WellKnownSkillEntryV2;
 export type WellKnownFileContent = string | Uint8Array;
 
-type NormalizedWellKnownEntry =
+export type NormalizedWellKnownEntry =
   | {
       version: '0.1.0';
       name: string;
@@ -138,18 +138,24 @@ export class WellKnownProvider implements HostProvider {
    * /.well-known/skills/index.json. For each path, tries path-relative
    * first, then root .well-known.
    */
-  async fetchIndex(baseUrl: string): Promise<{
+  async fetchIndex(
+    baseUrl: string,
+    options?: { updateCheck?: boolean }
+  ): Promise<{
     index: WellKnownIndex;
     entries: NormalizedWellKnownEntry[];
     resolvedBaseUrl: string;
     resolvedWellKnownPath: string;
     indexUrl: string;
   } | null> {
-    const candidates = await this.fetchIndexCandidates(baseUrl);
+    const candidates = await this.fetchIndexCandidates(baseUrl, options);
     return candidates[0] ?? null;
   }
 
-  private async fetchIndexCandidates(baseUrl: string): Promise<
+  private async fetchIndexCandidates(
+    baseUrl: string,
+    options?: { updateCheck?: boolean }
+  ): Promise<
     Array<{
       index: WellKnownIndex;
       entries: NormalizedWellKnownEntry[];
@@ -195,7 +201,10 @@ export class WellKnownProvider implements HostProvider {
 
       for (const { indexUrl, baseUrl: resolvedBase, wellKnownPath } of urlsToTry) {
         try {
-          const response = await fetch(indexUrl, { signal });
+          const response = await fetch(indexUrl, {
+            signal,
+            ...(options?.updateCheck ? { headers: { 'X-Skills-Update-Check': '1' } } : {}),
+          });
           if (!response.ok) continue;
 
           const rawIndex = (await response.json()) as unknown;
@@ -730,6 +739,20 @@ export class WellKnownProvider implements HostProvider {
     const result = await this.fetchIndex(url);
     return result !== null;
   }
+}
+
+export function computeWellKnownSkillDigest(skill: WellKnownSkill): string {
+  if ('digest' in skill.indexEntry && skill.indexEntry.digest) {
+    return skill.indexEntry.digest;
+  }
+  const hash = createHash('sha256');
+  for (const path of Array.from(skill.files.keys()).sort()) {
+    hash.update(path);
+    hash.update('\0');
+    hash.update(skill.files.get(path)!);
+    hash.update('\0');
+  }
+  return `sha256:${hash.digest('hex')}`;
 }
 
 export const wellKnownProvider = new WellKnownProvider();

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -35,6 +35,8 @@ export interface SkillLockEntry {
   updatedAt: string;
   /** Name of the plugin this skill belongs to (if any) */
   pluginName?: string;
+  sourceBaseUrl?: string;
+  wellKnownDigest?: string;
 }
 
 /**

--- a/src/update.ts
+++ b/src/update.ts
@@ -240,6 +240,41 @@ export async function getProjectSkillsForUpdate(
   return skills;
 }
 
+export async function promptDeletions(
+  source: string,
+  deletedSkills: string[],
+  isGlobal: boolean,
+  options: UpdateCheckOptions
+): Promise<void> {
+  if (deletedSkills.length === 0) return;
+
+  console.log();
+  console.log(
+    `${DIM}Warning:${RESET} The following skills from ${DIM}${source}${RESET} appear to have been deleted upstream:`
+  );
+  for (const s of deletedSkills) {
+    console.log(`  ${DIM}•${RESET} ${s}`);
+  }
+
+  const isNonInteractive = options.yes || !process.stdin.isTTY;
+
+  if (isNonInteractive) {
+    console.log(`${DIM}Skipping deletion in non-interactive mode.${RESET}`);
+    return;
+  }
+
+  const confirmed = await p.confirm({
+    message: `Would you like to remove the local copies of these deleted skills?`,
+  });
+
+  if (confirmed && !p.isCancel(confirmed)) {
+    for (const s of deletedSkills) {
+      console.log(`${DIM}Removing${RESET} ${s}…`);
+      await removeCommand([s], { yes: true, global: isGlobal });
+    }
+  }
+}
+
 export async function checkAndPromptForDeletions(
   source: string,
   allLockedForSource: string[],
@@ -254,32 +289,7 @@ export async function checkAndPromptForDeletions(
     return !discoveredPaths.includes(entry.skillPath);
   });
 
-  if (deletedSkills.length > 0) {
-    console.log();
-    console.log(
-      `${DIM}Warning:${RESET} The following skills from ${DIM}${source}${RESET} appear to have been deleted upstream:`
-    );
-    for (const s of deletedSkills) {
-      console.log(`  ${DIM}•${RESET} ${s}`);
-    }
-
-    const isNonInteractive = options.yes || !process.stdin.isTTY;
-
-    if (isNonInteractive) {
-      console.log(`${DIM}Skipping deletion in non-interactive mode.${RESET}`);
-    } else {
-      const confirmed = await p.confirm({
-        message: `Would you like to remove the local copies of these deleted skills?`,
-      });
-
-      if (confirmed && !p.isCancel(confirmed)) {
-        for (const s of deletedSkills) {
-          console.log(`${DIM}Removing${RESET} ${s}…`);
-          await removeCommand([s], { yes: true, global: isGlobal });
-        }
-      }
-    }
-  }
+  await promptDeletions(source, deletedSkills, isGlobal, options);
   return deletedSkills;
 }
 
@@ -324,7 +334,14 @@ export async function checkWellKnownForUpdates(
   }
 
   if (needsContentCheck.length > 0) {
-    const skills = await wellKnownProvider.fetchAllSkills(baseUrl).catch(() => []);
+    const tracked = new Set(needsContentCheck.map((item) => item.name));
+    const skills = (
+      await Promise.all(
+        indexResult.entries
+          .filter((entry) => tracked.has(entry.name))
+          .map((entry) => wellKnownProvider.fetchSkillByEntry(entry).catch(() => null))
+      )
+    ).filter((skill): skill is NonNullable<typeof skill> => skill !== null);
     if (skills.length === 0) return { status: 'error' };
     const digests = new Map(
       skills.map((skill) => [skill.installName, computeWellKnownSkillDigest(skill)])
@@ -341,41 +358,6 @@ export async function checkWellKnownForUpdates(
     return { status: 'current' };
   }
   return { status: 'changed', changedSkills, removedSkills };
-}
-
-async function promptWellKnownDeletions(
-  source: string,
-  deletedSkills: string[],
-  isGlobal: boolean,
-  options: UpdateCheckOptions
-): Promise<void> {
-  if (deletedSkills.length === 0) return;
-
-  console.log();
-  console.log(
-    `${DIM}Warning:${RESET} The following skills from ${DIM}${source}${RESET} appear to have been deleted upstream:`
-  );
-  for (const s of deletedSkills) {
-    console.log(`  ${DIM}•${RESET} ${s}`);
-  }
-
-  const isNonInteractive = options.yes || !process.stdin.isTTY;
-
-  if (isNonInteractive) {
-    console.log(`${DIM}Skipping deletion in non-interactive mode.${RESET}`);
-    return;
-  }
-
-  const confirmed = await p.confirm({
-    message: `Would you like to remove the local copies of these deleted skills?`,
-  });
-
-  if (confirmed && !p.isCancel(confirmed)) {
-    for (const s of deletedSkills) {
-      console.log(`${DIM}Removing${RESET} ${s}…`);
-      await removeCommand([s], { yes: true, global: isGlobal });
-    }
-  }
 }
 
 export async function processWellKnownUpdates(
@@ -401,7 +383,7 @@ export async function processWellKnownUpdates(
 
     changed = true;
 
-    await promptWellKnownDeletions(baseUrl, result.removedSkills, isGlobal, options);
+    await promptDeletions(baseUrl, result.removedSkills, isGlobal, options);
 
     if (result.changedSkills.length === 0) continue;
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -16,6 +16,7 @@ import {
 import { cloneRepo, cleanupTempDir } from './git.ts';
 import { discoverSkills } from './skills.ts';
 import { fetchRepoTree, getSkillFolderHashFromTree } from './blob.ts';
+import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/index.ts';
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
@@ -282,6 +283,179 @@ export async function checkAndPromptForDeletions(
   return deletedSkills;
 }
 
+export interface WellKnownUpdateItem {
+  name: string;
+  digest: string;
+  subagents?: string[];
+}
+
+export type WellKnownCheckResult =
+  | { status: 'error' }
+  | { status: 'current' }
+  | { status: 'changed'; changedSkills: string[]; removedSkills: string[] };
+
+export async function checkWellKnownForUpdates(
+  baseUrl: string,
+  items: WellKnownUpdateItem[]
+): Promise<WellKnownCheckResult> {
+  let indexResult: Awaited<ReturnType<typeof wellKnownProvider.fetchIndex>>;
+  try {
+    indexResult = await wellKnownProvider.fetchIndex(baseUrl, { updateCheck: true });
+  } catch {
+    return { status: 'error' };
+  }
+  if (!indexResult) return { status: 'error' };
+
+  const byName = new Map(indexResult.entries.map((entry) => [entry.name, entry]));
+  const removedSkills = items.filter((item) => !byName.has(item.name)).map((item) => item.name);
+  const changedSkills: string[] = [];
+  const needsContentCheck: WellKnownUpdateItem[] = [];
+
+  for (const item of items) {
+    const entry = byName.get(item.name);
+    if (!entry) continue;
+    if (entry.version === '0.2.0') {
+      if (!item.digest || entry.digest !== item.digest) {
+        changedSkills.push(item.name);
+      }
+    } else {
+      needsContentCheck.push(item);
+    }
+  }
+
+  if (needsContentCheck.length > 0) {
+    const skills = await wellKnownProvider.fetchAllSkills(baseUrl).catch(() => []);
+    if (skills.length === 0) return { status: 'error' };
+    const digests = new Map(
+      skills.map((skill) => [skill.installName, computeWellKnownSkillDigest(skill)])
+    );
+    for (const item of needsContentCheck) {
+      const digest = digests.get(item.name);
+      if (!digest || !item.digest || digest !== item.digest) {
+        changedSkills.push(item.name);
+      }
+    }
+  }
+
+  if (changedSkills.length === 0 && removedSkills.length === 0) {
+    return { status: 'current' };
+  }
+  return { status: 'changed', changedSkills, removedSkills };
+}
+
+async function promptWellKnownDeletions(
+  source: string,
+  deletedSkills: string[],
+  isGlobal: boolean,
+  options: UpdateCheckOptions
+): Promise<void> {
+  if (deletedSkills.length === 0) return;
+
+  console.log();
+  console.log(
+    `${DIM}Warning:${RESET} The following skills from ${DIM}${source}${RESET} appear to have been deleted upstream:`
+  );
+  for (const s of deletedSkills) {
+    console.log(`  ${DIM}•${RESET} ${s}`);
+  }
+
+  const isNonInteractive = options.yes || !process.stdin.isTTY;
+
+  if (isNonInteractive) {
+    console.log(`${DIM}Skipping deletion in non-interactive mode.${RESET}`);
+    return;
+  }
+
+  const confirmed = await p.confirm({
+    message: `Would you like to remove the local copies of these deleted skills?`,
+  });
+
+  if (confirmed && !p.isCancel(confirmed)) {
+    for (const s of deletedSkills) {
+      console.log(`${DIM}Removing${RESET} ${s}…`);
+      await removeCommand([s], { yes: true, global: isGlobal });
+    }
+  }
+}
+
+export async function processWellKnownUpdates(
+  groups: Map<string, WellKnownUpdateItem[]>,
+  isGlobal: boolean,
+  options: UpdateCheckOptions
+): Promise<{ successCount: number; failCount: number; changed: boolean }> {
+  let successCount = 0;
+  let failCount = 0;
+  let changed = false;
+
+  for (const [baseUrl, items] of groups) {
+    process.stdout.write(`\r${DIM}Checking skills from source: ${baseUrl}${RESET}\x1b[K\n`);
+
+    const result = await checkWellKnownForUpdates(baseUrl, items);
+
+    if (result.status === 'error') {
+      console.log(`  ${DIM}✗ Failed to check skills from ${baseUrl}${RESET}`);
+      continue;
+    }
+
+    if (result.status === 'current') continue;
+
+    changed = true;
+
+    await promptWellKnownDeletions(baseUrl, result.removedSkills, isGlobal, options);
+
+    if (result.changedSkills.length === 0) continue;
+
+    const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
+    if (!existsSync(cliEntry)) {
+      failCount += result.changedSkills.length;
+      console.log(`  ${DIM}✗ CLI entrypoint not found at ${cliEntry}${RESET}`);
+      continue;
+    }
+
+    const itemByName = new Map(items.map((item) => [item.name, item]));
+
+    for (const name of result.changedSkills) {
+      const safeName = sanitizeMetadata(name);
+      console.log(`${TEXT}Updating ${safeName}…${RESET}`);
+
+      const subagents = itemByName.get(name)?.subagents;
+      const subagentArgs =
+        !isGlobal && subagents?.length
+          ? ['--subagent', ...subagents.map((s) => (s === '' ? 'root' : s))]
+          : [];
+
+      const spawnResult = spawnSync(
+        process.execPath,
+        [
+          cliEntry,
+          'add',
+          baseUrl,
+          '--skill',
+          name,
+          ...subagentArgs,
+          ...(isGlobal ? ['-g'] : []),
+          '-y',
+        ],
+        {
+          stdio: ['inherit', 'pipe', 'pipe'],
+          encoding: 'utf-8',
+          shell: false,
+        }
+      );
+
+      if (spawnResult.status === 0) {
+        successCount++;
+        console.log(`  ${TEXT}✓${RESET} Updated ${safeName}`);
+      } else {
+        failCount++;
+        console.log(`  ${DIM}✗ Failed to update ${safeName}${RESET}`);
+      }
+    }
+  }
+
+  return { successCount, failCount, changed };
+}
+
 export async function updateGlobalSkills(
   options: UpdateCheckOptions = {}
 ): Promise<{ successCount: number; failCount: number; checkedCount: number }> {
@@ -301,12 +475,20 @@ export async function updateGlobalSkills(
   const updates: Array<{ name: string; source: string; entry: SkillLockEntry }> = [];
   const skipped: SkippedSkill[] = [];
   const checkable: Array<{ name: string; entry: SkillLockEntry }> = [];
+  const wellKnownGroups = new Map<string, WellKnownUpdateItem[]>();
 
   for (const skillName of skillNames) {
     if (!matchesSkillFilter(skillName, options.skills)) continue;
 
     const entry = lock.skills[skillName];
     if (!entry) continue;
+
+    if (entry.sourceType === 'well-known' && entry.sourceBaseUrl && entry.wellKnownDigest) {
+      const group = wellKnownGroups.get(entry.sourceBaseUrl) || [];
+      group.push({ name: skillName, digest: entry.wellKnownDigest });
+      wellKnownGroups.set(entry.sourceBaseUrl, group);
+      continue;
+    }
 
     if (!entry.skillFolderHash || !entry.skillPath) {
       skipped.push({
@@ -321,6 +503,18 @@ export async function updateGlobalSkills(
 
     checkable.push({ name: skillName, entry });
   }
+
+  const wellKnownCount = Array.from(wellKnownGroups.values()).reduce(
+    (sum, items) => sum + items.length,
+    0
+  );
+  const {
+    successCount: wkSuccessCount,
+    failCount: wkFailCount,
+    changed: wkChanged,
+  } = await processWellKnownUpdates(wellKnownGroups, true, options);
+  successCount += wkSuccessCount;
+  failCount += wkFailCount;
 
   const bySource = new Map<string, typeof checkable>();
   for (const item of checkable) {
@@ -423,13 +617,20 @@ export async function updateGlobalSkills(
     process.stdout.write('\r\x1b[K');
   }
 
-  const checkedCount = checkable.length + skipped.length;
+  const checkedCount = checkable.length + skipped.length + wellKnownCount;
 
-  if (checkable.length === 0 && skipped.length === 0) {
+  if (checkable.length === 0 && skipped.length === 0 && wellKnownCount === 0) {
     if (!options.skills) {
       console.log(`${DIM}No global skills to check.${RESET}`);
     }
     return { successCount, failCount, checkedCount: 0 };
+  }
+
+  if (checkable.length === 0 && skipped.length === 0) {
+    if (!wkChanged) {
+      console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    }
+    return { successCount, failCount, checkedCount };
   }
 
   if (checkable.length === 0 && skipped.length > 0) {
@@ -438,7 +639,9 @@ export async function updateGlobalSkills(
   }
 
   if (updates.length === 0) {
-    console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    if (!wkChanged) {
+      console.log(`${TEXT}✓ All global skills are up to date${RESET}`);
+    }
     return { successCount, failCount, checkedCount };
   }
 
@@ -511,10 +714,31 @@ export async function updateProjectSkills(
     return { successCount, failCount, foundCount: 0 };
   }
 
-  const updatable = projectSkills.filter((s) => s.entry.skillPath);
-  const legacy = projectSkills.filter((s) => !s.entry.skillPath);
+  const wellKnownGroups = new Map<string, WellKnownUpdateItem[]>();
+  const nonWellKnown: typeof projectSkills = [];
+  for (const skill of projectSkills) {
+    const { entry } = skill;
+    if (entry.sourceType === 'well-known' && entry.sourceUrl && entry.wellKnownDigest) {
+      const group = wellKnownGroups.get(entry.sourceUrl) || [];
+      group.push({
+        name: skill.name,
+        digest: entry.wellKnownDigest,
+        subagents: entry.subagents,
+      });
+      wellKnownGroups.set(entry.sourceUrl, group);
+    } else {
+      nonWellKnown.push(skill);
+    }
+  }
+  const wellKnownCount = Array.from(wellKnownGroups.values()).reduce(
+    (sum, items) => sum + items.length,
+    0
+  );
 
-  if (updatable.length === 0) {
+  const updatable = nonWellKnown.filter((s) => s.entry.skillPath);
+  const legacy = nonWellKnown.filter((s) => !s.entry.skillPath);
+
+  if (updatable.length === 0 && wellKnownCount === 0) {
     console.log(`${DIM}No project skills can be updated in place.${RESET}`);
     printLegacyProjectSkills(legacy);
     return { successCount, failCount, foundCount: projectSkills.length };
@@ -545,8 +769,16 @@ export async function updateProjectSkills(
     console.log(`${TEXT}Updating for: ${targetParts.join(', ')}${RESET}`);
   }
 
-  console.log(`${TEXT}Refreshing ${updatable.length} skill(s)…${RESET}`);
+  console.log(`${TEXT}Refreshing ${updatable.length + wellKnownCount} skill(s)…${RESET}`);
   console.log();
+
+  const { successCount: wkSuccessCount, failCount: wkFailCount } = await processWellKnownUpdates(
+    wellKnownGroups,
+    false,
+    options
+  );
+  successCount += wkSuccessCount;
+  failCount += wkFailCount;
 
   const bySource = new Map<string, typeof updatable>();
   for (const skill of updatable) {
@@ -559,9 +791,13 @@ export async function updateProjectSkills(
   const localLock = await readLocalLock();
   const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
 
-  if (!existsSync(cliEntry)) {
+  if (updatable.length > 0 && !existsSync(cliEntry)) {
     console.log(`${DIM}✗ CLI entrypoint not found at ${cliEntry}${RESET}`);
-    return { successCount, failCount: updatable.length, foundCount: projectSkills.length };
+    return {
+      successCount,
+      failCount: failCount + updatable.length,
+      foundCount: projectSkills.length,
+    };
   }
 
   for (const [source, skillsForSource] of bySource) {

--- a/tests/wellknown-update.test.ts
+++ b/tests/wellknown-update.test.ts
@@ -213,4 +213,19 @@ describe('checkWellKnownForUpdates', () => {
     if (result.status !== 'changed') return;
     expect(result.changedSkills).toEqual(['alpha-skill']);
   });
+
+  it('marks every v1 index fetch and downloads only tracked skill files', async () => {
+    const alphaDigest = await digestOf('alpha-skill');
+    const mock = stubWellKnownServer(v1Index(['alpha-skill', 'beta-skill']));
+    await checkWellKnownForUpdates(BASE_URL, [{ name: 'alpha-skill', digest: alphaDigest }]);
+    const indexCalls = mock.mock.calls.filter((call) => String(call[0]).endsWith('/index.json'));
+    expect(indexCalls.length).toBeGreaterThan(0);
+    for (const call of indexCalls) {
+      expect(new Headers((call[1] as RequestInit)?.headers).get('X-Skills-Update-Check')).toBe('1');
+    }
+    const fileCalls = mock.mock.calls
+      .map((call) => String(call[0]))
+      .filter((url) => url.endsWith('/SKILL.md'));
+    expect(fileCalls).toEqual([`${BASE_URL}/.well-known/skills/alpha-skill/SKILL.md`]);
+  });
 });

--- a/tests/wellknown-update.test.ts
+++ b/tests/wellknown-update.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { checkWellKnownForUpdates, type WellKnownUpdateItem } from '../src/update.ts';
+import {
+  computeWellKnownSkillDigest,
+  wellKnownProvider,
+  type WellKnownSkill,
+} from '../src/providers/index.ts';
+
+const BASE_URL = 'https://skills.example.com/p/testpack';
+
+const DIGEST_A = `sha256:${'a'.repeat(64)}`;
+const DIGEST_B = `sha256:${'b'.repeat(64)}`;
+const DIGEST_STALE = `sha256:${'0'.repeat(64)}`;
+
+function skillMd(name: string, body: string): string {
+  return `---\nname: ${name}\ndescription: ${name} description\n---\n${body}\n`;
+}
+
+const V1_CONTENTS: Record<string, string> = {
+  'alpha-skill': skillMd('alpha-skill', '# Alpha v1'),
+  'beta-skill': skillMd('beta-skill', '# Beta v1'),
+};
+
+function v1Index(names: string[]): unknown {
+  return {
+    skills: names.map((name) => ({
+      name,
+      description: `${name} description`,
+      files: ['SKILL.md'],
+    })),
+  };
+}
+
+function v2Index(entries: Array<{ name: string; digest: string }>): unknown {
+  return {
+    $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+    skills: entries.map((entry) => ({
+      name: entry.name,
+      type: 'skill-md',
+      description: `${entry.name} description`,
+      url: `${BASE_URL}/.well-known/skills/${entry.name}/SKILL.md`,
+      digest: entry.digest,
+    })),
+  };
+}
+
+function stubWellKnownServer(
+  index: unknown | null,
+  contents: Record<string, string> = V1_CONTENTS
+): ReturnType<typeof vi.fn> {
+  const mock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith('/.well-known/agent-skills/index.json')) {
+      return new Response(null, { status: 404 });
+    }
+    if (url.endsWith('/.well-known/skills/index.json')) {
+      if (index === null) return new Response(null, { status: 404 });
+      return Response.json(index);
+    }
+    const match = url.match(/\/\.well-known\/skills\/([^/]+)\/SKILL\.md$/);
+    if (match && contents[match[1]!]) {
+      return new Response(contents[match[1]!]);
+    }
+    return new Response(null, { status: 404 });
+  });
+  vi.stubGlobal('fetch', mock);
+  return mock;
+}
+
+async function digestOf(name: string, contents = V1_CONTENTS): Promise<string> {
+  stubWellKnownServer(v1Index(Object.keys(contents)), contents);
+  const skills = await wellKnownProvider.fetchAllSkills(BASE_URL);
+  const skill = skills.find((s) => s.installName === name);
+  if (!skill) throw new Error(`fixture skill ${name} not fetched`);
+  return computeWellKnownSkillDigest(skill);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('computeWellKnownSkillDigest', () => {
+  it('passes through the v2 index digest when present', () => {
+    const skill = {
+      files: new Map([['SKILL.md', 'content']]),
+      indexEntry: {
+        name: 'x',
+        type: 'skill-md',
+        description: 'd',
+        url: 'https://example.com/x',
+        digest: 'sha256:abc',
+      },
+    } as unknown as WellKnownSkill;
+    expect(computeWellKnownSkillDigest(skill)).toBe('sha256:abc');
+  });
+
+  it('hashes files deterministically for v1 entries', () => {
+    const entry = { name: 'x', description: 'd', files: ['SKILL.md', 'notes.md'] };
+    const forward = {
+      files: new Map<string, string>([
+        ['SKILL.md', 'root'],
+        ['notes.md', 'notes'],
+      ]),
+      indexEntry: entry,
+    } as unknown as WellKnownSkill;
+    const reversed = {
+      files: new Map<string, string>([
+        ['notes.md', 'notes'],
+        ['SKILL.md', 'root'],
+      ]),
+      indexEntry: entry,
+    } as unknown as WellKnownSkill;
+    expect(computeWellKnownSkillDigest(forward)).toBe(computeWellKnownSkillDigest(reversed));
+    expect(computeWellKnownSkillDigest(forward)).toMatch(/^sha256:/);
+  });
+
+  it('changes when file contents change', () => {
+    const entry = { name: 'x', description: 'd', files: ['SKILL.md'] };
+    const one = {
+      files: new Map([['SKILL.md', 'v1']]),
+      indexEntry: entry,
+    } as unknown as WellKnownSkill;
+    const two = {
+      files: new Map([['SKILL.md', 'v2']]),
+      indexEntry: entry,
+    } as unknown as WellKnownSkill;
+    expect(computeWellKnownSkillDigest(one)).not.toBe(computeWellKnownSkillDigest(two));
+  });
+});
+
+describe('checkWellKnownForUpdates', () => {
+  it('returns error when no index is served', async () => {
+    stubWellKnownServer(null);
+    const result = await checkWellKnownForUpdates(BASE_URL, [
+      { name: 'alpha-skill', digest: 'sha256:whatever' },
+    ]);
+    expect(result.status).toBe('error');
+  });
+
+  it('returns current when v1 content digests match', async () => {
+    const items: WellKnownUpdateItem[] = [
+      { name: 'alpha-skill', digest: await digestOf('alpha-skill') },
+      { name: 'beta-skill', digest: await digestOf('beta-skill') },
+    ];
+    stubWellKnownServer(v1Index(['alpha-skill', 'beta-skill']));
+    const result = await checkWellKnownForUpdates(BASE_URL, items);
+    expect(result.status).toBe('current');
+  });
+
+  it('classifies changed skills when v1 content changes', async () => {
+    const items: WellKnownUpdateItem[] = [
+      { name: 'alpha-skill', digest: await digestOf('alpha-skill') },
+      { name: 'beta-skill', digest: await digestOf('beta-skill') },
+    ];
+    const changedContents = {
+      ...V1_CONTENTS,
+      'alpha-skill': skillMd('alpha-skill', '# Alpha v2 CHANGED'),
+    };
+    stubWellKnownServer(v1Index(['alpha-skill', 'beta-skill']), changedContents);
+    const result = await checkWellKnownForUpdates(BASE_URL, items);
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills).toEqual(['alpha-skill']);
+    expect(result.removedSkills).toEqual([]);
+  });
+
+  it('classifies skills removed from the index', async () => {
+    const items: WellKnownUpdateItem[] = [
+      { name: 'alpha-skill', digest: await digestOf('alpha-skill') },
+      { name: 'beta-skill', digest: await digestOf('beta-skill') },
+    ];
+    stubWellKnownServer(v1Index(['alpha-skill']));
+    const result = await checkWellKnownForUpdates(BASE_URL, items);
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills).toEqual([]);
+    expect(result.removedSkills).toEqual(['beta-skill']);
+  });
+
+  it('compares v2 digests without fetching skill files', async () => {
+    const mock = stubWellKnownServer(
+      v2Index([
+        { name: 'alpha-skill', digest: DIGEST_A },
+        { name: 'beta-skill', digest: DIGEST_B },
+      ])
+    );
+    const result = await checkWellKnownForUpdates(BASE_URL, [
+      { name: 'alpha-skill', digest: DIGEST_A },
+      { name: 'beta-skill', digest: DIGEST_STALE },
+    ]);
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills).toEqual(['beta-skill']);
+    const fetchedUrls = mock.mock.calls.map((call) => String(call[0]));
+    expect(fetchedUrls.every((url) => !url.endsWith('/SKILL.md'))).toBe(true);
+  });
+
+  it('sends the update-check header on index fetches', async () => {
+    const mock = stubWellKnownServer(v2Index([{ name: 'alpha-skill', digest: DIGEST_A }]));
+    await checkWellKnownForUpdates(BASE_URL, [{ name: 'alpha-skill', digest: DIGEST_A }]);
+    const indexCall = mock.mock.calls.find((call) =>
+      String(call[0]).endsWith('/.well-known/skills/index.json')
+    );
+    expect(indexCall).toBeDefined();
+    const init = indexCall![1] as RequestInit;
+    expect(new Headers(init.headers).get('X-Skills-Update-Check')).toBe('1');
+  });
+
+  it('treats entries with missing digests as changed', async () => {
+    stubWellKnownServer(v1Index(['alpha-skill']));
+    const result = await checkWellKnownForUpdates(BASE_URL, [{ name: 'alpha-skill', digest: '' }]);
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills).toEqual(['alpha-skill']);
+  });
+});


### PR DESCRIPTION
## Why

`skills update` unconditionally parks every well-known install:

- Global: the lock is written with `skillFolderHash: ''`, so entries are skipped as **"Well-known skill — cannot be checked automatically"**.
- Project: the lock stores only the hostname (no re-fetch URL) and no `skillPath`, so entries land in the **legacy** list with a manual re-add hint.

skills.sh packs install through this exact path (`/p/<id>/.well-known/skills/index.json`), so pack owners can now edit packs (skills-leaderboard#183) but consumers have no way to pull the changes. Fixing update for well-known sources fixes packs and every other well-known publisher at once — no pack-specific code.

## What

- **Install** (`add.ts`): well-known lock entries now record the original install URL (`sourceBaseUrl` globally, existing `sourceUrl` field in the project lock) and a `wellKnownDigest` — the v2 index `digest` when the source publishes one, otherwise `sha256:` over the fetched files sorted by path.
- **Update** (`update.ts`): entries carrying both fields are partitioned out of the skip/legacy paths and grouped by source. One marked index fetch per source, then digest compare:
  - v2 sources: index digests compared directly — no skill files downloaded.
  - v1 sources (skills.sh packs today): tracked skills' files fetched via `fetchSkillByEntry` from the already-fetched index entries — no second index request, no downloads for untracked skills.
  - Changed skills reinstall via the existing per-skill `add <url> --skill <name> -y` respawn (Eve `--subagent` placement preserved project-side); skills missing from the index get the deletion-prompt UX (extracted into a `promptDeletions` helper shared with the repo-source path); unreachable index → "failed to check", never a deletion prompt.
- Every update-check index fetch sends `X-Skills-Update-Check: 1` so skills.sh can exclude checks from pack install analytics (skills-leaderboard#236).
- **Side effect worth noting**: project-lock entries for well-known installs now carry `sourceUrl`, so `skills install` (restore-from-lock) restores them from the full install URL instead of the bare hostname it recorded before.
- **Compat**: additive optional lock fields only. Entries written by older CLI versions keep today's skipped/legacy behavior until re-added once. Update semantics match repo sources: refresh installed skills, no auto-install of skills newly added upstream.

## Testing

- 11 tests: digest passthrough/determinism/sensitivity, current/changed/removed classification, v2 no-download guarantee, header on every index fetch (incl. the v1 fallback path), tracked-files-only download, missing-digest fallback.
- Full suite vs clean `origin/main` baseline worktree: identical failure sets (3 pre-existing local env flakes), zero regressions.
- Fixture-server e2e: install from a local well-known v1 server → lock carries URL + digest → no-op update reports nothing → upstream content change updates the skill on disk and refreshes the lock digest → skill removed upstream triggers the deletion warning → server down reports "failed to check".
- prettier + tsc clean.