### PR TITLE
feat: add claude-managed-agents install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Skills can be installed to any of these agents:
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
 | IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
+| Claude Managed Agents | `claude-managed-agents` | Uploads to the Anthropic Skills API | Uploads to the Anthropic Skills API |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
 | Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
@@ -315,7 +316,6 @@ Skills can be installed to any of these agents:
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
 | PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
-| Claude Managed Agents | `claude-managed-agents` | Uploads to the Anthropic Skills API | Uploads to the Anthropic Skills API |
 <!-- supported-agents:end -->
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -315,6 +315,7 @@ Skills can be installed to any of these agents:
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
 | PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
+| Claude Managed Agents | `claude-managed-agents` | Uploads to the Anthropic Skills API | Uploads to the Anthropic Skills API |
 <!-- supported-agents:end -->
 
 > [!NOTE]
@@ -329,6 +330,33 @@ Skills can be installed to any of these agents:
 
 The CLI automatically detects which coding agents you have installed. If none are detected, you'll be prompted to select
 which agents to install to.
+
+### Claude Managed Agents
+
+`claude-managed-agents` is an API target rather than a directory: each selected skill is uploaded to the
+[Anthropic Skills API](https://platform.claude.com/docs/en/agents-and-tools/agent-skills), where it becomes available
+to your [Claude managed agents](https://platform.claude.com/docs/en/agents-and-tools/managed-agents) (and to the
+Messages API code-execution container) as a custom skill.
+
+```bash
+npx skills add vercel-labs/agent-skills --agent claude-managed-agents
+```
+
+Credentials are resolved in this order:
+
+1. `ANTHROPIC_API_KEY` environment variable
+2. `ANTHROPIC_AUTH_TOKEN` environment variable
+3. The Anthropic CLI's stored login (run `ant auth login`); expired tokens are refreshed automatically
+4. The Anthropic CLI credentials file (`~/.config/anthropic`), when the `ant` binary isn't on `PATH`
+
+Behavior notes:
+
+- Adding a skill that already exists in your organization (matched by display title) uploads a new version of that
+  skill instead of failing.
+- This target is never auto-detected and is excluded from `--agent '*'` and `--all`, so bulk installs can't upload to
+  your Anthropic organization by accident. Select it explicitly with `--agent claude-managed-agents` or in the
+  interactive prompt.
+- `ANTHROPIC_BASE_URL` is honored for non-default API endpoints.
 
 ## Creating Skills
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "augment",
     "bob",
     "claude-code",
+    "claude-managed-agents",
     "openclaw",
     "cline",
     "codearts-agent",

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -31,7 +31,13 @@ function generateAvailableAgentsTable(): string {
     }
   >();
 
+  const virtualRows: string[] = [];
+
   for (const [key, a] of Object.entries(agents)) {
+    if (a.virtual) {
+      virtualRows.push(`| ${a.displayName} | \`${key}\` | ${a.installHint} | ${a.installHint} |`);
+      continue;
+    }
     const pathKey = `${a.skillsDir}|${a.globalSkillsDir}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
@@ -58,6 +64,7 @@ function generateAvailableAgentsTable(): string {
     '| Agent | `--agent` | Project Path | Global Path |',
     '|-------|-----------|--------------|-------------|',
     ...rows,
+    ...virtualRows,
   ].join('\n');
 }
 
@@ -70,7 +77,13 @@ function generateSkillDiscoveryPaths(): string {
     '- `skills/.system/`',
   ];
 
-  const agentPaths = [...new Set(Object.values(agents).map((a) => a.skillsDir))]
+  const agentPaths = [
+    ...new Set(
+      Object.values(agents)
+        .filter((a) => !a.virtual)
+        .map((a) => a.skillsDir)
+    ),
+  ]
     .filter((p) => p !== 'skills') // Filter out the standard `skills/` path
     .map((p) => `- \`${p}/\``);
 

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -20,7 +20,8 @@ function generateAgentNames(): string {
 }
 
 function generateAvailableAgentsTable(): string {
-  // Group agents by their paths
+  // Group agents by their paths. Virtual agents (API upload targets) have no
+  // paths; each gets its own group so it stays in registry order.
   const pathGroups = new Map<
     string,
     {
@@ -28,23 +29,19 @@ function generateAvailableAgentsTable(): string {
       displayNames: string[];
       skillsDir: string;
       globalSkillsDir: string | undefined;
+      installHint?: string;
     }
   >();
 
-  const virtualRows: string[] = [];
-
   for (const [key, a] of Object.entries(agents)) {
-    if (a.virtual) {
-      virtualRows.push(`| ${a.displayName} | \`${key}\` | ${a.installHint} | ${a.installHint} |`);
-      continue;
-    }
-    const pathKey = `${a.skillsDir}|${a.globalSkillsDir}`;
+    const pathKey = a.virtual ? `virtual|${key}` : `${a.skillsDir}|${a.globalSkillsDir}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
         keys: [],
         displayNames: [],
         skillsDir: a.skillsDir,
         globalSkillsDir: a.globalSkillsDir,
+        ...(a.virtual && { installHint: a.installHint }),
       });
     }
     const group = pathGroups.get(pathKey)!;
@@ -53,18 +50,20 @@ function generateAvailableAgentsTable(): string {
   }
 
   const rows = Array.from(pathGroups.values()).map((group) => {
+    const names = group.displayNames.join(', ');
+    const keys = group.keys.map((k) => `\`${k}\``).join(', ');
+    if (group.installHint) {
+      return `| ${names} | ${keys} | ${group.installHint} | ${group.installHint} |`;
+    }
     const globalPath = group.globalSkillsDir
       ? `\`${group.globalSkillsDir.replace(homedir(), '~')}/\``
       : 'N/A (project-only)';
-    const names = group.displayNames.join(', ');
-    const keys = group.keys.map((k) => `\`${k}\``).join(', ');
     return `| ${names} | ${keys} | \`${group.skillsDir}/\` | ${globalPath} |`;
   });
   return [
     '| Agent | `--agent` | Project Path | Global Path |',
     '|-------|-----------|--------------|-------------|',
     ...rows,
-    ...virtualRows,
   ].join('\n');
 }
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -23,8 +23,18 @@ import {
   getVisibleUniversalAgents,
   getNonUniversalAgents,
   isUniversalAgent,
+  isVirtualAgent,
+  getWildcardAgents,
   getEveSubagents,
 } from './agents.ts';
