### PR TITLE
fix: list Eve skills without name frontmatter

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1185,7 +1185,10 @@ export async function listInstalledSkills(
         }
 
         // Parse the skill
-        const skill = await parseSkillMd(skillMdPath);
+        const skill = await parseSkillMd(skillMdPath, {
+          // Eve derives packaged skill names from their directory path.
+          fallbackName: scope.agentType === 'eve' ? entry.name : undefined,
+        });
         if (!skill) {
           continue;
         }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -75,7 +75,11 @@ function warnSkippedSkill(skillMdPath: string, reason: string): void {
 
 export async function parseSkillMd(
   skillMdPath: string,
-  options?: { includeInternal?: boolean }
+  options?: {
+    includeInternal?: boolean;
+    /** Agent-specific formats such as Eve may derive the name from the path. */
+    fallbackName?: string;
+  }
 ): Promise<Skill | null> {
   let content: string;
   try {
@@ -93,19 +97,21 @@ export async function parseSkillMd(
     return null;
   }
 
-  if (!data.name || !data.description) {
+  const name = data.name ?? options?.fallbackName;
+
+  if (!name || !data.description) {
     const missing: string[] = [];
-    if (!data.name) missing.push('name');
+    if (!name) missing.push('name');
     if (!data.description) missing.push('description');
     warnSkippedSkill(skillMdPath, `missing required frontmatter field(s): ${missing.join(', ')}`);
     return null;
   }
 
   // Ensure name and description are strings (YAML can parse numbers, booleans, etc.)
-  if (typeof data.name !== 'string' || typeof data.description !== 'string') {
+  if (typeof name !== 'string' || typeof data.description !== 'string') {
     warnSkippedSkill(
       skillMdPath,
-      `frontmatter "name" and "description" must be strings (got ${typeof data.name} and ${typeof data.description})`
+      `frontmatter "name" and "description" must be strings (got ${typeof name} and ${typeof data.description})`
     );
     return null;
   }
@@ -120,7 +126,7 @@ export async function parseSkillMd(
   }
 
   return {
-    name: sanitizeMetadata(data.name),
+    name: sanitizeMetadata(name),
     description: sanitizeMetadata(data.description),
     path: dirname(skillMdPath),
     rawContent: content,

--- a/tests/eve-agent.test.ts
+++ b/tests/eve-agent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -115,6 +115,39 @@ describe('Eve agent support', () => {
       expect(installed).toContain('description: "Blob skill"');
       expect(installed).not.toContain('name:');
     } finally {
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('lists packaged Eve skills using the directory name when name is omitted', async () => {
+    const previousCwd = process.cwd();
+    const projectDir = await makeEveProject();
+    const skillDir = join(projectDir, 'agent', 'skills', 'directory-named-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\ndescription: A skill discovered by Eve\n---\n# Eve skill\n',
+      'utf-8'
+    );
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      process.chdir(projectDir);
+      const listed = await listInstalledSkills({ cwd: projectDir, global: false });
+
+      expect(listed).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'directory-named-skill',
+            description: 'A skill discovered by Eve',
+            agents: ['eve'],
+          }),
+        ])
+      );
+      expect(warning).not.toHaveBeenCalled();
+    } finally {
+      warning.mockRestore();
+      process.chdir(previousCwd);
       await rm(projectDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- derive a missing skill name from the containing directory when listing an Eve packaged skill
- keep Eve installation output unchanged, since Eve derives packaged names from paths
- add a regression test that verifies `skills list` discovery does not warn or drop the skill

Fixes #1848

## Validation

- `pnpm exec vitest run tests/eve-agent.test.ts src/list.test.ts --maxWorkers=1`
- `pnpm exec vitest run tests/eve-agent.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check "src/**/*.ts" "scripts/**/*.ts"`
- `pnpm build`
- Manual CLI reproduction with `skills@1.5.21` now completes `skills list` without the missing-name warning.

The full suite passed 726 tests; the separate `tests/git-lfs-clone.test.ts` environment case fails here because `git-lfs` is not installed.