### PR TITLE
Surface skills added upstream to well-known sources during update

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -301,8 +301,13 @@ export interface WellKnownUpdateItem {
 
 export type WellKnownCheckResult =
   | { status: 'error' }
-  | { status: 'current' }
-  | { status: 'changed'; changedSkills: string[]; removedSkills: string[] };
+  | { status: 'current'; newSkills: string[] }
+  | {
+      status: 'changed';
+      changedSkills: string[];
+      removedSkills: string[];
+      newSkills: string[];
+    };
 
 export async function checkWellKnownForUpdates(
   baseUrl: string,
@@ -318,6 +323,10 @@ export async function checkWellKnownForUpdates(
 
   const byName = new Map(indexResult.entries.map((entry) => [entry.name, entry]));
   const removedSkills = items.filter((item) => !byName.has(item.name)).map((item) => item.name);
+  const localNames = new Set(items.map((item) => item.name));
+  const newSkills = indexResult.entries
+    .map((entry) => entry.name)
+    .filter((name) => !localNames.has(name));
   const changedSkills: string[] = [];
   const needsContentCheck: WellKnownUpdateItem[] = [];
 
@@ -355,9 +364,20 @@ export async function checkWellKnownForUpdates(
   }
 
   if (changedSkills.length === 0 && removedSkills.length === 0) {
-    return { status: 'current' };
+    return { status: 'current', newSkills };
   }
-  return { status: 'changed', changedSkills, removedSkills };
+  return { status: 'changed', changedSkills, removedSkills, newSkills };
+}
+
+function printNewSkills(baseUrl: string, newSkills: string[], isGlobal: boolean): void {
+  if (newSkills.length === 0) return;
+  const names = newSkills.map(sanitizeMetadata);
+  console.log(
+    `  ${DIM}${newSkills.length} new skill(s) available from this source:${RESET} ${names.join(', ')}`
+  );
+  console.log(
+    `    ${DIM}To install: ${TEXT}npx skills add ${baseUrl} --skill ${names.join(' ')}${isGlobal ? ' -g' : ''}${RESET}`
+  );
 }
 
 export async function processWellKnownUpdates(
@@ -379,11 +399,15 @@ export async function processWellKnownUpdates(
       continue;
     }
 
-    if (result.status === 'current') continue;
+    if (result.status === 'current') {
+      printNewSkills(baseUrl, result.newSkills, isGlobal);
+      continue;
+    }
 
     changed = true;
 
     await promptDeletions(baseUrl, result.removedSkills, isGlobal, options);
+    printNewSkills(baseUrl, result.newSkills, isGlobal);
 
     if (result.changedSkills.length === 0) continue;
 

--- a/tests/wellknown-update.test.ts
+++ b/tests/wellknown-update.test.ts
@@ -177,6 +177,33 @@ describe('checkWellKnownForUpdates', () => {
     expect(result.removedSkills).toEqual(['beta-skill']);
   });
 
+  it('reports skills present upstream but not installed as new', async () => {
+    const items: WellKnownUpdateItem[] = [
+      { name: 'alpha-skill', digest: await digestOf('alpha-skill') },
+    ];
+    stubWellKnownServer(v1Index(['alpha-skill', 'beta-skill']));
+    const result = await checkWellKnownForUpdates(BASE_URL, items);
+    expect(result.status).toBe('current');
+    if (result.status !== 'current') return;
+    expect(result.newSkills).toEqual(['beta-skill']);
+  });
+
+  it('reports new skills alongside changes', async () => {
+    const alphaDigest = await digestOf('alpha-skill');
+    const changedContents = {
+      ...V1_CONTENTS,
+      'alpha-skill': skillMd('alpha-skill', '# Alpha v2 CHANGED'),
+    };
+    stubWellKnownServer(v1Index(['alpha-skill', 'beta-skill']), changedContents);
+    const result = await checkWellKnownForUpdates(BASE_URL, [
+      { name: 'alpha-skill', digest: alphaDigest },
+    ]);
+    expect(result.status).toBe('changed');
+    if (result.status !== 'changed') return;
+    expect(result.changedSkills).toEqual(['alpha-skill']);
+    expect(result.newSkills).toEqual(['beta-skill']);
+  });
+
   it('compares v2 digests without fetching skill files', async () => {
     const mock = stubWellKnownServer(
       v2Index([


### PR DESCRIPTION
## Why

Follow-up to #1821. `skills update` refreshes installed skills only, so when a pack owner adds a skill to a pack you've installed, update prints nothing — which reads as "did the check even run?" (found immediately in real-world testing).

## What

`checkWellKnownForUpdates` now also returns `newSkills` (index entries not installed locally), and update prints them with a copyable install command instead of installing anything automatically:

```
Checking skills from source: https://skills.sh/p/<id>
  1 new skill(s) available from this source: gamma-skill
    To install: npx skills add https://skills.sh/p/<id> --skill gamma-skill
```

(`-g` appended for global-scope entries; `--skill` takes space-separated names so multiple new skills stay one command.)

Shown on both the up-to-date and changed paths. No behavior change for sources without new skills, and the notice never affects success/fail counters or the up-to-date summary line.

## Testing

- 13 tests (2 new: new-skill classification on current and changed paths); full suite failure set unchanged vs main (same 3 pre-existing local env flakes).
- Fixture-server e2e: added a skill upstream after install → update prints the notice with the exact install command; nothing auto-installs.
- prettier + tsc clean.