### PR TITLE
Fix internal skill filtering for well-known sources

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -582,7 +582,11 @@ async function handleWellKnownSkills(
   // Fetch all skills from the well-known endpoint
   let skills: WellKnownSkill[] = [];
   try {
-    skills = await wellKnownProvider.fetchAllSkills(url);
+    skills = await wellKnownProvider.fetchAllSkills(url, {
+      includeInternal: Boolean(
+        options.skill && options.skill.length > 0 && !options.skill.includes('*')
+      ),
+    });
   } catch (error) {
     if (error instanceof WellKnownScopeNotFoundError) {
       spinner.stop(pc.red('No matching skills'));

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -3,6 +3,7 @@ import { gunzipSync } from 'node:zlib';
 import { readZipArchive } from '../archive.ts';
 import { parseFrontmatter } from '../frontmatter.ts';
 import { sanitizeMetadata } from '../sanitize.ts';
+import { shouldInstallInternalSkills } from '../skills.ts';
 import type { HostProvider, ProviderMatch, RemoteSkill } from './types.ts';
 
 const DISCOVERY_SCHEMA_V2 = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
@@ -104,6 +105,11 @@ export interface WellKnownSkill extends RemoteSkill {
   files: Map<string, WellKnownFileContent>;
   /** The entry from index.json */
   indexEntry: WellKnownSkillEntry;
+}
+
+export interface FetchAllSkillsOptions {
+  /** Include skills marked with metadata.internal: true. */
+  includeInternal?: boolean;
 }
 
 /**
@@ -598,20 +604,24 @@ export class WellKnownProvider implements HostProvider {
    * throws {@link WellKnownScopeNotFoundError} instead of silently widening
    * to the root index and returning the host's entire catalog.
    */
-  async fetchAllSkills(url: string): Promise<WellKnownSkill[]> {
+  async fetchAllSkills(
+    url: string,
+    options: FetchAllSkillsOptions = {}
+  ): Promise<WellKnownSkill[]> {
     try {
       const candidates = await this.fetchIndexCandidates(url);
       const scope = this.getScope(url);
       const scopedCandidates = scope
         ? candidates.filter((c) => c.resolvedBaseUrl !== scope.rootBaseUrl)
         : candidates;
+      const includeInternal = options.includeInternal || shouldInstallInternalSkills();
 
       for (const result of scopedCandidates) {
         const skillPromises = result.entries.map((entry) => this.fetchSkillByEntry(entry));
         const results = await Promise.all(skillPromises);
-        const skills = results.filter(
-          (s: WellKnownSkill | null): s is WellKnownSkill => s !== null
-        );
+        const skills = results
+          .filter((s: WellKnownSkill | null): s is WellKnownSkill => s !== null)
+          .filter((skill) => includeInternal || skill.metadata?.internal !== true);
         if (skills.length > 0) return skills;
       }
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -219,10 +219,14 @@ export async function runUse(
     let selectedSkill: UseSkill;
 
     if (parsed.type === 'well-known') {
-      const skills = await wellKnownProvider.fetchAllSkills(parsed.url).catch((error) => {
-        if (error instanceof WellKnownScopeNotFoundError) fail(error.message);
-        return [] as WellKnownSkill[];
-      });
+      const skills = await wellKnownProvider
+        .fetchAllSkills(parsed.url, {
+          includeInternal,
+        })
+        .catch((error) => {
+          if (error instanceof WellKnownScopeNotFoundError) fail(error.message);
+          return [] as WellKnownSkill[];
+        });
       if (skills.length > 0) {
         selectedSkill = selectWellKnownSkill(skills, selector, source);
       } else {

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -48,6 +48,7 @@ function createTarGz(files: Record<string, string>): Uint8Array {
 }
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -162,6 +163,57 @@ describe('WellKnownProvider', () => {
   });
 
   describe('fetchAllSkills', () => {
+    it('hides internal skills unless explicitly enabled', async () => {
+      vi.stubEnv('INSTALL_INTERNAL_SKILLS', '');
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === 'https://example.com/.well-known/agent-skills/index.json') {
+          return response({
+            skills: [
+              {
+                name: 'public-skill',
+                description: 'Public skill.',
+                files: ['SKILL.md'],
+              },
+              {
+                name: 'internal-skill',
+                description: 'Internal skill.',
+                files: ['SKILL.md'],
+              },
+            ],
+          });
+        }
+        if (href.endsWith('/public-skill/SKILL.md')) {
+          return response('---\nname: public-skill\ndescription: Public skill.\n---\n# Public');
+        }
+        if (href.endsWith('/internal-skill/SKILL.md')) {
+          return response(
+            '---\nname: internal-skill\ndescription: Internal skill.\nmetadata:\n  internal: true\n---\n# Internal'
+          );
+        }
+        return response('not found', { status: 404 });
+      });
+
+      const defaultSkills = await provider.fetchAllSkills('https://example.com');
+      expect(defaultSkills.map((skill) => skill.installName)).toEqual(['public-skill']);
+
+      vi.stubEnv('INSTALL_INTERNAL_SKILLS', '1');
+      const envEnabledSkills = await provider.fetchAllSkills('https://example.com');
+      expect(envEnabledSkills.map((skill) => skill.installName)).toEqual([
+        'public-skill',
+        'internal-skill',
+      ]);
+
+      vi.stubEnv('INSTALL_INTERNAL_SKILLS', '');
+      const explicitlyIncludedSkills = await provider.fetchAllSkills('https://example.com', {
+        includeInternal: true,
+      });
+      expect(explicitlyIncludedSkills.map((skill) => skill.installName)).toEqual([
+        'public-skill',
+        'internal-skill',
+      ]);
+    });
+
     it('bounds well-known discovery with a shared timeout signal', async () => {
       const signal = AbortSignal.abort(new DOMException('timed out', 'TimeoutError'));
       const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(signal);


### PR DESCRIPTION
## Summary

- hide well-known skills marked with `metadata.internal: true` by default
- honor `INSTALL_INTERNAL_SKILLS=1` and explicit skill selection
- add regression coverage for default, environment-enabled, and explicitly included discovery

## Root cause

The well-known provider parsed and retained skill metadata, but `fetchAllSkills()` returned every fetched skill without applying the internal-skill predicate used by repository and local discovery.

## Validation

- full test suite: 751 tests passed
- focused add/use/well-known tests: 104 tests passed
- TypeScript type-check
- Prettier format check
- distribution build

Fixes #1920
