### PR TITLE
feat: support installing skills pinned to a commit SHA

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -19,8 +19,10 @@ vi.mock('child_process', async () => {
 import {
   GitCloneError,
   cloneRepo,
+  isCommitSha,
   isGitHubHttpsCloneUrl,
   isGitHubSsoAuthError,
+  isMissingRefError,
   parseGitHubRepoUrl,
 } from './git.ts';
 
@@ -29,6 +31,20 @@ function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
     clone,
   };
 }
+
+// A client mock for the commit-SHA fetch path (cloneAtSha):
+// cwd().init().addRemote().fetch().checkout().
+function createShaClientMock(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}) {
+  return {
+    cwd: overrides.cwd ?? vi.fn().mockResolvedValue(undefined),
+    init: overrides.init ?? vi.fn().mockResolvedValue(undefined),
+    addRemote: overrides.addRemote ?? vi.fn().mockResolvedValue(undefined),
+    fetch: overrides.fetch ?? vi.fn().mockResolvedValue(undefined),
+    checkout: overrides.checkout ?? vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const FULL_SHA = '6c6076a293e7ffeb108bad2a231cbd855890d3b5';
 
 function mockExecFileSuccess(stdout = '', stderr = '') {
   execFileMock.mockImplementationOnce(
@@ -193,5 +209,102 @@ describe('git clone fallbacks', () => {
       GitCloneError
     );
     expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a commit-SHA fetch when --branch reports a missing ref', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(`fatal: Remote branch ${FULL_SHA} not found in upstream origin`)
+      );
+    const shaClient = createShaClientMock();
+
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(shaClient);
+
+    const tempDir = await cloneRepo('https://gitlab.com/group/repo.git', FULL_SHA);
+    createdDirs.push(tempDir);
+
+    expect(primaryClone).toHaveBeenCalledWith('https://gitlab.com/group/repo.git', tempDir, [
+      '--depth',
+      '1',
+      '--branch',
+      FULL_SHA,
+    ]);
+    expect(shaClient.fetch).toHaveBeenCalledWith(['--depth', '1', 'origin', FULL_SHA]);
+    expect(shaClient.checkout).toHaveBeenCalledWith('FETCH_HEAD');
+  });
+
+  it('does not attempt the SHA fetch for a non-SHA ref', async () => {
+    const primaryClone = vi
+      .fn()
+      .mockRejectedValue(new Error('fatal: Remote branch deadbeef not found in upstream origin'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/group/repo.git', 'deadbeef')).rejects.toThrow(
+      GitCloneError
+    );
+    // Only the primary --branch client is constructed; no SHA-fetch client.
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt the SHA fetch when the failure is not a missing ref', async () => {
+    const primaryClone = vi.fn().mockRejectedValue(new Error('fatal: Authentication failed'));
+
+    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+
+    await expect(cloneRepo('https://gitlab.com/group/repo.git', FULL_SHA)).rejects.toThrow(
+      GitCloneError
+    );
+    expect(simpleGitMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isCommitSha', () => {
+  it('matches a full 40-character hex SHA', () => {
+    expect(isCommitSha(FULL_SHA)).toBe(true);
+    expect(isCommitSha('abcdef0123456789abcdef0123456789abcdef01')).toBe(true);
+  });
+
+  it('rejects a 40-character string containing non-hex characters', () => {
+    expect(isCommitSha('z'.repeat(40))).toBe(false);
+    expect(isCommitSha('g0000000000000000000000000000000000000000'.slice(0, 40))).toBe(false);
+  });
+
+  it('rejects abbreviated SHAs (not fetchable by the protocol)', () => {
+    expect(isCommitSha('6c6076a')).toBe(false);
+    expect(isCommitSha('6c6076a293')).toBe(false);
+  });
+
+  it('rejects branch and tag names', () => {
+    expect(isCommitSha('main')).toBe(false);
+    expect(isCommitSha('v1.2.3')).toBe(false);
+    expect(isCommitSha('deadbeef')).toBe(false); // hex but only 8 chars
+    expect(isCommitSha('release/2.0')).toBe(false);
+  });
+});
+
+describe('isMissingRefError', () => {
+  it('matches the clone --branch missing-ref message', () => {
+    expect(isMissingRefError(`fatal: Remote branch ${FULL_SHA} not found in upstream origin`)).toBe(
+      true
+    );
+  });
+
+  it('matches the fetch shorthand missing-ref message', () => {
+    expect(isMissingRefError("fatal: couldn't find remote ref deadbeef")).toBe(true);
+  });
+
+  it('matches the server-side fetch-by-SHA rejection', () => {
+    expect(isMissingRefError(`fatal: remote error: upload-pack: not our ref ${FULL_SHA}`)).toBe(
+      true
+    );
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isMissingRefError('fatal: Authentication failed')).toBe(false);
+    expect(isMissingRefError('fatal: unable to access: timed out')).toBe(false);
   });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -14,6 +14,66 @@ const CLONE_TIMEOUT_MS = (() => {
 })();
 const execFileAsync = promisify(execFile);
 
+/**
+ * Whether a ref is a full 40-character Git commit SHA.
+ *
+ * Used only to decide whether the commit-SHA fetch fallback is worth attempting
+ * after a `--branch` clone fails. The fetch-by-SHA protocol requires the full
+ * 40-char SHA; abbreviated SHAs are rejected by the server, so they are not
+ * matched here. Branch and tag detection is never inferred from the string:
+ * `--branch` is always tried first, so any real branch or tag (including a
+ * hex-looking name like "deadbeef" or a 40-char-hex name) resolves correctly
+ * before the SHA fallback is ever considered.
+ */
+export function isCommitSha(ref: string): boolean {
+  return /^[0-9a-f]{40}$/i.test(ref);
+}
+
+/**
+ * Whether a clone or fetch error means the requested ref does not exist as a
+ * branch or tag. `git clone --branch <sha>` fails this way because `--branch`
+ * only accepts branch or tag names, never a bare commit SHA.
+ *
+ * These messages come from the git client and the server `upload-pack`, not from
+ * the host, so they are identical across GitHub, GitLab, self-hosted git, and
+ * `gh` (which wraps git). Verified on git 2.53. The variants cover the different
+ * code paths a missing ref can surface through:
+ *   - `clone --branch <ref>`            -> "Remote branch <ref> not found in upstream origin"
+ *   - GitHub shorthand fetch path       -> "couldn't find remote ref <ref>"
+ *   - server-side fetch by SHA rejected -> "upload-pack: not our ref <ref>"
+ */
+export function isMissingRefError(message: string): boolean {
+  return (
+    /Remote branch .* not found in upstream origin/i.test(message) ||
+    /couldn't find remote ref/i.test(message) ||
+    /upload-pack: not our ref/i.test(message)
+  );
+}
+
+/**
+ * Clone a repository pinned to a specific commit SHA.
+ *
+ * `git clone --branch` cannot target a bare SHA, and a `--depth 1` clone does
+ * not contain arbitrary commits. Instead, init an empty repo and fetch only the
+ * requested commit, then check it out. This requires the server to allow
+ * fetching reachable commits by SHA (`uploadpack.allowReachableSHA1InWant`),
+ * which GitHub and GitLab.com both enable. If the server rejects it, the caller
+ * falls back to the standard error handling.
+ */
+async function cloneAtSha(
+  url: string,
+  sha: string,
+  tempDir: string,
+  extraEnv?: NodeJS.ProcessEnv
+): Promise<void> {
+  const git = createGitClient(extraEnv);
+  await git.cwd(tempDir);
+  await git.init();
+  await git.addRemote('origin', url);
+  await git.fetch(['--depth', '1', 'origin', sha]);
+  await git.checkout('FETCH_HEAD');
+}
+
 interface GitHubRepoInfo {
   owner: string;
   repo: string;
@@ -191,6 +251,7 @@ function buildGitHubAuthError(url: string, repo: GitHubRepoInfo | null, message:
 export async function cloneRepo(url: string, ref?: string): Promise<string> {
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
   const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const refCanBeSha = !!ref && isCommitSha(ref);
   const repo = parseGitHubRepoUrl(url);
 
   try {
@@ -198,6 +259,21 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
     return tempDir;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // `--branch` cannot target a bare commit SHA. If the ref is a full SHA and
+    // the clone failed because the ref was not a branch or tag, retry by
+    // fetching the commit directly. This runs only after `--branch` fails, so a
+    // real branch or tag (any name) is always resolved first.
+    if (refCanBeSha && isMissingRefError(errorMessage)) {
+      try {
+        await resetTempDir(tempDir);
+        await cloneAtSha(url, ref!, tempDir);
+        return tempDir;
+      } catch {
+        // Fall through to the standard error handling below.
+      }
+    }
+
     const isTimeout = errorMessage.includes('block timeout') || errorMessage.includes('timed out');
     const isAuthError = isAuthFailure(errorMessage);
 
@@ -229,9 +305,20 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
       try {
         await resetTempDir(tempDir);
-        await createGitClient({
+        const sshEnv = {
           GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
-        }).clone(repo.sshUrl, tempDir, cloneOptions);
+        };
+        try {
+          await createGitClient(sshEnv).clone(repo.sshUrl, tempDir, cloneOptions);
+        } catch (sshError) {
+          const sshMessage = sshError instanceof Error ? sshError.message : String(sshError);
+          if (refCanBeSha && isMissingRefError(sshMessage)) {
+            await resetTempDir(tempDir);
+            await cloneAtSha(repo.sshUrl, ref!, tempDir, sshEnv);
+          } else {
+            throw sshError;
+          }
+        }
         return tempDir;
       } catch {
         // Fall through to the targeted auth error below.


### PR DESCRIPTION
## Summary

I’ve brought #1439 up to date with current `main` while preserving @mollux's work. I resolved the conflicts with the newer private-repository authentication and Git transport hardening.

Ref resolution still tries branches and tags first, then fetches full 40-character commit SHAs and checks out `FETCH_HEAD` detached.

I’ve kept the blob snapshot fix separate in #1934 to simplify review. Both PRs should ideally land in the same release, since allowlisted repositories require both changes for correct SHA-pinned installation.

## Validation

- `pnpm test -- --run` — 56 files, 761 tests
- `pnpm type-check`
- `pnpm format:check`
- Confirmed that generic and allowlisted GitHub installations produce the exact historical content when tested with #1934