### PR TITLE
fix: parse Azure Repos /_git/ URLs as git sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ npx skills add https://github.com/vercel-labs/agent-skills/tree/main/skills/web-
 # GitLab URL
 npx skills add https://gitlab.com/org/repo
 
+# Azure Repos (Azure DevOps Services or Server)
+npx skills add https://dev.azure.com/org/project/_git/repo
+
 # Any git URL
 npx skills add git@github.com:vercel-labs/agent-skills.git
 
@@ -61,6 +64,7 @@ npx skills add ssh://git@git.example.com/acme/private-skills.git
 
 # HTTPS on any Git host (uses your configured Git credential helper)
 npx skills add https://git.example.com/acme/private-skills.git
+npx skills add https://dev.azure.com/org/project/_git/private-skills
 ```
 
 For GitHub HTTPS and shorthand sources, `skills` first uses normal Git credentials. If that fails and GitHub CLI is authenticated, it tries `gh repo clone`, followed by SSH. It does not execute `gh auth token` or copy the stored GitHub CLI credential into the Node.js process.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx skills add https://gitlab.com/org/repo
 
 # Azure Repos (Azure DevOps Services or Server)
 npx skills add https://dev.azure.com/org/project/_git/repo
+npx skills add https://dev.azure.com/org/project/_git/repo?path=/skills/web-design&version=GBmain
 
 # Any git URL
 npx skills add git@github.com:vercel-labs/agent-skills.git

--- a/src/source-parser.test.ts
+++ b/src/source-parser.test.ts
@@ -52,6 +52,22 @@ describe('source-parser', () => {
     });
   });
 
+  describe('Azure Repos', () => {
+    it('does not treat Azure Repos HTTPS as well-known', () => {
+      expect(parseSource('https://dev.azure.com/fabrikam/Fiber/_git/skills').type).toBe('git');
+    });
+
+    it('parses Azure DevOps Server with port and /tfs/', () => {
+      const result = parseSource(
+        'http://ado.example.com:8080/tfs/DefaultCollection/MyProject/_git/skills'
+      );
+      expect(result).toEqual({
+        type: 'git',
+        url: 'http://ado.example.com:8080/tfs/DefaultCollection/MyProject/_git/skills',
+      });
+    });
+  });
+
   describe('Simplified Git Strategy', () => {
     it('treats custom domains with .git as generic git', () => {
       const result = parseSource('https://git.mycompany.com/my-group/my-repo.git');

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -130,9 +130,10 @@ function azureReposVersionToRef(version: string | null): string | undefined {
     return undefined;
   }
 
-  const prefixed = /^(?:GB|GT|GC)(.+)$/i.exec(version)?.[1];
-  const ref = prefixed ?? version;
-  return ref || undefined;
+  // GB = branch, GT = tag. GC (commit) is omitted because `git clone --branch`
+  // cannot check out a SHA.
+  const prefixed = /^(?:GB|GT)(.+)$/i.exec(version)?.[1];
+  return prefixed || undefined;
 }
 
 /**
@@ -149,45 +150,47 @@ function parseAzureReposSource(
     return null;
   }
 
+  let parsed: URL;
   try {
-    const parsed = new URL(input);
-    const segments = parsed.pathname.split('/').filter(Boolean);
-    const gitIndex = segments.indexOf('_git');
-    if (gitIndex < 0 || gitIndex === segments.length - 1) {
-      return null;
-    }
-
-    const repo = segments[gitIndex + 1]!.replace(/\.git$/, '');
-    if (!repo) {
-      return null;
-    }
-
-    const clonePath =
-      '/' +
-      [...segments.slice(0, gitIndex), '_git', repo]
-        .map((segment) => {
-          try {
-            return encodeURIComponent(decodeURIComponent(segment));
-          } catch {
-            return encodeURIComponent(segment);
-          }
-        })
-        .join('/');
-    const cloneUrl = `${parsed.protocol}//${parsed.host}${clonePath}`;
-    const ref = azureReposVersionToRef(parsed.searchParams.get('version')) || fragmentRef;
-    const pathParam = parsed.searchParams.get('path');
-    const subpath = pathParam ? sanitizeSubpath(pathParam.replace(/^\/+/, '')) : undefined;
-
-    return {
-      type: 'git',
-      url: cloneUrl,
-      ...(ref ? { ref } : {}),
-      ...(subpath ? { subpath } : {}),
-      ...(fragmentSkillFilter ? { skillFilter: fragmentSkillFilter } : {}),
-    };
+    parsed = new URL(input);
   } catch {
     return null;
   }
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  const gitIndex = segments.indexOf('_git');
+  if (gitIndex < 0 || gitIndex === segments.length - 1) {
+    return null;
+  }
+
+  const repo = segments[gitIndex + 1]!.replace(/\.git$/, '');
+  if (!repo) {
+    return null;
+  }
+
+  const clonePath =
+    '/' +
+    [...segments.slice(0, gitIndex), '_git', repo]
+      .map((segment) => {
+        try {
+          return encodeURIComponent(decodeURIComponent(segment));
+        } catch {
+          return encodeURIComponent(segment);
+        }
+      })
+      .join('/');
+  const cloneUrl = `${parsed.protocol}//${parsed.host}${clonePath}`;
+  const ref = azureReposVersionToRef(parsed.searchParams.get('version')) || fragmentRef;
+  const pathParam = parsed.searchParams.get('path');
+  const subpath = pathParam ? sanitizeSubpath(pathParam.replace(/^\/+/, '')) : undefined;
+
+  return {
+    type: 'git',
+    url: cloneUrl,
+    ...(ref ? { ref } : {}),
+    ...(subpath ? { subpath } : {}),
+    ...(fragmentSkillFilter ? { skillFilter: fragmentSkillFilter } : {}),
+  };
 }
 
 /**

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -122,6 +122,75 @@ export function sanitizeSubpath(subpath: string): string {
 }
 
 /**
+ * Azure Repos version query values: GBbranch, GTtag, GCcommit.
+ * Bare values are treated as refs as-is.
+ */
+function azureReposVersionToRef(version: string | null): string | undefined {
+  if (!version) {
+    return undefined;
+  }
+
+  const prefixed = /^(?:GB|GT|GC)(.+)$/i.exec(version)?.[1];
+  const ref = prefixed ?? version;
+  return ref || undefined;
+}
+
+/**
+ * Parse Azure Repos HTTPS URLs (cloud and Server).
+ * Marker is `/_git/{repo}` — the same path Azure DevOps uses for git clone,
+ * on any host. Query `path` and `version` come from the web UI.
+ */
+function parseAzureReposSource(
+  input: string,
+  fragmentRef?: string,
+  fragmentSkillFilter?: string
+): ParsedSource | null {
+  if (!input.startsWith('http://') && !input.startsWith('https://')) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(input);
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    const gitIndex = segments.indexOf('_git');
+    if (gitIndex < 0 || gitIndex === segments.length - 1) {
+      return null;
+    }
+
+    const repo = segments[gitIndex + 1]!.replace(/\.git$/, '');
+    if (!repo) {
+      return null;
+    }
+
+    const clonePath =
+      '/' +
+      [...segments.slice(0, gitIndex), '_git', repo]
+        .map((segment) => {
+          try {
+            return encodeURIComponent(decodeURIComponent(segment));
+          } catch {
+            return encodeURIComponent(segment);
+          }
+        })
+        .join('/');
+    const cloneUrl = `${parsed.protocol}//${parsed.host}${clonePath}`;
+    const ref = azureReposVersionToRef(parsed.searchParams.get('version')) || fragmentRef;
+    const pathParam = parsed.searchParams.get('path');
+    const subpath = pathParam ? sanitizeSubpath(pathParam.replace(/^\/+/, '')) : undefined;
+
+    return {
+      type: 'git',
+      url: cloneUrl,
+      ...(ref ? { ref } : {}),
+      ...(subpath ? { subpath } : {}),
+      ...(fragmentSkillFilter ? { skillFilter: fragmentSkillFilter } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Check if a string represents a local file system path
  */
 function isLocalPath(input: string): boolean {
@@ -138,7 +207,7 @@ function isLocalPath(input: string): boolean {
 
 /**
  * Parse a source string into a structured format
- * Supports: local paths, GitHub URLs, GitLab URLs, GitHub shorthand, well-known URLs,
+ * Supports: local paths, GitHub URLs, GitLab URLs, Azure Repos URLs, GitHub shorthand, well-known URLs,
  * hosted download URLs, and direct git URLs
  */
 // Source aliases: map common shorthand to canonical source
@@ -183,6 +252,14 @@ function looksLikeGitSource(input: string): boolean {
       // Only treat gitlab.com fragments as refs for repo/tree URLs.
       if (parsed.hostname === 'gitlab.com') {
         return /^\/.+?\/[^/]+(?:\.git)?(?:\/-\/tree\/[^/]+(?:\/.*)?)?\/?$/.test(pathname);
+      }
+
+      // Azure Repos clone and web URLs use /_git/{repo} on any host
+      // (dev.azure.com, *.visualstudio.com, Azure DevOps Server).
+      const azureSegments = pathname.split('/').filter(Boolean);
+      const azureGitIndex = azureSegments.indexOf('_git');
+      if (azureGitIndex >= 0 && azureGitIndex < azureSegments.length - 1) {
+        return true;
       }
     } catch {
       // Fall through to generic checks below.
@@ -428,6 +505,13 @@ export function parseSource(input: string): ParsedSource {
         ...(fragmentRef ? { ref: fragmentRef } : {}),
       };
     }
+  }
+
+  // Azure Repos (any host): https://dev.azure.com/org/project/_git/repo
+  // Also Azure DevOps Server: https://server[/tfs]/{collection}/{project}/_git/{repo}
+  const azureRepos = parseAzureReposSource(input, fragmentRef, fragmentSkillFilter);
+  if (azureRepos) {
+    return azureRepos;
   }
 
   // GitHub shorthand: owner/repo, owner/repo/path/to/skill, or owner/repo@skill-name

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -198,7 +198,7 @@ describe('parseSource', () => {
       expect(result.url).toBe('https://dev.azure.com/My%20Org/My%20Project/_git/agent-skills');
     });
 
-    it('version=GT is a tag ref and version=GC is a commit ref', () => {
+    it('version=GT is a tag ref; version=GC is not a cloneable ref', () => {
       expect(
         parseSource('https://dev.azure.com/fabrikam/Fiber/_git/skills?version=GTv1.2.0').ref
       ).toBe('v1.2.0');
@@ -206,7 +206,7 @@ describe('parseSource', () => {
         parseSource(
           'https://dev.azure.com/fabrikam/Fiber/_git/skills?version=GC2c732a035bae9fb21e7823d37b2b9553e272f0c6'
         ).ref
-      ).toBe('2c732a035bae9fb21e7823d37b2b9553e272f0c6');
+      ).toBeUndefined();
     });
 
     it('#fragment is a git ref on Azure Repos URLs', () => {

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -145,6 +145,86 @@ describe('parseSource', () => {
     });
   });
 
+  describe('Azure Repos URL tests', () => {
+    it('Azure DevOps Services clone URL is git, not well-known', () => {
+      const result = parseSource('https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills');
+      expect(result.ref).toBeUndefined();
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('Azure DevOps Services URL with .git suffix', () => {
+      const result = parseSource('https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills.git');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills');
+    });
+
+    it('Azure DevOps Services web URL with path and branch query', () => {
+      const result = parseSource(
+        'https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills?path=/skills/web-design&version=GBmain'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('skills/web-design');
+    });
+
+    it('visualstudio.com clone URL', () => {
+      const result = parseSource('https://fabrikam.visualstudio.com/FabrikamFiber/_git/skills');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://fabrikam.visualstudio.com/FabrikamFiber/_git/skills');
+    });
+
+    it('Azure DevOps Server collection/project/_git/repo', () => {
+      const result = parseSource('https://ado.example.com/DefaultCollection/MyProject/_git/skills');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://ado.example.com/DefaultCollection/MyProject/_git/skills');
+    });
+
+    it('Azure DevOps Server /tfs/ virtual directory', () => {
+      const result = parseSource(
+        'https://ado.example.com/tfs/DefaultCollection/MyProject/_git/skills'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe(
+        'https://ado.example.com/tfs/DefaultCollection/MyProject/_git/skills'
+      );
+    });
+
+    it('encoded spaces in organization and project', () => {
+      const result = parseSource('https://dev.azure.com/My%20Org/My%20Project/_git/agent-skills');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://dev.azure.com/My%20Org/My%20Project/_git/agent-skills');
+    });
+
+    it('version=GT is a tag ref and version=GC is a commit ref', () => {
+      expect(
+        parseSource('https://dev.azure.com/fabrikam/Fiber/_git/skills?version=GTv1.2.0').ref
+      ).toBe('v1.2.0');
+      expect(
+        parseSource(
+          'https://dev.azure.com/fabrikam/Fiber/_git/skills?version=GC2c732a035bae9fb21e7823d37b2b9553e272f0c6'
+        ).ref
+      ).toBe('2c732a035bae9fb21e7823d37b2b9553e272f0c6');
+    });
+
+    it('#fragment is a git ref on Azure Repos URLs', () => {
+      const result = parseSource(
+        'https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills#release-2026'
+      );
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://dev.azure.com/fabrikam/FabrikamFiber/_git/skills');
+      expect(result.ref).toBe('release-2026');
+    });
+
+    it('trailing slash after repo name', () => {
+      const result = parseSource('https://dev.azure.com/fabrikam/Fiber/_git/skills/');
+      expect(result.type).toBe('git');
+      expect(result.url).toBe('https://dev.azure.com/fabrikam/Fiber/_git/skills');
+    });
+  });
+
   describe('Generic URL tests', () => {
     it('generic HTTP URL is parsed as well-known with direct download fallback', () => {
       const result = parseSource('https://internal.example.com/download?id=123');

--- a/tests/subpath-traversal.test.ts
+++ b/tests/subpath-traversal.test.ts
@@ -109,4 +109,18 @@ describe('parseSource rejects traversal in subpaths', () => {
       expect(result.subpath).toBe('skills/my-skill');
     });
   });
+
+  describe('Azure Repos URLs with path traversal', () => {
+    it('rejects .. in Azure Repos path query', () => {
+      expect(() =>
+        parseSource('https://dev.azure.com/fabrikam/Fiber/_git/skills?path=../../etc')
+      ).toThrow('Unsafe subpath');
+    });
+
+    it('rejects encoded .. in Azure Repos path query', () => {
+      expect(() =>
+        parseSource('https://dev.azure.com/fabrikam/Fiber/_git/skills?path=%2e%2e/%2e%2e/etc')
+      ).toThrow('Unsafe subpath');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #737

## Summary
- Azure Repos clone URLs (`https://dev.azure.com/{org}/{project}/_git/{repo}` and Azure DevOps Server `…/_git/{repo}`) do not end in `.git`, so `parseSource` classified them as well-known and never cloned.
- Recognize the `/_git/{repo}` path marker on any host, the same way GitLab is recognized via `/-/tree/`. This covers Azure DevOps Services and Server without an allowlist of hostnames (the local workaround in #737 only added `dev.azure.com`).
- Optional web UI query params: `path=` → subpath, `version=GB*`/`GT*` → ref. `version=GC*` (commit SHA) is ignored because `git clone --branch` cannot check out a SHA.
- Unsafe `path=` values still throw from `sanitizeSubpath` (not swallowed into well-known).

This does not add `--source-type`. That flag is a broader design (also in #1670) and is not required once `/_git/` URLs parse as git.

## Test plan
- [x] `pnpm exec vitest run tests/source-parser.test.ts src/source-parser.test.ts tests/subpath-traversal.test.ts`
- [x] `pnpm test -- run` (762 tests before the follow-up commit; parser + traversal suites green after)
- [ ] `npx skills add https://dev.azure.com/{org}/{project}/_git/{repo} --list` against a public or credentialed Azure Repos repo
- [ ] Confirm a generic HTTPS URL without `/_git/` is still well-known