### PR TITLE
fix: preserve locked GitHub host during updates

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -44,6 +44,18 @@ export interface UpdateCheckOptions {
   skills?: string[];
 }
 
+/**
+ * Public GitHub lock entries use owner/repo shorthand to preserve the exact
+ * skill subpath. Pin that shorthand to github.com so an ambient GH_HOST for a
+ * GitHub Enterprise account cannot redirect an existing public installation.
+ */
+function getUpdateChildEnv(sourceType: string): NodeJS.ProcessEnv | undefined {
+  if (sourceType !== 'github') {
+    return undefined;
+  }
+  return { ...process.env, GH_HOST: 'github.com' };
+}
+
 export function parseUpdateOptions(args: string[]): UpdateCheckOptions {
   const options: UpdateCheckOptions = {};
   const positional: string[] = [];
@@ -677,10 +689,11 @@ export async function updateGlobalSkills(
     const fullDepthArgs = shouldUseFullDepthForUpdate(update.entry) ? ['--full-depth'] : [];
     const result = spawnSync(
       process.execPath,
-      [cliEntry, 'add', installUrl, ...fullDepthArgs, '-g', '-y'],
+      [cliEntry, 'add', installUrl, '--skill', update.name, ...fullDepthArgs, '-g', '-y'],
       {
         stdio: ['inherit', 'pipe', 'pipe'],
         encoding: 'utf-8',
+        env: getUpdateChildEnv(update.entry.sourceType),
         // Never spawn through a shell. process.execPath is an absolute path to the
         // node binary, so no shell is needed to resolve it. installUrl is derived
         // from the lock file (and ref is URL-decoded, so influenceable by whoever
@@ -887,6 +900,7 @@ export async function updateProjectSkills(
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
+          env: getUpdateChildEnv(skill.entry.sourceType),
           // Never spawn through a shell — same reasoning as updateGlobalSkills:
           // execPath is absolute (no shell resolution needed) and installUrl/ref
           // come from the lock file, so a shell would allow command injection on

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'child_process';
 import { updateProjectSkills, updateGlobalSkills, runUpdate } from '../src/update.ts';
 import * as git from '../src/git.ts';
@@ -79,6 +79,10 @@ describe('Update Cleanup Unit Tests', () => {
       value: true,
       configurable: true,
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   describe('updateProjectSkills', () => {
@@ -305,6 +309,38 @@ describe('Update Cleanup Unit Tests', () => {
       expect(argv).not.toContain('--full-depth');
     });
 
+    it('pins public GitHub project updates to github.com when GH_HOST points elsewhere', async () => {
+      vi.stubEnv('GH_HOST', 'github.example.com');
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv, options] = installCall!;
+      expect(argv).toEqual(
+        expect.arrayContaining(['add', 'owner/repo/skills/skill-a', '--skill', 'skill-a'])
+      );
+      expect((options as { env?: NodeJS.ProcessEnv }).env?.GH_HOST).toBe('github.com');
+    });
+
     it('does not reinterpret generic git shorthands as GitHub during project update', async () => {
       vi.mocked(localLock.readLocalLock).mockResolvedValue({
         version: 1,
@@ -529,9 +565,93 @@ describe('Update Cleanup Unit Tests', () => {
       expect(installCall).toBeDefined();
       const [, argv] = installCall!;
       expect(argv).toEqual(
-        expect.arrayContaining(['add', 'https://gitlab.example.com/acme/skills.git'])
+        expect.arrayContaining([
+          'add',
+          'https://gitlab.example.com/acme/skills.git',
+          '--skill',
+          'skill-a',
+        ])
       );
       expect(argv).not.toEqual(expect.arrayContaining(['acme/skills']));
+    });
+
+    it('pins public GitHub global updates to github.com when GH_HOST points elsewhere', async () => {
+      vi.stubEnv('GH_HOST', 'github.example.com');
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [{ path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'new-hash' }],
+      });
+      vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv, options] = installCall!;
+      expect(argv).toEqual(
+        expect.arrayContaining(['add', 'owner/repo/skills/skill-a', '--skill', 'skill-a'])
+      );
+      expect((options as { env?: NodeJS.ProcessEnv }).env?.GH_HOST).toBe('github.com');
+    });
+
+    it('keeps GitHub Enterprise updates on their recorded URL and targets one skill', async () => {
+      vi.stubEnv('GH_HOST', 'github.example.com');
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'https://github.example.com/acme/skills.git',
+            sourceUrl: 'https://github.example.com/acme/skills.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'git',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv, options] = installCall!;
+      expect(argv).toEqual(
+        expect.arrayContaining([
+          'add',
+          'https://github.example.com/acme/skills.git',
+          '--skill',
+          'skill-a',
+        ])
+      );
+      expect((options as { env?: NodeJS.ProcessEnv }).env).toBeUndefined();
     });
 
     it('spawns the update without a shell so a crafted ref cannot inject commands', async () => {


### PR DESCRIPTION
## Summary
- pin public GitHub update subprocesses to `github.com` so ambient `GH_HOST` cannot redirect hostless lockfile shorthand
- preserve recorded GitHub Enterprise and generic Git URLs
- pass the locked skill name during global updates so full-URL fallbacks cannot install every skill in a monorepo
- cover project, global, GitHub.com, and GitHub Enterprise update behavior

## Root cause

#1752 correctly made shorthand installs honor `GH_HOST`, but update reconstruction also emits shorthand for path-targeted GitHub updates. A public GitHub lock entry could therefore be re-resolved against an unrelated Enterprise host during `skills update`.

This keeps the original Enterprise behavior while making the lock entry source type authoritative during updates.

Fixes #1808

## Test plan
- `pnpm type-check`
- `pnpm format:check`
- `pnpm test` — 729 tests passed
- `pnpm build`