### PR TITLE
fix: refuse remove --all when specific skills are named

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -151,10 +151,10 @@ ${BOLD}Use Options:${RESET}
 
 ${BOLD}Remove Options:${RESET}
   -g, --global           Remove from global scope
-  -a, --agent <agents>   Remove from specific agents (use '*' for all agents)
+  -a, --agent <agents>   Remove from specific agents (omit to clean all agent links)
   -s, --skill <skills>   Specify skills to remove (use '*' for all skills)
   -y, --yes              Skip confirmation prompts
-  --all                  Shorthand for --skill '*' --agent '*' -y
+  --all                  Remove every installed skill (-y implied). Do not combine with named skills.
   
 ${BOLD}Experimental Sync Options:${RESET}
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
@@ -211,10 +211,10 @@ ${BOLD}Arguments:${RESET}
 
 ${BOLD}Options:${RESET}
   -g, --global       Remove from global scope (~/) instead of project scope
-  -a, --agent        Remove from specific agents (use '*' for all agents)
+  -a, --agent        Remove from specific agents (omit to clean all agent links)
   -s, --skill        Specify skills to remove (use '*' for all skills)
   -y, --yes          Skip confirmation prompts
-  --all              Shorthand for --skill '*' --agent '*' -y
+  --all              Remove every installed skill (-y implied). Do not combine with named skills.
 
 ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills remove                           ${DIM}# interactive selection${RESET}

--- a/src/parse-remove-options.test.ts
+++ b/src/parse-remove-options.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseRemoveOptions } from './remove.ts';
+
+describe('parseRemoveOptions', () => {
+  it('parses positional skill names', () => {
+    const result = parseRemoveOptions(['skill-one', 'skill-two', '-y']);
+    expect(result.skills).toEqual(['skill-one', 'skill-two']);
+    expect(result.options.yes).toBe(true);
+  });
+
+  it('parses -s/--skill names (documented remove flag)', () => {
+    const result = parseRemoveOptions(['--skill', 'skill-one', 'skill-two', '-g']);
+    expect(result.skills).toEqual(['skill-one', 'skill-two']);
+    expect(result.options.global).toBe(true);
+  });
+
+  it('does not treat --skill as an unknown token that drops the following name', () => {
+    // Regression: --skill was previously ignored, so
+    // `remove --skill foo --all` still collected `foo` as a positional name
+    // while --all wiped every skill.
+    const result = parseRemoveOptions(['--skill', 'agent-thread-visualizer', '--all', '-y']);
+    expect(result.skills).toEqual(['agent-thread-visualizer']);
+    expect(result.options.all).toBe(true);
+    expect(result.options.yes).toBe(true);
+  });
+
+  it('sets yes when --all is used', () => {
+    const result = parseRemoveOptions(['--all']);
+    expect(result.options.all).toBe(true);
+    expect(result.options.yes).toBe(true);
+  });
+});

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -185,6 +185,29 @@ This is a test skill.
       expect(existsSync(join(skillsDir, 'skill-three'))).toBe(false);
     });
 
+    it('should refuse --all combined with a named skill (mass-delete footgun)', () => {
+      const result = runCli(['remove', '--skill', 'skill-one', '--all', '-y'], testDir);
+
+      expect(result.stdout + result.stderr).toContain(
+        'Cannot combine --all with specific skill names'
+      );
+      expect(result.exitCode).toBe(1);
+
+      // Named skill and siblings must still be present
+      expect(existsSync(join(skillsDir, 'skill-one'))).toBe(true);
+      expect(existsSync(join(skillsDir, 'skill-two'))).toBe(true);
+      expect(existsSync(join(skillsDir, 'skill-three'))).toBe(true);
+    });
+
+    it('should remove a skill specified with --skill', () => {
+      const result = runCli(['remove', '--skill', 'skill-two', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(existsSync(join(skillsDir, 'skill-one'))).toBe(true);
+      expect(existsSync(join(skillsDir, 'skill-two'))).toBe(false);
+      expect(existsSync(join(skillsDir, 'skill-three'))).toBe(true);
+    });
+
     it('should show error for non-existent skill name when skills exist', () => {
       const result = runCli(['remove', 'non-existent', '-y'], testDir);
 

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -70,6 +70,25 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     );
   }
 
+  // `--skill '*'` is the documented synonym for selecting every skill.
+  if (skillNames.includes('*')) {
+    options.all = true;
+    skillNames = skillNames.filter((name) => name !== '*');
+  }
+
+  // Footgun: `remove --skill foo --all` used to ignore `foo` and wipe everything,
+  // because `--all` replaced the requested list with every installed skill.
+  // Refuse the combination so agents/scripts cannot accidentally mass-delete.
+  const namedSkills = skillNames.filter((name) => name !== '*');
+  if (options.all && namedSkills.length > 0) {
+    p.log.error('Cannot combine --all with specific skill names.');
+    p.log.info(
+      'Use `skills remove --all` to remove every skill, or omit --all to remove only the named skills.'
+    );
+    p.log.info(`Example: skills remove ${namedSkills[0]} -y`);
+    process.exit(1);
+  }
+
   const isGlobal = options.global ?? false;
   const cwd = process.cwd();
 
@@ -363,6 +382,10 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
 /**
  * Parse command line options for the remove command.
  * Separates skill names from options flags.
+ *
+ * Supports both positional names (`skills remove foo`) and `-s/--skill`
+ * (documented in the CLI help). Unknown flags that start with `-` are ignored
+ * so we do not treat `--skill` as a skill name when the flag is misspelled.
  */
 export function parseRemoveOptions(args: string[]): { skills: string[]; options: RemoveOptions } {
   const options: RemoveOptions = {};
@@ -377,6 +400,16 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
       options.yes = true;
     } else if (arg === '--all') {
       options.all = true;
+      options.yes = true;
+    } else if (arg === '-s' || arg === '--skill') {
+      i++;
+      let nextArg = args[i];
+      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+        skills.push(nextArg);
+        i++;
+        nextArg = args[i];
+      }
+      i--; // Back up one since the loop will increment
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       i++;


### PR DESCRIPTION
## Summary
- `skills remove --skill <name> --all` (and positional name + `--all`) previously ignored the named skills and deleted **every** installed skill — a dangerous footgun for agents/scripts.
- Reject that combination with a clear error and exit code 1 (no deletions).
- Actually parse `-s/--skill` for `remove` (help already documented it; the parser did not).
- Clarify remove help: `--all` means remove everything (`-y` implied); do not combine with named skills.

## Test plan
- [x] `npx vitest --run src/parse-remove-options.test.ts src/remove.test.ts tests/resolve-skills-to-remove.test.ts src/cli.test.ts` (76 passed)
- [ ] Manual: `skills remove --skill some-skill --all -y` → error, skill still present
- [ ] Manual: `skills remove --skill some-skill -y` → only that skill removed
- [ ] Manual: `skills remove --all -y` → still removes all