### PR TITLE
fix(add): keep search working when skills are grouped

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1353,7 +1353,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         items: skillChoices,
         required: true,
         maxVisible: 20,
-        searchable: !hasGroups,
+        searchable: true,
         showDetail: true,
         showSelectedSummary: false,
         selectGroups: hasGroups,

--- a/src/prompts/search-multiselect.test.ts
+++ b/src/prompts/search-multiselect.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { buildSearchEntries, toggleSearchEntry, type SearchItem } from './search-multiselect';
+
+const items: SearchItem<string>[] = [
+  { value: 'ask-matt', label: 'ask-matt', group: 'Engineering' },
+  { value: 'tdd', label: 'tdd', group: 'Engineering' },
+  { value: 'kmp-module-setup', label: 'kmp-module-setup', group: 'Team Mobile' },
+  { value: 'kmp-test-seams', label: 'kmp-test-seams', group: 'Team Mobile' },
+  { value: 'loose-skill', label: 'loose-skill' },
+];
+
+/** The prompt's own filter: substring match on label or value, case-insensitive. */
+const filterBy = (query: string): SearchItem<string>[] =>
+  items.filter(
+    (item) =>
+      item.label.toLowerCase().includes(query.toLowerCase()) ||
+      String(item.value).toLowerCase().includes(query.toLowerCase())
+  );
+
+const groupNames = (entries: ReturnType<typeof buildSearchEntries<string>>) =>
+  entries.filter((e) => e.type === 'group').map((e) => (e.type === 'group' ? e.group : ''));
+
+const itemValues = (entries: ReturnType<typeof buildSearchEntries<string>>) =>
+  entries.filter((e) => e.type === 'item').map((e) => (e.type === 'item' ? e.item.value : ''));
+
+describe('buildSearchEntries with groups', () => {
+  it('groups items and keeps ungrouped items as plain rows', () => {
+    const entries = buildSearchEntries(items, true);
+    expect(groupNames(entries)).toEqual(['Engineering', 'Team Mobile']);
+    expect(itemValues(entries)).toContain('loose-skill');
+  });
+
+  it('filters within groups and drops groups with no matches', () => {
+    const entries = buildSearchEntries(filterBy('kmp'), true);
+    expect(groupNames(entries)).toEqual(['Team Mobile']);
+    expect(itemValues(entries)).toEqual(['kmp-module-setup', 'kmp-test-seams']);
+  });
+
+  it('hides a collapsed group’s items but keeps its heading', () => {
+    const entries = buildSearchEntries(items, true, new Set(['Engineering']));
+    expect(groupNames(entries)).toEqual(['Engineering', 'Team Mobile']);
+    expect(itemValues(entries)).not.toContain('tdd');
+    expect(itemValues(entries)).toContain('kmp-module-setup');
+  });
+
+  it('reveals matches inside a collapsed group when the collapse set is ignored', () => {
+    // What the prompt does while a query is active: a filter is a temporary
+    // view, so it wins over the persistent collapse preference. Without this,
+    // typing a skill's exact name reports nothing when its group is collapsed.
+    const collapsed = new Set(['Engineering']);
+    expect(itemValues(buildSearchEntries(filterBy('tdd'), true, collapsed))).toEqual([]);
+    expect(itemValues(buildSearchEntries(filterBy('tdd'), true, new Set()))).toEqual(['tdd']);
+    // The preference itself is untouched — it is read, never cleared.
+    expect(collapsed.has('Engineering')).toBe(true);
+  });
+});
+
+describe('toggleSearchEntry on a group heading', () => {
+  it('selects every item the group currently shows', () => {
+    const entries = buildSearchEntries(items, true);
+    const selected = new Set<string>();
+    toggleSearchEntry(
+      selected,
+      entries.find((e) => e.type === 'group')
+    );
+    expect([...selected].sort()).toEqual(['ask-matt', 'tdd']);
+  });
+
+  it('selects only the visible matches while filtered, never the hidden ones', () => {
+    const entries = buildSearchEntries(filterBy('kmp-test'), true);
+    const selected = new Set<string>();
+    toggleSearchEntry(
+      selected,
+      entries.find((e) => e.type === 'group')
+    );
+    // kmp-module-setup shares the group but does not match the query, so a
+    // single keystroke must not install something the user cannot see.
+    expect([...selected]).toEqual(['kmp-test-seams']);
+  });
+
+  it('deselects a group only when every shown item is already selected', () => {
+    const entries = buildSearchEntries(items, true);
+    const group = entries.find((e) => e.type === 'group');
+    const selected = new Set<string>(['ask-matt']);
+    toggleSearchEntry(selected, group);
+    expect([...selected].sort()).toEqual(['ask-matt', 'tdd']);
+    toggleSearchEntry(selected, group);
+    expect([...selected]).toEqual([]);
+  });
+});

