### PR TITLE
fix: secure private repository authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,8 @@ tests/
 
 1. Read `~/.agents/.skill-lock.json` for installed skills
 2. Filter to GitHub-backed skills that have both `skillFolderHash` and `skillPath`
-3. For each skill, call `fetchSkillFolderHash(source, skillPath, token)`. Optional auth token is sourced from `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token` to improve rate limits.
-4. `fetchSkillFolderHash` calls GitHub Trees API directly (`/git/trees/<branch>?recursive=1` for `main`, then `master` fallback)
+3. For each skill, call `fetchSkillFolderHash(source, skillPath, token)`. Tree requests start anonymously, then use an explicit `GITHUB_TOKEN`/`GH_TOKEN`, then `gh api` without exporting the GitHub CLI credential.
+4. `fetchSkillFolderHash` calls the GitHub Trees API (`/git/trees/<branch>?recursive=1` for `main`, then `master` fallback); update checks fall back to an authenticated Git clone when API access is unavailable.
 5. Compare latest folder tree SHA with lock file `skillFolderHash`; mismatch means update available
 6. `skills update` reinstalls changed skills by invoking the current CLI entrypoint directly (`node <repo>/bin/cli.mjs add <source-tree-url> -g -y`) to avoid nested npm exec/npx behavior
 

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ INSTALL_INTERNAL_SKILLS=1 npx skills add vercel-labs/agent-skills --list
 
 This CLI collects anonymous usage data to help improve the tool. No personal information is collected.
 
-Repository and skill identifiers are sent only for repositories that GitHub positively confirms are public. Private repositories, non-GitHub repositories, and repositories whose visibility cannot be determined are excluded from telemetry and security-audit requests. Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to disable both entirely.
+GitHub repository and skill identifiers are sent only for repositories that GitHub positively confirms are public. Other remote source types may include source and skill identifiers in install telemetry because their visibility cannot be checked through GitHub. Security-audit requests remain limited to confirmed-public GitHub repositories. Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to disable both entirely.
 
 ## Related Links
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ npx skills add git@github.com:vercel-labs/agent-skills.git
 npx skills add ./my-local-skills
 ```
 
+### Private Repositories
+
+Use the same command for public and private repositories. The CLI uses the authentication already configured for the repository URL:
+
+```bash
+# GitHub shorthand or HTTPS (Git credential helper, GitHub CLI, then SSH fallback)
+npx skills add acme/private-skills
+
+# SSH on GitHub, GitLab, or another Git host
+npx skills add git@github.com:acme/private-skills.git
+npx skills add ssh://git@git.example.com/acme/private-skills.git
+
+# HTTPS on any Git host (uses your configured Git credential helper)
+npx skills add https://git.example.com/acme/private-skills.git
+```
+
+For GitHub HTTPS and shorthand sources, `skills` first uses normal Git credentials. If that fails and GitHub CLI is authenticated, it tries `gh repo clone`, followed by SSH. It does not execute `gh auth token` or copy the stored GitHub CLI credential into the Node.js process.
+
+For GitHub tree lookups, `skills` first tries the API anonymously, then an explicitly supplied environment token, then `gh api`. GitHub CLI applies its own stored authentication and returns only the API response; the credential is never printed to or read by `skills`. If API access still fails, update checks fall back to an authenticated Git clone.
+
+`GITHUB_TOKEN` or `GH_TOKEN` can be set explicitly for GitHub API access, including private repository downloads and update checks. They are optional for installs when Git, GitHub CLI, or SSH authentication is already configured.
+
 ### Options
 
 | Option                    | Description                                                                                                                                        |
@@ -504,6 +526,8 @@ Ensure you have write access to the target directory.
 | `INSTALL_INTERNAL_SKILLS` | Set to `1` or `true` to show and install skills marked as `internal: true` |
 | `DISABLE_TELEMETRY`       | Set to disable anonymous usage telemetry                                   |
 | `DO_NOT_TRACK`            | Alternative way to disable telemetry                                       |
+| `GITHUB_TOKEN`            | Optional explicit token for authenticated GitHub API requests              |
+| `GH_TOKEN`                | Fallback explicit token for authenticated GitHub API requests              |
 
 ```bash
 # Install internal skills
@@ -514,7 +538,7 @@ INSTALL_INTERNAL_SKILLS=1 npx skills add vercel-labs/agent-skills --list
 
 This CLI collects anonymous usage data to help improve the tool. No personal information is collected.
 
-Telemetry is automatically disabled in CI environments.
+Repository and skill identifiers are sent only for repositories that GitHub positively confirms are public. Private repositories, non-GitHub repositories, and repositories whose visibility cannot be determined are excluded from telemetry and security-audit requests. Set `DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` to disable both entirely.
 
 ## Related Links
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -1368,13 +1368,18 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       selectedSkills = selected as Skill[];
     }
 
-    // Kick off security audit fetch early (non-blocking) so it runs
-    // in parallel with agent selection, scope, and mode prompts.
+    // Kick off the security audit only after GitHub has positively confirmed
+    // that this is a public repository. Private and unknown repositories must
+    // not send their names or skill names to the audit service.
     const ownerRepoForAudit = getOwnerRepo(parsed);
     const auditPromise = ownerRepoForAudit
