### PR TITLE
feat: add Manus agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -279,7 +279,7 @@ Skills can be installed to any of these agents:
 | IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
+| Cline, Dexto, Kimi Code CLI, Loaf, Manus, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `manus`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codemaker | `codemaker` | `.codemaker/skills/` | `~/.codemaker/skills/` |

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "kode",
     "lingma",
     "loaf",
+    "manus",
     "mcpjam",
     "minimax-code",
     "mistral-vibe",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -474,6 +474,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.loaf'));
     },
   },
+  manus: {
+    name: 'manus',
+    displayName: 'Manus',
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.manus')) || existsSync('/Applications/Manus.app');
+    },
+  },
   mcpjam: {
     name: 'mcpjam',
     displayName: 'MCPJam',

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export type AgentType =
   | 'kode'
   | 'lingma'
   | 'loaf'
+  | 'manus'
   | 'mcpjam'
   | 'minimax-code'
   | 'mistral-vibe'

--- a/tests/manus-agent.test.ts
+++ b/tests/manus-agent.test.ts
@@ -1,0 +1,57 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { agents, getUniversalAgents, isUniversalAgent } from '../src/agents.ts';
+import { getAgentBaseDir, installSkillForAgent } from '../src/installer.ts';
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe('Manus agent', () => {
+  it('uses the canonical universal paths for project and global installs', () => {
+    const project = '/tmp/manus-project';
+
+    expect(agents.manus).toMatchObject({
+      name: 'manus',
+      displayName: 'Manus',
+      skillsDir: '.agents/skills',
+      globalSkillsDir: join(homedir(), '.agents', 'skills'),
+    });
+    expect(isUniversalAgent('manus')).toBe(true);
+    expect(getUniversalAgents()).toContain('manus');
+    expect(getAgentBaseDir('manus', false, project)).toBe(join(project, '.agents', 'skills'));
+    expect(getAgentBaseDir('manus', true)).toBe(join(homedir(), '.agents', 'skills'));
+  });
+
+  it('installs an explicitly selected Manus skill into one canonical project directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'manus-agent-'));
+    temporaryRoots.push(root);
+    const source = join(root, 'source');
+    const project = join(root, 'project');
+    await mkdir(source, { recursive: true });
+    await mkdir(project, { recursive: true });
+    await writeFile(
+      join(source, 'SKILL.md'),
+      '---\nname: manus-webdev\ndescription: Build web applications.\n---\n',
+      'utf-8'
+    );
+
+    const result = await installSkillForAgent(
+      { name: 'manus-webdev', description: 'Build web applications.', path: source },
+      'manus',
+      { cwd: project, global: false, mode: 'copy' }
+    );
+
+    const expected = join(project, '.agents', 'skills', 'manus-webdev');
+    expect(result).toMatchObject({ success: true, path: expected });
+    await expect(readFile(join(expected, 'SKILL.md'), 'utf-8')).resolves.toContain(
+      'name: manus-webdev'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- register `manus` as a supported Agent Skills target
- use the universal `.agents/skills` project and global paths
- update generated supported-agent documentation and package keywords
- test explicit Manus installation, global path resolution, and universal target deduplication

## Validation

- `pnpm exec vitest run`: 57 files and 752 tests passed
- `pnpm type-check`
- `pnpm format:check`
- `node scripts/validate-agents.ts`
- exact isolated-home install with `-a manus -g -y` placed `manus-webdev` at `~/.agents/skills/manus-webdev`
- repeating with `-a codex -g -y` kept the same single canonical directory
