### PR TITLE
feat(agents): add omp (Oh My Pi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -315,6 +315,7 @@ Skills can be installed to any of these agents:
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Moxby | `moxby` | `.moxby/skills/` | `~/.moxby/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
+| omp (Oh My Pi) | `omp` | `.omp/skills/` | `~/.omp/agent/skills/` |
 | OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Skills can be installed to any of these agents:
 | Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
 | Moxby | `moxby` | `.moxby/skills/` | `~/.moxby/skills/` |
 | Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
-| omp (Oh My Pi) | `omp` | `.omp/skills/` | `~/.omp/agent/skills/` |
+| Oh My Pi | `omp` | `.omp/skills/` | `~/.omp/agent/skills/` |
 | OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
 | OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
 | Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |
@@ -450,6 +450,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.vibe/skills/`
 - `.moxby/skills/`
 - `.mux/skills/`
+- `.omp/skills/`
 - `.openhands/skills/`
 - `.ona/skills/`
 - `.pi/skills/`

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "mistral-vibe",
     "moxby",
     "mux",
+    "omp",
     "opencode",
     "openhands",
     "ona",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -519,6 +519,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.mux'));
     },
   },
+  omp: {
+    name: 'omp',
+    displayName: 'Oh My Pi',
+    skillsDir: '.omp/skills',
+    globalSkillsDir: join(home, '.omp/agent/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.omp/agent'));
+    },
+  },
   opencode: {
     name: 'opencode',
     displayName: 'OpenCode',
@@ -535,15 +544,6 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.openhands/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.openhands'));
-    },
-  },
-  omp: {
-    name: 'omp',
-    displayName: 'omp (Oh My Pi)',
-    skillsDir: '.omp/skills',
-    globalSkillsDir: join(home, '.omp/agent/skills'),
-    detectInstalled: async () => {
-      return existsSync(join(home, '.omp/agent'));
     },
   },
   ona: {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -537,6 +537,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.openhands'));
     },
   },