+import {
+  resolveAnthropicAuth,
+  uploadSkillToManagedAgents,
+  collectSkillFiles,
+  MANAGED_AGENTS_AUTH_GUIDANCE,
+  type AnthropicAuth,
+  type SkillUploadFile,
+} from './managed-agents.ts';
 import {
   track,
   setVersion,
@@ -229,25 +239,29 @@ export function formatEveInstallPromptMessage(skills: Skill[]): string {
 }
 
 /**
- * Splits agents into universal and non-universal (symlinked) groups.
- * Returns display names for each group.
+ * Splits agents into universal, non-universal (symlinked), and virtual
+ * (API upload) groups. Returns display names for each group.
  */
 function splitAgentsByType(agentTypes: AgentType[]): {
   universal: string[];
   symlinked: string[];
+  virtual: string[];
 } {
   const universal: string[] = [];
   const symlinked: string[] = [];
+  const virtual: string[] = [];
 
   for (const a of agentTypes) {
-    if (isUniversalAgent(a)) {
+    if (isVirtualAgent(a)) {
+      virtual.push(agents[a].displayName);
+    } else if (isUniversalAgent(a)) {
       universal.push(agents[a].displayName);
     } else {
       symlinked.push(agents[a].displayName);
     }
   }
 
-  return { universal, symlinked };
+  return { universal, symlinked, virtual };
 }
 
 /**
@@ -255,7 +269,7 @@ function splitAgentsByType(agentTypes: AgentType[]): {
  */
 function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallMode): string[] {
   const lines: string[] = [];
-  const { universal, symlinked } = splitAgentsByType(targetAgents);
+  const { universal, symlinked, virtual } = splitAgentsByType(targetAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -265,9 +279,17 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
       lines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
     }
   } else {
-    // Copy mode - all agents get copies
-    const allNames = targetAgents.map((a) => agents[a].displayName);
-    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    // Copy mode - all filesystem agents get copies
+    const allNames = targetAgents
+      .filter((a) => !isVirtualAgent(a))
+      .map((a) => agents[a].displayName);
+    if (allNames.length > 0) {
+      lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    }
+  }
+
+  if (virtual.length > 0) {
+    lines.push(`  ${pc.dim('upload →')} ${formatList(virtual)}`);
   }
 
   return lines;
@@ -323,7 +345,7 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
   const lines: string[] = [];
   const rootAgents = targets.filter((t) => !t.subagent).map((t) => t.agent);
   const subagentNames = targets.filter((t) => t.subagent).map(targetDisplayName);
-  const { universal, symlinked } = splitAgentsByType(rootAgents);
+  const { universal, symlinked, virtual } = splitAgentsByType(rootAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -336,8 +358,14 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
       lines.push(`  ${pc.dim('copy →')} ${formatList(subagentNames)}`);
     }
   } else {
-    const allNames = targets.map(targetDisplayName);
-    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    const allNames = targets.filter((t) => !isVirtualAgent(t.agent)).map(targetDisplayName);
+    if (allNames.length > 0) {
+      lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    }
+  }
+
+  if (virtual.length > 0) {
+    lines.push(`  ${pc.dim('upload →')} ${formatList(virtual)}`);
   }
 
   return lines;
@@ -358,6 +386,96 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
   }
 
   return result;
