### PR TITLE
fix(update): normalize GitHub shorthand for project deletion checks

### DIFF
--- a/src/update-source.test.ts
+++ b/src/update-source.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildLocalCloneSource,
   buildLocalUpdateSource,
   buildUpdateInstallSource,
   formatSourceInput,
@@ -7,6 +8,38 @@ import {
 } from './update-source.ts';
 
 describe('update-source', () => {
+  describe('buildLocalCloneSource', () => {
+    it('expands GitHub shorthand to a cloneable URL', () => {
+      expect(buildLocalCloneSource({ source: 'owner/repo', sourceType: 'github' })).toBe(
+        'https://github.com/owner/repo.git'
+      );
+    });
+
+    it('preserves an explicit sourceUrl', () => {
+      expect(
+        buildLocalCloneSource({
+          source: 'owner/repo',
+          sourceUrl: 'https://github.com/owner/repo.git',
+          sourceType: 'github',
+        })
+      ).toBe('https://github.com/owner/repo.git');
+    });
+
+    it('preserves non-GitHub clone URLs', () => {
+      expect(
+        buildLocalCloneSource({
+          source: 'acme/skills',
+          sourceUrl: 'https://gitlab.example.com/acme/skills.git',
+          sourceType: 'git',
+        })
+      ).toBe('https://gitlab.example.com/acme/skills.git');
+    });
+
+    it('fails closed for a generic Git shorthand without sourceUrl', () => {
+      expect(buildLocalCloneSource({ source: 'acme/skills', sourceType: 'git' })).toBeNull();
+    });
+  });
+
   describe('formatSourceInput', () => {
     it('appends ref fragment when provided', () => {
       expect(formatSourceInput('https://github.com/owner/repo.git', 'feature/install')).toBe(

--- a/src/update-source.ts
+++ b/src/update-source.ts
@@ -78,6 +78,18 @@ function getLocalSource(entry: LocalUpdateSourceEntry): string | null {
   return entry.source;
 }
 
+/** Build a cloneable repository URL for project update source checks. */
+export function buildLocalCloneSource(entry: LocalUpdateSourceEntry): string | null {
+  const source = getLocalSource(entry);
+  if (!source) {
+    return null;
+  }
+  if (entry.sourceType === 'github' && isBareShorthand(source)) {
+    return `https://github.com/${source.replace(/\.git$/, '')}.git`;
+  }
+  return source;
+}
+
 export function shouldUseFullDepthForUpdate(entry: LocalUpdateSourceEntry): boolean {
   if (!entry.skillPath) return false;
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -11,6 +11,7 @@ import {
   formatSourceInput,
   buildUpdateInstallSource,
   buildLocalUpdateSource,
+  buildLocalCloneSource,
   shouldUseFullDepthForUpdate,
 } from './update-source.ts';
 import { cloneRepo, cleanupTempDir } from './git.ts';
@@ -808,7 +809,7 @@ export async function updateProjectSkills(
 
   for (const [source, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
-    const sourceUrl = firstEntry.sourceUrl || firstEntry.source;
+    const cloneSource = buildLocalCloneSource(firstEntry);
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)
@@ -818,7 +819,7 @@ export async function updateProjectSkills(
     let tempDir: string | null = null;
     let deletedSkills: string[] = [];
 
-    if (buildLocalUpdateSource(firstEntry) === null) {
+    if (cloneSource === null) {
       failCount += skillsForSource.length;
       console.log(
         `${DIM}✗ Cannot update ${source}: skills-lock.json is missing sourceUrl for this generic Git source${RESET}`
@@ -827,7 +828,7 @@ export async function updateProjectSkills(
     }
 
     try {
-      tempDir = await cloneRepo(sourceUrl, ref);
+      tempDir = await cloneRepo(cloneSource, ref);
       const discovered = await discoverSkills(tempDir, undefined, { fullDepth: true });
 
       const discoveredPaths = discovered.map((s) => {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -272,7 +272,7 @@ describe('Update Cleanup Unit Tests', () => {
       expect(argv).toContain('--full-depth');
     });
 
-    it('keeps GitHub project updates path-targeted without full-depth discovery', async () => {
+    it('normalizes GitHub shorthand for deletion checks and keeps updates path-targeted', async () => {
       vi.mocked(localLock.readLocalLock).mockResolvedValue({
         version: 1,
         skills: {
@@ -296,6 +296,7 @@ describe('Update Cleanup Unit Tests', () => {
 
       await updateProjectSkills({ yes: true });
 
+      expect(git.cloneRepo).toHaveBeenCalledWith('https://github.com/owner/repo.git', undefined);
       const installCall = vi
         .mocked(spawnSync)
         .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));


### PR DESCRIPTION
## Summary

- normalize project-lock GitHub shorthand to a cloneable HTTPS URL for deletion checks
- preserve explicit and non-GitHub clone URLs, while failing closed for ambiguous generic Git shorthand
- add unit and integration regression coverage without changing per-skill reinstall behavior

## Root cause

Project lock files store GitHub sources as `owner/repo` without a `sourceUrl`. `updateProjectSkills` passed that shorthand directly to `cloneRepo`, so cloning failed and deletion detection was skipped.

## Impact

`skills update -p` no longer emits `Failed to check for deleted skills` for normal GitHub shorthand sources, and deletion checks can run successfully.

Fixes #1530.

## Validation

- `pnpm exec vitest run src/update-source.test.ts tests/update.test.ts` (43 tests passed)
- full test suite plus isolated distribution-test rerun (730 tests passed)
- `pnpm type-check`
- `pnpm format:check`
