### PR TITLE
fix(prompts): clamp multiselect window to terminal height

### DIFF
--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -145,6 +145,42 @@ export function countVisualRowsForLines(lines: string[], columns: number | undef
   return lines.reduce((sum, line) => sum + visualRowsForLine(line, cols), 0);
 }
 
+/**
+ * Viewport height in rows used to size prompt frames. Non-TTY streams report
+ * no size, so fall back to a conservative default (mirrors the columns fallback).
+ */
+export function resolveViewportRows(rows: number | undefined): number {
+  return rows !== undefined && rows > 0 ? rows : 20;
+}
+
+export interface VisibleWindow {
+  windowSize: number;
+  showIndicator: boolean;
+}
+
+/**
+ * Clamp the entry window so the frame fits the viewport: maxVisible acts as a
+ * ceiling, not a fixed count. When entries overflow the window, one row is
+ * reserved up front for the "↑ N more / ↓ N more" indicator so rendering it can
+ * never itself push the frame past the viewport. The result depends only on
+ * counts and available rows — never the cursor — so the frame height stays
+ * stable while navigating.
+ */
+export function resolveVisibleWindow(
+  entryCount: number,
+  maxVisible: number,
+  availableRows: number,
+  minVisible = 5
+): VisibleWindow {
+  if (entryCount === 0) return { windowSize: 0, showIndicator: false };
+  if (entryCount <= Math.min(maxVisible, availableRows)) {
+    return { windowSize: entryCount, showIndicator: false };
+  }
+  const floor = Math.min(Math.max(1, minVisible), entryCount);
+  const windowSize = Math.max(floor, Math.min(maxVisible, availableRows - 1));
+  return { windowSize, showIndicator: true };
+}
+
 function truncateToWidth(text: string, width: number): string {
   let truncated = '';
   for (const char of text) {
@@ -319,41 +355,98 @@ export async function searchMultiselect<T>(
       lines.push(`${icon}  ${pc.bold(message)}`);
 
       if (state === 'active') {
+        const columns =
+          process.stdout.columns && process.stdout.columns > 0 ? process.stdout.columns : 80;
+
+        const preLines: string[] = [];
+
         // Locked section (universal agents)
         if (lockedSection && lockedSection.items.length > 0) {
-          lines.push(`${S_BAR}`);
+          preLines.push(`${S_BAR}`);
           const lockedTitle = `${pc.bold(lockedSection.title)} ${pc.dim('── always included')}`;
-          lines.push(`${S_BAR}  ${S_BAR_H}${S_BAR_H} ${lockedTitle} ${S_BAR_H.repeat(12)}`);
+          preLines.push(`${S_BAR}  ${S_BAR_H}${S_BAR_H} ${lockedTitle} ${S_BAR_H.repeat(12)}`);
           for (const item of lockedSection.items) {
-            lines.push(`${S_BAR}    ${S_BULLET} ${pc.bold(item.label)}`);
+            preLines.push(`${S_BAR}    ${S_BULLET} ${pc.bold(item.label)}`);
           }
           if (lockedSection.hiddenCount && lockedSection.hiddenCount > 0) {
-            lines.push(`${S_BAR}    ${pc.dim(`…and ${lockedSection.hiddenCount} more`)}`);
+            preLines.push(`${S_BAR}    ${pc.dim(`…and ${lockedSection.hiddenCount} more`)}`);
           }
-          lines.push(`${S_BAR}`);
-          lines.push(
+          preLines.push(`${S_BAR}`);
+          preLines.push(
             `${S_BAR}  ${S_BAR_H}${S_BAR_H} ${pc.bold('Additional agents')} ${S_BAR_H.repeat(29)}`
           );
         }
 
         if (searchable) {
           const searchLine = `${S_BAR}  ${pc.dim('Search:')} ${query}${pc.inverse(' ')}`;
-          lines.push(searchLine);
-          lines.push(`${S_BAR}  ${pc.dim('↑↓ move, space select, enter confirm')}`);
-          lines.push(`${S_BAR}`);
+          preLines.push(searchLine);
+          preLines.push(`${S_BAR}  ${pc.dim('↑↓ move, space select, enter confirm')}`);
+          preLines.push(`${S_BAR}`);
         }
 
-        // Items
-        const visibleStart = Math.max(
-          0,
-          Math.min(cursor - Math.floor(maxVisible / 2), entries.length - maxVisible)
-        );
-        const visibleEnd = Math.min(entries.length, visibleStart + maxVisible);
-        const visibleEntries = entries.slice(visibleStart, visibleEnd);
+        // The detail pane depends on the highlighted entry but not on the item
+        // window, so trailing chrome can be composed before the window is sized.
+        const composePostLines = (includeDetail: boolean): string[] => {
+          const postLines: string[] = [];
 
-        if (filtered.length === 0) {
-          lines.push(`${S_BAR}  ${pc.dim('No matches found')}`);
-        } else {
+          if (showDetail && includeDetail) {
+            const entry = entries[cursor];
+            const detail =
+              entry?.type === 'group'
+                ? `Select all ${entry.items.length} skills in ${entry.group}.`
+                : entry?.item.detail;
+            // Keep a small margin for the left rail and terminal wrapping behavior.
+            const detailWidth = Math.max(1, columns - 5);
+            postLines.push(`${S_BAR}`);
+            postLines.push(`${S_BAR}  ${pc.dim('Description')}`);
+            for (const line of formatDetailLines(detail, detailWidth, detailLines)) {
+              postLines.push(`${S_BAR}  ${pc.dim(line)}`);
+            }
+          }
+
+          if (showSelectedSummary) {
+            // Selected summary (include locked items)
+            postLines.push(`${S_BAR}`);
+            const allSelectedLabels = [
+              ...(lockedSection ? lockedSection.items.map((i) => i.label) : []),
+              ...items.filter((item) => selected.has(item.value)).map((item) => item.label),
+            ];
+            if (allSelectedLabels.length === 0) {
+              postLines.push(`${S_BAR}  ${pc.dim('Selected: (none)')}`);
+            } else {
+              const summary =
+                allSelectedLabels.length <= 3
+                  ? allSelectedLabels.join(', ')
+                  : `${allSelectedLabels.slice(0, 3).join(', ')} +${allSelectedLabels.length - 3} more`;
+              postLines.push(`${S_BAR}  ${pc.green('Selected:')} ${summary}`);
+            }
+          }
+
+          if (!searchable) {
+            postLines.push(`${S_BAR}`);
+            postLines.push(
+              `${S_BAR}  ${pc.dim('↑↓ move, ←→ collapse/expand, space select, enter confirm')}`
+            );
+          }
+          postLines.push(`${pc.dim('└')}`);
+          return postLines;
+        };
+
+        const composeEntryLines = (windowSize: number): string[] => {
+          const entryLines: string[] = [];
+
+          if (filtered.length === 0) {
+            entryLines.push(`${S_BAR}  ${pc.dim('No matches found')}`);
+            return entryLines;
+          }
+
+          const visibleStart = Math.max(
+            0,
+            Math.min(cursor - Math.floor(windowSize / 2), entries.length - windowSize)
+          );
+          const visibleEnd = Math.min(entries.length, visibleStart + windowSize);
+          const visibleEntries = entries.slice(visibleStart, visibleEnd);
+
           for (let i = 0; i < visibleEntries.length; i++) {
             const entry = visibleEntries[i]!;
             const actualIndex = visibleStart + i;
@@ -370,7 +463,7 @@ export async function searchMultiselect<T>(
               const label = isCursor ? pc.underline(pc.bold(entry.group)) : pc.bold(entry.group);
               const prefix = isCursor ? pc.cyan('❯') : ' ';
               const disclosure = pc.dim(entry.collapsed ? '▸' : '▾');
-              lines.push(`${S_BAR} ${prefix} ${disclosure} ${radio} ${label}`);
+              entryLines.push(`${S_BAR} ${prefix} ${disclosure} ${radio} ${label}`);
               continue;
             }
 
@@ -385,7 +478,7 @@ export async function searchMultiselect<T>(
               selectGroups && item.group ? filtered.filter((i) => i.group === item.group) : [];
             const isLastInGroup = groupItems.at(-1) === item;
             const tree = groupItems.length > 0 ? `${pc.dim(isLastInGroup ? '└─' : '├─')} ` : '';
-            lines.push(`${S_BAR} ${prefix} ${tree}${radio} ${label}${hint}`);
+            entryLines.push(`${S_BAR} ${prefix} ${tree}${radio} ${label}${hint}`);
           }
 
           // Show count if more items
@@ -395,52 +488,59 @@ export async function searchMultiselect<T>(
             const parts: string[] = [];
             if (hiddenBefore > 0) parts.push(`↑ ${hiddenBefore} more`);
             if (hiddenAfter > 0) parts.push(`↓ ${hiddenAfter} more`);
-            lines.push(`${S_BAR}  ${pc.dim(parts.join('  '))}`);
+            entryLines.push(`${S_BAR}  ${pc.dim(parts.join('  '))}`);
           }
-        }
+          return entryLines;
+        };
 
-        if (showDetail) {
-          const entry = entries[cursor];
-          const detail =
-            entry?.type === 'group'
-              ? `Select all ${entry.items.length} skills in ${entry.group}.`
-              : entry?.item.detail;
-          const columns =
-            process.stdout.columns && process.stdout.columns > 0 ? process.stdout.columns : 80;
-          // Keep a small margin for the left rail and terminal wrapping behavior.
-          const detailWidth = Math.max(1, columns - 5);
-          lines.push(`${S_BAR}`);
-          lines.push(`${S_BAR}  ${pc.dim('Description')}`);
-          for (const line of formatDetailLines(detail, detailWidth, detailLines)) {
-            lines.push(`${S_BAR}  ${pc.dim(line)}`);
-          }
-        }
+        // The trailing newline written after each frame consumes one extra
+        // viewport row, so the frame itself may use at most rows - 1. A frame
+        // taller than that scrolls the terminal and the cursor-up erase can no
+        // longer reach the frame's first row, stacking stale frames on redraw.
+        const frameBudget = resolveViewportRows(process.stdout.rows) - 1;
 
-        if (showSelectedSummary) {
-          // Selected summary (include locked items)
-          lines.push(`${S_BAR}`);
-          const allSelectedLabels = [
-            ...(lockedSection ? lockedSection.items.map((i) => i.label) : []),
-            ...items.filter((item) => selected.has(item.value)).map((item) => item.label),
-          ];
-          if (allSelectedLabels.length === 0) {
-            lines.push(`${S_BAR}  ${pc.dim('Selected: (none)')}`);
-          } else {
-            const summary =
-              allSelectedLabels.length <= 3
-                ? allSelectedLabels.join(', ')
-                : `${allSelectedLabels.slice(0, 3).join(', ')} +${allSelectedLabels.length - 3} more`;
-            lines.push(`${S_BAR}  ${pc.green('Selected:')} ${summary}`);
-          }
-        }
+        // Fitting attempts, most complete frame first: shrink the item window
+        // toward its floor, then trade the detail pane for entry rows, then
+        // lower the floor. The last attempt always renders, clamped erase
+        // bounds the damage on pathologically short terminals.
+        const attempts = [
+          { includeDetail: true, minVisible: 5 },
+          { includeDetail: false, minVisible: 5 },
+          { includeDetail: false, minVisible: 3 },
+        ];
 
-        if (!searchable) {
-          lines.push(`${S_BAR}`);
-          lines.push(
-            `${S_BAR}  ${pc.dim('↑↓ move, ←→ collapse/expand, space select, enter confirm')}`
+        for (const attempt of attempts) {
+          const postLines = composePostLines(attempt.includeDetail);
+          const chromeRows = countVisualRowsForLines(
+            [...lines, ...preLines, ...postLines],
+            columns
           );
+          const availableRows = frameBudget - chromeRows;
+          let { windowSize } = resolveVisibleWindow(
+            entries.length,
+            maxVisible,
+            availableRows,
+            attempt.minVisible
+          );
+          let entryLines = composeEntryLines(windowSize);
+
+          // Soft-wrapped labels can occupy more rows than the entry count;
+          // shrink the window until the measured rows fit.
+          const floor = Math.min(Math.max(1, attempt.minVisible), Math.max(1, entries.length));
+          while (
+            windowSize > floor &&
+            countVisualRowsForLines(entryLines, columns) > Math.max(0, availableRows)
+          ) {
+            windowSize -= 1;
+            entryLines = composeEntryLines(windowSize);
+          }
+
+          const fits = chromeRows + countVisualRowsForLines(entryLines, columns) <= frameBudget;
+          if (fits || attempt === attempts[attempts.length - 1]) {
+            lines.push(...preLines, ...entryLines, ...postLines);
+            break;
+          }
         }
-        lines.push(`${pc.dim('└')}`);
       } else if (state === 'submit') {
         // Final state - show what was selected (including locked)
         const allSelectedLabels = [
@@ -454,7 +554,10 @@ export async function searchMultiselect<T>(
 
       // Write the clear sequence and next frame together. Clearing individual rows first
       // makes larger prompts visibly flash between redraws in some terminals.
-      const clearPreviousFrame = lastRenderHeight > 0 ? `\x1b[${lastRenderHeight}A\x1b[J` : '';
+      // The erase distance is capped at the viewport: cursor-up cannot travel
+      // past the top margin, and rows above it already scrolled out of reach.
+      const eraseRows = Math.min(lastRenderHeight, resolveViewportRows(process.stdout.rows) - 1);
+      const clearPreviousFrame = eraseRows > 0 ? `\x1b[${eraseRows}A\x1b[J` : '';
       process.stdout.write(clearPreviousFrame + lines.join('\n') + '\n');
       // Use wrapped row count: logical lines can span multiple terminal rows when hints
       // or labels exceed column width. Using lines.length alone under-counts and fails to
@@ -462,8 +565,15 @@ export async function searchMultiselect<T>(
       lastRenderHeight = countVisualRowsForLines(lines, process.stdout.columns);
     };
 
+    const resizeHandler = (): void => {
+      // The previous frame may have rewrapped under the new dimensions; repaint
+      // and let the clamped erase recover what is still inside the viewport.
+      render();
+    };
+
     const cleanup = (): void => {
       process.stdin.removeListener('keypress', keypressHandler);
+      process.stdout.removeListener('resize', resizeHandler);
       if (process.stdin.isTTY) {
         process.stdin.setRawMode(false);
       }
@@ -562,6 +672,7 @@ export async function searchMultiselect<T>(
     };
 
     process.stdin.on('keypress', keypressHandler);
+    process.stdout.on('resize', resizeHandler);
 
     // Initial render
     render();

--- a/tests/search-multiselect-viewport.test.ts
+++ b/tests/search-multiselect-viewport.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi, type MockInstance } from 'vitest';
+import { stripVTControlCharacters } from 'node:util';
+import {
+  cancelSymbol,
+  countVisualRowsForLines,
+  searchMultiselect,
+} from '../src/prompts/search-multiselect.ts';
+
+/**
+ * rows/columns are read at render time, so stubbing the properties on
+ * process.stdout is enough to simulate a terminal size. Returns a restore
+ * function; call it in finally so parallel tests never leak dimensions.
+ */
+function stubDimension(name: 'rows' | 'columns', value: number): () => void {
+  const original = Object.getOwnPropertyDescriptor(process.stdout, name);
+  Object.defineProperty(process.stdout, name, { value, configurable: true });
+  return () => {
+    if (original) {
+      Object.defineProperty(process.stdout, name, original);
+    } else {
+      delete (process.stdout as unknown as Record<string, unknown>)[name];
+    }
+  };
+}
+
+/** Strip the fused erase prefix and trailing newline from the latest write. */
+function lastFrameLines(write: MockInstance): string[] {
+  const raw = String(write.mock.calls.at(-1)?.[0] ?? '');
+  return raw
+    .replace(/^\x1b\[\d+A\x1b\[J/, '')
+    .replace(/\n$/, '')
+    .split('\n');
+}
+
+function keypress(name: string): void {
+  process.stdin.emit('keypress', '', { name });
+}
+
+const groupedItems = Array.from({ length: 40 }, (_, i) => ({
+  value: `skill-${i}`,
+  label: `skill-${i}`,
+  group: `Plugin ${Math.floor(i / 8)}`,
+  detail: `Description for skill ${i}.`,
+}));
+
+const flatItems = Array.from({ length: 40 }, (_, i) => ({
+  value: `item-${i}`,
+  label: `item-${i}`,
+}));
+
+// Mirrors the grouped skill-selection prompt in add.ts, the repro in #925.
+const groupedOptions = {
+  message: 'Select skills',
+  items: groupedItems,
+  maxVisible: 20,
+  searchable: false,
+  showDetail: true,
+  showSelectedSummary: false,
+  selectGroups: true,
+};
+
+describe('searchMultiselect viewport sizing', () => {
+  it('keeps the frame inside a short viewport while navigating', async () => {
+    const restoreRows = stubDimension('rows', 15);
+    const restoreColumns = stubDimension('columns', 80);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const prompt = searchMultiselect(groupedOptions);
+
+      // The trailing newline consumes one extra row, so the frame itself must
+      // stay within rows - 1 or the erase sequence cannot reach its first row.
+      expect(countVisualRowsForLines(lastFrameLines(write), 80)).toBeLessThanOrEqual(14);
+
+      for (let i = 0; i < 12; i++) keypress('down');
+      expect(countVisualRowsForLines(lastFrameLines(write), 80)).toBeLessThanOrEqual(14);
+
+      for (let i = 0; i < 12; i++) keypress('up');
+      keypress('left');
+      expect(countVisualRowsForLines(lastFrameLines(write), 80)).toBeLessThanOrEqual(14);
+      keypress('right');
+      expect(countVisualRowsForLines(lastFrameLines(write), 80)).toBeLessThanOrEqual(14);
+
+      keypress('escape');
+      await expect(prompt).resolves.toBe(cancelSymbol);
+    } finally {
+      write.mockRestore();
+      restoreRows();
+      restoreColumns();
+    }
+  });
+
+  it('still redraws in one terminal write when the window is clamped', async () => {
+    const restoreRows = stubDimension('rows', 15);
+    const restoreColumns = stubDimension('columns', 80);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const prompt = searchMultiselect(groupedOptions);
+
+      write.mockClear();
+      keypress('down');
+      expect(write).toHaveBeenCalledTimes(1);
+
+      keypress('escape');
+      await expect(prompt).resolves.toBe(cancelSymbol);
+    } finally {
+      write.mockRestore();
+      restoreRows();
+      restoreColumns();
+    }
+  });
+
+  it('reports consistent hidden counts around the clamped window', async () => {
+    const restoreRows = stubDimension('rows', 15);
+    const restoreColumns = stubDimension('columns', 80);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const prompt = searchMultiselect({ message: 'Select items', items: flatItems });
+
+      const countsFor = (lines: string[]): { visible: number; hidden: number } => {
+        const plain = lines.map((line) => stripVTControlCharacters(line));
+        const visible = plain.filter((line) => /[○●]/.test(line)).length;
+        let hidden = 0;
+        for (const line of plain) {
+          const before = line.match(/↑ (\d+) more/);
+          const after = line.match(/↓ (\d+) more/);
+          if (before) hidden += Number(before[1]);
+          if (after) hidden += Number(after[1]);
+        }
+        return { visible, hidden };
+      };
+
+      const initial = countsFor(lastFrameLines(write));
+      expect(initial.visible).toBeGreaterThan(0);
+      expect(initial.visible + initial.hidden).toBe(flatItems.length);
+
+      for (let i = 0; i < 10; i++) keypress('down');
+      const scrolled = countsFor(lastFrameLines(write));
+      expect(scrolled.visible + scrolled.hidden).toBe(flatItems.length);
+
+      keypress('escape');
+      await expect(prompt).resolves.toBe(cancelSymbol);
+    } finally {
+      write.mockRestore();
+      restoreRows();
+      restoreColumns();
+    }
+  });
+
+  it('keeps maxVisible as the window size on tall terminals', async () => {
+    const restoreRows = stubDimension('rows', 60);
+    const restoreColumns = stubDimension('columns', 80);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const prompt = searchMultiselect({
+        message: 'Select items',
+        items: flatItems.slice(0, 10),
+        maxVisible: 8,
+      });
+
+      const plain = lastFrameLines(write).map((line) => stripVTControlCharacters(line));
+      expect(plain.filter((line) => /[○●]/.test(line))).toHaveLength(8);
+      expect(plain.some((line) => line.includes('↓ 2 more'))).toBe(true);
+
+      keypress('escape');
+      await expect(prompt).resolves.toBe(cancelSymbol);
+    } finally {
+      write.mockRestore();
+      restoreRows();
+      restoreColumns();
+    }
+  });
+
+  it('drops the detail pane before overflowing a tiny viewport', async () => {
+    const restoreRows = stubDimension('rows', 10);
+    const restoreColumns = stubDimension('columns', 80);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const prompt = searchMultiselect(groupedOptions);
+
+      const lines = lastFrameLines(write);
+      const plain = lines.map((line) => stripVTControlCharacters(line));
+      expect(plain.some((line) => line.includes('Description'))).toBe(false);
+      expect(countVisualRowsForLines(lines, 80)).toBeLessThanOrEqual(9);
+
+      keypress('escape');
+      await expect(prompt).resolves.toBe(cancelSymbol);
+    } finally {
+      write.mockRestore();
+      restoreRows();
+      restoreColumns();
+    }
+  });
+
+  it('clamps the erase distance after the viewport shrinks', async () => {
+    const restoreColumns = stubDimension('columns', 80);
+    let restoreRows = stubDimension('rows', 50);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const prompt = searchMultiselect({
+        message: 'Select items',
+        items: flatItems,
+        maxVisible: 20,
+      });
+
+      // The tall frame was rendered at 50 rows; shrink the terminal before the
+      // next redraw and the erase must not ask for more rows than the viewport.
+      restoreRows();
+      restoreRows = stubDimension('rows', 15);
+
+      write.mockClear();
+      keypress('down');
+      const raw = String(write.mock.calls.at(-1)?.[0] ?? '');
+      const cursorUp = raw.match(/^\x1b\[(\d+)A/);
+      expect(cursorUp).not.toBeNull();
+      expect(Number(cursorUp![1])).toBeLessThanOrEqual(14);
+
+      keypress('escape');
+      await expect(prompt).resolves.toBe(cancelSymbol);
+    } finally {
+      write.mockRestore();
+      restoreRows();
+      restoreColumns();
+    }
+  });
+});

--- a/tests/search-multiselect-visual-rows.test.ts
+++ b/tests/search-multiselect-visual-rows.test.ts
@@ -5,6 +5,8 @@ import {
   buildSearchEntries,
   countVisualRowsForLines,
   formatDetailLines,
+  resolveViewportRows,
+  resolveVisibleWindow,
   toggleSearchEntry,
   visualRowsForLine,
 } from '../src/prompts/search-multiselect.ts';
@@ -127,5 +129,43 @@ describe('searchMultiselect visual row counting', () => {
 
     toggleSearchEntry(selected, entries[0]);
     expect(selected).toEqual(new Set());
+  });
+});
+
+describe('resolveViewportRows', () => {
+  it('uses the reported terminal height when available', () => {
+    expect(resolveViewportRows(24)).toBe(24);
+  });
+
+  it('falls back to a conservative default without a reported height', () => {
+    expect(resolveViewportRows(undefined)).toBe(20);
+    expect(resolveViewportRows(0)).toBe(20);
+  });
+});
+
+describe('resolveVisibleWindow', () => {
+  it('shows every entry when the list fits the ceiling and the viewport', () => {
+    expect(resolveVisibleWindow(6, 8, 10)).toEqual({ windowSize: 6, showIndicator: false });
+  });
+
+  it('caps the window at maxVisible when the viewport has room', () => {
+    expect(resolveVisibleWindow(40, 20, 30)).toEqual({ windowSize: 20, showIndicator: true });
+  });
+
+  it('reserves one row for the overflow indicator', () => {
+    expect(resolveVisibleWindow(40, 20, 10)).toEqual({ windowSize: 9, showIndicator: true });
+  });
+
+  it('never shrinks the window below the floor', () => {
+    expect(resolveVisibleWindow(40, 20, 3)).toEqual({ windowSize: 5, showIndicator: true });
+    expect(resolveVisibleWindow(40, 20, 3, 3)).toEqual({ windowSize: 3, showIndicator: true });
+  });
+
+  it('lowers the floor to the entry count for short lists', () => {
+    expect(resolveVisibleWindow(4, 8, 2)).toEqual({ windowSize: 4, showIndicator: true });
+  });
+
+  it('handles empty entry lists', () => {
+    expect(resolveVisibleWindow(0, 8, 10)).toEqual({ windowSize: 0, showIndicator: false });
   });
 });


### PR DESCRIPTION
Fixes #925

**The bug:**

When the skill list **is taller than the terminal**, the selector breaks after the first arrow key: every redraw stacks a new copy of the frame below the previous one and the list "grows" infinitely into scrollback. Easy to repro with `npx skills add anthropics/skills` in a terminal around 15 rows tall.

Whether the garbling is visible on screen depends on the terminal (which is why the thread has reports of some terminals "working"), but the scrollback spam and the out-of-range cursor-up happen on all of them.
`Terminal.app` largely masks it visually, `iTerm2` shows it raw.

**Before:** [skills@1.5.22](https://github.com/vercel-labs/skills/releases/tag/v1.5.22):

https://github.com/user-attachments/assets/6ad70314-b360-49f3-8a43-cba1ac30b5e5

**After:** this branch:

https://github.com/user-attachments/assets/643ba197-8bce-4975-ba06-9f9ee2991779

**Root cause:**

The prompt erases the previous frame with cursor-up + erase-down, but nothing ever checks `process.stdout.rows` ([#858](https://github.com/vercel-labs/skills/pull/858) fixed the columns axis only). The grouped prompt composes ~30 rows, so on a short terminal the frame scrolls, cursor-up clamps at the top of the screen, and every keypress paints a new frame under the leftovers of the old one.

**The fix:**

`maxVisible` is now a ceiling instead of a fixed count: the item window is sized from the actual viewport (rows - 1 minus the measured chrome), with a row reserved for the **↑/↓** more indicator so the frame height stays stable while navigating. 
On very short terminals it degrades gracefully (smaller window, then no description pane), the erase distance is clamped to the viewport as a last resort, and the prompt **repaints** on terminal resize. The two new helpers (`resolveViewportRows`, `resolveVisibleWindow`) follow the same style as the wrap-count helpers from [#858](https://github.com/vercel-labs/skills/pull/858). Still exactly one write per redraw. 
The flicker fix from [e659306](https://github.com/vercel-labs/skills/commit/e6593060d693632ae82c8ef7a14ccf25b977769f) is untouched.

**Tests:**

New `tests/search-multiselect-viewport.test.ts` covers the **regression**: the frame stays inside a 15-row viewport while navigating and collapsing groups, the single-write-per-redraw invariant holds, hidden counts stay consistent, tall terminals behave exactly like before, a 10-row terminal drops the description pane, and the erase distance is clamped after a resize. 

The new helpers get unit tests in `tests/search-multiselect-visual-rows.test.ts`.

**Recommendation:**

`src/find.ts` has the same class of bug in a separate render path, but it's much harder to hit. I'd fix it in a follow-up reusing these helpers.

Fun one to debug 🙂