### PR TITLE
fix(agents): honor PI_CODING_AGENT_DIR for the pi agent

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -13,6 +13,7 @@ const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 const grokHome = process.env.GROK_HOME?.trim() || join(home, '.grok');
+const piHome = process.env.PI_CODING_AGENT_DIR?.trim() || join(home, '.pi', 'agent');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
 
@@ -550,9 +551,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'pi',
     displayName: 'Pi',
     skillsDir: '.pi/skills',
-    globalSkillsDir: join(home, '.pi/agent/skills'),
+    globalSkillsDir: join(piHome, 'skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.pi/agent'));
+      return existsSync(piHome);
     },
   },
   qoder: {


### PR DESCRIPTION
The `pi` agent entry hardcoded its `globalSkillsDir` and `detectInstalled` paths, ignoring any environment variable.

This mismatches pi itself, which reads skills from `$HOME/.config/pi/agent/skills`.

This patch adds piHome in code in order to fix that.

Behavior:
    - unset -> `piHome` defaults to `~/.pi/agent`; paths unchanged (backward compatible).
    - set   -> `skills add pi` targets the directory pi actually reads.

## In Action

<img width="1320" height="962" alt="Screenshot 2026-08-06 at 10 08 09 PM" src="https://github.com/user-attachments/assets/b45e1ee0-3660-4543-a42f-f912ec57dcc3" />

---
I used an llm for the whole implementation - please forgive me, review and let me know what to change

---