### PR TITLE
fix(add): sync shallow clone to GitHub API HEAD when upload-pack advertises a stale ref

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { rmSync } from 'fs';
+import { existsSync, rmSync } from 'fs';
+import { join } from 'path';
 
 const simpleGitMock = vi.hoisted(() => vi.fn());
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -24,13 +25,35 @@ import {
   parseGitHubRepoUrl,
 } from './git.ts';
 
-function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
-  const client = {
+interface GitClientMock {
+  clone: ReturnType<typeof vi.fn>;
+  env: ReturnType<typeof vi.fn>;
+  cwd: ReturnType<typeof vi.fn>;
+  raw: ReturnType<typeof vi.fn>;
+}
+
+function createGitClientMock(clone: ReturnType<typeof vi.fn>): GitClientMock {
+  const client: GitClientMock = {
     clone,
     env: vi.fn(),
+    cwd: vi.fn(),
+    raw: vi.fn(),
   };
   client.env.mockReturnValue(client);
+  client.cwd.mockResolvedValue(client);
   return client;
+}
+
+function mockJsonResponse(body: unknown, ok = true) {
+  return { ok, json: () => Promise.resolve(body) };
+}
+
+function mockApiHeadResponses(defaultBranch: string, sha: string) {
+  const fetchMock = vi.fn();
+  fetchMock.mockResolvedValueOnce(mockJsonResponse({ default_branch: defaultBranch }));
+  fetchMock.mockResolvedValueOnce(mockJsonResponse({ commit: { sha } }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
 }
 
 function mockExecFileSuccess(stdout = '', stderr = '') {
@@ -60,6 +83,7 @@ describe('git clone fallbacks', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
     for (const dir of createdDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -302,5 +326,103 @@ describe('git clone fallbacks', () => {
 
     expect(simpleGitMock).not.toHaveBeenCalled();
     expect(execFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('clone HEAD sync against the GitHub API', () => {
+  const createdDirs: string[] = [];
+  const staleSha = '3883889000000000000000000000000000000000';
+  const apiSha = '3c75e1f800000000000000000000000000000000';
+
+  beforeEach(() => {
+    simpleGitMock.mockReset();
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    for (const dir of createdDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fetches and checks out the API HEAD when upload-pack advertised a stale ref', async () => {
+    const clone = vi.fn().mockResolvedValue(undefined);
+    const syncClient = createGitClientMock(vi.fn());
+    syncClient.raw.mockResolvedValueOnce(`${staleSha}\n`);
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(clone)).mockReturnValueOnce(syncClient);
+    const fetchMock = mockApiHeadResponses('main', apiSha);
+
+    const tempDir = await cloneRepo('https://github.com/kunchenguid/lavish-axi.git');
+    createdDirs.push(tempDir);
+
+    expect(syncClient.raw).toHaveBeenNthCalledWith(1, ['rev-parse', 'HEAD']);
+    expect(syncClient.raw).toHaveBeenNthCalledWith(2, ['fetch', '--depth', '1', 'origin', apiSha]);
+    expect(syncClient.raw).toHaveBeenNthCalledWith(3, ['checkout', '--quiet', apiSha]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.github.com/repos/kunchenguid/lavish-axi');
+    expect(fetchMock.mock.calls[1]![0]).toBe(
+      'https://api.github.com/repos/kunchenguid/lavish-axi/branches/main'
+    );
+  });
+
+  it('leaves the clone untouched when the API HEAD matches the clone', async () => {
+    const clone = vi.fn().mockResolvedValue(undefined);
+    const syncClient = createGitClientMock(vi.fn());
+    syncClient.raw.mockResolvedValueOnce(`${apiSha}\n`);
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(clone)).mockReturnValueOnce(syncClient);
+    mockApiHeadResponses('main', apiSha);
+
+    const tempDir = await cloneRepo('https://github.com/kunchenguid/lavish-axi.git');
+    createdDirs.push(tempDir);
+
+    expect(syncClient.raw).toHaveBeenCalledTimes(1);
+    expect(syncClient.raw).toHaveBeenCalledWith(['rev-parse', 'HEAD']);
+  });
+
+  it('honors an explicit ref without consulting the API', async () => {
+    const clone = vi.fn().mockResolvedValue(undefined);
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(clone));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tempDir = await cloneRepo('https://github.com/kunchenguid/lavish-axi.git', 'v1.0.0');
+    createdDirs.push(tempDir);
+
+    expect(clone).toHaveBeenCalledWith('https://github.com/kunchenguid/lavish-axi.git', tempDir, [
+      '--depth',
+      '1',
+      '--branch',
+      'v1.0.0',
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the API cross-check for non-GitHub clone URLs', async () => {
+    const clone = vi.fn().mockResolvedValue(undefined);
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(clone));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tempDir = await cloneRepo('https://gitlab.com/Giphy/giphy-codex-skills.git');
+    createdDirs.push(tempDir);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the original clone when the API request fails', async () => {
+    const clone = vi.fn().mockResolvedValue(undefined);
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(clone));
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    const tempDir = await cloneRepo('https://github.com/kunchenguid/lavish-axi.git');
+    createdDirs.push(tempDir);
+
+    expect(existsSync(tempDir)).toBe(true); // original clone dir preserved
+    expect(existsSync(join(tempDir, '.git'))).toBe(false); // clone is mocked, nothing synced
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -243,7 +243,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
   try {
     await createGitClient().clone(url, tempDir, cloneOptions);
-    return tempDir;
+    return await syncCloneToApiHead(tempDir, url, ref, repo);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
@@ -269,7 +269,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       try {
         await resetTempDir(tempDir);
         if (await tryGhClone(repo, tempDir, ref)) {
-          return tempDir;
+          return await syncCloneToApiHead(tempDir, url, ref, repo);
         }
       } catch {
         // Fall through to SSH retry.
@@ -282,7 +282,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
           tempDir,
           cloneOptions
         );
-        return tempDir;
+        return await syncCloneToApiHead(tempDir, url, ref, repo);
       } catch {
         // Fall through to the targeted auth error below.
       }
@@ -296,6 +296,70 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
     throw new GitCloneError(`Failed to clone ${url}: ${errorMessage}`, url, false, false);
   }
+}
+
+/**
+ * Cross-check a shallow default-branch clone against the GitHub API's
+ * default-branch HEAD SHA. GitHub's git-upload-pack endpoint can advertise a
+ * stale refs/heads/<default> while the REST API (and raw.githubusercontent)
+ * already expose a newer HEAD, which makes skills that exist only on the
+ * newer commit invisible to discovery. When the SHAs differ, fetch and check
+ * out the API-reported HEAD (detached) so discovery runs against the
+ * authoritative tree.
+ *
+ * Skipped when the user pinned an explicit ref (--branch). Fully non-fatal:
+ * any failure leaves the original clone untouched.
+ */
+async function syncCloneToApiHead(
+  tempDir: string,
+  url: string,
+  ref: string | undefined,
+  repo: GitHubRepoInfo | null
+): Promise<string> {
+  if (ref) return tempDir; // Honor an explicit --branch ref
+  if (!repo) return tempDir; // Only github.com repos have an API to cross-check
+  try {
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'skills-cli',
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    const host = repo.sshUrl.match(/^git@([^:]+):/)?.[1] ?? 'github.com';
+    // GitHub Enterprise (GH_HOST) serves its REST API under /api/v3.
+    const apiBase =
+      host.toLowerCase() === 'github.com' ? 'https://api.github.com' : `https://${host}/api/v3`;
+
+    const repoRes = await fetch(`${apiBase}/repos/${repo.owner}/${repo.repo}`, {
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!repoRes.ok) return tempDir;
+    const { default_branch: defaultBranch } = (await repoRes.json()) as {
+      default_branch?: string;
+    };
+    if (!defaultBranch) return tempDir;
+
+    const branchRes = await fetch(
+      `${apiBase}/repos/${repo.owner}/${repo.repo}/branches/${encodeURIComponent(defaultBranch)}`,
+      { headers, signal: AbortSignal.timeout(10_000) }
+    );
+    if (!branchRes.ok) return tempDir;
+    const apiSha = ((await branchRes.json()) as { commit?: { sha?: string } }).commit?.sha;
+    if (!apiSha) return tempDir;
+
+    const git = createGitClient();
+    await git.cwd(tempDir);
+    const clonedHead = String(await git.raw(['rev-parse', 'HEAD'])).trim();
+    if (clonedHead === apiSha) return tempDir;
+
+    await git.raw(['fetch', '--depth', '1', 'origin', apiSha]);
+    await git.raw(['checkout', '--quiet', apiSha]);
+  } catch {
+    // Non-fatal: keep the original clone
+  }
+  return tempDir;
 }
 
 export async function cleanupTempDir(dir: string): Promise<void> {


### PR DESCRIPTION
## Bug

`skills add <github-url>` clones the repo with a shallow `--depth 1` clone of the default branch, then runs `discoverSkills()` on the clone. GitHub's `git-upload-pack` endpoint can advertise a **stale** `refs/heads/<default-branch>` SHA while the GitHub REST API (`/repos/{o}/{r}/branches/{branch}`) and raw.githubusercontent already expose a **newer** HEAD. Because the CLI only trusts the git clone, skills that exist only on the newer commit are invisible — `--skill <name>` matches nothing.

### Repro

[kunchenguid/lavish-axi](https://github.com/kunchenguid/lavish-axi) currently has git-protocol `main` = `3883889` but API `main` = `3c75e1f8` (+108 commits); `skills/lavish/SKILL.md` exists only on the newer commit, so:

```bash
npx skills add https://github.com/kunchenguid/lavish-axi --skill lavish
# Error: No matching skills found for: lavish
```

**Fun fact:** this exact bug bit this very PR — the initial clone of `vercel-labs/skills` for this work got a stale `main` from `upload-pack` (a v1.5.9-era commit) while the REST API already exposed a newer `main`, which is why the PR initially showed merge conflicts.

The blob/tree fast path (`tryBlobInstall`) would see the newer tree, but it is gated by an owner allowlist (`BLOB_ALLOWED_OWNERS` / `BLOB_ALLOWED_REPOS`), so most repos fall through to the clone path — which is why this hits non-allowlisted owners.

## Root cause

`cloneRepo()` in `src/git.ts` returns the temp dir immediately after the shallow default-branch clone, trusting whatever HEAD `upload-pack` advertised, with no cross-check against GitHub's authoritative view of the default branch.

## Fix

In `cloneRepo()`, after the shallow default-branch clone succeeds and before returning the temp dir, cross-check the cloned HEAD against the GitHub API default-branch HEAD SHA (new `syncCloneToApiHead` helper), at all three success sites (primary HTTPS clone, `gh` CLI fallback, SSH fallback):

1. Fetch `/repos/{owner}/{repo}` → `default_branch`, then `/repos/{owner}/{repo}/branches/{branch}` → `commit.sha` (10s timeouts, optional `GITHUB_TOKEN`/`GH_TOKEN` auth; `/api/v3` base for GitHub Enterprise hosts configured via `GH_HOST`).
2. If the API SHA differs from the cloned `HEAD`, `git fetch --depth 1 origin <api-sha>` then `git checkout --quiet <api-sha>` (detached), so discovery runs against the authoritative HEAD.

Guarantees:

- **Skipped when the user pinned an explicit ref** (`--branch` / `/tree/<ref>` URLs) — the requested ref is honored as-is.
- **No-op for non-github.com URLs** (GitLab, self-hosted, well-known) — there is no API to cross-check.
- **Fully non-fatal** — any API/network/git error leaves the original clone untouched.

## Tests

Added `clone HEAD sync against the GitHub API` suite in `src/git.test.ts` (mocked `simple-git` + `fetch`): stale-ref re-sync, matching-SHA no-op, explicit-ref skip, non-GitHub skip, and API-failure non-fatality.

## Verification

- Repro above now resolves `HEAD = 3c75e1f8` and finds `skills/lavish/SKILL.md`; explicit-ref clones (e.g. `--branch v1.5.9`) are untouched.
- `pnpm test` — 55 files / 731 tests pass
- `pnpm type-check`, `pnpm build`, `pnpm format:check` — all clean