### PR TITLE
fix: support global skill install for PromptScript

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -745,7 +745,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'promptscript',
     displayName: 'PromptScript',
     skillsDir: '.agents/skills',
-    globalSkillsDir: undefined,
+    globalSkillsDir: join(home, '.agents', 'skills'),
     showInUniversalPrompt: false,
     detectInstalled: async () => {
       return (


### PR DESCRIPTION
## Problem
`npx skills add -g` fails for the `promptscript` agent with:
`PromptScript does not support global skill installation`

`promptscript.globalSkillsDir` is `undefined`, and the installer treats `undefined` as an explicit signal that the agent has no global install support, rejecting the request before it ever reaches `getAgentBaseDir`'s fallback logic.

## Fix
`promptscript` uses the same project-level `skillsDir: '.agents/skills'` as several other agents (`cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed`), all of which already set:

```ts
globalSkillsDir: join(home, '.agents', 'skills'),
```

This PR applies the identical value to `promptscript`, matching the existing convention rather than introducing a new one.

## Testing
- `npx vitest run` — same 75 pre-existing failures present on unmodified `main` (unrelated environment/snapshot issues), no new failures introduced by this change.
- Diff is a single line change to `src/agents.ts`.