### PR TITLE
fix: fail scoped well-known installs instead of falling back to the root index

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -36,6 +36,7 @@ import { detectAgent, getAgentType } from './detect-agent.ts';
 import {
   wellKnownProvider,
   computeWellKnownSkillDigest,
+  WellKnownScopeNotFoundError,
   type WellKnownSkill,
 } from './providers/index.ts';
 import { downloadSource } from './download-source.ts';
@@ -579,7 +580,16 @@ async function handleWellKnownSkills(
   spinner.start('Discovering skills from well-known endpoint...');
 
   // Fetch all skills from the well-known endpoint
-  const skills = await wellKnownProvider.fetchAllSkills(url).catch(() => []);
+  let skills: WellKnownSkill[] = [];
+  try {
+    skills = await wellKnownProvider.fetchAllSkills(url);
+  } catch (error) {
+    if (error instanceof WellKnownScopeNotFoundError) {
+      spinner.stop(pc.red('No matching skills'));
+      p.log.error(error.message);
+      process.exit(1);
+    }
+  }
 
   if (skills.length === 0) {
     spinner.stop(pc.dim('No well-known skills found; trying direct download...'));

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,6 +7,7 @@ export { registry, registerProvider, findProvider, getProviders } from './regist
 // Export individual providers
 export {
   WellKnownProvider,
+  WellKnownScopeNotFoundError,
   wellKnownProvider,
   computeWellKnownSkillDigest,
   type NormalizedWellKnownEntry,

--- a/src/providers/wellknown.ts
+++ b/src/providers/wellknown.ts
@@ -49,6 +49,29 @@ export interface WellKnownSkillEntryV2 {
   digest: string;
 }
 
+/**
+ * Thrown when a path-scoped URL (for example https://host/s/my-list) has no
+ * usable skills under that path while the host does publish a root index.
+ * Falling back to the root index in that situation used to install the
+ * host's entire catalog, so the caller must surface the unresolved scope
+ * instead of installing anything.
+ */
+export class WellKnownScopeNotFoundError extends Error {
+  readonly scopePath: string;
+  readonly rootUrl: string;
+
+  constructor(scopePath: string, rootUrl: string) {
+    super(
+      `No skills found for the scoped path '${scopePath}' on ${rootUrl}. ` +
+        `Not falling back to the root skills index because that would install every skill the host publishes. ` +
+        `Check the URL, or run 'skills add ${rootUrl}' to install from the root index.`
+    );
+    this.name = 'WellKnownScopeNotFoundError';
+    this.scopePath = scopePath;
+    this.rootUrl = rootUrl;
+  }
+}
+
 export type WellKnownIndex = WellKnownIndexV1 | WellKnownIndexV2;
 export type WellKnownSkillEntry = WellKnownSkillEntryV1 | WellKnownSkillEntryV2;
 export type WellKnownFileContent = string | Uint8Array;
@@ -552,12 +575,38 @@ export class WellKnownProvider implements HostProvider {
     };
   }
 
-  /** Fetch all skills from a well-known endpoint. */
+  /**
+   * Get the path scope of a URL, if any. A URL such as https://host/s/my-list
+   * is scoped to '/s/my-list'; a bare origin has no scope.
+   */
+  private getScope(url: string): { scopePath: string; rootBaseUrl: string } | null {
+    try {
+      const parsed = new URL(url);
+      const scopePath = parsed.pathname.replace(/\/$/, '');
+      if (!scopePath) return null;
+      return { scopePath, rootBaseUrl: `${parsed.protocol}//${parsed.host}` };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Fetch all skills from a well-known endpoint.
+   *
+   * When the URL is scoped to a path, only path-relative indexes are used.
+   * If the scope yields no skills but the host publishes a root index, this
+   * throws {@link WellKnownScopeNotFoundError} instead of silently widening
+   * to the root index and returning the host's entire catalog.
+   */
   async fetchAllSkills(url: string): Promise<WellKnownSkill[]> {
     try {
       const candidates = await this.fetchIndexCandidates(url);
+      const scope = this.getScope(url);
+      const scopedCandidates = scope
+        ? candidates.filter((c) => c.resolvedBaseUrl !== scope.rootBaseUrl)
+        : candidates;
 
-      for (const result of candidates) {
+      for (const result of scopedCandidates) {
         const skillPromises = result.entries.map((entry) => this.fetchSkillByEntry(entry));
         const results = await Promise.all(skillPromises);
         const skills = results.filter(
@@ -566,8 +615,13 @@ export class WellKnownProvider implements HostProvider {
         if (skills.length > 0) return skills;
       }
 
+      if (scope && scopedCandidates.length < candidates.length) {
+        throw new WellKnownScopeNotFoundError(scope.scopePath, scope.rootBaseUrl);
+      }
+
       return [];
-    } catch {
+    } catch (error) {
+      if (error instanceof WellKnownScopeNotFoundError) throw error;
       return [];
     }
   }

--- a/src/use.ts
+++ b/src/use.ts
@@ -14,6 +14,7 @@ import type { AgentType, Skill } from './types.ts';
 import { downloadSource } from './download-source.ts';
 import {
   wellKnownProvider,
+  WellKnownScopeNotFoundError,
   type WellKnownSkill,
   type WellKnownFileContent,
 } from './providers/wellknown.ts';
@@ -218,7 +219,10 @@ export async function runUse(
     let selectedSkill: UseSkill;
 
     if (parsed.type === 'well-known') {
-      const skills = await wellKnownProvider.fetchAllSkills(parsed.url);
+      const skills = await wellKnownProvider.fetchAllSkills(parsed.url).catch((error) => {
+        if (error instanceof WellKnownScopeNotFoundError) fail(error.message);
+        return [] as WellKnownSkill[];
+      });
       if (skills.length > 0) {
         selectedSkill = selectWellKnownSkill(skills, selector, source);
       } else {

--- a/tests/wellknown-provider.test.ts
+++ b/tests/wellknown-provider.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { gzipSync } from 'node:zlib';
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { WellKnownProvider } from '../src/providers/wellknown.ts';
+import { WellKnownProvider, WellKnownScopeNotFoundError } from '../src/providers/wellknown.ts';
 import { createZip } from './fixtures/zip.ts';
 
 const SCHEMA_V2 = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
@@ -232,6 +232,85 @@ describe('WellKnownProvider', () => {
       expect(skills[0]!.sourceUrl).toBe(
         'https://code.claude.com/docs/.well-known/skills/claude/SKILL.md'
       );
+    });
+
+    it('fails instead of falling back to the root index when a scoped path has no index', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === 'https://example.com/.well-known/agent-skills/index.json') {
+          return response({
+            skills: [
+              { name: 'alpha', description: 'Alpha skill.', files: ['SKILL.md'] },
+              { name: 'beta', description: 'Beta skill.', files: ['SKILL.md'] },
+            ],
+          });
+        }
+        return response('not found', { status: 404 });
+      });
+
+      await expect(provider.fetchAllSkills('https://example.com/s/alpha')).rejects.toThrow(
+        WellKnownScopeNotFoundError
+      );
+      await expect(provider.fetchAllSkills('https://example.com/s/alpha')).rejects.toThrow(
+        /\/s\/alpha/
+      );
+    });
+
+    it('fails when the scoped index exists but lists no skills', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === 'https://example.com/s/alpha/.well-known/agent-skills/index.json') {
+          return response({ skills: [] });
+        }
+        if (href === 'https://example.com/.well-known/agent-skills/index.json') {
+          return response({
+            skills: [
+              { name: 'alpha', description: 'Alpha skill.', files: ['SKILL.md'] },
+              { name: 'beta', description: 'Beta skill.', files: ['SKILL.md'] },
+            ],
+          });
+        }
+        return response('not found', { status: 404 });
+      });
+
+      await expect(provider.fetchAllSkills('https://example.com/s/alpha')).rejects.toThrow(
+        WellKnownScopeNotFoundError
+      );
+    });
+
+    it('uses the scoped index without consulting the root index when the scope resolves', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+        const href = String(url);
+        if (href === 'https://example.com/s/alpha/.well-known/agent-skills/index.json') {
+          return response({
+            skills: [{ name: 'alpha', description: 'Alpha skill.', files: ['SKILL.md'] }],
+          });
+        }
+        if (href === 'https://example.com/s/alpha/.well-known/agent-skills/alpha/SKILL.md') {
+          return response('---\nname: alpha\ndescription: Alpha skill.\n---\n# Alpha');
+        }
+        if (href === 'https://example.com/.well-known/agent-skills/index.json') {
+          return response({
+            skills: [
+              { name: 'alpha', description: 'Alpha skill.', files: ['SKILL.md'] },
+              { name: 'beta', description: 'Beta skill.', files: ['SKILL.md'] },
+            ],
+          });
+        }
+        return response('not found', { status: 404 });
+      });
+
+      const skills = await provider.fetchAllSkills('https://example.com/s/alpha');
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.installName).toBe('alpha');
+    });
+
+    it('returns no skills for a scoped path when the host has no index at all', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+        response('not found', { status: 404 })
+      );
+
+      await expect(provider.fetchAllSkills('https://example.com/s/alpha')).resolves.toEqual([]);
     });
 
     it('supports v0.2.0 skill-md entries with relative URL resolution and digest checks', async () => {


### PR DESCRIPTION
`skills add <host>/s/<list>` fell back to the root `/.well-known/agent-skills/index.json` when the scoped index returned a 404 or an empty skill list, and with `-y` that installed the host's entire catalog (69 skills in the issue's repro) from a one-skill URL. The well-known provider now only uses path-relative indexes for a path-scoped URL, and when the scope resolves to nothing while the host publishes a root index it reports an error naming the unresolved scope, so `skills add` exits 1 without installing anything. Hosts with no index anywhere keep the existing direct-download fallback, and URLs whose scoped index resolves behave as before.

New tests in tests/wellknown-provider.test.ts cover the 404 scope, the empty scoped index, a resolving scope with a root index present, and a host with no index at all; the fix was also verified against the issue's stub server in all three modes.

Fixes #1978