--- a/src/prompts/search-multiselect.test.ts
+++ b/src/prompts/search-multiselect.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { buildSearchEntries, toggleSearchEntry, type SearchItem } from './search-multiselect';
+import {
+  activeCollapsedGroups,
+  buildSearchEntries,
+  collapseKeysActive,
+  filterSearchItems,
+  toggleSearchEntry,
+  type SearchItem,
+} from './search-multiselect';
 
 const items: SearchItem<string>[] = [
   { value: 'ask-matt', label: 'ask-matt', group: 'Engineering' },
@@ -9,13 +16,8 @@ const items: SearchItem<string>[] = [
   { value: 'loose-skill', label: 'loose-skill' },
 ];
 
-/** The prompt's own filter: substring match on label or value, case-insensitive. */
-const filterBy = (query: string): SearchItem<string>[] =>
-  items.filter(
-    (item) =>
-      item.label.toLowerCase().includes(query.toLowerCase()) ||
-      String(item.value).toLowerCase().includes(query.toLowerCase())
-  );
+/** The prompt's own filter, imported rather than reimplemented so it cannot drift. */
+const filterBy = (query: string): SearchItem<string>[] => filterSearchItems(items, query);
 
 const groupNames = (entries: ReturnType<typeof buildSearchEntries<string>>) =>
   entries.filter((e) => e.type === 'group').map((e) => (e.type === 'group' ? e.group : ''));
@@ -43,15 +45,60 @@ describe('buildSearchEntries with groups', () => {
     expect(itemValues(entries)).toContain('kmp-module-setup');
   });
 
-  it('reveals matches inside a collapsed group when the collapse set is ignored', () => {
-    // What the prompt does while a query is active: a filter is a temporary
-    // view, so it wins over the persistent collapse preference. Without this,
-    // typing a skill's exact name reports nothing when its group is collapsed.
+  it('reveals matches inside a manually-collapsed group while a query is active', () => {
+    // The regression this PR fixes, wired the way the prompt wires it: the
+    // collapse set goes through activeCollapsedGroups rather than being blanked
+    // by hand. Without it, typing a skill's exact name reports nothing because
+    // its group was collapsed earlier.
     const collapsed = new Set(['Engineering']);
-    expect(itemValues(buildSearchEntries(filterBy('tdd'), true, collapsed))).toEqual([]);
-    expect(itemValues(buildSearchEntries(filterBy('tdd'), true, new Set()))).toEqual(['tdd']);
+
+    const idle = buildSearchEntries(filterBy(''), true, activeCollapsedGroups('', collapsed));
+    expect(itemValues(idle)).not.toContain('tdd');
+
+    const searching = buildSearchEntries(
+      filterBy('tdd'),
+      true,
+      activeCollapsedGroups('tdd', collapsed)
+    );
+    expect(itemValues(searching)).toEqual(['tdd']);
+
     // The preference itself is untouched — it is read, never cleared.
     expect(collapsed.has('Engineering')).toBe(true);
+    expect(
+      itemValues(buildSearchEntries(items, true, activeCollapsedGroups('', collapsed)))
+    ).not.toContain('tdd');
+  });
+});
+
+describe('activeCollapsedGroups', () => {
+  it('honours the collapse preference when no query is active', () => {
+    const collapsed = new Set(['Engineering']);
+    expect(activeCollapsedGroups('', collapsed)).toBe(collapsed);
+  });
+
+  it('ignores the collapse preference while a query is active, without clearing it', () => {
+    const collapsed = new Set(['Engineering']);
+    expect([...activeCollapsedGroups('kmp', collapsed)]).toEqual([]);
+    expect([...collapsed]).toEqual(['Engineering']);
+  });
+});
+
+describe('collapseKeysActive', () => {
+  it('enables ←/→ only when grouping is on and no query is active', () => {
+    expect(collapseKeysActive(true, '')).toBe(true);
+  });
+
+  it('makes both ←/→ no-ops while a query is active', () => {
+    // Read-only during search. Previously ← still wrote to the collapse set
+    // while → was guarded by entry.collapsed — always false while filtering —
+    // so collapse state accumulated with no way to undo it until the query
+    // cleared. Neither key may act unless this predicate is true.
+    expect(collapseKeysActive(true, 'kmp')).toBe(false);
+  });
+
+  it('stays off when grouping is disabled', () => {
+    expect(collapseKeysActive(false, '')).toBe(false);
+    expect(collapseKeysActive(false, 'kmp')).toBe(false);
   });
 });
 

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -231,6 +231,54 @@ export function buildSearchEntries<T>(
   return entries;
 }
 
+/** The prompt's filter: case-insensitive substring match on label or value. */
+export function matchesSearchQuery<T>(item: SearchItem<T>, query: string): boolean {
+  if (!query) return true;
+  const lowerQuery = query.toLowerCase();
+  return (
+    item.label.toLowerCase().includes(lowerQuery) ||
+    String(item.value).toLowerCase().includes(lowerQuery)
+  );
+}
+
+/** Narrow a list to the items matching a query. */
+export function filterSearchItems<T>(items: SearchItem<T>[], query: string): SearchItem<T>[] {
+  return items.filter((item) => matchesSearchQuery(item, query));
+}
+
+const NO_COLLAPSED_GROUPS: ReadonlySet<string> = new Set();
+
+/**
+ * The collapse state to render with.
+ *
+ * A filter is a temporary view; a collapsed group is a persistent preference.
+ * While a query is active the view wins, so a group holding matches always
+ * reveals them — otherwise a user could type a skill's exact name and be told
+ * it does not exist, because it sits inside a group they collapsed earlier.
+ * `collapsedGroups` is only read here, never cleared, so the preference is
+ * intact the moment the query is.
+ */
+export function activeCollapsedGroups(
+  query: string,
+  collapsedGroups: ReadonlySet<string>
+): ReadonlySet<string> {
+  return query ? NO_COLLAPSED_GROUPS : collapsedGroups;
+}
+
+/**
+ * Whether ←/→ collapse and expand anything right now.
+ *
+ * They are live only when grouping is on and no query is active. While
+ * filtering, the rendered collapse state is forced empty by
+ * `activeCollapsedGroups`, so a keypress that wrote to the collapse set would
+ * change nothing on screen and then surprise the user the moment the query
+ * cleared. Both keys are read-only in that state — genuine no-ops, not one key
+ * recording state the other cannot undo.
+ */
+export function collapseKeysActive(selectGroups: boolean, query: string): boolean {
+  return selectGroups && !query;
+}
+
 /** Toggle one item, or every item represented by a selectable group heading. */
 export function toggleSearchEntry<T>(selected: Set<T>, entry: SearchEntry<T> | undefined): void {
   if (entry?.type === 'group') {
@@ -295,38 +343,19 @@ export async function searchMultiselect<T>(
     // Locked items are always included in the result
     const lockedValues = lockedSection ? lockedSection.items.map((i) => i.value) : [];
 
-    const filter = (item: SearchItem<T>, q: string): boolean => {
-      if (!q) return true;
-      const lowerQ = q.toLowerCase();
-      return (
-        item.label.toLowerCase().includes(lowerQ) ||
-        String(item.value).toLowerCase().includes(lowerQ)
-      );
-    };
+    const getFiltered = (): SearchItem<T>[] => filterSearchItems(items, query);
 
-    const getFiltered = (): SearchItem<T>[] => {
-      return items.filter((item) => filter(item, query));
-    };
+    /** The collapse state to render with — see `activeCollapsedGroups`. */
+    const renderedCollapsedGroups = (): ReadonlySet<string> =>
+      activeCollapsedGroups(query, collapsedGroups);
 
-    const NO_COLLAPSED_GROUPS: Set<string> = new Set();
-
-    /**
-     * Collapse state to render with.
-     *
-     * A filter is a temporary view; a collapsed group is a persistent
-     * preference. While a query is active the view wins, so a group holding
-     * matches always reveals them — otherwise a user could type a skill's exact
-     * name and be told it does not exist, because it sits inside a group they
-     * collapsed earlier. `collapsedGroups` is only read here, never cleared, so
-     * the preference is intact the moment the query is.
-     */
-    const activeCollapsedGroups = (): Set<string> =>
-      query ? NO_COLLAPSED_GROUPS : collapsedGroups;
+    /** Whether ←/→ do anything right now — see `collapseKeysActive`. */
+    const collapseKeysLive = (): boolean => collapseKeysActive(selectGroups, query);
 
     const render = (state: 'active' | 'submit' | 'cancel' = 'active'): void => {
       const lines: string[] = [];
       const filtered = getFiltered();
-      const entries = buildSearchEntries(filtered, selectGroups, activeCollapsedGroups());
+      const entries = buildSearchEntries(filtered, selectGroups, renderedCollapsedGroups());
 
       // Header
       const icon =
@@ -356,7 +385,7 @@ export async function searchMultiselect<T>(
           lines.push(searchLine);
           lines.push(
             `${S_BAR}  ${pc.dim(
-              selectGroups
+              collapseKeysLive()
                 ? '↑↓ move, ←→ collapse/expand, space select, enter confirm'
                 : '↑↓ move, space select, enter confirm'
             )}`
@@ -512,7 +541,7 @@ export async function searchMultiselect<T>(
     const keypressHandler = (_str: string, key: readline.Key): void => {
       if (!key) return;
 
-      const entries = buildSearchEntries(getFiltered(), selectGroups, activeCollapsedGroups());
+      const entries = buildSearchEntries(getFiltered(), selectGroups, renderedCollapsedGroups());
 
       if (key.name === 'return') {
         submit();
@@ -536,7 +565,7 @@ export async function searchMultiselect<T>(
         return;
       }
 
-      if (selectGroups && key.name === 'right') {
+      if (collapseKeysLive() && key.name === 'right') {
         const entry = entries[cursor];
         if (entry?.type === 'group' && entry.collapsed) {
           collapsedGroups.delete(entry.group);
@@ -545,7 +574,7 @@ export async function searchMultiselect<T>(
         return;
       }
 
-      if (selectGroups && key.name === 'left') {
+      if (collapseKeysLive() && key.name === 'left') {
         const entry = entries[cursor];
         const group = entry?.type === 'group' ? entry.group : entry?.item.group;
         if (group) {
@@ -553,7 +582,7 @@ export async function searchMultiselect<T>(
           const collapsedEntries = buildSearchEntries(
             getFiltered(),
             selectGroups,
-            activeCollapsedGroups()
+            renderedCollapsedGroups()
           );
           cursor = collapsedEntries.findIndex(
             (collapsedEntry) => collapsedEntry.type === 'group' && collapsedEntry.group === group

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -308,10 +308,25 @@ export async function searchMultiselect<T>(
       return items.filter((item) => filter(item, query));
     };
 
+    const NO_COLLAPSED_GROUPS: Set<string> = new Set();
+
+    /**
+     * Collapse state to render with.
+     *
+     * A filter is a temporary view; a collapsed group is a persistent
+     * preference. While a query is active the view wins, so a group holding
+     * matches always reveals them — otherwise a user could type a skill's exact
+     * name and be told it does not exist, because it sits inside a group they
+     * collapsed earlier. `collapsedGroups` is only read here, never cleared, so
+     * the preference is intact the moment the query is.
+     */
+    const activeCollapsedGroups = (): Set<string> =>
+      query ? NO_COLLAPSED_GROUPS : collapsedGroups;
+
     const render = (state: 'active' | 'submit' | 'cancel' = 'active'): void => {
       const lines: string[] = [];
       const filtered = getFiltered();
-      const entries = buildSearchEntries(filtered, selectGroups, collapsedGroups);
+      const entries = buildSearchEntries(filtered, selectGroups, activeCollapsedGroups());
 
       // Header
       const icon =
@@ -339,7 +354,13 @@ export async function searchMultiselect<T>(
         if (searchable) {
           const searchLine = `${S_BAR}  ${pc.dim('Search:')} ${query}${pc.inverse(' ')}`;
           lines.push(searchLine);
-          lines.push(`${S_BAR}  ${pc.dim('↑↓ move, space select, enter confirm')}`);
+          lines.push(
+            `${S_BAR}  ${pc.dim(
+              selectGroups
+                ? '↑↓ move, ←→ collapse/expand, space select, enter confirm'
+                : '↑↓ move, space select, enter confirm'
+            )}`
+          );
           lines.push(`${S_BAR}`);
         }
 
@@ -491,7 +512,7 @@ export async function searchMultiselect<T>(
     const keypressHandler = (_str: string, key: readline.Key): void => {
       if (!key) return;
 
-      const entries = buildSearchEntries(getFiltered(), selectGroups, collapsedGroups);
+      const entries = buildSearchEntries(getFiltered(), selectGroups, activeCollapsedGroups());
 
       if (key.name === 'return') {
         submit();
@@ -529,7 +550,11 @@ export async function searchMultiselect<T>(
         const group = entry?.type === 'group' ? entry.group : entry?.item.group;
         if (group) {
           collapsedGroups.add(group);
-          const collapsedEntries = buildSearchEntries(getFiltered(), selectGroups, collapsedGroups);
+          const collapsedEntries = buildSearchEntries(
+            getFiltered(),
+            selectGroups,
+            activeCollapsedGroups()
+          );
           cursor = collapsedEntries.findIndex(
             (collapsedEntry) => collapsedEntry.type === 'group' && collapsedEntry.group === group
           );

--- a/tests/search-multiselect-collapse-keys.test.ts
+++ b/tests/search-multiselect-collapse-keys.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { cancelSymbol, searchMultiselect } from '../src/prompts/search-multiselect.ts';
+
+const groupedItems = [
+  { value: 'ask-matt', label: 'ask-matt', group: 'Engineering' },
+  { value: 'tdd', label: 'tdd', group: 'Engineering' },
+  { value: 'kmp-module-setup', label: 'kmp-module-setup', group: 'Team Mobile' },
+  { value: 'kmp-test-seams', label: 'kmp-test-seams', group: 'Team Mobile' },
+];
+
+const startPrompt = () =>
+  searchMultiselect({
+    message: 'Select skills',
+    items: groupedItems,
+    selectGroups: true,
+    searchable: true,
+  });
+
+const type = (char: string) => process.stdin.emit('keypress', char, { name: char, sequence: char });
+
+const press = (name: string) => process.stdin.emit('keypress', '', { name });
+
+const framesSince = (write: ReturnType<typeof vi.spyOn>) =>
+  write.mock.calls.map((call) => String(call[0])).join('\n');
+
+describe('searchMultiselect ←/→ while a query is active', () => {
+  it('makes ← a no-op that leaves no collapse behind once the query clears', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const prompt = startPrompt();
+
+    // Filter down to one group, then try to collapse while filtering.
+    type('k');
+    write.mockClear();
+    press('left');
+
+    // A genuine no-op renders nothing at all. Before the fix this redrew the
+    // frame after writing to the collapse set.
+    expect(write).not.toHaveBeenCalled();
+
+    // Clear the query. The group must come back expanded — the ← above must not
+    // have recorded a collapse that only becomes visible now.
+    write.mockClear();
+    press('backspace');
+
+    const frame = framesSince(write);
+    expect(frame).toContain('kmp-module-setup');
+    expect(frame).toContain('tdd');
+
+    press('escape');
+    await expect(prompt).resolves.toBe(cancelSymbol);
+    write.mockRestore();
+  });
+
+  it('makes → a no-op while filtering', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const prompt = startPrompt();
+
+    type('k');
+    write.mockClear();
+    press('right');
+
+    expect(write).not.toHaveBeenCalled();
+
+    press('escape');
+    await expect(prompt).resolves.toBe(cancelSymbol);
+    write.mockRestore();
+  });
+
+  it('still collapses and expands with ←/→ when no query is active', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const prompt = startPrompt();
+
+    // Cursor starts on the first group heading.
+    write.mockClear();
+    press('left');
+    expect(framesSince(write)).not.toContain('ask-matt');
+
+    write.mockClear();
+    press('right');
+    expect(framesSince(write)).toContain('ask-matt');
+
+    press('escape');
+    await expect(prompt).resolves.toBe(cancelSymbol);
+    write.mockRestore();
+  });
+});


### PR DESCRIPTION
## The problem

`skills add` disables type-to-filter whenever the source repo groups its skills:

```ts
searchable: !hasGroups,
```

On a repo with a few dozen skills that trades one navigation problem for another. The groups make the list scannable, but a user who already knows the skill's name can no longer type it — they have to arrow through the tree instead.

## Why the two features can coexist

They already are compatible, mechanically:

- `buildSearchEntries` is called with the **filtered** items, so grouping is applied *after* filtering
- the collapse keys (←/→) are non-printable, so they never collide with the query buffer

So this enables search unconditionally and fixes the two places where the combination was not accounted for.

### 1. A collapsed group hid its matches

`buildSearchEntries` skips a collapsed group's items regardless of *why* it is collapsed — so typing a skill's exact name reported nothing if its group happened to be collapsed. That is the precise complaint this PR exists to fix, so it would have been a poor thing to reintroduce.

While a query is active the collapse set is now read as empty. A filter is a temporary view; a collapsed group is a persistent preference; the view wins while it is on. The set is only **read**, never cleared, so collapse state is intact the moment the query is.

### 2. The collapse hint only rendered when search was off

`←→ collapse/expand` lived exclusively in the non-searchable branch, so flipping the flag would have silently removed collapse's only discoverability. The searchable hint now includes it when groups are selectable.

## One behaviour this makes reachable

With a filter active, a group heading selects the items it currently **shows**, not every member. That is what `toggleSearchEntry` already does — it was simply unreachable while grouped lists were unsearchable.

It seems clearly right: one keystroke must not install something the user cannot see. And the heading already renders a tri-state radio (`●` / `◐` / `○`), so a partial selection stays honest once the filter clears. Say the word if you would rather a heading always mean the whole group.

## Tests

Adds `src/prompts/search-multiselect.test.ts` — the first coverage for grouped lists:

- filtering within groups, and groups with no matches dropping out
- a collapsed group hiding items but keeping its heading
- matches inside a collapsed group revealed while a query is active, with the collapse set left untouched
- group toggle: selects everything shown; selects **only** visible matches while filtered; deselects only when every shown item is selected

## Verification

`tsc --noEmit` clean, `prettier --check` clean, 753 tests pass.

Four tests fail identically **before and after** this change on my machine — 3 in `detect-agent.test.ts` (they read the ambient terminal's agent env vars, and I am running inside another agent) and 1 in `tests/git-lfs-clone.test.ts`. Both verified against a clean checkout of `main`; neither is touched here.

---

Sent alongside #1981, which adds an agent registry entry. They share no files and can merge in either order.