### PR TITLE
fix: protect existing skills during add

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, stripAnsi } from './test-utils.ts';
@@ -99,6 +107,40 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('refuses non-TTY overwrites and preserves an existing symlink', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'theme-factory');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: theme-factory
+description: Incoming skill
+---
+
+# Incoming Skill
+`
+    );
+
+    const isolatedHome = join(testDir, 'home');
+    const userSkillDir = join(isolatedHome, 'user-skills', 'theme-factory');
+    const agentSkillDir = join(isolatedHome, '.claude', 'skills', 'theme-factory');
+    mkdirSync(userSkillDir, { recursive: true });
+    writeFileSync(join(userSkillDir, 'SKILL.md'), '# User-owned skill\n');
+    mkdirSync(join(isolatedHome, '.claude', 'skills'), { recursive: true });
+    symlinkSync(userSkillDir, agentSkillDir);
+
+    const result = runCli(['add', sourceDir, '--global', '--agent', 'claude-code'], testDir, {
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('Re-run with -y/--yes or --force');
+    expect(lstatSync(agentSkillDir).isSymbolicLink()).toBe(true);
+    expect(readFileSync(join(userSkillDir, 'SKILL.md'), 'utf8')).toContain('User-owned skill');
   });
 
   it('deduplicates copied install paths for universal agents sharing the same directory', () => {
@@ -582,6 +624,12 @@ describe('parseAddOptions', () => {
     expect(result.options.global).toBe(true);
     expect(result.options.skill).toEqual(['*']);
     expect(result.options.yes).toBe(true);
+  });
+
+  it('should parse --force flag', () => {
+    const result = parseAddOptions(['source', '--force']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.force).toBe(true);
   });
 
   it('should parse --full-depth flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -541,6 +541,10 @@ export interface AddOptions {
   global?: boolean;
   agent?: string[];
   yes?: boolean;
+  /** Overwrite existing same-name skills without prompting about the conflict. */
+  force?: boolean;
+  /** @internal Whether overwrite consent was supplied before agent auto-detection. */
+  explicitOverwrite?: boolean;
   skill?: string[];
   /** Valid JSON to attach to the install telemetry event. */
   metadata?: string;
@@ -553,6 +557,76 @@ export interface AddOptions {
    * selects the root agent. Implies installing for Eve.
    */
   subagent?: string[];
+}
+
+interface OverwriteConflict {
+  skillName: string;
+  targetKey: string;
+  targetLabel: string;
+}
+
+/**
+ * Resolve existing install destinations before any installer can remove them.
+ * In a non-TTY, an implicit agent-mode `yes` is not enough: callers must pass
+ * `-y` or `--force` explicitly so a user's symlink or directory is never
+ * replaced accidentally.
+ */
+async function resolveOverwriteConflicts(
+  conflicts: OverwriteConflict[],
+  options: { explicitOverwrite: boolean }
+): Promise<Set<string>> {
+  const uniqueConflicts = new Map<string, OverwriteConflict>();
+  for (const conflict of conflicts) {
+    uniqueConflicts.set(`${conflict.skillName}\0${conflict.targetKey}`, conflict);
+  }
+
+  if (uniqueConflicts.size === 0 || options.explicitOverwrite) {
+    return new Set();
+  }
+
+  const conflictList = [...uniqueConflicts.values()];
+  const display = conflictList
+    .map((conflict) => `${conflict.skillName} → ${conflict.targetLabel}`)
+    .join(', ');
+
+  if (!process.stdin.isTTY) {
+    p.log.error(
+      `Existing skill${conflictList.length === 1 ? '' : 's'} found (${display}). ` +
+        'Re-run with -y/--yes or --force to explicitly overwrite.'
+    );
+    process.exit(1);
+  }
+
+  const choice = await p.select({
+    message: `Existing skill${conflictList.length === 1 ? '' : 's'} found. What should happen?`,
+    options: [
+      {
+        value: 'keep',
+        label: 'Keep existing',
+        hint: 'Skip only the conflicting destinations',
+      },
+      {
+        value: 'overwrite',
+        label: 'Overwrite',
+        hint: 'Replace the existing skill after confirmation',
+      },
+      { value: 'cancel', label: 'Cancel', hint: 'Do not install any skills' },
+    ],
+  });
+
+  if (p.isCancel(choice) || choice === 'cancel') {
+    p.cancel('Installation cancelled');
+    process.exit(0);
+  }
+
+  if (choice === 'keep') {
+    p.log.info(
+      `Keeping ${conflictList.length} existing skill destination${conflictList.length === 1 ? '' : 's'}.`
+    );
+    return new Set(conflictList.map((conflict) => `${conflict.skillName}\0${conflict.targetKey}`));
+  }
+
+  return new Set();
 }
 
 /**
@@ -847,6 +921,17 @@ async function handleWellKnownSkills(
   console.log();
   p.note(summaryLines.join('\n'), 'Installation Summary');
 
+  const skipConflicts = await resolveOverwriteConflicts(
+    overwriteChecks
+      .filter(({ installed }) => installed)
+      .map(({ skillName, agent }) => ({
+        skillName,
+        targetKey: agent,
+        targetLabel: agents[agent].displayName,
+      })),
+    { explicitOverwrite: options.explicitOverwrite ?? options.force === true }
+  );
+
   if (!options.yes) {
     const confirmed = await p.confirm({ message: 'Proceed with installation?' });
 
@@ -875,6 +960,7 @@ async function handleWellKnownSkills(
 
   for (const skill of selectedSkills) {
     for (const agent of targetAgents) {
+      if (skipConflicts.has(`${skill.installName}\0${agent}`)) continue;
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
@@ -1069,6 +1155,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     options.agent = ['*'];
     options.yes = true;
   }
+
+  // Capture explicit consent before agent detection can enable `yes` implicitly.
+  options.explicitOverwrite ??=
+    options.yes === true || options.force === true || options.all === true;
 
   // Auto-enable non-interactive mode when running inside an AI agent
   const agentResult = await detectAgent();
@@ -1697,6 +1787,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     console.log();
     p.note(summaryLines.join('\n'), 'Installation Summary');
 
+    const skipConflicts = await resolveOverwriteConflicts(
+      overwriteChecks
+        .filter(({ installed }) => installed)
+        .map(({ skillName, target }) => ({
+          skillName,
+          targetKey: targetKey(target),
+          targetLabel: targetDisplayName(target),
+        })),
+      { explicitOverwrite: options.explicitOverwrite === true }
+    );
+
     // Await and display security audit results (started earlier in parallel)
     // Wrapped in try/catch so a failed audit fetch never blocks installation.
     try {
@@ -1744,6 +1845,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     for (const skill of selectedSkills) {
       for (const target of installTargets) {
+        if (skipConflicts.has(`${skill.name}\0${targetKey(target)}`)) continue;
         const { agent, subagent } = target;
         let result;
         if (blobResult && 'files' in skill) {
@@ -2165,6 +2267,8 @@ export function parseAddOptions(args: string[]): {
       options.global = true;
     } else if (arg === '-y' || arg === '--yes') {
       options.yes = true;
+    } else if (arg === '--force') {
+      options.force = true;
     } else if (arg === '-l' || arg === '--list') {
       options.list = true;
     } else if (arg === '--all') {


### PR DESCRIPTION
## Summary

Fixes #1906.

`skills add` now detects existing destinations before installation can remove them. Interactive runs offer keep, overwrite, or cancel; non-TTY runs refuse implicit overwrites and require explicit `-y`/`--yes` or `--force` consent. This protects user-managed directories and symlinks, including the Claude Code reproduction in the issue.

## Evidence

- `src/add.ts` resolves conflicts before calling any installer and keeps agent auto-detection from counting as overwrite consent.
- `src/add.test.ts` verifies a non-TTY refusal leaves an existing user-owned symlink and its target unchanged.
- `pnpm vitest run src/add.test.ts` (49 passed)
- `pnpm exec tsc --noEmit`
- `git diff --check`

No maintainer-only, legal, or contributor-account action is required.
