### PR TITLE
alias: novoads/claude-code-ads -> novoads/agent-skills

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -144,6 +144,7 @@ function isLocalPath(input: string): boolean {
 // Source aliases: map common shorthand to canonical source
 const SOURCE_ALIASES: Record<string, string> = {
   'coinbase/agentWallet': 'coinbase/agentic-wallet-skills',
+  'novoads/claude-code-ads': 'novoads/agent-skills',
   'vercel-labs/vercel-skills': 'vercel-labs/agent-skills',
 };
 

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -449,6 +449,12 @@ describe('Source aliases', () => {
     expect(result.url).toBe('https://github.com/coinbase/agentic-wallet-skills.git');
   });
 
+  it('resolves novoads/claude-code-ads to novoads/agent-skills', () => {
+    const result = parseSource('novoads/claude-code-ads');
+    expect(result.type).toBe('github');
+    expect(result.url).toBe('https://github.com/novoads/agent-skills.git');
+  });
+
   it('resolves vercel-labs/vercel-skills to vercel-labs/agent-skills', () => {
     const result = parseSource('vercel-labs/vercel-skills');
     expect(result.type).toBe('github');


### PR DESCRIPTION
We renamed our skills repo from `novoads/claude-code-ads` to [`novoads/agent-skills`](https://github.com/novoads/agent-skills), and GitHub's 301 from the old path is live, so existing `skills add novoads/claude-code-ads` installs still resolve. Asking for the same alias treatment as the two existing `SOURCE_ALIASES` entries so those installs land on the canonical source and the telemetry follows the rename.

Adds the one entry plus a matching case in the existing `Source aliases` test block; `pnpm test tests/source-parser.test.ts`, `pnpm type-check` and `pnpm format:check` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011p4MpVkbHGPii6UVLfiEze
