### PR TITLE
Add SentinelDesk to the agent list

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -619,6 +619,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.roo'));
     },
   },
+  sentineldesk: {
+    name: 'sentineldesk',
+    displayName: 'SentinelDesk',
+    skillsDir: '.sentineldesk/skills',
+    globalSkillsDir: join(home, '.sentineldesk/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.sentineldesk'));
+    },
+  },
   'tabnine-cli': {
     name: 'tabnine-cli',
     displayName: 'Tabnine CLI',

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export type AgentType =
   | 'reasonix'
   | 'roo'
   | 'rovodev'
+  | 'sentineldesk'
   | 'tabnine-cli'
   | 'terramind'
   | 'tinycloud'


### PR DESCRIPTION
SentinelDesk is an agent runtime that drives a full Linux desktop over MCP — the desktop runs in a container and is shared with people over WebRTC, and the agent works the same screen through an MCP socket.

It already reads the Agent Skills layout: `.sentineldesk/skills` plus the compatible `.claude`, `.agents` and `.opencode` project directories and their home-directory equivalents, walking up to the git worktree root. So a skill installed with this CLI works there today — this entry just lets it be installed under its own name rather than as `universal`.

Paths follow the same shape as the neighbouring entries:

| | |
|---|---|
| project | `.sentineldesk/skills` |
| global | `~/.sentineldesk/skills` |
| detect | `~/.sentineldesk` exists |

`~/.sentineldesk` is where the runtime already keeps its configuration, so detection matches an install that has actually been used.

### Verified

Installed through the patched CLI:

```
skills add vercel-labs/skills --skill find-skills --agent sentineldesk
→ ./.sentineldesk/skills/find-skills
```

and the runtime picks it up:

```
$ sentineldesk-agent skills
find-skills  (project)
  Helps users discover and install agent skills…
  ./.sentineldesk/skills/find-skills/SKILL.md
```

`tsc --noEmit` and `prettier --check` are clean.

One thing worth flagging so it is not mistaken for this change: `vitest run` fails identically with and without the patch on my machine — 125 failed / 626 passed either way, on Node 22.12 against the `>=22.20` the package asks for. I did not investigate further since the numbers match exactly on a clean checkout.

Project: https://github.com/lordbasex/sentineldesk