### PR TITLE
feat: add Posit Assistant agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -297,6 +297,7 @@ Skills can be installed to any of these agents:
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |
 | Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
+| Posit Assistant | `posit-assistant` | `.posit/assistant/skills/` | `~/.posit/assistant/skills/` |
 | Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
 | Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
 | Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
@@ -430,6 +431,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.openhands/skills/`
 - `.ona/skills/`
 - `.pi/skills/`
+- `.posit/assistant/skills/`
 - `.qoder/skills/`
 - `.qwen/skills/`
 - `.reasonix/skills/`
@@ -542,6 +544,7 @@ Telemetry is automatically disabled in CI environments.
 - [Qwen Code Skills Documentation](https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/)
 - [OpenHands Skills Documentation](https://docs.openhands.ai/modules/usage/how-to/using-skills)
 - [Pi Skills Documentation](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/skills.md)
+- [Posit Assistant Skills Documentation](https://assistant.posit.co/docs/features/skills/)
 - [Qoder Skills Documentation](https://docs.qoder.com/cli/Skills)
 - [Replit Skills Documentation](https://docs.replit.com/replitai/skills)
 - [Roo Code Skills Documentation](https://docs.roocode.com/features/skills)

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "openhands",
     "ona",
     "pi",
+    "posit-assistant",
     "qoder",
     "qoder-cn",
     "qwen-code",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -67,6 +67,15 @@ export function isMiniMaxCodeInstalled(
   return pathExists(join(homeDir, '.minimax')) || pathExists('/Applications/MiniMax Code.app');
 }
 
+export function isPositAssistantInstalled(
+  homeDir = home,
+  pathExists: (path: string) => boolean = existsSync
+) {
+  // ~/.positai is the pre-rename config dir, still present on installs
+  // that haven't launched a current version yet.
+  return pathExists(join(homeDir, '.posit/assistant')) || pathExists(join(homeDir, '.positai'));
+}
+
 export const agents: Record<AgentType, AgentConfig> = {
   'aider-desk': {
     name: 'aider-desk',
@@ -553,6 +562,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.pi/agent/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.pi/agent'));
+    },
+  },
+  'posit-assistant': {
+    name: 'posit-assistant',
+    displayName: 'Posit Assistant',
+    skillsDir: '.posit/assistant/skills',
+    globalSkillsDir: join(home, '.posit/assistant/skills'),
+    detectInstalled: async () => {
+      return isPositAssistantInstalled();
     },
   },
   qoder: {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -275,6 +275,7 @@ const PRIORITY_PREFIXES = [
   '.opencode/skills/',
   '.openhands/skills/',
   '.pi/skills/',
+  '.posit/assistant/skills/',
   '.qoder/skills/',
   '.roo/skills/',
   '.trae/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -31,6 +31,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.opencode/skills',
   '.openhands/skills',
   '.pi/skills',
+  '.posit/assistant/skills',
   '.qoder/skills',
   '.roo/skills',
   '.trae/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type AgentType =
   | 'openhands'
   | 'ona'
   | 'pi'
+  | 'posit-assistant'
   | 'qoder'
   | 'qoder-cn'
   | 'qwen-code'

--- a/tests/posit-assistant-agent.test.ts
+++ b/tests/posit-assistant-agent.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { agents, isPositAssistantInstalled } from '../src/agents.ts';
+import { findSkillMdPaths } from '../src/blob.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+const skillFile = (name: string) => `---
+name: ${name}
+description: ${name} test skill
+---
+
+# ${name}
+`;
+
+describe('Posit Assistant agent support', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'skills-posit-assistant-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('uses the documented project and global skill directories', () => {
+    const agent = agents['posit-assistant'];
+
+    expect(agent.name).toBe('posit-assistant');
+    expect(agent.displayName).toBe('Posit Assistant');
+    expect(agent.skillsDir).toBe('.posit/assistant/skills');
+    expect(agent.globalSkillsDir).toBe(join(homedir(), '.posit', 'assistant', 'skills'));
+  });
+
+  it('detects Posit Assistant from its config directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.posit/assistant');
+
+    expect(isPositAssistantInstalled(home, exists)).toBe(true);
+  });
+
+  it('detects Posit Assistant from the legacy config directory', () => {
+    const home = '/tmp/home';
+    const exists = (path: string) => path === join(home, '.positai');
+
+    expect(isPositAssistantInstalled(home, exists)).toBe(true);
+  });
+
+  it('returns false when no known Posit Assistant path exists', () => {
+    expect(isPositAssistantInstalled('/tmp/home', () => false)).toBe(false);
+  });
+
+  it('discovers project skills from .posit/assistant/skills alongside standard skills', async () => {
+    const positSkillDir = join(testDir, '.posit', 'assistant', 'skills', 'posit-skill');
+    const standardSkillDir = join(testDir, 'skills', 'standard-skill');
+    mkdirSync(positSkillDir, { recursive: true });
+    mkdirSync(standardSkillDir, { recursive: true });
+    writeFileSync(join(positSkillDir, 'SKILL.md'), skillFile('posit-skill'));
+    writeFileSync(join(standardSkillDir, 'SKILL.md'), skillFile('standard-skill'));
+
+    const discovered = await discoverSkills(testDir);
+
+    expect(discovered.map((skill) => skill.name).sort()).toEqual(['posit-skill', 'standard-skill']);
+  });
+
+  it('discovers .posit/assistant/skills through the GitHub tree fast path', () => {
+    const discovered = findSkillMdPaths({
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: '.claude/skills/standard-skill/SKILL.md',
+          type: 'blob',
+          sha: 'standard-sha',
+        },
+        {
+          path: '.posit/assistant/skills/posit-skill/SKILL.md',
+          type: 'blob',
+          sha: 'posit-sha',
+        },
+      ],
+    });
+
+    expect(discovered).toContain('.posit/assistant/skills/posit-skill/SKILL.md');
+  });
+});


### PR DESCRIPTION
# feat: add Posit Assistant agent support

Adds [Posit Assistant](https://assistant.posit.co) as a supported agent.

Posit Assistant is Posit's AI assistant for data science, available for Positron, RStudio, VS Code, and as standalone desktop/server/TUI apps. It implements the [Agent Skills specification](https://agentskills.io) and loads skills from `.posit/assistant/skills/` (project) and `~/.posit/assistant/skills/` (user), documented at <https://assistant.posit.co/docs/features/skills/>.

## Agent details

| Field | Value |
| --- | --- |
| Agent name | Posit Assistant |
| Skills documentation | <https://assistant.posit.co/docs/features/skills/> |
| Project skills directory | `.posit/assistant/skills` |
| Global skills directory | `~/.posit/assistant/skills` |
| Detection path | `~/.posit/assistant` (fallback: legacy `~/.positai`) |

All Posit Assistant platforms share `~/.posit/assistant/` as their config base, so a single detection path covers every variant. Older releases used `~/.positai`, which is checked as a fallback for installs that haven't launched a current version yet.

## Changes

- `src/types.ts` — add `posit-assistant` to `AgentType`
- `src/agents.ts` — agent config and `isPositAssistantInstalled()` detection helper
- `src/skills.ts` — add `.posit/assistant/skills` to `AGENT_PROJECT_SKILL_DIRS`
- `src/blob.ts` — add `.posit/assistant/skills/` to `PRIORITY_PREFIXES`
- `tests/posit-assistant-agent.test.ts` — directory config, detection, local discovery, and GitHub tree fast-path tests
- `README.md` / `package.json` — regenerated via `scripts/sync-agents.ts`, plus a Related Links entry

## Verification

- `node scripts/validate-agents.ts` passes
- `pnpm type-check`, `pnpm format:check`, and `pnpm test` pass (746 tests)
- Smoke test: `skills add <local-skill> -a posit-assistant -y --copy` installs to `.posit/assistant/skills/` and `skills list` attributes it to Posit Assistant
