### PR TITLE
fix(remove): accept --agent '*' as every agent

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -311,6 +311,14 @@ This is a test skill.
       );
       expect(result.stdout).not.toContain('Invalid agents');
     });
+
+    it("should accept '*' as every agent", () => {
+      const result = runCli(['remove', 'test-skill', '--agent', '*', '-y'], testDir);
+
+      expect(result.stdout).not.toContain('Invalid agents');
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(skillsDir, 'test-skill'))).toBe(false);
+    });
   });
 
   describe('global flag', () => {

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -135,12 +135,19 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   // Validate agent options BEFORE prompting for skill selection
   if (options.agent && options.agent.length > 0) {
     const validAgents = Object.keys(agents);
-    const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
 
-    if (invalidAgents.length > 0) {
-      p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
-      p.log.info(`Valid agents: ${validAgents.join(', ')}`);
-      process.exit(1);
+    if (options.agent.includes('*')) {
+      // '*' selects every agent, matching `skills add --agent '*'`. Expanding it
+      // here keeps it out of the name check below, which would reject it.
+      options.agent = validAgents;
+    } else {
+      const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
+
+      if (invalidAgents.length > 0) {
+        p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
+        p.log.info(`Valid agents: ${validAgents.join(', ')}`);
+        process.exit(1);
+      }
     }
   }
 


### PR DESCRIPTION
`skills remove my-skill --agent '*'` is documented in the README, and `-a, --agent` is described as "use `'*'` for all", but it exits 1 with `Invalid agents: *` because the wildcard is compared against the literal agent names. `skills add --agent '*'` already works, so the two commands disagree.

<img width="2080" height="1314" alt="CleanShot 2026-08-06 at 10  56 29@2x" src="https://github.com/user-attachments/assets/64716d8d-5786-409a-83a8-c20370d605fa" />

- Expand `'*'` to every known agent in `removeCommand` before the agent-name validation
- Add a regression test covering `remove <skill> --agent '*' -y`
- Verified with `pnpm test src/remove.test.ts` (31 passed), `pnpm type-check`, and `pnpm format:check`