+  omp: {
+    name: 'omp',
+    displayName: 'omp (Oh My Pi)',
+    skillsDir: '.omp/skills',
+    globalSkillsDir: join(home, '.omp/agent/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.omp/agent'));
+    },
+  },
   ona: {
     name: 'ona',
     displayName: 'Ona',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -327,6 +327,7 @@ const PRIORITY_PREFIXES = [
   '.minimax/skills/',
   '.mux/skills/',
   '.neovate/skills/',
+  '.omp/skills/',
   '.opencode/skills/',
   '.openhands/skills/',
   '.pi/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -28,6 +28,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.minimax/skills',
   '.mux/skills',
   '.neovate/skills',
+  '.omp/skills',
   '.opencode/skills',
   '.openhands/skills',
   '.pi/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type AgentType =
   | 'moxby'
   | 'mux'
   | 'neovate'
+  | 'omp'
   | 'opencode'
   | 'openhands'
   | 'ona'

--- a/tests/omp-agent.test.ts
+++ b/tests/omp-agent.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtemp, mkdir, rm, readFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { agents } from '../src/agents.ts';
+import { findSkillMdPaths } from '../src/blob.ts';
+import { installSkillForAgent } from '../src/installer.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+const skillFile = (name: string) => `---
+name: ${name}
+description: ${name} test skill
+---
+
+# ${name}
+`;
+
+describe('Oh My Pi (omp) agent support', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'skills-omp-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('uses the documented project and global skill directories', () => {
+    expect(agents.omp.name).toBe('omp');
+    expect(agents.omp.displayName).toBe('Oh My Pi');
+    expect(agents.omp.skillsDir).toBe('.omp/skills');
+    expect(agents.omp.globalSkillsDir).toBe(join(homedir(), '.omp', 'agent', 'skills'));
+  });
+
+  it('installs a skill into .omp/skills', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-omp-install-'));
+    const projectDir = join(root, 'project');
+    const sourceDir = join(root, 'source-skill');
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(sourceDir, { recursive: true });
+    writeFileSync(join(sourceDir, 'SKILL.md'), skillFile('omp-skill'));
+
+    try {
+      const result = await installSkillForAgent(
+        { name: 'omp-skill', description: 'test', path: sourceDir },
+        'omp',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      await expect(
+        readFile(join(projectDir, '.omp/skills', 'omp-skill', 'SKILL.md'), 'utf-8')
+      ).resolves.toContain('name: omp-skill');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('discovers project skills from .omp/skills alongside standard skills', async () => {
+    const ompSkillDir = join(testDir, '.omp', 'skills', 'omp-skill');
+    const standardSkillDir = join(testDir, 'skills', 'standard-skill');
+    mkdirSync(ompSkillDir, { recursive: true });
+    mkdirSync(standardSkillDir, { recursive: true });
+    writeFileSync(join(ompSkillDir, 'SKILL.md'), skillFile('omp-skill'));
+    writeFileSync(join(standardSkillDir, 'SKILL.md'), skillFile('standard-skill'));
+
+    const discovered = await discoverSkills(testDir);
+
+    expect(discovered.map((skill) => skill.name).sort()).toEqual(['omp-skill', 'standard-skill']);
+  });
+
+  it('discovers .omp/skills through the GitHub tree fast path', () => {
+    const discovered = findSkillMdPaths({
+      sha: 'root-sha',
+      branch: 'main',
+      tree: [
+        {
+          path: '.claude/skills/standard-skill/SKILL.md',
+          type: 'blob',
+          sha: 'standard-sha',
+        },
+        {
+          path: '.omp/skills/omp-skill/SKILL.md',
+          type: 'blob',
+          sha: 'omp-sha',
+        },
+      ],
+    });
+
+    expect(discovered).toContain('.omp/skills/omp-skill/SKILL.md');
+  });
+});


### PR DESCRIPTION
## What

Registers [omp (Oh My Pi)](https://omp.sh) as a supported agent. It is a terminal coding agent that reads skills from `.omp/skills` in a project and `~/.omp/agent/skills` globally, with its agent home at `~/.omp/agent`. It is not currently in the registry, so `skills add` offers no omp target by name.

## Changes

| File | Change |
|---|---|
| `src/types.ts` | `omp` in the `AgentType` union |
| `src/agents.ts` | registry entry with native paths and `detectInstalled` |
| `src/skills.ts` | `.omp/skills` in `AGENT_PROJECT_SKILL_DIRS` |
| `src/blob.ts` | `.omp/skills/` in the trailing-slash variant |
| `README.md` | supported-agents table row, and the count in the intro |

## One thing worth your call

omp also reads `~/.agents/skills` natively, which the existing `.agents/skills` targets already write to. A user selecting omp alongside, say, Codex will have the skill present in both locations. Per [omp's docs](https://github.com/can1357/oh-my-pi/blob/main/docs/skills.md), provider directories are merged and the first same-named skill wins, so this resolves to one *loaded* skill rather than a duplicate.

Registering omp at its own home is what every other entry does, so that is what this PR does — but if you would rather avoid the overlap entirely, pointing the entry at `.agents/skills` (as `opencode`/`cursor`/`codex` already do) is a one-line change and I am happy to make it.

## Verification

- `tsc --noEmit` clean, `prettier --check` clean
- 746 tests pass
- End to end: `skills add <repo> --skill <name> --agent omp --copy -y` installs to `.omp/skills/<name>/SKILL.md`

Four tests fail identically **before and after** this change on my machine — 3 in `detect-agent.test.ts` (they read the ambient terminal's agent env vars, and I am running inside another agent) and 1 in `tests/git-lfs-clone.test.ts`. Both verified against a clean checkout of `main`; neither is touched here.

---

Sent alongside #1982, which restores type-to-filter for grouped skill lists. They share no files and can merge in either order.