+}
+
+/**
+ * Resolve Anthropic API credentials when any selected target is a virtual
+ * (API upload) agent. Prints guidance and returns null when no credential is
+ * available; callers should abort the install in that case.
+ */
+async function resolveManagedAgentsAuth(
+  targetAgents: AgentType[],
+  spinner: ReturnType<typeof p.spinner>
+): Promise<{ auth: AnthropicAuth | null; required: boolean }> {
+  if (!targetAgents.some((a) => isVirtualAgent(a))) {
+    return { auth: null, required: false };
+  }
+
+  spinner.start('Checking Anthropic credentials…');
+  const auth = await resolveAnthropicAuth();
+  if (!auth) {
+    spinner.stop(pc.red('No Anthropic credentials found'));
+    p.log.error('Claude Managed Agents requires Anthropic API credentials.');
+    p.log.message(pc.dim(`  ${MANAGED_AGENTS_AUTH_GUIDANCE}`));
+    return { auth: null, required: true };
+  }
+  spinner.stop(`Anthropic credentials: ${pc.cyan(auth.source)}`);
+  return { auth, required: true };
+}
+
+interface ManagedUploadOutcome {
+  skill: string;
+  success: boolean;
+  skillId?: string;
+  version?: string;
+  action?: 'created' | 'updated';
+  error?: string;
+}
+
+/**
+ * Upload skills to the Anthropic Skills API for the Claude Managed Agents
+ * target. Uploads happen one skill at a time; a failure on one skill doesn't
+ * stop the rest.
+ */
+async function uploadSkillsToManagedAgents(
+  skills: Array<{ name: string; files: SkillUploadFile[] }>,
+  auth: AnthropicAuth
+): Promise<ManagedUploadOutcome[]> {
+  const outcomes: ManagedUploadOutcome[] = [];
+  for (const skill of skills) {
+    try {
+      const result = await uploadSkillToManagedAgents(skill, auth);
+      outcomes.push({ skill: skill.name, success: true, ...result });
+    } catch (error) {
+      outcomes.push({
+        skill: skill.name,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+  return outcomes;
+}
+
+/**
+ * Render upload outcomes for the Claude Managed Agents target.
+ */
+function printManagedUploadOutcomes(outcomes: ManagedUploadOutcome[]): void {
+  if (outcomes.length === 0) return;
+
+  const successful = outcomes.filter((o) => o.success);
+  const failed = outcomes.filter((o) => !o.success);
+
+  if (successful.length > 0) {
+    const lines = successful.map((o) => {
+      const label = o.action === 'updated' ? 'new version' : 'created';
+      return `${pc.green('✓')} ${o.skill} ${pc.dim(`(${label}: ${o.skillId})`)}`;
+    });
+    p.note(
+      lines.join('\n'),
+      pc.green(
+        `Uploaded ${successful.length} skill${successful.length !== 1 ? 's' : ''} to Claude Managed Agents`
+      )
+    );
+  }
+
+  if (failed.length > 0) {
+    console.log();
+    p.log.error(pc.red(`Failed to upload ${failed.length} to Claude Managed Agents`));
+    for (const o of failed) {
+      p.log.message(`  ${pc.red('✗')} ${o.skill}: ${pc.dim(o.error)}`);
+    }
+  }
 }
 
 /**
@@ -475,8 +593,10 @@ export async function promptForAgents(
 async function selectAgentsInteractive(options: {
   global?: boolean;
 }): Promise<AgentType[] | symbol> {
-  // Filter out agents that don't support global installation when --global is used
-  const supportsGlobalFilter = (a: AgentType) => !options.global || agents[a].globalSkillsDir;
+  // Filter out agents that don't support global installation when --global is used.
+  // Virtual agents (API uploads) are scope-independent, so they always remain.
+  const supportsGlobalFilter = (a: AgentType) =>
+    !options.global || agents[a].globalSkillsDir || isVirtualAgent(a);
 
   const universalAgents = getUniversalAgents().filter(supportsGlobalFilter);
   const visibleUniversalAgents = getVisibleUniversalAgents().filter(supportsGlobalFilter);
@@ -498,7 +618,8 @@ async function selectAgentsInteractive(options: {
   const otherChoices = otherAgents.map((a) => ({
     value: a,
     label: agents[a].displayName,
-    hint: options.global ? agents[a].globalSkillsDir! : agents[a].skillsDir,
+    hint:
+      agents[a].installHint ?? (options.global ? agents[a].globalSkillsDir! : agents[a].skillsDir),
   }));
 
   // Get last selected agents (filter to only non-universal ones for initial selection)
@@ -671,8 +792,9 @@ async function handleWellKnownSkills(
   const validAgents = Object.keys(agents);
 
   if (options.agent?.includes('*')) {
-    // --agent '*' selects all agents
-    targetAgents = validAgents as AgentType[];
+    // --agent '*' selects all filesystem agents; virtual agents (API uploads)
+    // must be requested explicitly.
+    targetAgents = getWildcardAgents();
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -692,7 +814,8 @@ async function handleWellKnownSkills(
 
     if (installedAgents.length === 0) {
       if (options.yes) {
-        targetAgents = validAgents as AgentType[];
+        // Covers filesystem agents only; virtual agents need an explicit -a.
+        targetAgents = getWildcardAgents();
         p.log.info('Installing to all agents');
       } else {
         p.log.info('Select agents to install skills to');
@@ -738,6 +861,15 @@ async function handleWellKnownSkills(
     }
   }
 
+  // Resolve API credentials up front when Claude Managed Agents is targeted,
+  // so a missing login fails before anything is installed.
+  const { auth: managedAgentsAuth, required: managedAgentsRequired } =
+    await resolveManagedAgentsAuth(targetAgents, spinner);
+  if (managedAgentsRequired && !managedAgentsAuth) {
+    p.outro(pc.red('Installation failed'));
+    process.exit(1);
+  }
+
   let installGlobally = options.global ?? false;
 
   // Check if any selected agents support global installation
@@ -773,7 +905,10 @@ async function handleWellKnownSkills(
 
   // Only prompt for install mode when there are multiple unique target directories.
   // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-  const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+  // Virtual agents have no target directory and don't participate in the choice.
+  const uniqueDirs = new Set(
+    targetAgents.filter((a) => !isVirtualAgent(a)).map((a) => agents[a].skillsDir)
+  );
 
   if (!options.copy && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
@@ -823,12 +958,19 @@ async function handleWellKnownSkills(
     overwriteStatus.get(skillName)!.set(agent, installed);
   }
 
+  const allVirtualTargets = targetAgents.every((a) => isVirtualAgent(a));
+
   for (const skill of selectedSkills) {
     if (summaryLines.length > 0) summaryLines.push('');
 
-    const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
-    const shortCanonical = shortenPath(canonicalPath, cwd);
-    summaryLines.push(`${pc.cyan(shortCanonical)}`);
+    // API-only installs have no local path to show
+    if (allVirtualTargets) {
+      summaryLines.push(`${pc.cyan(skill.installName)}`);
+    } else {
+      const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
+      const shortCanonical = shortenPath(canonicalPath, cwd);
+      summaryLines.push(`${pc.cyan(shortCanonical)}`);
+    }
     summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
@@ -875,6 +1017,7 @@ async function handleWellKnownSkills(
 
   for (const skill of selectedSkills) {
     for (const agent of targetAgents) {
+      if (isVirtualAgent(agent)) continue;
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
@@ -885,6 +1028,17 @@ async function handleWellKnownSkills(
         ...result,
       });
     }
+  }
+
+  let uploadOutcomes: ManagedUploadOutcome[] = [];
+  if (managedAgentsAuth) {
+    uploadOutcomes = await uploadSkillsToManagedAgents(
+      selectedSkills.map((skill) => ({
+        name: skill.name,
+        files: Array.from(skill.files, ([path, content]) => ({ path, content })),
+      })),
+      managedAgentsAuth
+    );
   }
 
   spinner.stop('Installation complete');
@@ -1025,6 +1179,8 @@ async function handleWellKnownSkills(
       p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
     }
   }
+
+  printManagedUploadOutcomes(uploadOutcomes);
 
   console.log();
   p.outro(
@@ -1382,8 +1538,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const validAgents = Object.keys(agents);
 
     if (options.agent?.includes('*')) {
-      // --agent '*' selects all agents
-      targetAgents = validAgents as AgentType[];
+      // --agent '*' selects all filesystem agents; virtual agents (API
+      // uploads) must be requested explicitly.
+      targetAgents = getWildcardAgents();
       p.log.info(`Installing to all ${targetAgents.length} agents`);
     } else if (options.agent && options.agent.length > 0) {
       const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -1432,7 +1589,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
       } else if (installedAgents.length === 0) {
         if (options.yes) {
-          targetAgents = validAgents as AgentType[];
+          // Covers filesystem agents only; virtual agents need an explicit -a.
+          targetAgents = getWildcardAgents();
           p.log.info('Installing to all agents');
         } else {
           p.log.info('Select agents to install skills to');
@@ -1526,6 +1684,16 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    // Resolve API credentials up front when Claude Managed Agents is targeted,
+    // so a missing login fails before anything is installed.
+    const { auth: managedAgentsAuth, required: managedAgentsRequired } =
+      await resolveManagedAgentsAuth(targetAgents, spinner);
+    if (managedAgentsRequired && !managedAgentsAuth) {
+      await cleanup(tempDir);
+      p.outro(pc.red('Installation failed'));
+      process.exit(1);
+    }
+
     const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
 
     let installGlobally = options.global ?? false;
@@ -1568,9 +1736,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // never meaningful when every target is Eve.
     const allEve = installTargets.every((t) => t.agent === 'eve');
     const uniqueDirs = new Set(
-      installTargets.map((t) =>
-        t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir
-      )
+      installTargets
+        .filter((t) => !isVirtualAgent(t.agent))
+        .map((t) => (t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir))
     );
 
     if (!options.copy && !options.yes && uniqueDirs.size > 1 && !allEve) {
@@ -1640,20 +1808,26 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Helper to print summary lines for a list of skills
+    const allVirtualTargets = installTargets.every((t) => isVirtualAgent(t.agent));
     const printSkillSummary = (skills: Skill[]) => {
       for (const skill of skills) {
         if (summaryLines.length > 0) summaryLines.push('');
 
-        const canonicalPath =
-          installTargets.length === 1
-            ? getCanonicalPath(skill.name, {
-                global: installGlobally,
-                agent: installTargets[0]!.agent,
-                eveSubagent: installTargets[0]!.subagent,
-              })
-            : getCanonicalPath(skill.name, { global: installGlobally });
-        const shortCanonical = shortenPath(canonicalPath, cwd);
-        summaryLines.push(`${pc.cyan(shortCanonical)}`);
+        // API-only installs have no local path to show
+        if (allVirtualTargets) {
+          summaryLines.push(`${pc.cyan(getSkillDisplayName(skill))}`);
+        } else {
+          const canonicalPath =
+            installTargets.length === 1
+              ? getCanonicalPath(skill.name, {
+                  global: installGlobally,
+                  agent: installTargets[0]!.agent,
+                  eveSubagent: installTargets[0]!.subagent,
+                })
+              : getCanonicalPath(skill.name, { global: installGlobally });
+          const shortCanonical = shortenPath(canonicalPath, cwd);
+          summaryLines.push(`${pc.cyan(shortCanonical)}`);
+        }
         summaryLines.push(...buildTargetSummaryLines(installTargets, installMode));
 
         const skillOverwrites = overwriteStatus.get(skill.name);
@@ -1740,6 +1914,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     for (const skill of selectedSkills) {
       for (const target of installTargets) {
         const { agent, subagent } = target;
+        // Virtual agents are handled by the API upload pass below.
+        if (isVirtualAgent(agent)) continue;
         let result;
         if (blobResult && 'files' in skill) {
           // Blob-based install: write files from snapshot
@@ -1768,6 +1944,32 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           ...result,
         });
       }
+    }
+
+    // API upload pass for Claude Managed Agents.
+    const uploadOutcomes: ManagedUploadOutcome[] = [];
+    if (managedAgentsAuth) {
+      const uploads: Array<{ name: string; files: SkillUploadFile[] }> = [];
+      for (const skill of selectedSkills) {
+        try {
+          if (blobResult && 'files' in skill) {
+            const blobSkill = skill as BlobSkill;
+            uploads.push({
+              name: skill.name,
+              files: blobSkill.files.map((f) => ({ path: f.path, content: f.contents })),
+            });
+          } else {
+            uploads.push({ name: skill.name, files: await collectSkillFiles(skill.path) });
+          }
+        } catch (error) {
+          uploadOutcomes.push({
+            skill: skill.name,
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+      uploadOutcomes.push(...(await uploadSkillsToManagedAgents(uploads, managedAgentsAuth)));
     }
 
     spinner.stop('Installation complete');
@@ -2030,6 +2232,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
       }
     }
+
+    printManagedUploadOutcomes(uploadOutcomes);
 
     console.log();
     p.outro(

--- a/src/add.ts
+++ b/src/add.ts
@@ -389,6 +389,17 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
 }
 
 /**
+ * Expand `--agent '*'` to all filesystem agents, keeping any virtual agents
+ * the user listed explicitly alongside the wildcard.
+ */
+function expandWildcardAgents(requested: string[]): AgentType[] {
+  const explicitVirtual = requested.filter(
+    (a): a is AgentType => a !== '*' && a in agents && isVirtualAgent(a as AgentType)
+  );
+  return [...new Set([...getWildcardAgents(), ...explicitVirtual])];
+}
+
+/**
  * Resolve Anthropic API credentials when any selected target is a virtual
  * (API upload) agent. Prints guidance and returns null when no credential is
  * available; callers should abort the install in that case.
@@ -474,6 +485,11 @@ function printManagedUploadOutcomes(outcomes: ManagedUploadOutcome[]): void {
     p.log.error(pc.red(`Failed to upload ${failed.length} to Claude Managed Agents`));
     for (const o of failed) {
       p.log.message(`  ${pc.red('✗')} ${o.skill}: ${pc.dim(o.error)}`);
+    }
+    // The upload was explicitly requested; if nothing reached the API, make
+    // that visible to scripts via the exit code.
+    if (successful.length === 0) {
+      process.exitCode = 1;
     }
   }
 }
@@ -793,8 +809,8 @@ async function handleWellKnownSkills(
 
   if (options.agent?.includes('*')) {
     // --agent '*' selects all filesystem agents; virtual agents (API uploads)
-    // must be requested explicitly.
-    targetAgents = getWildcardAgents();
+    // are included only when listed explicitly alongside the wildcard.
+    targetAgents = expandWildcardAgents(options.agent);
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -1033,8 +1049,10 @@ async function handleWellKnownSkills(
   let uploadOutcomes: ManagedUploadOutcome[] = [];
   if (managedAgentsAuth) {
     uploadOutcomes = await uploadSkillsToManagedAgents(
+      // installName is the unique identifier for well-known skills; frontmatter
+      // names may collide across entries.
       selectedSkills.map((skill) => ({
-        name: skill.name,
+        name: skill.installName,
         files: Array.from(skill.files, ([path, content]) => ({ path, content })),
       })),
       managedAgentsAuth
@@ -1539,8 +1557,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     if (options.agent?.includes('*')) {
       // --agent '*' selects all filesystem agents; virtual agents (API
-      // uploads) must be requested explicitly.
-      targetAgents = getWildcardAgents();
+      // uploads) are included only when listed explicitly alongside the
+      // wildcard.
+      targetAgents = expandWildcardAgents(options.agent);
       p.log.info(`Installing to all ${targetAgents.length} agents`);
     } else if (options.agent && options.agent.length > 0) {
       const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -149,6 +149,19 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(claudeHome);
     },
   },
+  'claude-managed-agents': {
+    name: 'claude-managed-agents',
+    displayName: 'Claude Managed Agents',
+    // Placeholder path; never written to. Skills for this target are uploaded
+    // to the Anthropic Skills API (see managed-agents.ts).
+    skillsDir: '.claude-managed-agents/skills',
+    globalSkillsDir: undefined,
+    virtual: true,
+    installHint: 'Uploads to the Anthropic Skills API',
+    // Uploading to the user's Anthropic organization must be an explicit
+    // choice, so this target is never auto-detected.
+    detectInstalled: async () => false,
+  },
   openclaw: {
     name: 'openclaw',
     displayName: 'OpenClaw',
@@ -860,4 +873,20 @@ export function getNonUniversalAgents(): AgentType[] {
  */
 export function isUniversalAgent(type: AgentType): boolean {
   return agents[type].skillsDir === '.agents/skills';
+}
+
+/**
+ * Check if an agent is virtual (no filesystem skills directory; skills are
+ * delivered through a dedicated integration such as an API upload).
+ */
+export function isVirtualAgent(type: AgentType): boolean {
+  return agents[type].virtual === true;
+}
+
+/**
+ * Agent types that install to the filesystem. Virtual agents (API-backed
+ * targets) are excluded; they must be requested explicitly by name.
+ */
+export function getWildcardAgents(): AgentType[] {
+  return (Object.keys(agents) as AgentType[]).filter((type) => !isVirtualAgent(type));
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,6 +135,8 @@ ${BOLD}Project:${RESET}
 ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
+                         'claude-managed-agents' uploads to the Anthropic Skills API
+                         (requires \`ant auth login\` or ANTHROPIC_API_KEY)
   -s, --skill <skills>   Specify skill names to install (use '*' for all skills)
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -41,6 +41,16 @@ interface InstallResult {
   error?: string;
 }
 
+function virtualAgentInstallError(agentType: AgentType, mode?: InstallMode): InstallResult {
+  const agent = agents[agentType];
+  return {
+    success: false,
+    path: '',
+    mode: mode ?? 'symlink',
+    error: `${agent.displayName} skills are uploaded through the Anthropic API and cannot be installed to a directory`,
+  };
+}
+
 /**
  * Sanitizes a filename/directory name to prevent path traversal attacks
  * and ensures it follows kebab-case convention
@@ -271,6 +281,12 @@ export async function installSkillForAgent(
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const eveSubagent = options.eveSubagent;
+
+  // Virtual agents have no filesystem install; their skills are delivered
+  // through a dedicated integration (see managed-agents.ts).
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -624,6 +640,12 @@ export async function installRemoteSkillForAgent(
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
 
+  // Virtual agents have no filesystem install; their skills are delivered
+  // through a dedicated integration (see managed-agents.ts).
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
+
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {
@@ -764,6 +786,12 @@ export async function installWellKnownSkillForAgent(
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
+
+  // Virtual agents have no filesystem install; their skills are delivered
+  // through a dedicated integration (see managed-agents.ts).
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -910,6 +938,10 @@ export async function installBlobSkillForAgent(
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
+
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
 
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -436,8 +436,8 @@ export async function installSkillForAgent(
   }
 }
 
-const EXCLUDE_FILES = new Set(['metadata.json']);
-const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
+export const EXCLUDE_FILES = new Set(['metadata.json']);
+export const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 
 const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
   if (EXCLUDE_FILES.has(name)) return true;

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { readFile, readdir, stat } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
-import { sanitizeName } from './installer.ts';
+import { sanitizeName, EXCLUDE_FILES, EXCLUDE_DIRS } from './installer.ts';
 
 /**
  * Claude Managed Agents support.
@@ -26,6 +26,8 @@ import { sanitizeName } from './installer.ts';
 const SKILLS_BETA = 'skills-2025-10-02';
 const OAUTH_BETA = 'oauth-2025-04-20';
 const ANTHROPIC_VERSION = '2023-06-01';
+const FETCH_TIMEOUT_MS = 30000;
+const ANT_CLI_TIMEOUT_MS = 10000;
 
 export interface AnthropicAuth {
   /** Credential headers (x-api-key or Authorization, plus workspace binding). */
@@ -113,6 +115,9 @@ function readAntCliCredentials(): AnthropicAuth | null {
     const output = execFileSync('ant', ['auth', 'print-credentials'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      // Don't hang the CLI on an ant binary that prompts or stalls on a
+      // token refresh; the credentials-file fallback still gets a chance.
+      timeout: ANT_CLI_TIMEOUT_MS,
     });
     const credentials = JSON.parse(output) as AntCredentials;
     return authFromOAuthToken(credentials, 'ant CLI');
@@ -161,9 +166,6 @@ export interface SkillUploadFile {
   path: string;
   content: string | Uint8Array;
 }
-
-const EXCLUDE_FILES = new Set(['metadata.json']);
-const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 
 /**
  * Collect a skill directory's files for upload, applying the same exclusion
@@ -278,7 +280,10 @@ async function findSkillByDisplayTitle(
     const params = new URLSearchParams({ beta: 'true', source: 'custom', limit: '100' });
     if (afterId) params.set('after_id', afterId);
 
-    const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, { headers });
+    const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
       throw new ManagedAgentsApiError(
         response.status,
@@ -324,6 +329,7 @@ export async function uploadSkillToManagedAgents(
     method: 'POST',
     headers,
     body: buildSkillForm(directory, skill.name, skill.files),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   if (createResponse.ok) {
@@ -351,6 +357,7 @@ export async function uploadSkillToManagedAgents(
       method: 'POST',
       headers,
       body: buildSkillForm(directory, null, skill.files),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     }
   );
 

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -1,0 +1,367 @@
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { readFile, readdir, stat } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { sanitizeName } from './installer.ts';
+
+/**
+ * Claude Managed Agents support.
+ *
+ * Skills for the `claude-managed-agents` target are not copied to a directory;
+ * they are uploaded to the Anthropic Skills API, where they become available
+ * to the user's managed agents (and to the Messages API code-execution
+ * container). See https://platform.claude.com/docs/en/agents-and-tools/agent-skills
+ *
+ * Endpoints (beta `skills-2025-10-02`):
+ *   POST /v1/skills                     create a skill (multipart `files[]`)
+ *   GET  /v1/skills?source=custom       list custom skills
+ *   POST /v1/skills/{id}/versions       create a new version of a skill
+ *
+ * Each multipart file part is named `files[]` and its filename carries the
+ * skill-relative path prefixed with the skill directory name, e.g.
+ * `my-skill/SKILL.md`.
+ */
+
+const SKILLS_BETA = 'skills-2025-10-02';
+const OAUTH_BETA = 'oauth-2025-04-20';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+export interface AnthropicAuth {
+  /** Credential headers (x-api-key or Authorization, plus workspace binding). */
+  headers: Record<string, string>;
+  /** Extra anthropic-beta values required by this credential kind. */
+  betas: string[];
+  /** Where the credential came from, for user-facing messages. */
+  source: 'ANTHROPIC_API_KEY' | 'ANTHROPIC_AUTH_TOKEN' | 'ant CLI' | 'ant credentials file';
+}
+
+interface AntCredentials {
+  type?: string;
+  access_token?: string;
+  expires_at?: number;
+  workspace_id?: string;
+}
+
+function getAntConfigDir(): string {
+  const fromEnv = process.env.ANTHROPIC_CONFIG_DIR?.trim();
+  if (fromEnv) return fromEnv;
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  if (xdg) return join(xdg, 'anthropic');
+  return join(homedir(), '.config', 'anthropic');
+}
+
+function authFromOAuthToken(
+  credentials: AntCredentials,
+  source: AnthropicAuth['source']
+): AnthropicAuth | null {
+  if (!credentials.access_token) return null;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${credentials.access_token}`,
+  };
+  if (credentials.workspace_id) {
+    headers['anthropic-workspace-id'] = credentials.workspace_id;
+  }
+  return { headers, betas: [OAUTH_BETA], source };
+}
+
+/**
+ * Read credentials written by `ant auth login` directly from disk. Used only
+ * when the `ant` binary itself isn't available; unlike the CLI this cannot
+ * refresh expired tokens, so expired credentials are rejected.
+ */
+async function readAntCredentialsFile(): Promise<AnthropicAuth | null> {
+  try {
+    const configDir = getAntConfigDir();
+    let profile = process.env.ANTHROPIC_PROFILE?.trim();
+    if (!profile) {
+      const activeConfigPath = join(configDir, 'active_config');
+      profile = existsSync(activeConfigPath)
+        ? (await readFile(activeConfigPath, 'utf-8')).trim() || 'default'
+        : 'default';
+    }
+
+    const credentialsPath = join(configDir, 'credentials', `${profile}.json`);
+    const credentials = JSON.parse(await readFile(credentialsPath, 'utf-8')) as AntCredentials;
+
+    // `type` may be omitted by external writers, but anything else is not an
+    // OAuth token we know how to use.
+    if (credentials.type !== undefined && credentials.type !== 'oauth_token') {
+      return null;
+    }
+    // Leave a minute of headroom; without the ant binary we cannot refresh.
+    if (
+      typeof credentials.expires_at === 'number' &&
+      credentials.expires_at * 1000 < Date.now() + 60_000
+    ) {
+      return null;
+    }
+
+    return authFromOAuthToken(credentials, 'ant credentials file');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Shell out to `ant auth print-credentials`, which resolves the active
+ * profile and refreshes the OAuth access token if it is expired or close to
+ * expiry.
+ */
+function readAntCliCredentials(): AnthropicAuth | null {
+  try {
+    const output = execFileSync('ant', ['auth', 'print-credentials'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const credentials = JSON.parse(output) as AntCredentials;
+    return authFromOAuthToken(credentials, 'ant CLI');
+  } catch {
+    // ant not installed or not logged in
+    return null;
+  }
+}
+
+/**
+ * Resolve a credential for the Anthropic API, in the same precedence order
+ * the Anthropic CLI uses: explicit env vars first, then the ant CLI's stored
+ * (and auto-refreshed) OAuth credentials.
+ */
+export async function resolveAnthropicAuth(): Promise<AnthropicAuth | null> {
+  const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
+  if (apiKey) {
+    return { headers: { 'x-api-key': apiKey }, betas: [], source: 'ANTHROPIC_API_KEY' };
+  }
+
+  const authToken = process.env.ANTHROPIC_AUTH_TOKEN?.trim();
+  if (authToken) {
+    return {
+      headers: { Authorization: `Bearer ${authToken}` },
+      betas: [],
+      source: 'ANTHROPIC_AUTH_TOKEN',
+    };
+  }
+
+  const fromCli = readAntCliCredentials();
+  if (fromCli) return fromCli;
+
+  return readAntCredentialsFile();
+}
+
+export const MANAGED_AGENTS_AUTH_GUIDANCE =
+  'Log in with the Anthropic CLI (`ant auth login`) or set the ANTHROPIC_API_KEY environment variable.';
+
+function getApiBaseUrl(): string {
+  const base = process.env.ANTHROPIC_BASE_URL?.trim();
+  return (base || 'https://api.anthropic.com').replace(/\/+$/, '');
+}
+
+export interface SkillUploadFile {
+  /** Path relative to the skill directory, using forward slashes. */
+  path: string;
+  content: string | Uint8Array;
+}
+
+const EXCLUDE_FILES = new Set(['metadata.json']);
+const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
+
+/**
+ * Collect a skill directory's files for upload, applying the same exclusion
+ * rules as filesystem installs (see installer.ts copyDirectory).
+ */
+export async function collectSkillFiles(
+  skillDir: string,
+  relativeDir = ''
+): Promise<SkillUploadFile[]> {
+  const files: SkillUploadFile[] = [];
+  const entries = await readdir(skillDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = join(skillDir, entry.name);
+    const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+
+    let isDirectory = entry.isDirectory();
+    if (!isDirectory && entry.isSymbolicLink()) {
+      try {
+        isDirectory = (await stat(entryPath)).isDirectory();
+      } catch {
+        // Broken symlink — skip, matching copyDirectory behavior
+        continue;
+      }
+    }
+
+    if (isDirectory) {
+      if (EXCLUDE_DIRS.has(entry.name)) continue;
+      files.push(...(await collectSkillFiles(entryPath, relativePath)));
+    } else {
+      if (EXCLUDE_FILES.has(entry.name)) continue;
+      files.push({ path: relativePath, content: await readFile(entryPath) });
+    }
+  }
+
+  return files;
+}
+
+export class ManagedAgentsApiError extends Error {
+  status: number;
+  apiMessage: string;
+
+  constructor(status: number, apiMessage: string, context: string) {
+    super(`${context}: ${apiMessage} (HTTP ${status})`);
+    this.name = 'ManagedAgentsApiError';
+    this.status = status;
+    this.apiMessage = apiMessage;
+  }
+}
+
+async function readApiError(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: { message?: string } };
+    return body.error?.message || response.statusText;
+  } catch {
+    return response.statusText;
+  }
+}
+
+function buildHeaders(auth: AnthropicAuth): Record<string, string> {
+  return {
+    ...auth.headers,
+    'anthropic-version': ANTHROPIC_VERSION,
+    'anthropic-beta': [...auth.betas, SKILLS_BETA].join(','),
+  };
+}
+
+function buildSkillForm(directory: string, displayTitle: string | null, files: SkillUploadFile[]) {
+  const form = new FormData();
+  if (displayTitle !== null) {
+    form.append('display_title', displayTitle);
+  }
+  for (const file of files) {
+    // The multipart filename carries the file's path within the skill,
+    // prefixed with the skill's top-level directory name.
+    const content = typeof file.content === 'string' ? file.content : new Uint8Array(file.content);
+    form.append('files[]', new File([content], `${directory}/${file.path}`));
+  }
+  return form;
+}
+
+interface SkillResponse {
+  id: string;
+  display_title: string | null;
+  latest_version: string | null;
+}
+
+interface SkillVersionResponse {
+  skill_id: string;
+  version: string;
+}
+
+interface SkillListResponse {
+  data: SkillResponse[];
+  has_more: boolean;
+  last_id: string | null;
+}
+
+/**
+ * Find an existing custom skill by display title. Used to upgrade a create
+ * into a new-version upload when the skill already exists.
+ */
+async function findSkillByDisplayTitle(
+  displayTitle: string,
+  auth: AnthropicAuth
+): Promise<SkillResponse | null> {
+  const headers = buildHeaders(auth);
+  let afterId: string | null = null;
+
+  // Paginate defensively; orgs can accumulate many custom skills.
+  for (let page = 0; page < 20; page++) {
+    const params = new URLSearchParams({ beta: 'true', source: 'custom', limit: '100' });
+    if (afterId) params.set('after_id', afterId);
+
+    const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, { headers });
+    if (!response.ok) {
+      throw new ManagedAgentsApiError(
+        response.status,
+        await readApiError(response),
+        'Failed to list skills'
+      );
+    }
+
+    const body = (await response.json()) as SkillListResponse;
+    const match = body.data.find((skill) => skill.display_title === displayTitle);
+    if (match) return match;
+    if (!body.has_more || !body.last_id) return null;
+    afterId = body.last_id;
+  }
+
+  return null;
+}
+
+export interface ManagedSkillUploadResult {
+  skillId: string;
+  version: string;
+  action: 'created' | 'updated';
+}
+
+/**
+ * Upload a skill to the Anthropic Skills API. Creates the skill if it doesn't
+ * exist; if a skill with the same display title already exists, uploads the
+ * files as a new version of that skill instead.
+ */
+export async function uploadSkillToManagedAgents(
+  skill: { name: string; files: SkillUploadFile[] },
+  auth: AnthropicAuth
+): Promise<ManagedSkillUploadResult> {
+  if (!skill.files.some((file) => file.path === 'SKILL.md')) {
+    throw new Error('Skill is missing a SKILL.md at its root');
+  }
+
+  const directory = sanitizeName(skill.name);
+  const headers = buildHeaders(auth);
+  const baseUrl = getApiBaseUrl();
+
+  const createResponse = await fetch(`${baseUrl}/v1/skills?beta=true`, {
+    method: 'POST',
+    headers,
+    body: buildSkillForm(directory, skill.name, skill.files),
+  });
+
+  if (createResponse.ok) {
+    const created = (await createResponse.json()) as SkillResponse;
+    return { skillId: created.id, version: created.latest_version ?? 'latest', action: 'created' };
+  }
+
+  const createError = await readApiError(createResponse);
+  const isDisplayTitleConflict =
+    createResponse.status === 400 && /display_title/i.test(createError);
+
+  if (!isDisplayTitleConflict) {
+    throw new ManagedAgentsApiError(createResponse.status, createError, 'Failed to create skill');
+  }
+
+  // A skill with this display title already exists — upload a new version.
+  const existing = await findSkillByDisplayTitle(skill.name, auth);
+  if (!existing) {
+    throw new ManagedAgentsApiError(createResponse.status, createError, 'Failed to create skill');
+  }
+
+  const versionResponse = await fetch(
+    `${baseUrl}/v1/skills/${encodeURIComponent(existing.id)}/versions?beta=true`,
+    {
+      method: 'POST',
+      headers,
+      body: buildSkillForm(directory, null, skill.files),
+    }
+  );
+
+  if (!versionResponse.ok) {
+    throw new ManagedAgentsApiError(
+      versionResponse.status,
+      await readApiError(versionResponse),
+      'Failed to create skill version'
+    );
+  }
+
+  const version = (await versionResponse.json()) as SkillVersionResponse;
+  return { skillId: version.skill_id, version: version.version, action: 'updated' };
+}

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
-import { agents, detectInstalledAgents, getEveSubagents } from './agents.ts';
+import { agents, detectInstalledAgents, getEveSubagents, isVirtualAgent } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
@@ -178,6 +178,21 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   let targetAgents: AgentType[];
   if (options.agent && options.agent.length > 0) {
     targetAgents = options.agent as AgentType[];
+
+    // Virtual agents have no local files; their skills live in the user's
+    // Anthropic organization and are not deleted by this command. Say so
+    // instead of reporting a successful no-op removal.
+    const virtualRequested = targetAgents.filter((a) => isVirtualAgent(a));
+    if (virtualRequested.length > 0) {
+      targetAgents = targetAgents.filter((a) => !isVirtualAgent(a));
+      p.log.warn(
+        `${virtualRequested.map((a) => agents[a].displayName).join(', ')} skills are managed through the Anthropic API and are not removed by this command.`
+      );
+      if (targetAgents.length === 0) {
+        p.outro(pc.yellow('Nothing to remove.'));
+        return;
+      }
+    }
   } else {
     // When removing, we should target all known agents to ensure
     // ghost symlinks are cleaned up, even if the agent is not detected.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -243,6 +243,13 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
       p.log.info(`Valid agents: ${validAgents.join(', ')}`);
       process.exit(1);
     }
+    const virtualRequested = options.agent.filter((a) => isVirtualAgent(a as AgentType));
+    if (virtualRequested.length > 0) {
+      p.log.error(
+        `${virtualRequested.join(', ')} is not supported by experimental_sync; use \`skills add\` to upload skills`
+      );
+      process.exit(1);
+    }
     targetAgents = options.agent as AgentType[];
   } else {
     spinner.start('Loading agents…');

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -11,6 +11,8 @@ import {
   getUniversalAgents,
   getVisibleUniversalAgents,
   getNonUniversalAgents,
+  getWildcardAgents,
+  isVirtualAgent,
 } from './agents.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
@@ -231,7 +233,8 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   const visibleUniversalAgents = getVisibleUniversalAgents();
 
   if (options.agent?.includes('*')) {
-    targetAgents = validAgents as AgentType[];
+    // Covers filesystem agents only; virtual agents need an explicit -a.
+    targetAgents = getWildcardAgents();
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -252,7 +255,8 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         targetAgents = universalAgents;
         p.log.info('Installing to universal agents');
       } else {
-        const otherAgents = getNonUniversalAgents();
+        // Virtual agents (API uploads) aren't sync targets.
+        const otherAgents = getNonUniversalAgents().filter((a) => !isVirtualAgent(a));
 
         const otherChoices = otherAgents.map((a) => ({
           value: a,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type AgentType =
   | 'augment'
   | 'bob'
   | 'claude-code'
+  | 'claude-managed-agents'
   | 'openclaw'
   | 'cline'
   | 'codearts-agent'
@@ -98,6 +99,15 @@ export interface AgentConfig {
   showInUniversalList?: boolean;
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
+  /**
+   * Virtual agents have no filesystem skills directory; skills are delivered
+   * through a dedicated integration (e.g. an API upload) instead of a copy or
+   * symlink. Virtual agents are never auto-detected, are excluded from
+   * `--agent '*'` expansion, and must be selected explicitly.
+   */
+  virtual?: boolean;
+  /** Hint shown in interactive agent selection instead of a skills directory. */
+  installHint?: string;
 }
 
 export interface ParsedSource {

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => {
+      throw new Error('ant not installed');
+    }),
+  };
+});
+
+import { execFileSync } from 'child_process';
+import {
+  resolveAnthropicAuth,
+  collectSkillFiles,
+  uploadSkillToManagedAgents,
+  ManagedAgentsApiError,
+  type AnthropicAuth,
+} from '../src/managed-agents.ts';
+import { agents, getWildcardAgents, isVirtualAgent } from '../src/agents.ts';
+
+const API_KEY_AUTH: AnthropicAuth = {
+  headers: { 'x-api-key': 'sk-ant-test' },
+  betas: [],
+  source: 'ANTHROPIC_API_KEY',
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('claude-managed-agents agent registry entry', () => {
+  it('is registered as a virtual agent', () => {
+    expect(agents['claude-managed-agents']).toBeDefined();
+    expect(isVirtualAgent('claude-managed-agents')).toBe(true);
+  });
+
+  it('is never auto-detected', async () => {
+    expect(await agents['claude-managed-agents'].detectInstalled()).toBe(false);
+  });
+
+  it('is excluded from wildcard agent expansion', () => {
+    const wildcard = getWildcardAgents();
+    expect(wildcard).not.toContain('claude-managed-agents');
+    expect(wildcard).toContain('claude-code');
+  });
+});
+
+describe('resolveAnthropicAuth', () => {
+  beforeEach(() => {
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    vi.stubEnv('ANTHROPIC_AUTH_TOKEN', '');
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', '/nonexistent-config-dir');
+    vi.stubEnv('ANTHROPIC_PROFILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('ant not installed');
+    });
+  });
+
+  it('prefers ANTHROPIC_API_KEY and maps it to x-api-key', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-abc');
+    const auth = await resolveAnthropicAuth();
+    expect(auth).toEqual({
+      headers: { 'x-api-key': 'sk-ant-abc' },
+      betas: [],
+      source: 'ANTHROPIC_API_KEY',
+    });
+  });
+
+  it('uses ANTHROPIC_AUTH_TOKEN as a bearer token', async () => {
+    vi.stubEnv('ANTHROPIC_AUTH_TOKEN', 'tok-123');
+    const auth = await resolveAnthropicAuth();
+    expect(auth?.headers.Authorization).toBe('Bearer tok-123');
+    expect(auth?.source).toBe('ANTHROPIC_AUTH_TOKEN');
+  });
+
+  it('uses the ant CLI credentials when available', async () => {
+    vi.mocked(execFileSync).mockReturnValue(
+      JSON.stringify({
+        type: 'oauth_token',
+        access_token: 'oauth-token-xyz',
+        workspace_id: 'wrkspc_123',
+      })
+    );
+
+    const auth = await resolveAnthropicAuth();
+    expect(auth?.headers.Authorization).toBe('Bearer oauth-token-xyz');
+    expect(auth?.headers['anthropic-workspace-id']).toBe('wrkspc_123');
+    expect(auth?.betas).toContain('oauth-2025-04-20');
+    expect(auth?.source).toBe('ant CLI');
+  });
+
+  it('falls back to reading the credentials file when ant is unavailable', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'ant-config-'));
+    try {
+      await mkdir(join(configDir, 'credentials'), { recursive: true });
+      await writeFile(join(configDir, 'active_config'), 'work\n');
+      await writeFile(
+        join(configDir, 'credentials', 'work.json'),
+        JSON.stringify({
+          type: 'oauth_token',
+          access_token: 'file-token',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          workspace_id: 'wrkspc_456',
+        })
+      );
+      vi.stubEnv('ANTHROPIC_CONFIG_DIR', configDir);
+
+      const auth = await resolveAnthropicAuth();
+      expect(auth?.headers.Authorization).toBe('Bearer file-token');
+      expect(auth?.headers['anthropic-workspace-id']).toBe('wrkspc_456');
+      expect(auth?.source).toBe('ant credentials file');
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects expired credentials from the file fallback', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'ant-config-'));
+    try {
+      await mkdir(join(configDir, 'credentials'), { recursive: true });
+      await writeFile(join(configDir, 'active_config'), 'default');
+      await writeFile(
+        join(configDir, 'credentials', 'default.json'),
+        JSON.stringify({
+          type: 'oauth_token',
+          access_token: 'stale-token',
+          expires_at: Math.floor(Date.now() / 1000) - 10,
+        })
+      );
+      vi.stubEnv('ANTHROPIC_CONFIG_DIR', configDir);
+
+      expect(await resolveAnthropicAuth()).toBeNull();
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when no credential source is available', async () => {
+    expect(await resolveAnthropicAuth()).toBeNull();
+  });
+});
+
+describe('collectSkillFiles', () => {
+  it('collects files recursively and applies install exclusions', async () => {
+    const skillDir = await mkdtemp(join(tmpdir(), 'skill-'));
+    try {
+      await writeFile(join(skillDir, 'SKILL.md'), '# skill');
+      await writeFile(join(skillDir, 'metadata.json'), '{}');
+      await mkdir(join(skillDir, 'scripts'));
+      await writeFile(join(skillDir, 'scripts', 'run.py'), 'print(1)');
+      await mkdir(join(skillDir, '.git'));
+      await writeFile(join(skillDir, '.git', 'HEAD'), 'ref');
+
+      const files = await collectSkillFiles(skillDir);
+      const paths = files.map((f) => f.path).sort();
+      expect(paths).toEqual(['SKILL.md', 'scripts/run.py']);
+    } finally {
+      await rm(skillDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('uploadSkillToManagedAgents', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects skills without a root SKILL.md', async () => {
+    await expect(
+      uploadSkillToManagedAgents(
+        { name: 'my-skill', files: [{ path: 'docs/README.md', content: 'x' }] },
+        API_KEY_AUTH
+      )
+    ).rejects.toThrow('missing a SKILL.md');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('creates a skill with a multipart form of dir-prefixed files', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { id: 'skill_01A', display_title: 'My Skill', latest_version: '123' })
+    );
+
+    const result = await uploadSkillToManagedAgents(
+      {
+        name: 'My Skill',
+        files: [
+          { path: 'SKILL.md', content: '# hi' },
+          { path: 'scripts/run.py', content: 'print(1)' },
+        ],
+      },
+      API_KEY_AUTH
+    );
+
+    expect(result).toEqual({ skillId: 'skill_01A', version: '123', action: 'created' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.anthropic.com/v1/skills?beta=true');
+    expect(init?.method).toBe('POST');
+
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-test');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['anthropic-beta']).toBe('skills-2025-10-02');
+
+    const form = init?.body as FormData;
+    expect(form.get('display_title')).toBe('My Skill');
+    const files = form.getAll('files[]') as File[];
+    // Directory name is the sanitized skill name
+    expect(files.map((f) => f.name).sort()).toEqual([
+      'my-skill/SKILL.md',
+      'my-skill/scripts/run.py',
+    ]);
+  });
+
+  it('appends the skills beta to auth-required betas', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { id: 'skill_01A', display_title: null, latest_version: '1' })
+    );
+
+    await uploadSkillToManagedAgents(
+      { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      {
+        headers: { Authorization: 'Bearer t' },
+        betas: ['oauth-2025-04-20'],
+        source: 'ant CLI',
+      }
+    );
+
+    const headers = fetchMock.mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20,skills-2025-10-02');
+  });
+
+  it('uploads a new version when the display title already exists', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(400, {
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: 'Skill cannot reuse an existing display_title: My Skill',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          data: [
+            { id: 'skill_00Z', display_title: 'Other', latest_version: '1' },
+            { id: 'skill_01A', display_title: 'My Skill', latest_version: '1' },
+          ],
+          has_more: false,
+          last_id: 'skill_01A',
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { skill_id: 'skill_01A', version: '456' }));
+
+    const result = await uploadSkillToManagedAgents(
+      { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      API_KEY_AUTH
+    );
+
+    expect(result).toEqual({ skillId: 'skill_01A', version: '456', action: 'updated' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const listUrl = String(fetchMock.mock.calls[1]![0]);
+    expect(listUrl).toContain('/v1/skills?');
+    expect(listUrl).toContain('source=custom');
+    const versionUrl = String(fetchMock.mock.calls[2]![0]);
+    expect(versionUrl).toBe('https://api.anthropic.com/v1/skills/skill_01A/versions?beta=true');
+
+    // Version uploads carry no display_title
+    const versionForm = fetchMock.mock.calls[2]![1]?.body as FormData;
+    expect(versionForm.get('display_title')).toBeNull();
+  });
+
+  it('throws a ManagedAgentsApiError on other API failures', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(401, {
+        type: 'error',
+        error: { type: 'authentication_error', message: 'invalid x-api-key' },
+      })
+    );
+
+    await expect(
+      uploadSkillToManagedAgents(
+        { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+        API_KEY_AUTH
+      )
+    ).rejects.toThrow(ManagedAgentsApiError);
+  });
+
+  it('honors ANTHROPIC_BASE_URL', async () => {
+    vi.stubEnv('ANTHROPIC_BASE_URL', 'https://api.staging.example/');
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { id: 'skill_01A', display_title: null, latest_version: '1' })
+    );
+
+    await uploadSkillToManagedAgents(
+      { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      API_KEY_AUTH
+    );
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      'https://api.staging.example/v1/skills?beta=true'
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a `claude-managed-agents` agent target that uploads skills to the [Anthropic Skills API](https://platform.claude.com/docs/en/agents-and-tools/agent-skills) instead of copying them to a directory:

```bash
npx skills add vercel-labs/agent-skills --agent claude-managed-agents
```

Each selected skill is uploaded as a custom skill in the user's Anthropic organization, where it can be attached to [Claude managed agents](https://platform.claude.com/docs/en/agents-and-tools/managed-agents) (`skills: [{ skill_id, type: "custom" }]`) and the Messages API code-execution container.

## How

- Introduces a **virtual agent** concept in the agent registry: no filesystem skills directory; `skills add` runs an API upload pass for these targets instead of the copy/symlink installers (which now hard-reject virtual agents as defense in depth). Supported in both the git/local flow and the well-known flow.
- **Credentials** resolve in the same order the Anthropic CLI uses: `ANTHROPIC_API_KEY` (x-api-key), `ANTHROPIC_AUTH_TOKEN` (bearer), `ant auth print-credentials` (stored OAuth login, auto-refreshes, adds the `oauth-2025-04-20` beta and workspace header), then the `~/.config/anthropic` credentials file as a last resort when `ant` isn't installed (expired tokens rejected). Missing credentials fail fast with guidance before anything installs. `ANTHROPIC_BASE_URL` is honored.
- **Upsert semantics**: create via multipart `POST /v1/skills`; when the API reports the display title already exists, the CLI finds the existing skill (`GET /v1/skills?source=custom`, paginated) and uploads the files as a new version (`POST /v1/skills/{id}/versions`). So re-adding a skill updates it instead of failing.
- **Safety**: the target is never auto-detected and is excluded from `--agent '*'` / `--all`, so bulk installs can't upload to an Anthropic org by accident; it must be listed explicitly (including next to `'*'`, where it is honored) or picked interactively. `experimental_sync` rejects it with a clear error; `remove` warns that org skills aren't deleted locally. All uploads-failed exits nonzero. API fetches have 30s timeouts, the `ant` shell-out 10s.

## Testing

- 16 unit tests (`tests/managed-agents.test.ts`): credential precedence and file fallback (including expiry), upload multipart shape (dir-prefixed `files[]` filenames, beta headers), display-title-conflict → new-version flow, error handling, base URL override, wildcard exclusion.
- Verified end to end against the live API: create, re-add → new version, mixed filesystem + API install, missing-credentials failure, invalid-key failure (exit 1), `--agent '*' claude-managed-agents`, `experimental_sync`/`remove` guards.