### PR TITLE
fix: remove obsolete OpenClaw use warning

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -593,19 +593,6 @@ describe('parseAddOptions', () => {
   });
 });
 
-describe('obsolete OpenClaw risk bypass flag', () => {
-  it('should not expose the obsolete OpenClaw risk bypass flag', () => {
-    const result = parseAddOptions([
-      'openclaw/skills',
-      '--dangerously-accept-openclaw-risks',
-      '-y',
-    ]);
-    expect(result.source).toEqual(['openclaw/skills']);
-    expect(result.options).not.toHaveProperty('dangerouslyAcceptOpenclawRisks');
-    expect(result.options.yes).toBe(true);
-  });
-});
-
 describe('find-skills prompt with -y flag', () => {
   let testDir: string;
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -21,6 +21,7 @@ describe('skills CLI', () => {
       expect(output).toContain('-l, --list');
       expect(output).toContain('-y, --yes');
       expect(output).toContain('--all');
+      expect(output).not.toContain('OpenClaw community skills');
     });
 
     it('should show same output for -h alias', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -148,8 +148,6 @@ ${BOLD}Use Options:${RESET}
   -s, --skill <skill>    Specify the skill to use
   -a, --agent <agent>    Start one supported agent interactively
   --full-depth           Search all subdirectories even when a root SKILL.md exists
-  --dangerously-accept-openclaw-risks
-                         Allow unverified OpenClaw community skills
 
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -80,6 +80,13 @@ describe('use command', () => {
       expect(result.errors).toContain('Unknown option: --wat');
     });
 
+    it('parses OpenClaw sources like other GitHub owners', () => {
+      const result = parseUseOptions(['openclaw/skills@demo']);
+
+      expect(result.source).toEqual(['openclaw/skills@demo']);
+      expect(result.errors).toEqual([]);
+    });
+
     it('parses --agent and -a values', () => {
       const longFlag = parseUseOptions(['vercel-labs/agent-skills', '--agent', 'claude-code']);
       const shortFlag = parseUseOptions(['vercel-labs/agent-skills', '-a', 'codex']);
@@ -368,13 +375,6 @@ describe('use command', () => {
       const result = runCli(['run', testDir], testDir);
 
       expect(result.stdout).toContain('Unknown command: run');
-    });
-
-    it('blocks OpenClaw sources before network access unless explicitly accepted', () => {
-      const result = runCli(['use', 'openclaw/example@demo'], testDir);
-
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain('OpenClaw skills are unverified');
     });
   });
 });

--- a/src/use.ts
+++ b/src/use.ts
@@ -22,7 +22,6 @@ export interface UseOptions {
   skill?: string;
   agent?: string[];
   fullDepth?: boolean;
-  dangerouslyAcceptOpenclawRisks?: boolean;
   help?: boolean;
 }
 
@@ -99,8 +98,6 @@ export function parseUseOptions(args: string[]): ParseUseOptionsResult {
       options.help = true;
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
-    } else if (arg === '--dangerously-accept-openclaw-risks') {
-      options.dangerouslyAcceptOpenclawRisks = true;
     } else if (arg === '--skill' || arg === '-s') {
       const value = args[i + 1];
       if (!value || value.startsWith('-')) {
@@ -214,18 +211,6 @@ export async function runUse(
 
     const source = sourceArgs[0]!;
     const parsed = parseSource(source);
-    const ownerRepoRaw = getOwnerRepo(parsed);
-    const sourceOwner = ownerRepoRaw?.split('/')[0]?.toLowerCase();
-
-    if (sourceOwner === 'openclaw' && !options.dangerouslyAcceptOpenclawRisks) {
-      fail(
-        [
-          'OpenClaw skills are unverified community submissions.',
-          'Skills run with full agent permissions and could be malicious.',
-          `If you understand the risks, re-run with: skills use ${source} --dangerously-accept-openclaw-risks`,
-        ].join('\n')
-      );
-    }
 
     const selector = resolveSelector(parsed.skillFilter, options.skill);
     const includeInternal = selector !== undefined;
@@ -403,8 +388,6 @@ Options:
   -s, --skill <skill>   Select the skill to use
   -a, --agent <agent>   Start one supported agent interactively (${SUPPORTED_USE_AGENTS.join(', ')})
   --full-depth          Search nested directories like skills add --full-depth
-  --dangerously-accept-openclaw-risks
-                         Allow unverified OpenClaw community skills
   -h, --help            Show this help message
 
 Examples:


### PR DESCRIPTION
## Summary

- remove the owner-specific OpenClaw block from `skills use`
- remove the obsolete risk-bypass option from parsing and both help surfaces
- remove the leftover add-command regression fixture and verify OpenClaw sources parse like other GitHub owners

This follows up on #1280, which removed the same warning from `skills add`; the newer `skills use` path still retained it. The current published `skills@1.5.21` exposes the flag in `npx skills update -h`.

## Validation

- `pnpm test --run` (55 files, 725 tests)
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`
- built `node dist/cli.mjs update -h` and `node dist/cli.mjs use -h` no longer show the obsolete warning or flag