### PR TITLE
feat: add Oh My Pi agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -296,6 +296,7 @@ Skills can be installed to any of these agents:
 | OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |
+| Oh My Pi | `omp` | `.omp/skills/` | `~/.omp/agent/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
@@ -428,6 +429,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.mux/skills/`
 - `.openhands/skills/`
 - `.ona/skills/`
+- `.omp/skills/`
 - `.pi/skills/`
 - `.qoder/skills/`
 - `.qwen/skills/`

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "opencode",
     "openhands",
     "ona",
+    "omp",
     "pi",
     "qoder",
     "qoder-cn",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -60,6 +60,13 @@ export function isKimchiInstalled(
   return pathExists(join(homeDir, '.config', 'kimchi'));
 }
 
+export function isOhMyPiInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+): boolean {
+  return pathExists(join(homeDir, '.omp', 'agent'));
+}
+
 export function isMiniMaxCodeInstalled(
   homeDir = home,
   pathExists: (path: string) => boolean = existsSync
@@ -544,6 +551,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.ona/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.ona'));
+    },
+  },
+  omp: {
+    name: 'omp',
+    displayName: 'Oh My Pi',
+    skillsDir: '.omp/skills',
+    globalSkillsDir: join(home, '.omp/agent/skills'),
+    detectInstalled: async () => {
+      return isOhMyPiInstalled();
     },
   },
   pi: {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -273,6 +273,7 @@ const PRIORITY_PREFIXES = [
   '.neovate/skills/',
   '.opencode/skills/',
   '.openhands/skills/',
+  '.omp/skills/',
   '.pi/skills/',
   '.qoder/skills/',
   '.roo/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -29,6 +29,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.neovate/skills',
   '.opencode/skills',
   '.openhands/skills',
+  '.omp/skills',
   '.pi/skills',
   '.qoder/skills',
   '.roo/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type AgentType =
   | 'opencode'
   | 'openhands'
   | 'ona'
+  | 'omp'
   | 'pi'
   | 'qoder'
   | 'qoder-cn'

--- a/tests/omp-agent.test.ts
+++ b/tests/omp-agent.test.ts
@@ -1,0 +1,75 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { agents, isOhMyPiInstalled } from '../src/agents.ts';
+import { findSkillMdPaths, type RepoTree } from '../src/blob.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+describe('Oh My Pi agent support', () => {
+  it('uses the documented OMP project and global skill directories', () => {
+    expect(agents.omp.name).toBe('omp');
+    expect(agents.omp.displayName).toBe('Oh My Pi');
+    expect(agents.omp.skillsDir).toBe('.omp/skills');
+    expect(agents.omp.globalSkillsDir).toBe(join(homedir(), '.omp', 'agent', 'skills'));
+  });
+
+  it('detects Oh My Pi from its agent directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.omp', 'agent');
+
+    expect(isOhMyPiInstalled(home, exists)).toBe(true);
+  });
+
+  it('returns false when the Oh My Pi agent directory does not exist', () => {
+    expect(isOhMyPiInstalled('/tmp/home', () => false)).toBe(false);
+  });
+
+  it('discovers grouped project skills under .omp/skills', async () => {
+    const projectDir = join(tmpdir(), `omp-project-${Date.now()}`);
+    const skillDir = join(projectDir, '.omp', 'skills', 'team', 'review');
+    const sourceSkillDir = join(projectDir, 'skills', 'source');
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(sourceSkillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: review\ndescription: Review code changes.\n---\n\n# Review\n'
+    );
+    writeFileSync(
+      join(sourceSkillDir, 'SKILL.md'),
+      '---\nname: source\ndescription: Source skill.\n---\n\n# Source\n'
+    );
+
+    try {
+      const skills = await discoverSkills(projectDir);
+
+      expect(skills.map((skill) => skill.name).sort()).toEqual(['review', 'source']);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('discovers grouped OMP project skills from remote repository trees', () => {
+    const tree: RepoTree = {
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: 'skills/source/SKILL.md',
+          type: 'blob',
+          sha: 'source-skill-sha',
+        },
+        {
+          path: '.omp/skills/team/review/SKILL.md',
+          type: 'blob',
+          sha: 'skill-sha',
+        },
+      ],
+    };
+
+    expect(findSkillMdPaths(tree).sort()).toEqual([
+      '.omp/skills/team/review/SKILL.md',
+      'skills/source/SKILL.md',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add an `omp` agent adapter using `.omp/skills` for project installs and `~/.omp/agent/skills` for global installs
- detect Oh My Pi from `~/.omp/agent`
- include `.omp/skills` in local and GitHub-tree skill discovery
- update generated agent metadata and add focused adapter tests

## Verification
- `pnpm exec vitest run tests/omp-agent.test.ts` (5 tests passed)
- `node scripts/validate-agents.ts`
- `pnpm format:check`
- `pnpm type-check`
- `pnpm exec vitest run` (731 tests passed)
- `pnpm build`
- branch CLI smoke test installed a local fixture into `.omp/skills/<skill>/SKILL.md`
