### PR TITLE
fix: don't delete a skill from the same repo pinned to a different ref

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -535,16 +535,21 @@ export async function updateGlobalSkills(
   successCount += wkSuccessCount;
   failCount += wkFailCount;
 
+  // Key by source AND ref: two skills from the same repo pinned to different
+  // refs must each be checked against their own ref's tree. Grouping by source
+  // alone checks the whole group against the first entry's ref, which falsely
+  // reports the other-ref skills as deleted upstream (and then removes them).
   const bySource = new Map<string, typeof checkable>();
   for (const item of checkable) {
-    const source = item.entry.source;
-    const existing = bySource.get(source) || [];
+    const key = `${item.entry.source}\n${item.entry.ref ?? ''}`;
+    const existing = bySource.get(key) || [];
     existing.push(item);
-    bySource.set(source, existing);
+    bySource.set(key, existing);
   }
 
-  for (const [source, itemsForSource] of bySource) {
+  for (const [, itemsForSource] of bySource) {
     const firstEntry = itemsForSource[0]!.entry;
+    const source = firstEntry.source;
     const sourceUrl = firstEntry.sourceUrl || firstEntry.source;
     let tempDir: string | null = null;
 
@@ -562,7 +567,7 @@ export async function updateGlobalSkills(
             .map((entry) => entry.path);
 
           const allLockedForSource = Object.entries(lock.skills)
-            .filter(([_, entry]) => entry.source === source)
+            .filter(([_, entry]) => entry.source === source && entry.ref === firstEntry.ref)
             .map(([name, _]) => name);
 
           const deletedSkills = await checkAndPromptForDeletions(
@@ -599,7 +604,7 @@ export async function updateGlobalSkills(
       );
 
       const allLockedForSource = Object.entries(lock.skills)
-        .filter(([_, entry]) => entry.source === source)
+        .filter(([_, entry]) => entry.source === source && entry.ref === firstEntry.ref)
         .map(([name, _]) => name);
 
       const deletedSkills = await checkAndPromptForDeletions(
@@ -802,12 +807,15 @@ export async function updateProjectSkills(
   successCount += wkSuccessCount;
   failCount += wkFailCount;
 
+  // Key by source AND ref (see updateGlobalSkills) so skills from one repo
+  // pinned to different refs are each checked against their own ref's tree.
   const bySource = new Map<string, typeof updatable>();
   for (const skill of updatable) {
     const source = skill.entry.sourceUrl || skill.entry.source;
-    const existing = bySource.get(source) || [];
+    const key = `${source}\n${skill.entry.ref ?? ''}`;
+    const existing = bySource.get(key) || [];
     existing.push(skill);
-    bySource.set(source, existing);
+    bySource.set(key, existing);
   }
 
   const localLock = await readLocalLock();
@@ -822,13 +830,14 @@ export async function updateProjectSkills(
     };
   }
 
-  for (const [source, skillsForSource] of bySource) {
+  for (const [, skillsForSource] of bySource) {
     const firstEntry = skillsForSource[0]!.entry;
+    const source = firstEntry.sourceUrl || firstEntry.source;
     const cloneSource = buildLocalCloneSource(firstEntry);
     const ref = firstEntry.ref;
 
     const allLockedForSource = Object.entries(localLock.skills)
-      .filter(([_, entry]) => (entry.sourceUrl || entry.source) === source)
+      .filter(([_, entry]) => (entry.sourceUrl || entry.source) === source && entry.ref === ref)
       .map(([name, _]) => name);
 
     let tempDir: string | null = null;

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -450,6 +450,54 @@ describe('Update Cleanup Unit Tests', () => {
       expect(remove.removeCommand).not.toHaveBeenCalled();
     });
 
+    it('does not delete a skill from the same repo pinned to a different ref', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            ref: 'v1',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'abc',
+            installedAt: '',
+            updatedAt: '',
+          },
+          'skill-b': {
+            source: 'owner/repo',
+            ref: 'v2',
+            skillPath: 'skills/skill-b/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'def',
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+
+      // Each ref exposes only its own skill.
+      vi.mocked(blob.fetchRepoTree).mockImplementation(async (_source, ref) => {
+        const isV2 = ref === 'v2';
+        const dir = isV2 ? 'skills/skill-b' : 'skills/skill-a';
+        return {
+          sha: 'rootsha',
+          branch: 'main',
+          tree: [
+            { path: `${dir}/SKILL.md`, type: 'blob', sha: 'blobsha' },
+            { path: dir, type: 'tree', sha: isV2 ? 'def' : 'abc' },
+          ],
+        };
+      });
+      vi.mocked(p.confirm).mockResolvedValue(true);
+
+      await updateGlobalSkills();
+
+      // Before the fix, skill-b was grouped with skill-a by source alone and
+      // checked against v1's tree, then reported deleted upstream and removed.
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
+
     it('checks a private GitHub update by cloning when authenticated API access is unavailable', async () => {
       vi.mocked(skillLock.readSkillLock).mockResolvedValue({
         version: 3,


### PR DESCRIPTION
## Summary

`skills update` can remove a valid, still-upstream skill when two skills from the same repo are installed at different refs.

The deletion/update check buckets skills by **source only** (the ref is stored separately in `entry.ref`), then checks the whole bucket against a single ref's tree — `firstEntry.ref`:

```ts
// src/update.ts (updateGlobalSkills)
const bySource = new Map<string, typeof checkable>();
for (const item of checkable) {
  const source = item.entry.source;      // owner/repo — no ref
  ...
}
// ...
const tree = await fetchRepoTree(source, firstEntry.ref, getGitHubToken);   // one ref for all
const allLockedForSource = Object.entries(lock.skills)
  .filter(([_, entry]) => entry.source === source)                          // ignores ref
  .map(([name, _]) => name);
```

So if you `skills add owner/repo/skillA#v1` and `skills add owner/repo/skillB#v2` (normal for a monorepo with tagged skills), on `skills update` both land in one bucket checked against `v1`. `skillB` lives only at `v2`, so it's absent from the `v1` tree, reported as **"deleted upstream"**, and passed to `removeCommand(..., { yes: true })` on confirm — a valid skill is removed locally.

## Fix

Key the per-source buckets by **source AND ref**, and filter the "locked for source" list by ref too, so each ref is checked against its own tree:

```ts
const key = `${item.entry.source}\n${item.entry.ref ?? ''}`;
...
.filter(([_, entry]) => entry.source === source && entry.ref === firstEntry.ref)
```

Applied to both `updateGlobalSkills` (GitHub-API and clone paths) and `updateProjectSkills`.

## Testing

Added a regression test (`tests/update.test.ts`): two skills from `owner/repo` pinned to `v1`/`v2`, each ref's tree exposing only its own skill; `removeCommand` must not be called.

- With the fix: **21 passed** (`tests/update.test.ts`).
- Reverting `src/update.ts`: the new test fails — `removeCommand` is called once (skill-b removed).
- `tsc --noEmit` clean; `prettier --check` clean on the changed files.