### PR TITLE
fix(install): symlink global universal skills into agent-native dirs

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -444,6 +444,13 @@ export async function installSkillForAgent(
       await cleanAndCreateDirectory(agentDir);
       await copyDirectory(skill.path, agentDir, agentType);
 
+      // Mirror the copy-mode native block: also populate the agent-native
+      // global dir so the agent still sees the skill on symlink-less systems.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        await copyDirectory(skill.path, nativeGlobalTarget, agentType);
+      }
+
       return {
         success: true,
         path: agentDir,
@@ -797,6 +804,20 @@ export async function installRemoteSkillForAgent(
         'utf-8'
       );
 
+      // Mirror the copy-mode native block: also populate the agent-native
+      // global dir so the agent still sees the skill on symlink-less systems.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        const nativeSkillFileName =
+          agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
+        const nativeSkillMdPath = join(nativeGlobalTarget, nativeSkillFileName);
+        await writeFile(
+          nativeSkillMdPath,
+          agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
+          'utf-8'
+        );
+      }
+
       return {
         success: true,
         path: agentDir,
@@ -963,6 +984,13 @@ export async function installWellKnownSkillForAgent(
       // Symlink failed, fall back to copy
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
+
+      // Mirror the copy-mode native block: also populate the agent-native
+      // global dir so the agent still sees the skill on symlink-less systems.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        await writeSkillFiles(nativeGlobalTarget);
+      }
 
       return {
         success: true,
@@ -1151,6 +1179,13 @@ export async function installBlobSkillForAgent(
     if (!symlinkCreated) {
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
+
+      // Mirror the copy-mode native block: also populate the agent-native
+      // global dir so the agent still sees the skill on symlink-less systems.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        await writeSkillFiles(nativeGlobalTarget);
+      }
       return {
         success: true,
         path: agentDir,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -148,6 +148,38 @@ export function getAgentBaseDir(
   return join(baseDir, agent.skillsDir);
 }
 
+/**
+ * Whether a universal agent reads globally installed skills directly from the
+ * canonical ~/.agents/skills dir, making an agent-specific global symlink
+ * redundant:
+ * - the agent's native global dir IS the canonical dir, or
+ * - GitHub Copilot, which reads ~/.agents/skills natively on top of
+ *   ~/.copilot/skills (see #294 — a symlink there duplicates skills in VS Code).
+ */
+export function agentReadsCanonicalGlobally(agentType: AgentType): boolean {
+  const nativeDir = agents[agentType].globalSkillsDir;
+  if (nativeDir === undefined) return false;
+  if (resolve(nativeDir) === resolve(getCanonicalSkillsDir(true))) return true;
+  return agentType === 'github-copilot';
+}
+
+/**
+ * For a global install of a universal agent, resolves the path in the agent's
+ * native global skills directory where the skill must be linked (or copied) so
+ * the agent actually sees it (e.g. ~/.gemini/antigravity-cli/skills/<skill>).
+ * Returns undefined when no separate native location is needed (the agent is
+ * not a universal agent, or it reads the canonical dir directly).
+ */
+export function getUniversalGlobalSkillTarget(
+  agentType: AgentType,
+  skillName: string
+): string | undefined {
+  if (!isUniversalAgent(agentType)) return undefined;
+  const nativeDir = agents[agentType].globalSkillsDir;
+  if (nativeDir === undefined || agentReadsCanonicalGlobally(agentType)) return undefined;
+  return join(nativeDir, skillName);
+}
+
 function resolveSymlinkTarget(linkPath: string, linkTarget: string): string {
   return resolve(dirname(linkPath), linkTarget);
 }
@@ -299,6 +331,13 @@ export async function installSkillForAgent(
   const agentBase = getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent);
   const agentDir = join(agentBase, skillName);
 
+  // For global universal-agent installs, the location in the agent's native
+  // global skills dir (when it differs from canonical) that must be linked or
+  // copied so the agent actually sees the skill.
+  const nativeGlobalTarget = isGlobal
+    ? getUniversalGlobalSkillTarget(agentType, skillName)
+    : undefined;
+
   // Validate paths
   if (!isPathSafe(canonicalBase, canonicalDir)) {
     return {
@@ -338,6 +377,13 @@ export async function installSkillForAgent(
       await cleanAndCreateDirectory(agentDir);
       await copyDirectory(skill.path, agentDir, agentType);
 
+      // For global universal-agent installs whose native global dir differs from
+      // canonical, also copy to the native dir so the agent actually sees the skill.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        await copyDirectory(skill.path, nativeGlobalTarget, agentType);
+      }
+
       return {
         success: true,
         path: agentDir,
@@ -360,9 +406,12 @@ export async function installSkillForAgent(
     await copyDirectory(skill.path, canonicalDir, agentType);
 
     // For universal agents with global install, the skill is already in the canonical
-    // ~/.agents/skills directory. Skip creating a symlink to the agent-specific global dir
-    // (e.g. ~/.copilot/skills) to avoid duplicates.
-    if (isGlobal && isUniversalAgent(agentType)) {
+    // ~/.agents/skills directory. Skip creating a symlink to the agent's native global
+    // dir when the agent reads canonical directly (native dir IS canonical, or GitHub
+    // Copilot — see #294). For universal agents whose native global dir differs
+    // (e.g. ~/.gemini/antigravity-cli/skills), the symlink is created there below so
+    // the agent actually sees the skill (see #1874).
+    if (isGlobal && isUniversalAgent(agentType) && nativeGlobalTarget === undefined) {
       return {
         success: true,
         path: canonicalDir,
@@ -388,7 +437,7 @@ export async function installSkillForAgent(
       }
     }
 
-    const symlinkCreated = await createSymlink(canonicalDir, agentDir);
+    const symlinkCreated = await createSymlink(canonicalDir, nativeGlobalTarget ?? agentDir);
 
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
@@ -648,6 +697,13 @@ export async function installRemoteSkillForAgent(
   const agentBase = getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent);
   const agentDir = join(agentBase, skillName);
 
+  // For global universal-agent installs, the location in the agent's native
+  // global skills dir (when it differs from canonical) that must be linked or
+  // copied so the agent actually sees the skill.
+  const nativeGlobalTarget = isGlobal
+    ? getUniversalGlobalSkillTarget(agentType, skillName)
+    : undefined;
+
   // Validate paths
   if (!isPathSafe(canonicalBase, canonicalDir)) {
     return {
@@ -680,6 +736,20 @@ export async function installRemoteSkillForAgent(
         'utf-8'
       );
 
+      // For global universal-agent installs whose native global dir differs from
+      // canonical, also copy to the native dir so the agent actually sees the skill.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        const nativeSkillFileName =
+          agentType === 'eve' ? toEveFlatSkillFileName(skill.installName) : 'SKILL.md';
+        const nativeSkillMdPath = join(nativeGlobalTarget, nativeSkillFileName);
+        await writeFile(
+          nativeSkillMdPath,
+          agentType === 'eve' ? stripIgnoredEveFrontmatter(skill.content) : skill.content,
+          'utf-8'
+        );
+      }
+
       return {
         success: true,
         path: agentDir,
@@ -698,8 +768,13 @@ export async function installRemoteSkillForAgent(
       'utf-8'
     );
 
-    // For universal agents with global install, skip creating agent-specific symlink
-    if (isGlobal && isUniversalAgent(agentType)) {
+    // For universal agents with global install, the skill is already in the canonical
+    // ~/.agents/skills directory. Skip creating a symlink to the agent's native global
+    // dir when the agent reads canonical directly (native dir IS canonical, or GitHub
+    // Copilot — see #294). For universal agents whose native global dir differs
+    // (e.g. ~/.gemini/antigravity-cli/skills), the symlink is created there below so
+    // the agent actually sees the skill (see #1874).
+    if (isGlobal && isUniversalAgent(agentType) && nativeGlobalTarget === undefined) {
       return {
         success: true,
         path: canonicalDir,
@@ -708,7 +783,7 @@ export async function installRemoteSkillForAgent(
       };
     }
 
-    const symlinkCreated = await createSymlink(canonicalDir, agentDir);
+    const symlinkCreated = await createSymlink(canonicalDir, nativeGlobalTarget ?? agentDir);
 
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
@@ -789,6 +864,13 @@ export async function installWellKnownSkillForAgent(
   const agentBase = getAgentBaseDir(agentType, isGlobal, cwd, eveSubagent);
   const agentDir = join(agentBase, skillName);
 
+  // For global universal-agent installs, the location in the agent's native
+  // global skills dir (when it differs from canonical) that must be linked or
+  // copied so the agent actually sees the skill.
+  const nativeGlobalTarget = isGlobal
+    ? getUniversalGlobalSkillTarget(agentType, skillName)
+    : undefined;
+
   // Validate paths
   if (!isPathSafe(canonicalBase, canonicalDir)) {
     return {
@@ -842,6 +924,13 @@ export async function installWellKnownSkillForAgent(
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
 
+      // For global universal-agent installs whose native global dir differs from
+      // canonical, also copy to the native dir so the agent actually sees the skill.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        await writeSkillFiles(nativeGlobalTarget);
+      }
+
       return {
         success: true,
         path: agentDir,
@@ -853,8 +942,13 @@ export async function installWellKnownSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     await writeSkillFiles(canonicalDir);
 
-    // For universal agents with global install, skip creating agent-specific symlink
-    if (isGlobal && isUniversalAgent(agentType)) {
+    // For universal agents with global install, the skill is already in the canonical
+    // ~/.agents/skills directory. Skip creating a symlink to the agent's native global
+    // dir when the agent reads canonical directly (native dir IS canonical, or GitHub
+    // Copilot — see #294). For universal agents whose native global dir differs
+    // (e.g. ~/.gemini/antigravity-cli/skills), the symlink is created there below so
+    // the agent actually sees the skill (see #1874).
+    if (isGlobal && isUniversalAgent(agentType) && nativeGlobalTarget === undefined) {
       return {
         success: true,
         path: canonicalDir,
@@ -863,7 +957,7 @@ export async function installWellKnownSkillForAgent(
       };
     }
 
-    const symlinkCreated = await createSymlink(canonicalDir, agentDir);
+    const symlinkCreated = await createSymlink(canonicalDir, nativeGlobalTarget ?? agentDir);
 
     if (!symlinkCreated) {
       // Symlink failed, fall back to copy
@@ -956,6 +1050,13 @@ export async function installBlobSkillForAgent(
   const canonicalDir = join(canonicalBase, skillName);
   const agentDir = join(agentBase, skillName);
 
+  // For global universal-agent installs, the location in the agent's native
+  // global skills dir (when it differs from canonical) that must be linked or
+  // copied so the agent actually sees the skill.
+  const nativeGlobalTarget = isGlobal
+    ? getUniversalGlobalSkillTarget(agentType, skillName)
+    : undefined;
+
   if (!isPathSafe(canonicalBase, canonicalDir)) {
     return {
       success: false,
@@ -998,6 +1099,14 @@ export async function installBlobSkillForAgent(
     if (installMode === 'copy') {
       await cleanAndCreateDirectory(agentDir);
       await writeSkillFiles(agentDir);
+
+      // For global universal-agent installs whose native global dir differs from
+      // canonical, also copy to the native dir so the agent actually sees the skill.
+      if (nativeGlobalTarget !== undefined && nativeGlobalTarget !== agentDir) {
+        await cleanAndCreateDirectory(nativeGlobalTarget);
+        await writeSkillFiles(nativeGlobalTarget);
+      }
+
       return { success: true, path: agentDir, mode: 'copy' };
     }
 
@@ -1005,7 +1114,13 @@ export async function installBlobSkillForAgent(
     await cleanAndCreateDirectory(canonicalDir);
     await writeSkillFiles(canonicalDir);
 
-    if (isGlobal && isUniversalAgent(agentType)) {
+    // For universal agents with global install, the skill is already in the canonical
+    // ~/.agents/skills directory. Skip creating a symlink to the agent's native global
+    // dir when the agent reads canonical directly (native dir IS canonical, or GitHub
+    // Copilot — see #294). For universal agents whose native global dir differs
+    // (e.g. ~/.gemini/antigravity-cli/skills), the symlink is created there below so
+    // the agent actually sees the skill (see #1874).
+    if (isGlobal && isUniversalAgent(agentType) && nativeGlobalTarget === undefined) {
       return {
         success: true,
         path: canonicalDir,
@@ -1031,7 +1146,7 @@ export async function installBlobSkillForAgent(
       }
     }
 
-    const symlinkCreated = await createSymlink(canonicalDir, agentDir);
+    const symlinkCreated = await createSymlink(canonicalDir, nativeGlobalTarget ?? agentDir);
 
     if (!symlinkCreated) {
       await cleanAndCreateDirectory(agentDir);

--- a/tests/installer-global-universal.test.ts
+++ b/tests/installer-global-universal.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Regression tests for global installs of universal agents (#1874, #294).
+ *
+ * Global installs write to the user's home directory, so all tests run with
+ * HOME (and friends) stubbed to a temp directory. The agents module caches
+ * homedir() at import time, so modules must be re-imported after stubbing.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import {
+  mkdtemp,
+  mkdir,
+  rm,
+  writeFile,
+  lstat,
+  readlink,
+  realpath,
+  readFile,
+} from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { WellKnownSkill } from '../src/providers/wellknown.ts';
+import { createTestHomeEnvironment } from '../src/test-utils.ts';
+
+let installer: typeof import('../src/installer.ts');
+let agentsModule: typeof import('../src/agents.ts');
+let testHome: string;
+
+async function makeSkillSource(root: string, name: string): Promise<string> {
+  const dir = join(root, 'source-skill');
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: test\n---\n`, 'utf-8');
+  return dir;
+}
+
+describe('global universal-agent installs', () => {
+  beforeAll(async () => {
+    testHome = await mkdtemp(join(tmpdir(), 'skills-global-universal-home-'));
+
+    for (const [name, value] of Object.entries(createTestHomeEnvironment(testHome))) {
+      vi.stubEnv(name, value);
+    }
+
+    vi.resetModules();
+    agentsModule = await import('../src/agents.ts');
+    installer = await import('../src/installer.ts');
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await rm(testHome, { recursive: true, force: true });
+  });
+
+  it('agentReadsCanonicalGlobally: only agents whose native dir IS canonical (or Copilot) read canonical directly', () => {
+    // Native dir differs from canonical (e.g. ~/.gemini/antigravity-cli/skills):
+    // the agent needs a symlink in its own dir.
+    for (const agentType of [
+      'antigravity-cli',
+      'antigravity',
+      'gemini-cli',
+      'codex',
+      'cursor',
+      'deepagents',
+      'firebender',
+      'opencode',
+      'amp',
+      'replit',
+      'universal',
+    ]) {
+      expect(installer.agentReadsCanonicalGlobally(agentType as any), agentType).toBe(false);
+      expect(installer.getUniversalGlobalSkillTarget(agentType as any, 'foo'), agentType).toBe(
+        join(
+          agentsModule.agents[agentType as keyof typeof agentsModule.agents].globalSkillsDir ?? '',
+          'foo'
+        )
+      );
+    }
+
+    // Native dir IS canonical (~/.agents/skills): no symlink needed.
+    for (const agentType of ['cline', 'dexto', 'kimi-code-cli', 'loaf', 'warp', 'zed']) {
+      expect(installer.agentReadsCanonicalGlobally(agentType as any), agentType).toBe(true);
+      expect(installer.getUniversalGlobalSkillTarget(agentType as any, 'foo'), agentType).toBe(
+        undefined
+      );
+    }
+
+    // GitHub Copilot reads ~/.agents/skills natively on top of ~/.copilot/skills
+    // (see #294): a symlink there would duplicate skills in VS Code.
+    expect(installer.agentReadsCanonicalGlobally('github-copilot')).toBe(true);
+    expect(installer.getUniversalGlobalSkillTarget('github-copilot', 'foo')).toBe(undefined);
+
+    // Non-universal agents are unaffected by the universal global logic.
+    expect(installer.agentReadsCanonicalGlobally('claude-code')).toBe(false);
+    expect(installer.getUniversalGlobalSkillTarget('claude-code', 'foo')).toBe(undefined);
+  });
+
+  it('creates a symlink in the native global dir for universal agents whose dir differs from canonical', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-global-universal-'));
+    const skillName = 'native-dir-symlink-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installer.installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'antigravity-cli',
+        { global: true, mode: 'symlink' }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalDir = join(testHome, '.agents', 'skills', skillName);
+      const nativeDir = join(testHome, '.gemini', 'antigravity-cli', 'skills', skillName);
+
+      // Skill lives as a real directory in canonical ~/.agents/skills
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+      expect(canonicalStats.isSymbolicLink()).toBe(false);
+      expect(result.path).toBe(canonicalDir);
+      expect(result.canonicalPath).toBe(canonicalDir);
+
+      // Agent's native global dir holds a symlink to canonical
+      const nativeStats = await lstat(nativeDir);
+      expect(nativeStats.isSymbolicLink()).toBe(true);
+      expect(await realpath(nativeDir)).toBe(await realpath(canonicalDir));
+      const linkTarget = await readlink(nativeDir);
+      expect(linkTarget).toContain('.agents');
+
+      // Skill content is readable through the symlink
+      await expect(readFile(join(nativeDir, 'SKILL.md'), 'utf-8')).resolves.toContain(skillName);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create a symlink for GitHub Copilot global installs (regression for #294)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-global-universal-'));
+    const skillName = 'copilot-skip-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installer.installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'github-copilot',
+        { global: true, mode: 'symlink' }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(testHome, '.agents', 'skills', skillName));
+
+      const copilotDir = join(testHome, '.copilot', 'skills', skillName);
+      await expect(lstat(copilotDir)).rejects.toThrow();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create a symlink when the native global dir IS canonical (cline)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-global-universal-'));
+    const skillName = 'canonical-native-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installer.installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'cline',
+        { global: true, mode: 'symlink' }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.path).toBe(join(testHome, '.agents', 'skills', skillName));
+
+      const canonicalDir = join(testHome, '.agents', 'skills', skillName);
+      const stats = await lstat(canonicalDir);
+      expect(stats.isDirectory()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('copies to both canonical and the native global dir in copy mode', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-global-universal-'));
+    const skillName = 'copy-mode-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installer.installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'antigravity-cli',
+        { global: true, mode: 'copy' }
+      );
+
+      expect(result.success).toBe(true);
+
+      const canonicalDir = join(testHome, '.agents', 'skills', skillName);
+      const nativeDir = join(testHome, '.gemini', 'antigravity-cli', 'skills', skillName);
+
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+      expect(canonicalStats.isSymbolicLink()).toBe(false);
+
+      // Copy mode writes real files to the native dir (no symlink)
+      const nativeStats = await lstat(nativeDir);
+      expect(nativeStats.isDirectory()).toBe(true);
+      expect(nativeStats.isSymbolicLink()).toBe(false);
+      await expect(readFile(join(nativeDir, 'SKILL.md'), 'utf-8')).resolves.toContain(skillName);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates the native-dir symlink for blob installs on global installs', async () => {
+    const skillName = 'blob-global-skill';
+
+    try {
+      const result = await installer.installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            {
+              path: 'SKILL.md',
+              contents: `---\nname: ${skillName}\ndescription: test\n---\n`,
+            },
+          ],
+        },
+        'antigravity-cli',
+        { global: true, mode: 'symlink' }
+      );
+
+      expect(result.success).toBe(true);
+
+      const canonicalDir = join(testHome, '.agents', 'skills', skillName);
+      const nativeDir = join(testHome, '.gemini', 'antigravity-cli', 'skills', skillName);
+
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+      expect(canonicalStats.isSymbolicLink()).toBe(false);
+
+      const nativeStats = await lstat(nativeDir);
+      expect(nativeStats.isSymbolicLink()).toBe(true);
+      expect(await realpath(nativeDir)).toBe(await realpath(canonicalDir));
+    } finally {
+      await rm(join(testHome, '.agents', 'skills', skillName), { recursive: true, force: true });
+    }
+  });
+
+  it('creates the native-dir symlink for remote installs on global installs', async () => {
+    const skillName = 'remote-global-skill';
+
+    try {
+      const result = await installer.installRemoteSkillForAgent(
+        {
+          name: skillName,
+          description: 'test',
+          content: `---\nname: ${skillName}\ndescription: test\n---\n`,
+          installName: skillName,
+          sourceUrl: 'https://example.com/skill',
+          providerId: 'test',
+          sourceIdentifier: 'example.com',
+        },
+        'antigravity-cli',
+        { global: true, mode: 'symlink' }
+      );
+
+      expect(result.success).toBe(true);
+
+      const canonicalDir = join(testHome, '.agents', 'skills', skillName);
+      const nativeDir = join(testHome, '.gemini', 'antigravity-cli', 'skills', skillName);
+
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+      expect(canonicalStats.isSymbolicLink()).toBe(false);
+
+      const nativeStats = await lstat(nativeDir);
+      expect(nativeStats.isSymbolicLink()).toBe(true);
+      expect(await realpath(nativeDir)).toBe(await realpath(canonicalDir));
+    } finally {
+      await rm(join(testHome, '.agents', 'skills', skillName), { recursive: true, force: true });
+    }
+  });
+
+  it('creates the native-dir symlink for well-known installs on global installs', async () => {
+    const skillName = 'wellknown-global-skill';
+    const skill = {
+      name: skillName,
+      description: 'test',
+      content: `---\nname: ${skillName}\ndescription: test\n---\n`,
+      installName: skillName,
+      sourceUrl: 'https://example.com/skill',
+      providerId: 'well-known',
+      sourceIdentifier: 'example.com',
+      files: new Map([['SKILL.md', `---\nname: ${skillName}\ndescription: test\n---\n`]]),
+      indexEntry: {
+        name: skillName,
+        type: 'skill-md',
+        description: 'test',
+        url: 'https://example.com/skill',
+      },
+    } as unknown as WellKnownSkill;
+
+    try {
+      const result = await installer.installWellKnownSkillForAgent(skill, 'antigravity-cli', {
+        global: true,
+        mode: 'symlink',
+      });
+
+      expect(result.success).toBe(true);
+
+      const canonicalDir = join(testHome, '.agents', 'skills', skillName);
+      const nativeDir = join(testHome, '.gemini', 'antigravity-cli', 'skills', skillName);
+
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+      expect(canonicalStats.isSymbolicLink()).toBe(false);
+
+      const nativeStats = await lstat(nativeDir);
+      expect(nativeStats.isSymbolicLink()).toBe(true);
+      expect(await realpath(nativeDir)).toBe(await realpath(canonicalDir));
+    } finally {
+      await rm(join(testHome, '.agents', 'skills', skillName), { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/installer-global-universal.test.ts
+++ b/tests/installer-global-universal.test.ts
@@ -22,6 +22,27 @@ import { tmpdir } from 'node:os';
 import type { WellKnownSkill } from '../src/providers/wellknown.ts';
 import { createTestHomeEnvironment } from '../src/test-utils.ts';
 
+const { setSymlinkFailure, shouldSymlinkFail } = vi.hoisted(() => {
+  const state = { fail: false };
+  return {
+    setSymlinkFailure: (v: boolean) => {
+      state.fail = v;
+    },
+    shouldSymlinkFail: () => state.fail,
+  };
+});
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    symlink: (target: string, linkPath: string, type?: string | null) =>
+      shouldSymlinkFail()
+        ? Promise.reject(new Error('symlink not supported'))
+        : actual.symlink(target, linkPath, type),
+  };
+});
+
 let installer: typeof import('../src/installer.ts');
 let agentsModule: typeof import('../src/agents.ts');
 let testHome: string;
@@ -206,6 +227,41 @@ describe('global universal-agent installs', () => {
       expect(nativeStats.isSymbolicLink()).toBe(false);
       await expect(readFile(join(nativeDir, 'SKILL.md'), 'utf-8')).resolves.toContain(skillName);
     } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to copy for the native global dir when symlink creation fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-global-universal-'));
+    const skillName = 'symlink-failed-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    setSymlinkFailure(true);
+    try {
+      const result = await installer.installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'antigravity-cli',
+        { global: true, mode: 'symlink' }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.symlinkFailed).toBe(true);
+
+      const canonicalDir = join(testHome, '.agents', 'skills', skillName);
+      const nativeDir = join(testHome, '.gemini', 'antigravity-cli', 'skills', skillName);
+
+      // Canonical dir is a real directory (no symlink was created)
+      const canonicalStats = await lstat(canonicalDir);
+      expect(canonicalStats.isDirectory()).toBe(true);
+      expect(canonicalStats.isSymbolicLink()).toBe(false);
+
+      // Agent-native global dir is populated with real files despite the failure
+      const nativeStats = await lstat(nativeDir);
+      expect(nativeStats.isDirectory()).toBe(true);
+      expect(nativeStats.isSymbolicLink()).toBe(false);
+      await expect(readFile(join(nativeDir, 'SKILL.md'), 'utf-8')).resolves.toContain(skillName);
+    } finally {
+      setSymlinkFailure(false);
       await rm(root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Closes #1874

## Problem

A universal-only **global** install (`skills add <skill> --global`) writes the skill to canonical `~/.agents/skills/` but never creates the agent-specific symlink for universal agents, so agents whose native global skills dir differs from canonical never see it (e.g. `--agent antigravity-cli` leaves nothing in `~/.gemini/antigravity-cli/skills`).

The `isGlobal && isUniversalAgent(agentType)` skip was introduced in 87d3b8b to fix #294 (GitHub Copilot reads `~/.agents/skills` natively, so a symlink in `~/.copilot/skills` duplicated skills in VS Code), but it was over-broad: it also suppressed the link for every other universal agent.

## Fix

New helper `agentReadsCanonicalGlobally()` determines when a symlink is redundant, i.e. when the agent reads canonical directly:

- its `globalSkillsDir` IS `~/.agents/skills` (cline, dexto, kimi-code-cli, loaf, warp, zed), or
- it is GitHub Copilot (#294 special case).

All four install paths (`installSkillForAgent`, `installRemoteSkillForAgent`, `installWellKnownSkillForAgent`, `installBlobSkillForAgent`) now:

- skip the agent-specific link only for canonical-reading agents, and
- otherwise create the symlink at `globalSkillsDir/<skill>` pointing to canonical (copy mode also copies there), so antigravity-cli, gemini-cli, codex, cursor, deepagents, firebender, opencode, amp, replit, and `universal` all see globally installed skills.

`list` and `remove` already scan agent-native global dirs and dedupe by scope:name, so no changes were needed there.

## Testing

- 8 new tests in `tests/installer-global-universal.test.ts`: real global installs with HOME stubbed to a temp dir. Covers symlink creation for antigravity-cli, no symlink for Copilot (#294) and cline, copy-mode population, blob/remote/well-known install paths, and the helper matrix across all universal agents.
- `tsc --noEmit` and prettier clean.
- 61/61 installer/list/update/well-known unit tests pass.