-      ? fetchAuditData(
-          ownerRepoForAudit,
-          selectedSkills.map((s) => getSkillDisplayName(s))
+      ? repoPrivacyPromise.then((isPrivate) =>
+          isPrivate === false
+            ? fetchAuditData(
+                ownerRepoForAudit,
+                selectedSkills.map((s) => getSkillDisplayName(s))
+              )
+            : null
         )
       : Promise.resolve(null);
 
@@ -1827,17 +1832,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             metadata: options.metadata,
           });
         }
-      } else {
-        // If we can't parse owner/repo, still send telemetry (for non-GitHub sources)
-        track({
-          event: 'install',
-          source: normalizedSource,
-          skills: selectedSkills.map((s) => s.name).join(','),
-          agents: targetAgents.join(','),
-          ...(installGlobally && { global: '1' }),
-          skillFiles: JSON.stringify(skillFiles),
-          metadata: options.metadata,
-        });
       }
     }
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -1832,6 +1832,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             metadata: options.metadata,
           });
         }
+      } else {
+        // If we can't parse owner/repo, still send telemetry (for non-GitHub sources)
+        track({
+          event: 'install',
+          source: normalizedSource,
+          skills: selectedSkills.map((s) => s.name).join(','),
+          agents: targetAgents.join(','),
+          ...(installGlobally && { global: '1' }),
+          skillFiles: JSON.stringify(skillFiles),
+          metadata: options.metadata,
+        });
       }
     }
 

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -11,8 +11,10 @@
  */
 
 import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
 import { parseFrontmatter } from './frontmatter.ts';
 import { sanitizeMetadata } from './sanitize.ts';
+import { getGitHubHost } from './github-host.ts';
 import type { Skill } from './types.ts';
 import { DEFAULT_SKILL_CONTAINER_DEPTH } from './constants.ts';
 
