### PR TITLE
fix(update): normalize skill paths for deletion detection

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -296,10 +296,11 @@ export async function checkAndPromptForDeletions(
   options: UpdateCheckOptions,
   discoveredPaths: string[]
 ): Promise<string[]> {
+  const discoveredSet = new Set(discoveredPaths.map((p) => p.replace(/\\/g, '/')));
   const deletedSkills = allLockedForSource.filter((name) => {
     const entry = lockSkills[name];
     if (!entry?.skillPath) return false;
-    return !discoveredPaths.includes(entry.skillPath);
+    return !discoveredSet.has(entry.skillPath.replace(/\\/g, '/'));
   });
 
   await promptDeletions(source, deletedSkills, isGlobal, options);
@@ -612,12 +613,13 @@ export async function updateGlobalSkills(
       );
 
       const deletedSkillSet = new Set(deletedSkills);
+      const discoveredForUpdate = new Set(discoveredPaths.map((p) => p.replace(/\\/g, '/')));
 
       for (const { name: skillName, entry } of itemsForSource) {
         if (deletedSkillSet.has(skillName)) continue;
 
         const skillPath = entry.skillPath!;
-        if (!discoveredPaths.includes(skillPath)) continue;
+        if (!discoveredForUpdate.has(skillPath.replace(/\\/g, '/'))) continue;
 
         const usesGitTreeHash = isGitHubSource && /^[0-9a-f]{40}$/i.test(entry.skillFolderHash);
         const latestHash = usesGitTreeHash


### PR DESCRIPTION
## Summary

Normalizes path comparison in `checkAndPromptForDeletions` and the global update path so `tools/skills/*` layouts (e.g. `sveltejs/ai-tools` at `tools/skills/svelte-code-writer`) are not treated as deleted when the discovered paths use a different separator.

The project update clones to a temp dir and discovers via `discoverSkills(tempDir, undefined, {fullDepth: true})`, producing `tools/skills/.../SKILL.md`; the stored `skillPath` is the same logical path but may differ in separator. Comparing through a normalized `Set` prevents false positives that previously warned 'appear to have been deleted upstream' and offered to remove valid locals.

## Issue

Fixes #1916 — `skills update -p` falsely reports `svelte-code-writer` and `svelte-core-bestpractices` under `tools/skills/` as deleted upstream even though they exist and are byte-identical.

## Validation

- `git diff --check` passes
- Narrow deletion-detection fix; existing `update.test.ts` covers project/global flows

## Notes

No unrelated reformats. Keeps the existing project-update flow (clone + discover + prompt) unchanged aside from path normalization.