### PR TITLE
fix(add): exit non-zero when install prompts cannot run without a TTY

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -101,6 +101,37 @@ Instructions here.
     expect(result.exitCode).toBe(0);
   });
 
+  it('should exit non-zero when the agent prompt cannot run without a TTY', () => {
+    // Create a test skill
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+# My Skill
+
+Instructions here.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    // No agents are detected in the isolated test home, and stdin is a pipe
+    // that hits EOF immediately, so the agent picker cannot collect input.
+    // The CLI previously exited 0 here with nothing installed.
+    const result = runCli(['add', testDir], targetDir);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toContain('Installation cancelled');
+    expect(result.stderr).toContain('not a TTY');
+    expect(existsSync(join(targetDir, '.claude', 'skills', 'my-skill'))).toBe(false);
+    expect(existsSync(join(targetDir, '.agents', 'skills', 'my-skill'))).toBe(false);
+  });
+
   it('deduplicates copied install paths for universal agents sharing the same directory', () => {
     const sourceDir = join(testDir, 'source');
     const skillDir = join(sourceDir, 'skills', 'shared-skill');

--- a/src/add.ts
+++ b/src/add.ts
@@ -398,6 +398,26 @@ function buildResultLines(
 }
 
 /**
+ * Exit after an installation prompt was cancelled before anything was installed.
+ *
+ * Without a TTY the prompt cannot collect input at all: stdin EOF cancels it
+ * immediately. Exiting 0 there reports success to scripts and CI even though
+ * nothing was installed, so exit non-zero and point at the non-interactive
+ * flags instead. A deliberate interactive cancel still exits 0.
+ */
+function exitInstallationCancelled(): never {
+  p.cancel('Installation cancelled');
+  if (!process.stdin.isTTY) {
+    console.error(
+      'Interactive prompt required but stdin is not a TTY. Nothing was installed. ' +
+        `Use --agent <name> (or --agent '*') and -y to run non-interactively.`
+    );
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+/**
  * Prompts the user to select agents using interactive search.
  * Pre-selects the last used agents if available.
  * Saves the selection for future use.
@@ -657,8 +677,7 @@ async function handleWellKnownSkills(
     });
 
     if (isCancelled(selected)) {
-      p.cancel('Installation cancelled');
-      process.exit(0);
+      exitInstallationCancelled();
     }
 
     selectedSkills = selected as WellKnownSkill[];
@@ -706,9 +725,8 @@ async function handleWellKnownSkills(
           allAgentChoices
         );
 
-        if (p.isCancel(selected)) {
-          p.cancel('Installation cancelled');
-          process.exit(0);
+        if (isCancelled(selected)) {
+          exitInstallationCancelled();
         }
 
         targetAgents = selected as AgentType[];
@@ -727,9 +745,8 @@ async function handleWellKnownSkills(
     } else {
       const selected = await selectAgentsInteractive({ global: options.global });
 
-      if (p.isCancel(selected)) {
-        p.cancel('Installation cancelled');
-        process.exit(0);
+      if (isCancelled(selected)) {
+        exitInstallationCancelled();
       }
 
       targetAgents = selected as AgentType[];
@@ -759,8 +776,7 @@ async function handleWellKnownSkills(
     });
 
     if (p.isCancel(scope)) {
-      p.cancel('Installation cancelled');
-      process.exit(0);
+      exitInstallationCancelled();
     }
 
     installGlobally = scope as boolean;
@@ -787,8 +803,7 @@ async function handleWellKnownSkills(
     });
 
     if (p.isCancel(modeChoice)) {
-      p.cancel('Installation cancelled');
-      process.exit(0);
+      exitInstallationCancelled();
     }
 
     installMode = modeChoice as InstallMode;
@@ -849,8 +864,7 @@ async function handleWellKnownSkills(
     const confirmed = await p.confirm({ message: 'Proceed with installation?' });
 
     if (p.isCancel(confirmed) || !confirmed) {
-      p.cancel('Installation cancelled');
-      process.exit(0);
+      exitInstallationCancelled();
     }
   }
 
@@ -1365,9 +1379,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       });
 
       if (isCancelled(selected)) {
-        p.cancel('Installation cancelled');
         await cleanup(tempDir);
-        process.exit(0);
+        exitInstallationCancelled();
       }
 
       selectedSkills = selected as Skill[];
@@ -1421,9 +1434,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             });
 
         if (p.isCancel(useEve)) {
-          p.cancel('Installation cancelled');
           await cleanup(tempDir);
-          process.exit(0);
+          exitInstallationCancelled();
         }
 
         if (useEve) {
@@ -1432,10 +1444,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         } else {
           const selected = await selectAgentsInteractive({ global: options.global });
 
-          if (p.isCancel(selected)) {
-            p.cancel('Installation cancelled');
+          if (isCancelled(selected)) {
             await cleanup(tempDir);
-            process.exit(0);
+            exitInstallationCancelled();
           }
 
           targetAgents = selected as AgentType[];
@@ -1460,10 +1471,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             allAgentChoices
           );
 
-          if (p.isCancel(selected)) {
-            p.cancel('Installation cancelled');
+          if (isCancelled(selected)) {
             await cleanup(tempDir);
-            process.exit(0);
+            exitInstallationCancelled();
           }
 
           targetAgents = selected as AgentType[];
@@ -1482,10 +1492,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       } else {
         const selected = await selectAgentsInteractive({ global: options.global });
 
-        if (p.isCancel(selected)) {
-          p.cancel('Installation cancelled');
+        if (isCancelled(selected)) {
           await cleanup(tempDir);
-          process.exit(0);
+          exitInstallationCancelled();
         }
 
         targetAgents = selected as AgentType[];
@@ -1527,9 +1536,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         });
 
         if (p.isCancel(selectedSubagents)) {
-          p.cancel('Installation cancelled');
           await cleanup(tempDir);
-          process.exit(0);
+          exitInstallationCancelled();
         }
 
         eveSubagentTargets = (selectedSubagents as string[]).map((s) => (s === '' ? undefined : s));
@@ -1561,9 +1569,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       });
 
       if (p.isCancel(scope)) {
-        p.cancel('Installation cancelled');
         await cleanup(tempDir);
-        process.exit(0);
+        exitInstallationCancelled();
       }
 
       installGlobally = scope as boolean;
@@ -1597,9 +1604,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       });
 
       if (p.isCancel(modeChoice)) {
-        p.cancel('Installation cancelled');
         await cleanup(tempDir);
-        process.exit(0);
+        exitInstallationCancelled();
       }
 
       installMode = modeChoice as InstallMode;
@@ -1727,9 +1733,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const confirmed = await p.confirm({ message: 'Proceed with installation?' });
 
       if (p.isCancel(confirmed) || !confirmed) {
-        p.cancel('Installation cancelled');
         await cleanup(tempDir);
-        process.exit(0);
+        exitInstallationCancelled();
       }
     }
 

--- a/src/prompts/search-multiselect.ts
+++ b/src/prompts/search-multiselect.ts
@@ -567,6 +567,7 @@ export async function searchMultiselect<T>(
     };
 
     const cleanup = (): void => {
+      rl.removeListener('close', closeHandler);
       process.stdin.removeListener('keypress', keypressHandler);
       if (process.stdin.isTTY) {
         process.stdin.setRawMode(false);
@@ -574,11 +575,15 @@ export async function searchMultiselect<T>(
       rl.close();
     };
 
+    let settled = false;
+
     const submit = (): void => {
+      if (settled) return;
       // If required and no locked items, don't allow submitting with no selection
       if (required && selected.size === 0 && lockedValues.length === 0) {
         return;
       }
+      settled = true;
       render('submit');
       cleanup();
       // Include locked values in the result
@@ -586,9 +591,18 @@ export async function searchMultiselect<T>(
     };
 
     const cancel = (): void => {
+      if (settled) return;
+      settled = true;
       render('cancel');
       cleanup();
       resolve(cancelSymbol);
+    };
+
+    // Treat end of input as a cancel. Without this, a non-TTY stdin (CI,
+    // piped input) that reaches EOF leaves the promise pending forever and
+    // the process exits 0 as if the prompt had succeeded.
+    const closeHandler = (): void => {
+      cancel();
     };
 
     // Handle keypresses
@@ -671,6 +685,15 @@ export async function searchMultiselect<T>(
     };
 
     process.stdin.on('keypress', keypressHandler);
+    rl.on('close', closeHandler);
+
+    // stdin may have already reached EOF before this prompt attached (an
+    // earlier readline consumer, such as a spinner, reads the stream), in
+    // which case the interface above never emits 'close'.
+    if (process.stdin.readableEnded || process.stdin.destroyed) {
+      cancel();
+      return;
+    }
 
     // Initial render
     render();


### PR DESCRIPTION
With no detected agents and no TTY, `skills add` rendered the agent picker, hit EOF on stdin, and exited 0 having installed nothing, so a CI run of an install command reported success while doing nothing. The picker's promise never settled on an already-ended stdin (an earlier spinner consumes the EOF event) and the process simply drained; the prompt now treats EOF as a cancel, and a cancelled install exits 1 with a stderr pointer to `--agent` and `-y` when stdin is not a TTY, while a deliberate interactive cancel keeps exiting 0. This also fixes a latent crash where several call sites checked the custom picker's cancel symbol with clack's `isCancel`, which does not recognize it.

A new test in src/add.test.ts runs the CLI with piped stdin and no detected agents and asserts a non-zero exit, the stderr message, and that nothing was installed.

Fixes #1974
