### PR TITLE
Add Explyt agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -272,6 +272,7 @@ Skills can be installed to any of these agents:
 | Devin for Terminal | `devin` | `.devin/skills/` | `~/.config/devin/skills/` |
 | Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
 | Eve | `eve` | `agent/skills/` | N/A (project-only) |
+| Explyt | `explyt` | `.explyt/skills/` | `~/.explyt/skills/` |
 | Firebender | `firebender` | `.agents/skills/` | `~/.firebender/skills/` |
 | ForgeCode | `forgecode` | `.forge/skills/` | `~/.forge/skills/` |
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
@@ -408,6 +409,7 @@ to also discover `SKILL.md` files outside these container directories
 - `.devin/skills/`
 - `.factory/skills/`
 - `agent/skills/`
+- `.explyt/skills/`
 - `.forge/skills/`
 - `.goose/skills/`
 - `.grok/skills/`

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dexto",
     "droid",
     "eve",
+    "explyt",
     "firebender",
     "forgecode",
     "gemini-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -67,6 +67,13 @@ export function isMiniMaxCodeInstalled(
   return pathExists(join(homeDir, '.minimax')) || pathExists('/Applications/MiniMax Code.app');
 }
 
+export function isExplytInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  return pathExists(join(homeDir, '.explyt'));
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   'aider-desk': {
     name: 'aider-desk',
@@ -308,6 +315,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return (
         existsSync(join(cwd, 'agent')) && packageJsonHasDependency(join(cwd, 'package.json'), 'eve')
       );
+    },
+  },
+  explyt: {
+    name: 'explyt',
+    displayName: 'Explyt',
+    skillsDir: '.explyt/skills',
+    globalSkillsDir: join(home, '.explyt/skills'),
+    detectInstalled: async () => {
+      return isExplytInstalled();
     },
   },
   firebender: {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -260,6 +260,7 @@ const PRIORITY_PREFIXES = [
   '.codex/skills/',
   '.commandcode/skills/',
   '.continue/skills/',
+  '.explyt/skills/',
   '.github/skills/',
   '.goose/skills/',
   '.grok/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -16,6 +16,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.codex/skills',
   '.commandcode/skills',
   '.continue/skills',
+  '.explyt/skills',
   '.github/skills',
   '.goose/skills',
   '.grok/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type AgentType =
   | 'dexto'
   | 'droid'
   | 'eve'
+  | 'explyt'
   | 'firebender'
   | 'forgecode'
   | 'gemini-cli'

--- a/tests/explyt-agent.test.ts
+++ b/tests/explyt-agent.test.ts
@@ -1,0 +1,48 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { agents, isExplytInstalled } from '../src/agents.ts';
+import { findSkillMdPaths } from '../src/blob.ts';
+
+describe('Explyt agent support', () => {
+  it('uses the documented project and global skill directories', () => {
+    const agent = agents.explyt;
+
+    expect(agent.name).toBe('explyt');
+    expect(agent.displayName).toBe('Explyt');
+    expect(agent.skillsDir).toBe('.explyt/skills');
+    expect(agent.globalSkillsDir).toBe(join(homedir(), '.explyt', 'skills'));
+  });
+
+  it('detects Explyt from its user configuration directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.explyt');
+
+    expect(isExplytInstalled(home, exists)).toBe(true);
+  });
+
+  it('returns false when the Explyt configuration directory does not exist', () => {
+    expect(isExplytInstalled('/tmp/home', () => false)).toBe(false);
+  });
+
+  it('discovers .explyt/skills through the GitHub tree fast path', () => {
+    const discovered = findSkillMdPaths({
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: '.claude/skills/standard-skill/SKILL.md',
+          type: 'blob',
+          sha: 'standard-sha',
+        },
+        {
+          path: '.explyt/skills/explyt-skill/SKILL.md',
+          type: 'blob',
+          sha: 'explyt-sha',
+        },
+      ],
+    });
+
+    expect(discovered).toContain('.explyt/skills/explyt-skill/SKILL.md');
+  });
+});


### PR DESCRIPTION
## Why Explyt

[Explyt](https://explyt.ai) is an AI coding agent built natively for JetBrains IDEs. Rather than relying only on text search and terminal output, it can use the IDE's project model and tools: symbol navigation and usage search, connected-library sources, inspections, configured builds and tests, coverage feedback, refactorings, and debugger state such as variables, call stacks, and execution paths.

That makes it especially useful for controlled changes and cleanup in large or legacy codebases: developers can keep project instructions in versioned `AGENTS.md`, constrain writes, inspect and accept/reject every diff, and have a review agent check the result. Adding first-class skill support gives Explyt users access to the same portable, reusable engineering procedures that the `skills` ecosystem provides, directly in their IDE workflow.

## What this PR adds

- an `explyt` agent adapter, installing project skills to `.explyt/skills` and global skills to `~/.explyt/skills`;
- detection via Explyt's `~/.explyt` user configuration directory;
- local and GitHub-tree discovery of `.explyt/skills`;
- generated README/package metadata plus focused adapter tests.

## Why merge it

The change is deliberately small and follows the existing agent-adapter conventions, so it broadens the skills CLI's compatibility without changing the behavior of other agents. It lets JetBrains developers discover, install, and share skills through the standard `skills` workflow instead of needing a parallel Explyt-specific distribution path.

## Verification

- `corepack pnpm exec vitest run tests/explyt-agent.test.ts tests/full-depth-discovery.test.ts tests/blob-root-skill.test.ts`
- `corepack pnpm type-check`
- `node scripts/validate-agents.ts`
- `corepack pnpm exec prettier --check src/agents.ts src/types.ts src/skills.ts src/blob.ts tests/explyt-agent.test.ts`
- `corepack pnpm build`
- `git diff --check`