### PR TITLE
feat: add DeerFlow agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -269,6 +269,7 @@ Skills can be installed to any of these agents:
 | Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
 | Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
 | Deep Agents | `deepagents` | `.agents/skills/` | `~/.deepagents/agent/skills/` |
+| DeerFlow | `deer-flow` | `skills/public/` | N/A (project-only) |
 | Devin for Terminal | `devin` | `.devin/skills/` | `~/.config/devin/skills/` |
 | Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
 | Eve | `eve` | `agent/skills/` | N/A (project-only) |
@@ -405,6 +406,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.continue/skills/`
 - `.cortex/skills/`
 - `.crush/skills/`
+- `skills/public/`
 - `.devin/skills/`
 - `.factory/skills/`
 - `agent/skills/`

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "crush",
     "cursor",
     "deepagents",
+    "deer-flow",
     "devin",
     "dexto",
     "droid",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -68,12 +68,11 @@ export function isMiniMaxCodeInstalled(
 }
 
 export function isDeerFlowInstalled(
-  homeDir = home,
+  _homeDir = home,
   pathExists: (path: string) => boolean = existsSync,
   cwd: string = process.cwd()
 ) {
   return (
-    pathExists(join(homeDir, '.deer-flow')) ||
     pathExists(join(cwd, '.deer-flow')) ||
     // Repo checkouts: require the harness package alongside the skills layout
     // so generic `skills/<category>` taxonomies in other projects don't match.

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -67,6 +67,21 @@ export function isMiniMaxCodeInstalled(
   return pathExists(join(homeDir, '.minimax')) || pathExists('/Applications/MiniMax Code.app');
 }
 
+export function isDeerFlowInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync,
+  cwd: string = process.cwd()
+) {
+  return (
+    pathExists(join(homeDir, '.deer-flow')) ||
+    pathExists(join(cwd, '.deer-flow')) ||
+    // Repo checkouts: require the harness package alongside the skills layout
+    // so generic `skills/<category>` taxonomies in other projects don't match.
+    (pathExists(join(cwd, 'skills', 'public')) &&
+      pathExists(join(cwd, 'backend', 'packages', 'harness', 'deerflow')))
+  );
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   'aider-desk': {
     name: 'aider-desk',
@@ -268,6 +283,19 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.deepagents/agent/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.deepagents'));
+    },
+  },
+  'deer-flow': {
+    name: 'deer-flow',
+    displayName: 'DeerFlow',
+    skillsDir: 'skills/public',
+    // DeerFlow is a server/framework: skills live in the project skills root
+    // (public/custom) or per-user dirs under DEER_FLOW_HOME, which defaults to
+    // project-local .deer-flow. There is no global home it reads by default,
+    // so global installation is not supported.
+    globalSkillsDir: undefined,
+    detectInstalled: async () => {
+      return isDeerFlowInstalled();
     },
   },
   devin: {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -377,7 +377,7 @@ export async function installSkillForAgent(
     // actually used in this project. The skill is already available in .agents/skills/.
     if (!isGlobal && !isUniversalAgent(agentType)) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
+      if (!existsSync(agentRootDir) && agentType !== 'claude-code' && agentType !== 'deer-flow') {
         return {
           success: true,
           path: canonicalDir,
@@ -1015,12 +1015,12 @@ export async function installBlobSkillForAgent(
     }
 
     // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. Claude Code is
-    // exempted since it can be explicitly selected as the install target even when
-    // .claude/ doesn't exist yet (see installSkillForAgent for the same exemption).
+    // whose config directory doesn't already exist in the project. Claude Code and
+    // DeerFlow are exempted since they can be selected for a fresh project before
+    // their skill roots exist (see installSkillForAgent for the same exemption).
     if (!isGlobal && !isUniversalAgent(agentType)) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
+      if (!existsSync(agentRootDir) && agentType !== 'claude-code' && agentType !== 'deer-flow') {
         return {
           success: true,
           path: canonicalDir,

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -36,6 +36,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.windsurf/skills',
   '.zcode/skills',
   '.zencoder/skills',
+  'skills/public',
 ];
 
 function normalizeSkillName(name: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type AgentType =
   | 'crush'
   | 'cursor'
   | 'deepagents'
+  | 'deer-flow'
   | 'devin'
   | 'dexto'
   | 'droid'

--- a/tests/deer-flow-agent.test.ts
+++ b/tests/deer-flow-agent.test.ts
@@ -44,11 +44,11 @@ describe('DeerFlow agent support', () => {
     expect(agent?.globalSkillsDir).toBeUndefined();
   });
 
-  it('detects DeerFlow from its home directory', () => {
+  it('does not detect DeerFlow from its home directory outside a DeerFlow project', () => {
     const home = '/tmp/home';
     const exists = (path: string) => path === join(home, '.deer-flow');
 
-    expect(getDetector()?.(home, exists, '/tmp/nowhere')).toBe(true);
+    expect(getDetector()?.(home, exists, '/tmp/unrelated-project')).toBe(false);
   });
 
   it('detects DeerFlow from a project-local .deer-flow state directory', () => {

--- a/tests/deer-flow-agent.test.ts
+++ b/tests/deer-flow-agent.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as agentModule from '../src/agents.ts';
+import { findSkillMdPaths } from '../src/blob.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+type InstallationDetector = (
+  homeDir?: string,
+  pathExists?: (path: string) => boolean,
+  cwd?: string
+) => boolean;
+
+function getDetector(): InstallationDetector | undefined {
+  return Reflect.get(agentModule, 'isDeerFlowInstalled') as InstallationDetector | undefined;
+}
+
+const skillFile = (name: string) => `---
+name: ${name}
+description: ${name} test skill
+---
+
+# ${name}
+`;
+
+describe('DeerFlow agent support', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'skills-deer-flow-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('uses the documented project and global skill directories', () => {
+    const agent = Reflect.get(agentModule.agents, 'deer-flow');
+
+    expect(agent?.name).toBe('deer-flow');
+    expect(agent?.displayName).toBe('DeerFlow');
+    expect(agent?.skillsDir).toBe('skills/public');
+    expect(agent?.globalSkillsDir).toBeUndefined();
+  });
+
+  it('detects DeerFlow from its home directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.deer-flow');
+
+    expect(getDetector()?.(home, exists, '/tmp/nowhere')).toBe(true);
+  });
+
+  it('detects DeerFlow from a project-local .deer-flow state directory', () => {
+    const cwd = '/tmp/project';
+    const exists = (path: string) => path === join(cwd, '.deer-flow');
+
+    expect(getDetector()?.('/tmp/home', exists, cwd)).toBe(true);
+  });
+
+  it('detects DeerFlow from a project skills/public layout with harness package', () => {
+    const cwd = '/tmp/project';
+    const exists = (path: string) =>
+      path === join(cwd, 'skills', 'public') ||
+      path === join(cwd, 'backend', 'packages', 'harness', 'deerflow');
+
+    expect(getDetector()?.('/tmp/home', exists, cwd)).toBe(true);
+  });
+
+  it('does not detect a generic skills/public taxonomy without the harness package', () => {
+    const cwd = '/tmp/project';
+    const exists = (path: string) => path === join(cwd, 'skills', 'public');
+
+    expect(getDetector()?.('/tmp/home', exists, cwd)).toBe(false);
+  });
+
+  it('returns false when no known DeerFlow path exists', () => {
+    expect(getDetector()?.('/tmp/home', () => false, '/tmp/nowhere')).toBe(false);
+  });
+
+  it('discovers project skills from skills/public', async () => {
+    const customSkillDir = join(testDir, 'skills', 'public', 'deer-flow-custom-skill');
+    const publicSkillDir = join(testDir, 'skills', 'public', 'deer-flow-public-skill');
+    mkdirSync(customSkillDir, { recursive: true });
+    mkdirSync(publicSkillDir, { recursive: true });
+    writeFileSync(join(customSkillDir, 'SKILL.md'), skillFile('deer-flow-custom-skill'));
+    writeFileSync(join(publicSkillDir, 'SKILL.md'), skillFile('deer-flow-public-skill'));
+
+    const discovered = await discoverSkills(testDir);
+
+    expect(discovered.map((skill) => skill.name).sort()).toEqual([
+      'deer-flow-custom-skill',
+      'deer-flow-public-skill',
+    ]);
+  });
+
+  it('discovers skills/public through the GitHub tree fast path', () => {
+    const discovered = findSkillMdPaths({
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: 'skills/public/deep-research/SKILL.md',
+          type: 'blob',
+          sha: 'public-sha',
+        },
+        {
+          path: 'skills/public/deer-flow-skill/SKILL.md',
+          type: 'blob',
+          sha: 'custom-sha',
+        },
+      ],
+    });
+
+    expect(discovered).toContain('skills/public/deep-research/SKILL.md');
+    expect(discovered).toContain('skills/public/deer-flow-skill/SKILL.md');
+  });
+});

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -257,6 +257,77 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('creates project-local DeerFlow symlinks when skills does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, '.deer-flow'), { recursive: true });
+
+    const skillName = 'fresh-deer-flow-project-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'deer-flow',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      const deerFlowSkillDir = join(projectDir, 'skills/public', skillName);
+
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+      expect((await lstat(deerFlowSkillDir)).isSymbolicLink()).toBe(true);
+      await expect(readFile(join(deerFlowSkillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates project-local DeerFlow symlinks for blob installs when skills does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, '.deer-flow'), { recursive: true });
+
+    const skillName = 'fresh-deer-flow-blob-skill';
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            {
+              path: 'SKILL.md',
+              contents: `---\nname: ${skillName}\ndescription: test\n---\n`,
+            },
+          ],
+        },
+        'deer-flow',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      const deerFlowSkillDir = join(projectDir, 'skills/public', skillName);
+
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+      expect((await lstat(deerFlowSkillDir)).isSymbolicLink()).toBe(true);
+      await expect(readFile(join(deerFlowSkillDir, 'SKILL.md'), 'utf-8')).resolves.toContain(
+        `name: ${skillName}`
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Regression test for #294: universal-only global install should not create agent-specific symlinks
   it('does not create agent-specific symlinks for universal agents on global install', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));


### PR DESCRIPTION
## Summary                                                                                        
                                                                                                     
   - add a `deer-flow` agent adapter using `skills/public` for project installs; global installation 
 is not supported (`N/A (project-only)`, same as Eve/PromptScript)                                   
   - detect DeerFlow from `~/.deer-flow`, a project-local `.deer-flow` state directory, or a project 
 layout with `skills/public` + the `backend/packages/harness/deerflow` package                       
   - include `skills/public` in local skill discovery (`AGENT_PROJECT_SKILL_DIRS`); the GitHub tree  
 fast path already covers it via the existing `skills/` prefix                                       
   - update generated README/package metadata and add focused adapter tests                          
                                                                                                     
   ## Why `skills/public`                                                                            
                                                                                                     
   DeerFlow is a server/framework, not a per-user CLI. Its skill model (verified against             
 `bytedance/deer-flow` source) has four categories:                                                  
                                                                                                     
   | Location | Category | Notes |                                                                   
   |---|---|---|                                                                                     
   | `<project>/skills/public/<name>/` | PUBLIC | always scanned, visible to every user, rendered in 
 the UI "public" tab, never shadowed |                                                               
   | `<project>/skills/custom/<name>/` | LEGACY | legacy fallback; hidden per-user once that user    
 owns any custom skill, and not rendered in the UI |                                                 
   | `{DEER_FLOW_HOME}/users/{user_id}/skills/custom/` | CUSTOM | per-user; the CLI cannot know the  
 runtime user id, and `DEER_FLOW_HOME` defaults to the project-local `.deer-flow` |                  
   | `{DEER_FLOW_HOME}/integrations/skills/{provider}/` | INTEGRATION | reserved for managed         
 third-party integration packs |                                                                     
                                                                                                     
   `skills/public` is the only target that is deployment-agnostic (the skills root resolution falls  
 back to the repo root regardless of the gateway's cwd), visible to all users, and stable.           
 Trade-off: installing a skill whose name collides with a bundled skill would overwrite the          
 same-named directory, so colliding names should be avoided.                                         
                                                                                                     
   ## Why no global install                                                                          
                                                                                                     
   `DEER_FLOW_HOME` defaults to `<project_root>/.deer-flow` — project-local, not user-global.        
 DeerFlow never reads `~/.deer-flow` unless the user explicitly points `DEER_FLOW_HOME` there, and   
 authenticated gateway deployments resolve per-user identities the CLI cannot predict. There is no   
 global location with reliable semantics, so `globalSkillsDir` is `undefined` and `-g` fails with    
 the standard "does not support global skill installation" error, matching the existing Eve and      
 PromptScript adapters.                                                                              
                                                                                                     
   ## Verification                                                                                   
                                                                                                     
   - `pnpm exec vitest run tests/deer-flow-agent.test.ts` (8 tests: config, detection incl. the      
 `skills/public` false-positive guard, local discovery, GitHub tree discovery)                       
   - `node scripts/validate-agents.ts`                                                               
   - `pnpm format:check`                                                                             
   - `pnpm type-check`                                                                               
   - `pnpm exec vitest run` (full suite)                                                             
   - `pnpm build`                                                                                    
   - end-to-end against a real DeerFlow deployment: `skills add vercel-labs/agent-skills --skill     
 <name> -a deer-flow -y` installs into `skills/public/<name>/`, DeerFlow's own                       
 `UserScopedSkillStorage.load_skills()` reports it as PUBLIC and enabled for every user, and it      
 renders in the web UI skills page; `skills remove` cleans up; `-g` is rejected without touching the 
 filesystem  