### PR TITLE
feat: add global skill repair mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,11 @@ tests/
 5. Compare latest folder tree SHA with lock file `skillFolderHash`; mismatch means update available
 6. `skills update` reinstalls changed skills by invoking the current CLI entrypoint directly (`node <repo>/bin/cli.mjs add <source-tree-url> -g -y`) to avoid nested npm exec/npx behavior
 
+Use `skills update --global --repair` to explicitly reinstall global
+repository-backed skills even when their upstream tree hash is unchanged. This
+is intended to repair files that drifted on disk; it does not change the normal
+hash-based update path.
+
 ### Lock File Compatibility
 
 The lock file format is v3. Key field: `skillFolderHash` (GitHub tree SHA for the skill folder).

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ npx skills update -p
 
 # Non-interactive (auto-detects scope: project if in a project, else global)
 npx skills update -y
+
+# Repair global repository skills even when their upstream hash is unchanged
+npx skills update --global --repair
 ```
 
 | Option          | Description                                                               |
@@ -174,6 +177,7 @@ npx skills update -y
 | `-g, --global`  | Only update global skills                                                 |
 | `-p, --project` | Only update project skills                                                |
 | `-y, --yes`     | Skip scope prompt (auto-detect: project if in a project dir, else global) |
+| `--repair`      | Reinstall global repository skills even when no upstream update is found  |
 | `[skills...]`   | Update specific skills by name instead of all                             |
 
 ### `skills init`

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -20,6 +20,7 @@ describe('skills CLI', () => {
       expect(output).toContain('-s, --skill');
       expect(output).toContain('-l, --list');
       expect(output).toContain('-y, --yes');
+      expect(output).toContain('--repair');
       expect(output).toContain('--all');
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,6 +126,7 @@ ${BOLD}Update Options:${RESET}
   -g, --global           Update global skills only
   -p, --project          Update project skills only
   -y, --yes              Skip scope prompt (auto-detect: project if in a project, else global)
+  --repair               Reinstall global repository skills even when no upstream update is found
 
 ${BOLD}Project:${RESET}
   experimental_install Restore skills from skills-lock.json

--- a/src/update.ts
+++ b/src/update.ts
@@ -40,6 +40,8 @@ export interface UpdateCheckOptions {
   global?: boolean;
   project?: boolean;
   yes?: boolean;
+  /** Reinstall global repository skills even when their upstream hash is current. */
+  repair?: boolean;
   /** Optional skill name(s) to filter on (positional args) */
   skills?: string[];
 }
@@ -54,6 +56,9 @@ export function parseUpdateOptions(args: string[]): UpdateCheckOptions {
       options.project = true;
     } else if (arg === '-y' || arg === '--yes') {
       options.yes = true;
+    } else if (arg === '--repair') {
+      options.repair = true;
+      options.global = true;
     } else if (!arg.startsWith('-')) {
       positional.push(arg);
     }
@@ -535,7 +540,15 @@ export async function updateGlobalSkills(
     const sourceUrl = firstEntry.sourceUrl || firstEntry.source;
     let tempDir: string | null = null;
 
-    process.stdout.write(`\r${DIM}Checking skills from source: ${source}${RESET}\x1b[K\n`);
+    const sourceAction = options.repair ? 'Repairing' : 'Checking';
+    process.stdout.write(`\r${DIM}${sourceAction} skills from source: ${source}${RESET}\x1b[K\n`);
+
+    if (options.repair) {
+      for (const { name, entry } of itemsForSource) {
+        updates.push({ name, source, entry });
+      }
+      continue;
+    }
 
     try {
       const isGitHubSource = firstEntry.sourceType === 'github';

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'child_process';
-import { updateProjectSkills, updateGlobalSkills, runUpdate } from '../src/update.ts';
+import {
+  parseUpdateOptions,
+  updateProjectSkills,
+  updateGlobalSkills,
+  runUpdate,
+} from '../src/update.ts';
 import * as git from '../src/git.ts';
 import * as skills from '../src/skills.ts';
 import * as blob from '../src/blob.ts';
@@ -78,6 +83,16 @@ describe('Update Cleanup Unit Tests', () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       configurable: true,
+    });
+  });
+
+  describe('parseUpdateOptions', () => {
+    it('treats --repair as a global repair request', () => {
+      expect(parseUpdateOptions(['--repair', 'skill-a'])).toEqual({
+        global: true,
+        repair: true,
+        skills: ['skill-a'],
+      });
     });
   });
 
@@ -327,6 +342,33 @@ describe('Update Cleanup Unit Tests', () => {
   });
 
   describe('updateGlobalSkills', () => {
+    it('reinstalls a GitHub skill when repair is requested even if its hash is current', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'same-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      await updateGlobalSkills({ repair: true, yes: true });
+
+      expect(blob.fetchRepoTree).not.toHaveBeenCalled();
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv] = installCall!;
+      expect(argv).toEqual(
+        expect.arrayContaining(['add', 'owner/repo/skills/skill-a', '-g', '-y'])
+      );
+    });
+
     it('should prompt to remove deleted skill on global update', async () => {
       // Mock readSkillLock
       vi.mocked(skillLock.readSkillLock).mockResolvedValue({


### PR DESCRIPTION
## Summary

- Add a `--repair` update option that explicitly targets global skills.
- Reuse the existing `skills add` reinstall path without requiring an upstream hash change, so drifted global files can be restored.
- Document the option and add parser, help, and regression coverage.

Fixes #1812

## Validation

- `pnpm exec vitest run tests/update.test.ts src/cli.test.ts --maxWorkers=1`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`
- `pnpm exec vitest run --exclude tests/git-lfs-clone.test.ts --maxWorkers=1` — 54 files and 727 tests passed
- Full suite attempted: 727 tests passed; the only failure was `tests/git-lfs-clone.test.ts` because `git-lfs` is unavailable in the environment.