### PR TITLE
fix: discover skills nested under two categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,12 +377,13 @@ metadata:
 ### Skill Discovery
 
 The CLI searches for skills in these locations within a repository. Each
-skill container directory is walked one level deep for the common flat
-layout (`skills/<name>/SKILL.md`) and one extra level deep for catalog
-layouts (`skills/<category>/<name>/SKILL.md`). A `SKILL.md` discovered at
-the shallower level shadows anything nested below it. Use `--full-depth`
-to also discover `SKILL.md` files outside these container directories
-(e.g. under `examples/` or `tests/`).
+skill container directory is walked up to three levels deep, covering flat
+layouts (`skills/<name>/SKILL.md`) and catalog layouts with one or two category
+levels (`skills/<category>/<name>/SKILL.md` or
+`skills/<category>/<category>/<name>/SKILL.md`). A `SKILL.md` discovered at a
+shallower level shadows anything nested below it. Use `--full-depth` to also
+discover `SKILL.md` files outside these container directories (e.g. under
+`examples/` or `tests/`).
 
 <!-- skill-discovery:start -->
 - Root directory (if it contains `SKILL.md`)
@@ -464,7 +465,7 @@ If `.claude-plugin/marketplace.json` or `.claude-plugin/plugin.json` exists, ski
 }
 ```
 
-This enables compatibility with the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) ecosystem. Skill paths declared in a manifest are searched at their declared depth and are not subject to the depth-2 catalog walk described above.
+This enables compatibility with the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) ecosystem. Skill paths declared in a manifest are searched at their declared depth and are not subject to the bounded depth-3 catalog walk described above.
 
 If no skills are found in standard locations, a recursive search is performed.
 

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -223,6 +223,53 @@ description: Second skill
     expect(result.stdout).toContain('skill-one');
   });
 
+  it('finds a selected skill nested under two category levels when shallower skills exist', () => {
+    const sourceDir = join(testDir, 'source');
+    const shallowSkillDir = join(sourceDir, 'skills', 'core-skills', 'amazon-bedrock');
+    mkdirSync(shallowSkillDir, { recursive: true });
+    writeFileSync(
+      join(shallowSkillDir, 'SKILL.md'),
+      `---
+name: amazon-bedrock
+description: Amazon Bedrock skill
+---
+# Amazon Bedrock
+`
+    );
+
+    const skillDir = join(
+      sourceDir,
+      'skills',
+      'specialized-skills',
+      'database-skills',
+      'amazon-dynamodb'
+    );
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: amazon-dynamodb
+description: Amazon DynamoDB skill
+---
+# Amazon DynamoDB
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = runCli(
+      ['add', sourceDir, '--skill', 'amazon-dynamodb', '--agent', 'codex', '--copy', '-y'],
+      projectDir
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Selected 1 skill: amazon-dynamodb');
+    expect(existsSync(join(projectDir, '.agents', 'skills', 'amazon-dynamodb', 'SKILL.md'))).toBe(
+      true
+    );
+  });
+
   it('should show error for invalid agent name', () => {
     // Create a test skill
     const skillDir = join(testDir, 'test-skill');

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -14,6 +14,7 @@ import { createHash } from 'node:crypto';
 import { parseFrontmatter } from './frontmatter.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import type { Skill } from './types.ts';
+import { DEFAULT_SKILL_CONTAINER_DEPTH } from './constants.ts';
 
 // ─── Types ───
 
@@ -302,7 +303,7 @@ export function findSkillMdPaths(tree: RepoTree, subpath?: string): string[] {
   if (filtered.length === 0) return [];
 
   // Check priority directories first (same order as discoverSkills).
-  // Non-root prefixes also accept depth-2 paths so the blob fast path stays
+  // Non-root prefixes also accept paths up to depth 3 so the blob fast path stays
   // in sync with the on-disk walk's catalog-layout discovery.
   const priorityResults: string[] = [];
   const seen = new Set<string>();
@@ -339,19 +340,24 @@ export function findSkillMdPaths(tree: RepoTree, subpath?: string): string[] {
         continue;
       }
 
-      // SKILL.md two levels deep under a known container prefix
-      // (e.g., "skills/<category>/<skill>/SKILL.md"). Skip if the parent
-      // child dir already has its own SKILL.md (no descent past), or if
+      // SKILL.md two or three levels deep under a known container prefix
+      // (e.g., "skills/<category>/<category>/<skill>/SKILL.md"). Skip if an
+      // ancestor dir already has its own SKILL.md (no descent past), or if
       // any path segment is an ignored directory.
+      const skillDirs = parts.slice(0, -1);
+      const hasAncestorSkill = skillDirs.slice(0, -1).some((_, index) => {
+        const ancestorPath = skillDirs.slice(0, index + 1).join('/');
+        return lowerSkillMdSet.has(`${fullPrefix}${ancestorPath}/SKILL.md`.toLowerCase());
+      });
       if (
         isContainer &&
-        parts.length === 3 &&
-        parts[2]!.toLowerCase() === 'skill.md' &&
-        !SKIP_DIRS.has(parts[0]!) &&
-        !SKIP_DIRS.has(parts[1]!)
+        parts.length >= 3 &&
+        parts.length <= DEFAULT_SKILL_CONTAINER_DEPTH + 1 &&
+        parts.at(-1)!.toLowerCase() === 'skill.md' &&
+        skillDirs.every((part) => !SKIP_DIRS.has(part)) &&
+        !hasAncestorSkill
       ) {
-        const parentSkillMd = `${fullPrefix}${parts[0]}/SKILL.md`.toLowerCase();
-        if (!lowerSkillMdSet.has(parentSkillMd) && !seen.has(skillMd)) {
+        if (!seen.has(skillMd)) {
           priorityResults.push(skillMd);
           seen.add(skillMd);
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,6 @@
 export const AGENTS_DIR = '.agents';
 export const SKILLS_SUBDIR = 'skills';
 export const UNIVERSAL_SKILLS_DIR = '.agents/skills';
+
+/** Maximum skill-directory depth searched inside a known container by default. */
+export const DEFAULT_SKILL_CONTAINER_DEPTH = 3;

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -5,6 +5,7 @@ import { sanitizeMetadata, stripTerminalEscapes } from './sanitize.ts';
 import type { Skill } from './types.ts';
 import { getPluginSkillPaths, getPluginGroupings } from './plugin-manifest.ts';
 import { readLocalLock } from './local-lock.ts';
+import { DEFAULT_SKILL_CONTAINER_DEPTH } from './constants.ts';
 
 const SKIP_DIRS = ['node_modules', '.git', 'dist', 'build', '__pycache__'];
 
@@ -253,8 +254,8 @@ export async function discoverSkills(
     ...AGENT_PROJECT_SKILL_DIRS.map((dir) => join(searchPath, dir)),
   ];
 
-  // Known skill container dirs are walked one extra level deep so layouts
-  // like `skills/<category>/<skill>/SKILL.md` are discovered without
+  // Known skill container dirs are walked up to three levels deep so layouts
+  // like `skills/<category>/<category>/<skill>/SKILL.md` are discovered without
   // requiring `--full-depth`. The repo root (first entry) keeps its
   // existing depth-1 behavior to avoid surfacing unrelated `SKILL.md`
   // files (e.g. `examples/foo/SKILL.md`), and plugin-manifest-declared
@@ -275,9 +276,7 @@ export async function discoverSkills(
     return true;
   };
 
-  for (const dir of prioritySearchDirs) {
-    const walkDeep = deepContainerDirs.has(dir);
-
+  const walkSkillDirs = async (dir: string, maxDepth: number, depth = 1): Promise<void> => {
     try {
       const entries = await readdir(dir, { withFileTypes: true });
 
@@ -287,26 +286,20 @@ export async function discoverSkills(
         const childDir = join(dir, entry.name);
         const foundAtChild = await tryAddSkillAt(childDir);
 
-        // Don't descend past a discovered SKILL.md (matches the existing
-        // flat-layout semantics) and don't go deeper inside non-container
-        // priority dirs.
-        if (foundAtChild || !walkDeep) continue;
-        if (SKIP_DIRS.includes(entry.name)) continue;
+        // Preserve flat-layout semantics by stopping below a discovered
+        // skill, and never descend through ignored directories.
+        if (foundAtChild || depth >= maxDepth || SKIP_DIRS.includes(entry.name)) continue;
 
-        // Walk one extra level for catalog layouts.
-        try {
-          const grandEntries = await readdir(childDir, { withFileTypes: true });
-          for (const grand of grandEntries) {
-            if (!grand.isDirectory() || SKIP_DIRS.includes(grand.name)) continue;
-            await tryAddSkillAt(join(childDir, grand.name));
-          }
-        } catch {
-          // Child dir unreadable; skip silently.
-        }
+        await walkSkillDirs(childDir, maxDepth, depth + 1);
       }
     } catch {
-      // Directory doesn't exist
+      // Directory doesn't exist or is unreadable; skip silently.
     }
+  };
+
+  for (const dir of prioritySearchDirs) {
+    const walkDeep = deepContainerDirs.has(dir);
+    await walkSkillDirs(dir, walkDeep ? DEFAULT_SKILL_CONTAINER_DEPTH : 1);
   }
 
   // Fall back to recursive search if nothing found, or if fullDepth is set

--- a/tests/nested-container-discovery.test.ts
+++ b/tests/nested-container-discovery.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for bounded depth-2 discovery inside skill container directories.
+ * Tests for bounded depth-3 discovery inside skill container directories.
  *
  * Layouts like `skills/<category>/<skill>/SKILL.md` are common when a repo
  * groups skills by product or category. They should be discovered by
@@ -34,7 +34,7 @@ function makeTree(paths: string[]): RepoTree {
   return { sha: 'root-sha', branch: 'main', tree: entries };
 }
 
-describe('discoverSkills — bounded depth-2 inside skill container dirs', () => {
+describe('discoverSkills — bounded depth-3 inside skill container dirs', () => {
   let testDir: string;
 
   beforeEach(() => {
@@ -133,8 +133,11 @@ describe('discoverSkills — bounded depth-2 inside skill container dirs', () =>
     expect(skills.map((s) => s.name)).toEqual(['real-skill']);
   });
 
-  it('still requires --full-depth for skills deeper than two levels in a container', async () => {
-    writeSkill(join(testDir, 'skills', 'level-1', 'level-2', 'deep-skill'), 'deep-skill');
+  it('still requires --full-depth for skills deeper than three levels in a container', async () => {
+    writeSkill(
+      join(testDir, 'skills', 'level-1', 'level-2', 'level-3', 'deep-skill'),
+      'deep-skill'
+    );
     writeSkill(join(testDir, 'skills', 'shallow'), 'shallow-skill');
 
     const defaultSkills = await discoverSkills(testDir);
@@ -155,7 +158,7 @@ describe('discoverSkills — bounded depth-2 inside skill container dirs', () =>
   });
 });
 
-describe('findSkillMdPaths — bounded depth-2 inside skill container prefixes', () => {
+describe('findSkillMdPaths — bounded depth-3 inside skill container prefixes', () => {
   it('returns nested SKILL.md paths under skills/<category>/<skill>/', () => {
     const tree = makeTree([
       'skills/product-a/skill-one/SKILL.md',
@@ -176,6 +179,18 @@ describe('findSkillMdPaths — bounded depth-2 inside skill container prefixes',
     expect(findSkillMdPaths(tree).sort()).toEqual([
       'skills/category/nested-skill/SKILL.md',
       'skills/flat-skill/SKILL.md',
+    ]);
+  });
+
+  it('returns skills nested under two category levels', () => {
+    const tree = makeTree([
+      'skills/core-skills/amazon-bedrock/SKILL.md',
+      'skills/specialized-skills/database-skills/amazon-dynamodb/SKILL.md',
+    ]);
+
+    expect(findSkillMdPaths(tree).sort()).toEqual([
+      'skills/core-skills/amazon-bedrock/SKILL.md',
+      'skills/specialized-skills/database-skills/amazon-dynamodb/SKILL.md',
     ]);
   });
 


### PR DESCRIPTION
## Summary

- replace the hard-coded grandchild scan with a bounded recursive walk
- discover skills at skills/category/category/skill/SKILL.md by default
- keep blob-based and on-disk discovery depth aligned
- preserve root-level discovery behavior and require --full-depth beyond the new bound

## Root cause

Default discovery stopped after one extra directory beneath known skill containers. Repositories with shallower skills therefore skipped the recursive fallback and hid deeper valid skills such as AWS's amazon-dynamodb skill.

## Verification

- pnpm test --run (728 tests)
- pnpm type-check
- pnpm format:check
- pnpm build
- built CLI successfully installed amazon-dynamodb from https://github.com/aws/agent-toolkit-for-aws

Closes #1506
