### PR TITLE
fix: bypass blob snapshots for explicit refs

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -506,7 +506,8 @@ function computeSnapshotHash(files: SkillSnapshotFile[]): string {
  * (the caller should fall back to git clone).
  *
  * @param ownerRepo - e.g., "vercel-labs/agent-skills"
- * @param options - subpath, skillFilter, ref, token
+ * @param options - subpath, skillFilter, ref, token. An explicit ref bypasses
+ *   this ref-agnostic snapshot path and returns null for the caller's git fallback.
  */
 export async function tryBlobInstall(
   ownerRepo: string,
@@ -518,6 +519,12 @@ export async function tryBlobInstall(
     includeInternal?: boolean;
   } = {}
 ): Promise<BlobInstallResult | null> {
+  // Snapshot downloads are keyed only by owner, repository, and skill slug. They
+  // are not bound to the requested ref, so using this path for an explicit ref
+  // could install different bytes than the tree and frontmatter resolved below.
+  // Return null to use the caller's existing git clone fallback instead.
+  if (options.ref !== undefined) return null;
+
   // 1. Fetch the full repo tree
   const tree = await fetchRepoTree(ownerRepo, options.ref, options.getToken);
   if (!tree) return null;

--- a/tests/blob-root-skill.test.ts
+++ b/tests/blob-root-skill.test.ts
@@ -22,7 +22,7 @@ function textResponse(body: string): Response {
   });
 }
 
-describe('tryBlobInstall root-level skills', () => {
+describe('tryBlobInstall', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
 
@@ -35,6 +35,16 @@ describe('tryBlobInstall root-level skills', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  it('bypasses ref-agnostic snapshots when an explicit ref is requested', async () => {
+    const result = await tryBlobInstall('vercel-labs/skills', {
+      ref: '66a7b901aad3b30f541f646199ff0df3050b764b',
+      skillFilter: 'find-skills',
+    });
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('does not install the full repository snapshot for a root SKILL.md', async () => {


### PR DESCRIPTION
## Summary

- bypass the blob snapshot fast path whenever an explicit ref is requested
- use the existing Git fallback for branch, tag, and future commit-SHA resolution
- leave unpinned blob installs unchanged
- add regression coverage proving no snapshot request occurs for explicit refs

## Root cause

The GitHub blob fast path resolves the repository tree and `SKILL.md` frontmatter at the requested ref, but downloads the full skill snapshot from:

`/api/download/<owner>/<repo>/<skill>`

That endpoint is not keyed by branch, tag, or commit. An explicit ref could therefore report a successful installation while installing current cached bytes instead of the requested repository state.

`tryBlobInstall` now returns `null` before making network requests when an explicit ref is present. Both `add` and `use` already interpret `null` as a request to fall back to `cloneRepo(url, ref)`.

Branch and tag refs therefore install through Git immediately. Full commit SHA checkout remains dependent on #1439.

## Validation

- `pnpm test -- --run` — 56 files, 751 tests passed
- `pnpm type-check`
- `pnpm format:check`

Fixes #1925
Related: #1439