### PR TITLE
fix: exclude internal skills from --skill '*' wildcard

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -441,6 +441,78 @@ metadata:
       const result = runCli(['add', testDir, '--list'], testDir);
       expect(result.stdout).toContain('not-internal-skill');
     });
+
+    it('should not include internal skills for the --skill wildcard', () => {
+      const internalDir = join(testDir, 'skills', 'internal-skill');
+      const publicDir = join(testDir, 'skills', 'public-skill');
+      mkdirSync(internalDir, { recursive: true });
+      mkdirSync(publicDir, { recursive: true });
+
+      writeFileSync(
+        join(internalDir, 'SKILL.md'),
+        `---
+name: internal-skill
+description: An internal skill
+metadata:
+  internal: true
+---
+# Internal Skill
+`
+      );
+      writeFileSync(
+        join(publicDir, 'SKILL.md'),
+        `---
+name: public-skill
+description: A public skill
+---
+# Public Skill
+`
+      );
+
+      const result = runCli(['add', testDir, '--skill', '*', '--list'], testDir);
+      expect(result.stdout).toContain('public-skill');
+      expect(result.stdout).not.toContain('internal-skill');
+    });
+
+    it('should include internal skills when explicitly requested by name', () => {
+      const internalDir = join(testDir, 'skills', 'internal-skill');
+      mkdirSync(internalDir, { recursive: true });
+      writeFileSync(
+        join(internalDir, 'SKILL.md'),
+        `---
+name: internal-skill
+description: An internal skill
+metadata:
+  internal: true
+---
+# Internal Skill
+`
+      );
+
+      const result = runCli(['add', testDir, '--skill', 'internal-skill', '--list'], testDir);
+      expect(result.stdout).toContain('internal-skill');
+    });
+
+    it('should include internal skills for the wildcard when INSTALL_INTERNAL_SKILLS=1', () => {
+      const internalDir = join(testDir, 'skills', 'internal-skill');
+      mkdirSync(internalDir, { recursive: true });
+      writeFileSync(
+        join(internalDir, 'SKILL.md'),
+        `---
+name: internal-skill
+description: An internal skill
+metadata:
+  internal: true
+---
+# Internal Skill
+`
+      );
+
+      const result = runCli(['add', testDir, '--skill', '*', '--list'], testDir, {
+        INSTALL_INTERNAL_SKILLS: '1',
+      });
+      expect(result.stdout).toContain('internal-skill');
+    });
   });
 });
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -1143,8 +1143,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Include internal skills when a specific skill is explicitly requested
-    // (via --skill or @skill syntax)
-    const includeInternal = !!(options.skill && options.skill.length > 0);
+    // (via --skill or @skill syntax). The '*' wildcard is a bulk request, not
+    // an explicit one, so internal skills stay hidden from it unless
+    // INSTALL_INTERNAL_SKILLS is set.
+    const includeInternal = !!(
+      options.skill &&
+      options.skill.length > 0 &&
+      !options.skill.includes('*')
+    );
 
     let skills: Skill[];
     let blobResult: BlobInstallResult | null = null;


### PR DESCRIPTION
## Problem

`skills add <repo> --skill '*'` (and its `--all` shorthand) installs skills marked `metadata.internal: true`, even though the README documents internal skills as "only visible and installable when `INSTALL_INTERNAL_SKILLS=1` is set".

The cause is in `src/add.ts` — `includeInternal` is enabled whenever `--skill` is present, and the `'*'` wildcard flows through the same branch as explicitly named skills:

```ts
const includeInternal = !!(options.skill && options.skill.length > 0);
```

Repro (list mode reflects the same discovery result):

- `skills add <repo> --list` → internal skill hidden ✅
- `skills add <repo> --skill '*' --list` → internal skill listed ❌

## Fix

Treat the wildcard as a bulk request rather than an explicit one, so it no longer sets `includeInternal`:

- `--skill '*'` / `--all` → internal skills excluded
- `--skill <name>` → an explicitly named internal skill still installs (unchanged)
- `INSTALL_INTERNAL_SKILLS=1` → still includes internal skills everywhere (unchanged)

## Tests

Three cases added to the `internal skills` block in `src/add.test.ts`: wildcard excludes internal, explicit name includes it, and env var + wildcard includes it. `vitest run src/add.test.ts` passes 50/50; `tsc --noEmit` and Prettier are clean.

Modified and maintained by initred <initred@gmail.com>