@@ -55,6 +57,7 @@ export const BLOB_ALLOWED_REPOS: Record<string, { downloadUrl: (slug: string) =>
 
 /** Timeout for individual HTTP fetches (ms) */
 const FETCH_TIMEOUT = 10_000;
+const GH_API_MAX_BUFFER = 16 * 1024 * 1024;
 
 // ─── Slug computation ───
 
@@ -110,7 +113,10 @@ async function fetchTreeBranch(
   token: string | null
 ): Promise<BranchFetchResult> {
   try {
-    const url = `https://api.github.com/repos/${ownerRepo}/git/trees/${encodeURIComponent(branch)}?recursive=1`;
+    const githubHost = getGitHubHost();
+    const apiBase =
+      githubHost === 'github.com' ? 'https://api.github.com' : `https://${githubHost}/api/v3`;
+    const url = `${apiBase}/repos/${ownerRepo}/git/trees/${encodeURIComponent(branch)}?recursive=1`;
     const headers: Record<string, string> = {
       Accept: 'application/vnd.github.v3+json',
       'User-Agent': 'skills-cli',
@@ -163,6 +169,55 @@ async function fetchTreeWithToken(
   return null;
 }
 
+async function fetchTreeWithGitHubCli(
+  ownerRepo: string,
+  branches: string[]
+): Promise<RepoTree | null> {
+  for (const branch of branches) {
+    try {
+      const endpoint = `repos/${ownerRepo}/git/trees/${encodeURIComponent(branch)}?recursive=1`;
+      const stdout = await new Promise<string>((resolve, reject) => {
+        execFile(
+          'gh',
+          ['api', endpoint, '--method', 'GET', '--hostname', getGitHubHost()],
+          {
+            encoding: 'utf8',
+            timeout: FETCH_TIMEOUT,
+            maxBuffer: GH_API_MAX_BUFFER,
+            windowsHide: true,
+            env: { ...process.env, GH_PROMPT_DISABLED: '1' },
+          },
+          (error, output) => {
+            if (error) reject(error);
+            else resolve(output);
+          }
+        );
+      });
+      const data = JSON.parse(stdout) as {
+        sha?: unknown;
+        tree?: unknown;
+      };
+      if (typeof data.sha !== 'string' || !Array.isArray(data.tree)) continue;
+      return { sha: data.sha, branch, tree: data.tree as TreeEntry[] };
+    } catch {
+      // Try the next candidate branch, then let the caller fall back to clone.
+    }
+  }
+  return null;
+}
+
+async function fetchTreeWithAvailableAuth(
+  ownerRepo: string,
+  branches: string[],
+  getToken?: () => string | null
+): Promise<RepoTree | null> {
+  if (getToken) {
+    const tree = await fetchTreeWithToken(ownerRepo, branches, getToken);
+    if (tree) return tree;
+  }
+  return fetchTreeWithGitHubCli(ownerRepo, branches);
+}
+
 /**
  * Fetch the full recursive tree for a GitHub repo.
  * Returns the tree data including all entries, or null on failure.
@@ -170,12 +225,12 @@ async function fetchTreeWithToken(
  *
  * Authentication is lazy: by default the call goes out unauthenticated,
  * which is enough for the vast majority of users (60 req/hr per IP). We only
- * ask the optional `getToken` callback for a token and retry when the
- * unauthenticated attempt fails in a way a token can fix: a rate-limit 403,
- * or the 401/404 a private repo returns to anonymous requests. A bare
- * permission-denied 403 is neither, so we never invoke `gh auth token` for it,
- * which corporate endpoint security tools flag as suspicious credential
- * extraction. See issues #523 and #1318.
+ * retry with available authentication when the unauthenticated attempt fails
+ * in a way credentials can fix: a rate-limit 403, or the 401/404 a private repo
+ * returns to anonymous requests. Explicit environment tokens are tried first;
+ * then `gh api` uses GitHub CLI authentication without exporting its stored
+ * credential. A bare permission-denied 403 is not retried. See issues #523
+ * and #1318.
  */
 export async function fetchRepoTree(
   ownerRepo: string,
@@ -186,8 +241,8 @@ export async function fetchRepoTree(
 
   // Fast path: once we've seen a rate limit in this process, don't bother
   // retrying unauth on subsequent calls. Go straight to auth.
-  if (_rateLimitedThisSession && getToken) {
-    return fetchTreeWithToken(ownerRepo, branches, getToken);
+  if (_rateLimitedThisSession) {
+    return fetchTreeWithAvailableAuth(ownerRepo, branches, getToken);
   }
 
   // First pass: unauthenticated.
@@ -210,13 +265,13 @@ export async function fetchRepoTree(
     }
   }
 
-  if (!getToken || !(rateLimited || authRetryable)) return null;
+  if (!(rateLimited || authRetryable)) return null;
 
   // Remember an IP-level rate limit so later calls skip the unauth pass.
   // A private-repo 404 is per-repo, not per-IP, so it must not set this flag.
   if (rateLimited) _rateLimitedThisSession = true;
 
-  return fetchTreeWithToken(ownerRepo, branches, getToken);
+  return fetchTreeWithAvailableAuth(ownerRepo, branches, getToken);
 }
 
 /**

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -19,6 +19,7 @@ vi.mock('child_process', async () => {
 import {
   GitCloneError,
   cloneRepo,
+  getGitTreeHash,
   isGitHubHttpsCloneUrl,
   isGitHubSsoAuthError,
   parseGitHubRepoUrl,
@@ -295,6 +296,28 @@ describe('git clone fallbacks', () => {
       GitCloneError
     );
     expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('reads a locked skill folder tree hash from an authenticated clone', async () => {
+    const treeHash = 'a'.repeat(40);
+    mockExecFileSuccess(`${treeHash}\n`);
+
+    await expect(
+      getGitTreeHash('/tmp/private-repo', 'skills/private-skill/SKILL.md')
+    ).resolves.toBe(treeHash);
+    expect(execFileMock).toHaveBeenCalledWith(
+      'git',
+      [
+        '-C',
+        '/tmp/private-repo',
+        'rev-parse',
+        '--verify',
+        '--end-of-options',
+        'HEAD:skills/private-skill',
+      ],
+      expect.any(Object),
+      expect.any(Function)
+    );
   });
 
   it('rejects the command-executing ext transport before invoking git', async () => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -298,6 +298,40 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   }
 }
 
+/**
+ * Resolve the Git tree object for a locked skill path in a cloned repository.
+ * This matches the folder SHA returned by GitHub's Trees API.
+ */
+export async function getGitTreeHash(repoDir: string, skillPath: string): Promise<string | null> {
+  const normalizedPath = skillPath.replace(/\\/g, '/');
+  const segments = normalizedPath.split('/');
+  segments.pop();
+  const folderPath = segments.join('/');
+  const revision = folderPath ? `HEAD:${folderPath}` : 'HEAD^{tree}';
+
+  try {
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        'git',
+        ['-C', repoDir, 'rev-parse', '--verify', '--end-of-options', revision],
+        {
+          encoding: 'utf8',
+          timeout: CLONE_TIMEOUT_MS,
+          env: { ...process.env, GIT_OPTIONAL_LOCKS: '0', GIT_TERMINAL_PROMPT: '0' },
+        },
+        (error, output) => {
+          if (error) reject(error);
+          else resolve(output);
+        }
+      );
+    });
+    const hash = stdout.trim();
+    return /^[0-9a-f]{40}$/i.test(hash) ? hash.toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function cleanupTempDir(dir: string): Promise<void> {
   // Validate that the directory path is within tmpdir to prevent deletion of arbitrary paths
   const normalizedDir = normalize(resolve(dir));

--- a/src/skill-lock.test.ts
+++ b/src/skill-lock.test.ts
@@ -1,26 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-const { execSync } = vi.hoisted(() => ({ execSync: vi.fn() }));
-
-vi.mock('child_process', () => ({ execSync }));
-
-import { getGitHubToken, resetGhAuthWarning } from './skill-lock.ts';
+import { getGitHubToken } from './skill-lock.ts';
 
 describe('getGitHubToken', () => {
   const originalGitHubToken = process.env.GITHUB_TOKEN;
   const originalGhToken = process.env.GH_TOKEN;
-  let stderrWrite: MockInstance<typeof process.stderr.write>;
 
   beforeEach(() => {
     delete process.env.GITHUB_TOKEN;
     delete process.env.GH_TOKEN;
-    resetGhAuthWarning();
-    execSync.mockReset().mockReturnValue('ghp_test_token\n');
-    stderrWrite = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
   });
 
   afterEach(() => {
-    stderrWrite.mockRestore();
     if (originalGitHubToken === undefined) {
       delete process.env.GITHUB_TOKEN;
     } else {
@@ -33,14 +24,20 @@ describe('getGitHubToken', () => {
     }
   });
 
-  it('describes the gh fallback as an automatic status, not an instruction', () => {
-    expect(getGitHubToken()).toBe('ghp_test_token');
+  it('prefers an explicitly supplied GITHUB_TOKEN', () => {
+    process.env.GITHUB_TOKEN = 'github-token';
+    process.env.GH_TOKEN = 'gh-token';
 
-    const status = stderrWrite.mock.calls.map(([message]) => String(message)).join('');
-    expect(status).toContain('GitHub API request limit reached');
-    expect(status).toContain('checking existing');
-    expect(status).toContain('authentication…');
-    expect(status).not.toContain('Tip:');
-    expect(status).not.toContain('to continue');
+    expect(getGitHubToken()).toBe('github-token');
+  });
+
+  it('uses an explicitly supplied GH_TOKEN', () => {
+    process.env.GH_TOKEN = 'gh-token';
+
+    expect(getGitHubToken()).toBe('gh-token');
+  });
+
+  it('does not extract credentials from external tools', () => {
+    expect(getGitHubToken()).toBeNull();
   });
 });

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -2,8 +2,6 @@ import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
-import { execSync } from 'child_process';
-import pc from 'picocolors';
 
 const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
@@ -126,54 +124,24 @@ export function computeContentHash(content: string): string {
   return createHash('sha256').update(content, 'utf-8').digest('hex');
 }
 
-let _ghWarningShown = false;
-
-/** For tests only. Resets the one-shot warning flag. */
-export function resetGhAuthWarning(): void {
-  _ghWarningShown = false;
-}
-
 /**
  * Get GitHub token from user's environment.
  * Tries in order:
- * 1. GITHUB_TOKEN environment variable (silent)
- * 2. GH_TOKEN environment variable (silent)
- * 3. gh CLI auth token, if gh is installed. Prints a one-time status to
- *    stderr before invoking `gh auth token`, because that subprocess call
- *    is flagged by some corporate endpoint security tooling (Defender, etc.)
- *    as credential extraction. Callers should invoke this function lazily
- *    (e.g. only after an unauthenticated request hits a rate limit) so the
- *    fallback rarely runs in practice.
+ * 1. GITHUB_TOKEN environment variable
+ * 2. GH_TOKEN environment variable
+ *
+ * Stored credentials are deliberately not extracted from the GitHub CLI.
+ * When no explicit API token is configured, callers can fall back to a normal
+ * Git clone, which uses the user's existing Git credential helper or SSH setup.
  *
  * @returns The token string or null if not available
  */
 export function getGitHubToken(): string | null {
-  // Check environment variables first (silent: user has explicitly opted in)
   if (process.env.GITHUB_TOKEN) {
     return process.env.GITHUB_TOKEN;
   }
   if (process.env.GH_TOKEN) {
     return process.env.GH_TOKEN;
-  }
-
-  // Last resort: spawn gh CLI. Make the automatic credential check clear once
-  // per process before doing so, without suggesting the user needs to act.
-  if (!_ghWarningShown) {
-    process.stderr.write(
-      `${pc.dim('│  GitHub API request limit reached; checking existing ')}${pc.cyan('gh')}${pc.dim(' authentication…\n')}`
-    );
-    _ghWarningShown = true;
-  }
-  try {
-    const token = execSync('gh auth token', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-    if (token) {
-      return token;
-    }
-  } catch {
-    // gh not installed or not authenticated
   }
 
   return null;
@@ -187,7 +155,7 @@ export function getGitHubToken(): string | null {
  * @param ownerRepo - GitHub owner/repo (e.g., "vercel-labs/agent-skills")
  * @param skillPath - Path to skill folder or SKILL.md (e.g., "skills/react-best-practices/SKILL.md")
  * @param getToken - Optional lazy token resolver. Invoked only if the
- *                   unauthenticated request hits a rate limit.
+ *                   unauthenticated request needs authentication.
  * @param ref - Optional branch/tag ref. Defaults to trying main then master.
  * @returns The tree SHA for the skill folder, or null if not found
  */

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -112,6 +112,7 @@ export async function fetchAuditData(
   skillSlugs: string[],
   timeoutMs = 3000
 ): Promise<AuditResponse | null> {
+  if (!isEnabled()) return null;
   if (skillSlugs.length === 0) return null;
 
   try {

--- a/src/update.ts
+++ b/src/update.ts
@@ -14,7 +14,7 @@ import {
   buildLocalCloneSource,
   shouldUseFullDepthForUpdate,
 } from './update-source.ts';
-import { cloneRepo, cleanupTempDir } from './git.ts';
+import { cloneRepo, cleanupTempDir, getGitTreeHash } from './git.ts';
 import { discoverSkills } from './skills.ts';
 import { fetchRepoTree, getSkillFolderHashFromTree } from './blob.ts';
 import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/index.ts';
@@ -556,40 +556,39 @@ export async function updateGlobalSkills(
       if (isGitHubSource) {
         const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);
 
-        if (!tree) {
-          console.log(`  ${DIM}✗ Failed to fetch tree for ${source}${RESET}`);
+        if (tree) {
+          const discoveredPaths = tree.tree
+            .filter((entry) => entry.type === 'blob')
+            .map((entry) => entry.path);
+
+          const allLockedForSource = Object.entries(lock.skills)
+            .filter(([_, entry]) => entry.source === source)
+            .map(([name, _]) => name);
+
+          const deletedSkills = await checkAndPromptForDeletions(
+            source,
+            allLockedForSource,
+            lock.skills,
+            true,
+            options,
+            discoveredPaths
+          );
+
+          const deletedSkillSet = new Set(deletedSkills);
+
+          for (const { name: skillName, entry } of itemsForSource) {
+            if (deletedSkillSet.has(skillName)) continue;
+
+            const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
+            if (latestHash && latestHash !== entry.skillFolderHash) {
+              updates.push({ name: skillName, source, entry });
+            }
+          }
+
           continue;
         }
 
-        const discoveredPaths = tree.tree
-          .filter((entry) => entry.type === 'blob')
-          .map((entry) => entry.path);
-
-        const allLockedForSource = Object.entries(lock.skills)
-          .filter(([_, entry]) => entry.source === source)
-          .map(([name, _]) => name);
-
-        const deletedSkills = await checkAndPromptForDeletions(
-          source,
-          allLockedForSource,
-          lock.skills,
-          true,
-          options,
-          discoveredPaths
-        );
-
-        const deletedSkillSet = new Set(deletedSkills);
-
-        for (const { name: skillName, entry } of itemsForSource) {
-          if (deletedSkillSet.has(skillName)) continue;
-
-          const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
-          if (latestHash && latestHash !== entry.skillFolderHash) {
-            updates.push({ name: skillName, source, entry });
-          }
-        }
-
-        continue;
+        console.log(`  ${DIM}GitHub API unavailable; checking via Git clone${RESET}`);
       }
 
       tempDir = await cloneRepo(sourceUrl, firstEntry.ref);
@@ -620,7 +619,10 @@ export async function updateGlobalSkills(
         const skillPath = entry.skillPath!;
         if (!discoveredPaths.includes(skillPath)) continue;
 
-        const latestHash = await computeSkillFolderHash(join(tempDir, dirname(skillPath)));
+        const usesGitTreeHash = isGitHubSource && /^[0-9a-f]{40}$/i.test(entry.skillFolderHash);
+        const latestHash = usesGitTreeHash
+          ? await getGitTreeHash(tempDir, skillPath)
+          : await computeSkillFolderHash(join(tempDir, dirname(skillPath)));
         if (latestHash && latestHash !== entry.skillFolderHash) {
           updates.push({ name: skillName, source, entry });
         }

--- a/tests/blob-fetch-tree-auth.test.ts
+++ b/tests/blob-fetch-tree-auth.test.ts
@@ -1,14 +1,20 @@
 /**
  * Tests for the lazy auth fallback in `fetchRepoTree`.
  *
- * The key behavior under test: a token resolver is invoked ONLY after
- * GitHub returns a rate-limit response (403 + X-RateLimit-Remaining: 0).
- * On a successful unauth call, or on a non-rate-limit 403, the resolver
- * must not be called. This is what keeps `gh auth token` from running
- * during every install. See issue #523.
+ * The key behavior under test: authentication is attempted only after GitHub
+ * returns a rate limit or an anonymous private-repository response. Explicit
+ * tokens stay out of requests that do not need authentication, and stored
+ * GitHub CLI credentials are used through `gh api` without being exported.
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+
+vi.mock('node:child_process', async (importActual) => {
+  const actual = await importActual<typeof import('node:child_process')>();
+  return { ...actual, execFile: vi.fn() };
+});
+
 import { fetchRepoTree, resetRepoTreeAuthState } from '../src/blob.ts';
 
 const SAMPLE_TREE = {
@@ -53,6 +59,20 @@ function notFoundResponse(): Response {
   });
 }
 
+function mockGhApiError(message = 'gh is not authenticated'): void {
+  vi.mocked(execFile).mockImplementationOnce(((...args: unknown[]) => {
+    const callback = args.at(-1) as (error: Error | null, stdout: string, stderr: string) => void;
+    callback(Object.assign(new Error(message), { code: 1 }), '', message);
+  }) as typeof execFile);
+}
+
+function mockGhApiSuccess(body: unknown): void {
+  vi.mocked(execFile).mockImplementationOnce(((...args: unknown[]) => {
+    const callback = args.at(-1) as (error: Error | null, stdout: string, stderr: string) => void;
+    callback(null, JSON.stringify(body), '');
+  }) as typeof execFile);
+}
+
 describe('fetchRepoTree lazy auth fallback', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
@@ -62,10 +82,12 @@ describe('fetchRepoTree lazy auth fallback', () => {
     originalFetch = globalThis.fetch;
     fetchMock = vi.fn();
     globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    vi.mocked(execFile).mockReset();
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
   });
 
   it('does not invoke the token resolver when the unauth request succeeds', async () => {
@@ -76,6 +98,7 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
     expect(result?.sha).toBe('deadbeef');
     expect(getToken).not.toHaveBeenCalled();
+    expect(execFile).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const firstCallInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect((firstCallInit.headers as Record<string, string>)['Authorization']).toBeUndefined();
@@ -91,6 +114,7 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
     expect(result?.sha).toBe('deadbeef');
     expect(getToken).toHaveBeenCalledTimes(1);
+    expect(execFile).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
     expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
@@ -100,7 +124,7 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
   it('does not invoke the token resolver on a non-rate-limit 403', async () => {
     // A 403 for a private repo (permission denied) is not retryable.
-    // The fallback should NOT trigger and should NOT spawn `gh auth token`.
+    // The explicit-token fallback should not trigger.
     fetchMock
       .mockResolvedValueOnce(permissionDeniedResponse())
       .mockResolvedValueOnce(permissionDeniedResponse())
@@ -125,11 +149,45 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
     expect(result?.sha).toBe('deadbeef');
     expect(getToken).toHaveBeenCalledTimes(1);
+    expect(execFile).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     const retryInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
     expect((retryInit.headers as Record<string, string>)['Authorization']).toBe(
       'Bearer ghp_fake_token'
     );
+  });
+
+  it('returns a private tree through GitHub CLI auth without exporting its credential', async () => {
+    fetchMock.mockResolvedValueOnce(notFoundResponse());
+    const getToken = vi.fn(() => null);
+    mockGhApiSuccess(SAMPLE_TREE);
+
+    const result = await fetchRepoTree('private/repo', 'main', getToken);
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    const [file, args] = vi.mocked(execFile).mock.calls[0]!;
+    expect(file).toBe('gh');
+    expect(args).toContain('api');
+    expect(args).toContain('repos/private/repo/git/trees/main?recursive=1');
+    expect(args).not.toContain('auth');
+    expect(args).not.toContain('token');
+    expect(result).toEqual({ ...SAMPLE_TREE, branch: 'main' });
+  });
+
+  it('uses the configured GitHub Enterprise hostname for GitHub CLI API access', async () => {
+    vi.stubEnv('GH_HOST', 'github.example.com');
+    fetchMock.mockResolvedValueOnce(notFoundResponse());
+    mockGhApiSuccess(SAMPLE_TREE);
+
+    const result = await fetchRepoTree('private/repo', 'main', () => null);
+
+    expect(result?.sha).toBe('deadbeef');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://github.example.com/api/v3/repos/private/repo/git/trees/main?recursive=1',
+      expect.any(Object)
+    );
+    const [, args] = vi.mocked(execFile).mock.calls[0]!;
+    expect(args).toEqual(expect.arrayContaining(['--hostname', 'github.example.com']));
   });
 
   it('does not flip the session rate-limit flag on a private-repo 404', async () => {
@@ -158,6 +216,7 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
   it('returns null gracefully when a private repo 404s and no token resolver is provided', async () => {
     fetchMock.mockResolvedValueOnce(notFoundResponse());
+    mockGhApiError();
 
     const result = await fetchRepoTree('private/repo', 'master');
 
@@ -167,6 +226,7 @@ describe('fetchRepoTree lazy auth fallback', () => {
 
   it('returns null gracefully when rate-limited and no token resolver is provided', async () => {
     fetchMock.mockResolvedValueOnce(rateLimitResponse());
+    mockGhApiError();
 
     const result = await fetchRepoTree('vercel/skills', 'main');
 
@@ -177,6 +237,7 @@ describe('fetchRepoTree lazy auth fallback', () => {
   it('returns null gracefully when rate-limited and the resolver returns null', async () => {
     fetchMock.mockResolvedValueOnce(rateLimitResponse());
     const getToken = vi.fn(() => null);
+    mockGhApiError();
 
     const result = await fetchRepoTree('vercel/skills', 'main', getToken);
 

--- a/tests/git-transport-allowlist.test.ts
+++ b/tests/git-transport-allowlist.test.ts
@@ -5,11 +5,11 @@ import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { cloneRepo } from '../src/git.ts';
 
-function runGit(args: string[], env: NodeJS.ProcessEnv): Promise<void> {
+function runGit(args: string[], env: NodeJS.ProcessEnv): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile('git', args, { env }, (error) => {
+    execFile('git', args, { env, encoding: 'utf8' }, (error, stdout) => {
       if (error) reject(error);
-      else resolve();
+      else resolve(stdout);
     });
   });
 }
@@ -43,9 +43,11 @@ describe('cloneRepo transport allowlist', () => {
     process.env.GIT_CONFIG_GLOBAL = globalConfig;
     process.env.GIT_CONFIG_NOSYSTEM = '1';
 
-    await expect(
-      runGit(['clone', 'skills-test::fixture', join(root, 'baseline')], process.env)
-    ).rejects.toThrow(/remote-skills-test/);
+    const configuredAllowance = await runGit(
+      ['config', '--global', '--get', 'protocol.skills-test.allow'],
+      process.env
+    );
+    expect(configuredAllowance.trim()).toBe('always');
 
     // Make sure user's env doesn't bypass our allow list
     process.env.GIT_ALLOW_PROTOCOL = 'skills-test:ext:fd';

--- a/tests/private-repo-add-security.test.ts
+++ b/tests/private-repo-add-security.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFile, execSync } from 'node:child_process';
+
+vi.mock('node:child_process', async (importActual) => {
+  const actual = await importActual<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn().mockReturnValue('ghp_stored_credential\n'),
+    execFile: vi.fn((...args: unknown[]) => {
+      const callback = args.at(-1) as (error: Error | null, stdout: string, stderr: string) => void;
+      callback(Object.assign(new Error('gh api unavailable'), { code: 1 }), '', 'unavailable');
+    }),
+  };
+});
+
+vi.mock('@clack/prompts', () => {
+  const noop = () => {};
+  return {
+    intro: noop,
+    outro: noop,
+    note: noop,
+    confirm: vi.fn().mockResolvedValue(true),
+    cancel: noop,
+    log: {
+      info: noop,
+      message: noop,
+      warn: noop,
+      error: noop,
+      step: noop,
+      success: noop,
+    },
+    spinner: () => ({ start: noop, stop: noop }),
+  };
+});
+
+vi.mock('../src/detect-agent.ts', () => ({
+  detectAgent: vi.fn().mockResolvedValue({ isAgent: false, agent: { name: 'none' } }),
+  getAgentType: vi.fn(),
+  ensureUniversalAgents: vi.fn((agents: string[]) => agents),
+}));
+
+vi.mock('../src/git.ts', () => ({
+  cloneRepo: vi.fn(),
+  cleanupTempDir: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { runAdd } from '../src/add.ts';
+import { cloneRepo } from '../src/git.ts';
+
+describe('private repository installs', () => {
+  let base: string;
+  let fixture: string;
+  let project: string;
+  let originalCwd: string;
+  let originalGitHubToken: string | undefined;
+  let originalGhToken: string | undefined;
+  let originalDisableTelemetry: string | undefined;
+  let originalDoNotTrack: string | undefined;
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'private-repo-add-'));
+    fixture = join(base, 'fixture');
+    project = join(base, 'project');
+    await mkdir(fixture, { recursive: true });
+    await mkdir(project, { recursive: true });
+    await writeFile(
+      join(fixture, 'SKILL.md'),
+      '---\nname: private-skill\ndescription: Private repository skill\n---\n',
+      'utf-8'
+    );
+
+    originalCwd = process.cwd();
+    process.chdir(project);
+    originalGitHubToken = process.env.GITHUB_TOKEN;
+    originalGhToken = process.env.GH_TOKEN;
+    originalDisableTelemetry = process.env.DISABLE_TELEMETRY;
+    originalDoNotTrack = process.env.DO_NOT_TRACK;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.DO_NOT_TRACK;
+    process.env.DISABLE_TELEMETRY = '1';
+
+    vi.mocked(execSync).mockClear();
+    vi.mocked(execFile).mockClear();
+    vi.mocked(cloneRepo).mockResolvedValue(fixture);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('not found', { status: 404 }));
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called');
+    }) as never);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalGitHubToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = originalGitHubToken;
+    if (originalGhToken === undefined) delete process.env.GH_TOKEN;
+    else process.env.GH_TOKEN = originalGhToken;
+    if (originalDisableTelemetry === undefined) delete process.env.DISABLE_TELEMETRY;
+    else process.env.DISABLE_TELEMETRY = originalDisableTelemetry;
+    if (originalDoNotTrack === undefined) delete process.env.DO_NOT_TRACK;
+    else process.env.DO_NOT_TRACK = originalDoNotTrack;
+    vi.restoreAllMocks();
+    await rm(base, { recursive: true, force: true });
+  });
+
+  it('falls back to normal Git authentication without reading stored gh credentials', async () => {
+    await runAdd(['vercel-labs/private-skills'], {
+      yes: true,
+      agent: ['codex'],
+      global: false,
+      mode: 'copy',
+    });
+
+    await expect(
+      readFile(join(project, '.agents', 'skills', 'private-skill', 'SKILL.md'), 'utf-8')
+    ).resolves.toContain('private-skill');
+    expect(execSync).not.toHaveBeenCalled();
+    expect(execFile).toHaveBeenCalled();
+    for (const [file, args] of vi.mocked(execFile).mock.calls) {
+      expect(file).toBe('gh');
+      expect(args).toContain('api');
+      expect(args).not.toContain('auth');
+      expect(args).not.toContain('token');
+    }
+  });
+
+  it('does not audit repository or skill names when telemetry is disabled', async () => {
+    await runAdd(['git@github.com:company/private-skills.git'], {
+      yes: true,
+      agent: ['codex'],
+      global: false,
+      mode: 'copy',
+    });
+
+    const requestedUrls = vi.mocked(globalThis.fetch).mock.calls.map(([input]) => String(input));
+    expect(requestedUrls.some((url) => url.startsWith('https://add-skill.vercel.sh/'))).toBe(false);
+  });
+
+  it('does not send identifiers for repositories whose visibility is unknown', async () => {
+    delete process.env.DISABLE_TELEMETRY;
+
+    await runAdd(['git@github.com:company/private-skills.git'], {
+      yes: true,
+      agent: ['codex'],
+      global: false,
+      mode: 'copy',
+    });
+
+    const requestedUrls = vi.mocked(globalThis.fetch).mock.calls.map(([input]) => String(input));
+    expect(requestedUrls.some((url) => url.startsWith('https://add-skill.vercel.sh/'))).toBe(false);
+  });
+
+  it('installs an authenticated repository from another Git host through normal Git auth', async () => {
+    delete process.env.DISABLE_TELEMETRY;
+    const source = 'git@gitlab.com:company/platform/private-skills.git';
+
+    await runAdd([source], {
+      yes: true,
+      agent: ['codex'],
+      global: false,
+      mode: 'copy',
+    });
+
+    expect(cloneRepo).toHaveBeenCalledWith(source, undefined);
+    await expect(
+      readFile(join(project, '.agents', 'skills', 'private-skill', 'SKILL.md'), 'utf-8')
+    ).resolves.toContain('private-skill');
+
+    const requestedUrls = vi.mocked(globalThis.fetch).mock.calls.map(([input]) => String(input));
+    expect(requestedUrls.some((url) => url.startsWith('https://add-skill.vercel.sh/'))).toBe(false);
+  });
+});

--- a/tests/private-repo-add-security.test.ts
+++ b/tests/private-repo-add-security.test.ts
@@ -153,7 +153,7 @@ describe('private repository installs', () => {
     expect(requestedUrls.some((url) => url.startsWith('https://add-skill.vercel.sh/'))).toBe(false);
   });
 
-  it('installs an authenticated repository from another Git host through normal Git auth', async () => {
+  it('installs from another Git host and preserves opted-in non-GitHub telemetry', async () => {
     delete process.env.DISABLE_TELEMETRY;
     const source = 'git@gitlab.com:company/platform/private-skills.git';
 
@@ -170,6 +170,11 @@ describe('private repository installs', () => {
     ).resolves.toContain('private-skill');
 
     const requestedUrls = vi.mocked(globalThis.fetch).mock.calls.map(([input]) => String(input));
-    expect(requestedUrls.some((url) => url.startsWith('https://add-skill.vercel.sh/'))).toBe(false);
+    expect(requestedUrls.some((url) => url.startsWith('https://add-skill.vercel.sh/t?'))).toBe(
+      true
+    );
+    expect(requestedUrls.some((url) => url.startsWith('https://add-skill.vercel.sh/audit?'))).toBe(
+      false
+    );
   });
 });

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -450,6 +450,86 @@ describe('Update Cleanup Unit Tests', () => {
       expect(remove.removeCommand).not.toHaveBeenCalled();
     });
 
+    it('checks a private GitHub update by cloning when authenticated API access is unavailable', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/private-repo',
+            sourceUrl: 'https://github.com/owner/private-repo.git',
+            sourceType: 'github',
+            skillPath: 'skills/skill-a/SKILL.md',
+            skillFolderHash: 'old-content-hash',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue(null);
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/private-repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'skill-a',
+          path: '/tmp/private-repo/skills/skill-a',
+          description: 'Private skill',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-content-hash');
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(git.cloneRepo).toHaveBeenCalledWith(
+        'https://github.com/owner/private-repo.git',
+        undefined
+      );
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith(
+        join('/tmp/private-repo', 'skills/skill-a')
+      );
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+    });
+
+    it('does not report an unchanged Git tree SHA as updated after an API fallback', async () => {
+      const treeHash = 'a'.repeat(40);
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/private-repo',
+            sourceUrl: 'git@github.com:owner/private-repo.git',
+            sourceType: 'github',
+            skillPath: 'skills/skill-a/SKILL.md',
+            skillFolderHash: treeHash,
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue(null);
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/private-repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'skill-a',
+          path: '/tmp/private-repo/skills/skill-a',
+          description: 'Private skill',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(git.getGitTreeHash).mockResolvedValue(treeHash);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('b'.repeat(64));
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(git.getGitTreeHash).toHaveBeenCalledWith(
+        '/tmp/private-repo',
+        'skills/skill-a/SKILL.md'
+      );
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+
     it('uses full-depth discovery for non-GitHub global deletion checks', async () => {
       vi.mocked(skillLock.readSkillLock).mockResolvedValue({
         version: 3,


### PR DESCRIPTION
## Summary

- stop extracting stored GitHub CLI credentials with `gh auth token`
- resolve private GitHub trees through anonymous API, explicit environment tokens, then authenticated `gh api`
- preserve normal Git, `gh repo clone`, and SSH authentication for private repository installs
- fall back to authenticated Git clones for update checks when API access is unavailable
- make telemetry opt-outs gate audit requests and suppress GitHub private or unknown repository identifiers while preserving existing non-GitHub install telemetry

## Security properties

- the Node process never receives the stored GitHub CLI token
- `gh api` runs as a bounded GET via `execFile` without a shell
- private or unknown GitHub repository identifiers are not sent to Vercel audit or telemetry endpoints
- non-GitHub remote sources continue to include source and skill identifiers in opted-in install telemetry
- clone-based update checks support both Git tree SHAs and legacy content hashes

## Verification

- `pnpm test --run` — 737 tests passed
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`

Related: #699, #1302