### PR TITLE
fix(update): skip unchanged project skill reinstalls

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -8,6 +8,7 @@ import {
   parseAddOptions,
   getLockSource,
   getProjectLockSourceUrl,
+  getProjectLockComputedHashScope,
   formatEveInstallPromptMessage,
 } from './add.ts';
 
@@ -441,6 +442,14 @@ metadata:
       const result = runCli(['add', testDir, '--list'], testDir);
       expect(result.stdout).toContain('not-internal-skill');
     });
+  });
+});
+
+describe('getProjectLockComputedHashScope', () => {
+  it('marks only root-level blob installs as skill-file hashes', () => {
+    expect(getProjectLockComputedHashScope(true, 'SKILL.md')).toBe('skill-file');
+    expect(getProjectLockComputedHashScope(true, 'skills/example/SKILL.md')).toBeUndefined();
+    expect(getProjectLockComputedHashScope(false, 'SKILL.md')).toBeUndefined();
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -99,6 +99,13 @@ export function getLockSource(parsedUrl: string, normalizedSource: string | null
 export function getProjectLockSourceUrl(sourceType: string, sourceUrl: string): string | undefined {
   return sourceType === 'git' || sourceType === 'gitlab' ? sourceUrl : undefined;
 }
+
+export function getProjectLockComputedHashScope(
+  isBlobInstall: boolean,
+  skillPath?: string
+): 'skill-file' | undefined {
+  return isBlobInstall && skillPath && !skillPath.includes('/') ? 'skill-file' : undefined;
+}
 export function initTelemetry(version: string): void {
   setVersion(version);
 }
@@ -1902,12 +1909,16 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
+            const skillPathValue = skillFiles[skill.name];
             // For blob skills, use the snapshot hash; for disk skills, compute from files
             const computedHash =
               blobResult && 'snapshotHash' in skill
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
-            const skillPathValue = skillFiles[skill.name];
+            const computedHashScope = getProjectLockComputedHashScope(
+              blobResult !== null,
+              skillPathValue
+            );
             await addSkillToLocalLock(
               skill.name,
               {
@@ -1917,6 +1928,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
+                ...(computedHashScope && { computedHashScope }),
                 ...(recordSubagents && { subagents: eveSubagents }),
               },
               cwd

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -586,8 +586,9 @@ export async function tryBlobInstall(
       rawContent: skill.content,
       metadata: skill.metadata,
       files,
-      snapshotHash:
-        files.length === download!.files.length ? download!.hash : computeSnapshotHash(files),
+      // Server hashes may use a different file set or path basis. Compute this
+      // locally so project locks can compare it with cloned folder contents.
+      snapshotHash: computeSnapshotHash(files),
       repoPath: skill.mdPath,
     };
   });

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -36,6 +36,12 @@ export interface LocalSkillLockEntry {
    */
   computedHash: string;
   /**
+   * Narrows the hash to the root SKILL.md for blob installs that intentionally
+   * exclude the rest of a root-level repository. Omitted means the whole skill
+   * folder is hashed.
+   */
+  computedHashScope?: 'skill-file';
+  /**
    * Eve subagent targets this skill was installed into, so `update` can
    * restore the same placement. Each entry is an Eve subagent directory name;
    * the empty string `''` denotes the root agent (`agent/skills`). Omitted for
@@ -146,6 +152,19 @@ export async function computeSkillFolderHash(skillDir: string): Promise<string> 
   const files: Array<{ relativePath: string; content: Buffer }> = [];
   await collectFiles(skillDir, skillDir, files);
 
+  return computeFilesHash(files);
+}
+
+/** Compute the same deterministic hash for one skill entry file. */
+export async function computeSkillFileHash(
+  skillDir: string,
+  skillFileName = 'SKILL.md'
+): Promise<string> {
+  const content = await readFile(join(skillDir, skillFileName));
+  return computeFilesHash([{ relativePath: skillFileName, content }]);
+}
+
+function computeFilesHash(files: Array<{ relativePath: string; content: Buffer }>): string {
   // Sort by relative path for deterministic hashing
   files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,12 +1,17 @@
 import { spawnSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
-import { join, dirname, relative, sep } from 'path';
+import { basename, join, dirname, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 
 import { readSkillLock, getGitHubToken, type SkillLockEntry } from './skill-lock.ts';
-import { computeSkillFolderHash, readLocalLock, type LocalSkillLockEntry } from './local-lock.ts';
+import {
+  computeSkillFileHash,
+  computeSkillFolderHash,
+  readLocalLock,
+  type LocalSkillLockEntry,
+} from './local-lock.ts';
 import {
   formatSourceInput,
   buildUpdateInstallSource,
@@ -869,7 +874,10 @@ export async function updateProjectSkills(
         const discoveredPath = discoveredByPath.get(skill.entry.skillPath!);
         if (!discoveredPath) continue;
 
-        const latestHash = await computeSkillFolderHash(discoveredPath);
+        const latestHash =
+          skill.entry.computedHashScope === 'skill-file'
+            ? await computeSkillFileHash(discoveredPath, basename(skill.entry.skillPath!))
+            : await computeSkillFolderHash(discoveredPath);
         if (latestHash !== skill.entry.computedHash) {
           skillsToUpdate.push(skill);
         }

--- a/src/update.ts
+++ b/src/update.ts
@@ -831,6 +831,7 @@ export async function updateProjectSkills(
 
     let tempDir: string | null = null;
     let deletedSkills: string[] = [];
+    let skillsToUpdate = skillsForSource;
 
     if (cloneSource === null) {
       failCount += skillsForSource.length;
@@ -844,10 +845,12 @@ export async function updateProjectSkills(
       tempDir = await cloneRepo(cloneSource, ref);
       const discovered = await discoverSkills(tempDir, undefined, { fullDepth: true });
 
-      const discoveredPaths = discovered.map((s) => {
-        const relPath = relative(tempDir!, s.path);
-        return join(relPath, 'SKILL.md').split(sep).join('/');
-      });
+      const discoveredByPath = new Map<string, string>();
+      for (const discoveredSkill of discovered) {
+        const relPath = relative(tempDir!, discoveredSkill.path);
+        discoveredByPath.set(join(relPath, 'SKILL.md').split(sep).join('/'), discoveredSkill.path);
+      }
+      const discoveredPaths = Array.from(discoveredByPath.keys());
 
       deletedSkills = await checkAndPromptForDeletions(
         source,
@@ -857,7 +860,24 @@ export async function updateProjectSkills(
         options,
         discoveredPaths
       );
+
+      const deletedSkillSet = new Set(deletedSkills);
+      skillsToUpdate = [];
+      for (const skill of skillsForSource) {
+        if (deletedSkillSet.has(skill.name)) continue;
+
+        const discoveredPath = discoveredByPath.get(skill.entry.skillPath!);
+        if (!discoveredPath) continue;
+
+        const latestHash = await computeSkillFolderHash(discoveredPath);
+        if (latestHash !== skill.entry.computedHash) {
+          skillsToUpdate.push(skill);
+        }
+      }
     } catch (error) {
+      // Preserve the existing conservative behavior when the source cannot be
+      // checked completely: reinstall every non-deleted skill from this source.
+      skillsToUpdate = skillsForSource;
       console.log(`${DIM}✗ Failed to check for deleted skills from ${source}${RESET}`);
     } finally {
       if (tempDir) {
@@ -865,7 +885,7 @@ export async function updateProjectSkills(
       }
     }
 
-    const remainingSkills = skillsForSource.filter((s) => !deletedSkills.includes(s.name));
+    const remainingSkills = skillsToUpdate.filter((s) => !deletedSkills.includes(s.name));
 
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);

--- a/tests/blob-root-skill.test.ts
+++ b/tests/blob-root-skill.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { resetRepoTreeAuthState, tryBlobInstall } from '../src/blob.ts';
+import { computeSkillFolderHash } from '../src/local-lock.ts';
 
 const ROOT_SKILL_MD = `---
 name: eve
@@ -102,6 +106,17 @@ description: Nested skill.
 
     expect(result).not.toBeNull();
     expect(result!.skills[0]!.files.map((file) => file.path)).toEqual(['SKILL.md', 'reference.md']);
-    expect(result!.skills[0]!.snapshotHash).toBe('nested-snapshot-hash');
+    expect(result!.skills[0]!.snapshotHash).not.toBe('nested-snapshot-hash');
+
+    const snapshotDir = await mkdtemp(join(tmpdir(), 'blob-hash-'));
+    try {
+      for (const file of result!.skills[0]!.files) {
+        await mkdir(dirname(join(snapshotDir, file.path)), { recursive: true });
+        await writeFile(join(snapshotDir, file.path), file.contents, 'utf-8');
+      }
+      expect(result!.skills[0]!.snapshotHash).toBe(await computeSkillFolderHash(snapshotDir));
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/local-lock.test.ts
+++ b/tests/local-lock.test.ts
@@ -7,6 +7,7 @@ import {
   writeLocalLock,
   addSkillToLocalLock,
   removeSkillFromLocalLock,
+  computeSkillFileHash,
   computeSkillFolderHash,
   getLocalLockPath,
 } from '../src/local-lock.ts';
@@ -461,6 +462,23 @@ describe('local-lock', () => {
 
         const hash2 = await computeSkillFolderHash(skillDir);
         expect(hash1).toBe(hash2);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('computeSkillFileHash', () => {
+    it('ignores supporting files while retaining the folder-hash format', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'lock-test-'));
+      try {
+        await writeFile(join(dir, 'SKILL.md'), 'skill contents', 'utf-8');
+        const skillFileHash = await computeSkillFileHash(dir);
+        expect(skillFileHash).toBe(await computeSkillFolderHash(dir));
+
+        await writeFile(join(dir, 'supporting.md'), 'supporting contents', 'utf-8');
+        expect(await computeSkillFileHash(dir)).toBe(skillFileHash);
+        expect(await computeSkillFolderHash(dir)).not.toBe(skillFileHash);
       } finally {
         await rm(dir, { recursive: true, force: true });
       }

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -335,6 +335,33 @@ describe('Update Cleanup Unit Tests', () => {
       expect(result).toEqual({ successCount: 0, failCount: 0, foundCount: 1 });
     });
 
+    it('compares root blob installs using only the installed skill file', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'root-skill': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'SKILL.md',
+            computedHash: 'same-hash',
+            computedHashScope: 'skill-file',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'root-skill', path: '/tmp/repo', description: 'Root', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFileHash).mockResolvedValue('same-hash');
+
+      const result = await updateProjectSkills({ yes: true });
+
+      expect(localLock.computeSkillFileHash).toHaveBeenCalledWith('/tmp/repo', 'SKILL.md');
+      expect(localLock.computeSkillFolderHash).not.toHaveBeenCalled();
+      expect(spawnSync).not.toHaveBeenCalled();
+      expect(result).toEqual({ successCount: 0, failCount: 0, foundCount: 1 });
+    });
+
     it('reinstalls only project skills whose upstream hash changed', async () => {
       vi.mocked(localLock.readLocalLock).mockResolvedValue({
         version: 1,

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -310,6 +310,92 @@ describe('Update Cleanup Unit Tests', () => {
       expect(argv).not.toContain('--full-depth');
     });
 
+    it('skips reinstalling a project skill whose upstream hash is unchanged', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'skills/skill-a/SKILL.md',
+            computedHash: 'same-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('same-hash');
+
+      const result = await updateProjectSkills({ yes: true });
+
+      expect(localLock.computeSkillFolderHash).toHaveBeenCalledWith('/tmp/repo/skills/skill-a');
+      expect(spawnSync).not.toHaveBeenCalled();
+      expect(result).toEqual({ successCount: 0, failCount: 0, foundCount: 1 });
+    });
+
+    it('reinstalls only project skills whose upstream hash changed', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'skills/skill-a/SKILL.md',
+            computedHash: 'same-hash',
+          },
+          'skill-b': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'skills/skill-b/SKILL.md',
+            computedHash: 'old-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+        { name: 'skill-b', path: '/tmp/repo/skills/skill-b', description: 'B', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockImplementation(async (path) =>
+        path.endsWith('skill-a') ? 'same-hash' : 'new-hash'
+      );
+
+      const result = await updateProjectSkills({ yes: true });
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      const [, argv] = vi.mocked(spawnSync).mock.calls[0]!;
+      expect(argv).toEqual(expect.arrayContaining(['--skill', 'skill-b']));
+      expect(argv).not.toContain('skill-a');
+      expect(result).toEqual({ successCount: 1, failCount: 0, foundCount: 2 });
+    });
+
+    it('reinstalls project skills conservatively when hashing fails', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'skills/skill-a/SKILL.md',
+            computedHash: 'old-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockRejectedValue(new Error('hash failed'));
+
+      const result = await updateProjectSkills({ yes: true });
+
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+      expect(git.cleanupTempDir).toHaveBeenCalledWith('/tmp/repo');
+      expect(result).toEqual({ successCount: 1, failCount: 0, foundCount: 1 });
+    });
+
     it('pins public GitHub project updates to github.com when GH_HOST points elsewhere', async () => {
       vi.stubEnv('GH_HOST', 'github.example.com');
       vi.mocked(localLock.readLocalLock).mockResolvedValue({


### PR DESCRIPTION
## Summary

- compare each discovered project skill's upstream folder hash with its `computedHash` in `skills-lock.json`
- invoke the child `skills add` process only for skills whose contents changed
- keep blob-installed project hashes clone-comparable and record the narrower scope used by root-only blob snapshots
- preserve the existing conservative reinstall behavior if cloning, discovery, or hashing cannot complete
- add regression coverage for unchanged, selectively changed, hash-failure, and blob-hash cases

## User evidence

[#1530](https://github.com/vercel-labs/skills/issues/1530) reported unnecessary reinstalls of every tracked project skill from a source. #1865 fixed the shorthand clone failure in that report. After that fix, however, the successful project-check path still unconditionally reinstalled every non-deleted tracked skill because it never compared `computedHash`.

The same hash-comparison approach was implemented in #1371 by @AronRubin, who measured an unchanged 28-skill project going from 28 reinstalls to zero. This PR refreshes that work on current `main`, hashes the validated directories returned by discovery, and adds regression tests.

@tenequm field-tested the patch across 9 projects / 30 lock entries, confirming unchanged projects dropped from 10 to 0 and 3 to 0 reinstalls. That test also exposed an incompatible skills.sh blob hash basis; the follow-up commit makes blob hashes locally reproducible and covers root-only blob snapshots explicitly.

## Root cause

`updateProjectSkills` cloned and discovered each source for deletion checks, then discarded that content information and unconditionally reinstalled every remaining skill. Project lock entries already contain a deterministic SHA-256 `computedHash`, so the clone can also determine which skills actually changed without additional network work.

Blob installs could previously store a server-provided snapshot hash in the same field. That hash was not guaranteed to use the same paths and file set as `computeSkillFolderHash`, making unchanged blob-installed skills appear changed.

## Impact

Running `skills update -p` no longer spawns child install processes or recopies files for unchanged project skills. Changed skills still update normally. Blob-installed skills use a comparable local hash, including the intentional SKILL.md-only scope for root-level snapshots. If the source cannot be checked completely, all non-deleted skills are reinstalled as before.

## Validation

- `pnpm test` — 55 files, 746 tests passed
- `pnpm type-check`
- `pnpm format:check`
- `pnpm build`
- end-to-end `vercel-labs/agent-browser` project install followed by two no-op `update -p` runs
