### PR TITLE
feat(list): Add portable skill export commands to list `--export`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This file provides guidance to AI coding agents working on the `skills` CLI code
 | `skills use <pkg>@<skill>`    | Use one skill without installing                    |
 | `skills experimental_install` | Restore skills from skills-lock.json                |
 | `skills experimental_sync`    | Sync skills from node_modules into agent dirs       |
-| `skills list`                 | List installed skills (alias: `ls`)                 |
+| `skills list`                 | List installed skills (alias: `ls`; `--export` prints one reinstall command per line) |
 | `skills update [skills...]`   | Update skills to latest versions                    |
 | `skills init [name]`          | Create a new SKILL.md template                      |
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ npx skills ls -g
 
 # Filter by specific agents
 npx skills ls -a claude-code -a cursor
+
+# Export install commands (one per line) to replicate these skills on another
+# machine. Skills installed from local paths or node_modules are skipped.
+npx skills ls -g --export > skills.sh
 ```
 
 ### `skills find`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -164,6 +164,11 @@ ${BOLD}List Options:${RESET}
   -g, --global           List global skills (default: project)
   -a, --agent <agents>   Filter by specific agents
   --json                 Output as JSON (machine-readable, no ANSI codes)
+  --export               Output one install command per line, ready to run on
+                         another machine to replicate these skills (e.g. save to
+                         a file and run it with sh). Skills installed from local
+                         paths or node_modules cannot be exported this way and
+                         are listed as skipped on stderr.
 
 ${BOLD}Options:${RESET}
   --help, -h        Show this help message
@@ -183,6 +188,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills ls -g                         ${DIM}# list global skills${RESET}
   ${DIM}$${RESET} skills ls -a claude-code             ${DIM}# filter by agent${RESET}
   ${DIM}$${RESET} skills ls --json                      ${DIM}# JSON output${RESET}
+  ${DIM}$${RESET} skills ls -g --export > skills.sh    ${DIM}# install commands to replicate global skills${RESET}
   ${DIM}$${RESET} skills find                          ${DIM}# interactive search${RESET}
   ${DIM}$${RESET} skills find typescript               ${DIM}# search by keyword${RESET}
   ${DIM}$${RESET} skills find react --owner vercel     ${DIM}# search within an owner${RESET}

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -3,7 +3,9 @@ import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli } from './test-utils.ts';
-import { parseListOptions } from './list.ts';
+import { parseListOptions, buildExportCommands } from './list.ts';
+import type { InstalledSkill } from './installer.ts';
+import type { SkillLockEntry } from './skill-lock.ts';
 
 describe('list command', () => {
   let testDir: string;
@@ -74,6 +76,17 @@ description: ${description}
     it('should parse --json flag', () => {
       const options = parseListOptions(['--json']);
       expect(options.json).toBe(true);
+    });
+
+    it('should parse --export flag', () => {
+      const options = parseListOptions(['--export']);
+      expect(options.export).toBe(true);
+    });
+
+    it('should parse combined --export and -g flags', () => {
+      const options = parseListOptions(['-g', '--export']);
+      expect(options.global).toBe(true);
+      expect(options.export).toBe(true);
     });
 
     it('should parse combined --json and -g flags', () => {
@@ -336,6 +349,297 @@ description: ${description}
       const result = runCli(['list'], testDir);
       // Path is shown inline with skill name (handles both Unix / and Windows \)
       expect(result.stdout).toMatch(/\.agents[/\\]skills[/\\]test-skill/);
+    });
+  });
+
+  describe('--export', () => {
+    function writeProjectLock(skills: Record<string, Record<string, unknown>>): void {
+      writeFileSync(join(testDir, 'skills-lock.json'), JSON.stringify({ version: 1, skills }));
+    }
+
+    describe('buildExportCommands', () => {
+      function makeSkill(name: string): InstalledSkill {
+        return {
+          name,
+          description: '',
+          path: `/skills/${name}`,
+          canonicalPath: `/skills/${name}`,
+          scope: 'global',
+          agents: [],
+        };
+      }
+
+      function lockLookup(
+        entries: Record<string, Partial<SkillLockEntry>>
+      ): (skillName: string) => SkillLockEntry | undefined {
+        return (name) => entries[name] as SkillLockEntry | undefined;
+      }
+
+      it('should return no commands when no skills are installed', () => {
+        const { commands, skipped } = buildExportCommands([], () => undefined, false);
+        expect(commands).toEqual([]);
+        expect(skipped).toEqual([]);
+      });
+
+      it('should group skills from the same source into one command', () => {
+        const { commands } = buildExportCommands(
+          [makeSkill('skill-a'), makeSkill('skill-b')],
+          lockLookup({
+            'skill-a': { source: 'owner/repo', sourceType: 'github' },
+            'skill-b': { source: 'owner/repo', sourceType: 'github' },
+          }),
+          false
+        );
+        expect(commands).toEqual(['skills add owner/repo --skill skill-a skill-b -y']);
+      });
+
+      it('should use github shorthand for github.com and full URLs otherwise', () => {
+        const { commands } = buildExportCommands(
+          [makeSkill('hub'), makeSkill('ghe')],
+          lockLookup({
+            hub: {
+              source: 'owner/repo',
+              sourceUrl: 'https://github.com/owner/repo.git',
+              sourceType: 'github',
+            },
+            ghe: {
+              source: 'team/repo',
+              sourceUrl: 'https://ghe.acme.com/team/repo.git',
+              sourceType: 'github',
+            },
+          }),
+          false
+        );
+        expect(commands).toEqual([
+          'skills add https://ghe.acme.com/team/repo.git --skill ghe -y',
+          'skills add owner/repo --skill hub -y',
+        ]);
+      });
+
+      it('should keep skills with different refs in separate commands', () => {
+        const { commands } = buildExportCommands(
+          [makeSkill('pinned'), makeSkill('floating')],
+          lockLookup({
+            pinned: { source: 'owner/repo', sourceType: 'github', ref: 'v2' },
+            floating: { source: 'owner/repo', sourceType: 'github' },
+          }),
+          false
+        );
+        expect(commands).toEqual([
+          'skills add owner/repo --skill floating -y',
+          "skills add 'owner/repo#v2' --skill pinned -y",
+        ]);
+      });
+
+      it('should preserve each skill path from the lock file', () => {
+        const { commands } = buildExportCommands(
+          [makeSkill('root-skill'), makeSkill('nested-skill')],
+          lockLookup({
+            'root-skill': {
+              source: 'owner/repo',
+              sourceType: 'github',
+              skillPath: 'SKILL.md',
+            },
+            'nested-skill': {
+              source: 'owner/repo',
+              sourceType: 'github',
+              skillPath: 'skills/nested-skill/SKILL.md',
+            },
+          }),
+          false
+        );
+        expect(commands).toEqual([
+          'skills add owner/repo --skill root-skill -y',
+          'skills add owner/repo/skills/nested-skill --skill nested-skill -y',
+        ]);
+      });
+
+      it('should use full-depth when a git URL cannot include a skill path', () => {
+        const { commands } = buildExportCommands(
+          [makeSkill('nested-skill')],
+          lockLookup({
+            'nested-skill': {
+              source: 'git@git.example.com:owner/repo.git',
+              sourceType: 'git',
+              skillPath: 'skills/nested-skill/SKILL.md',
+            },
+          }),
+          false
+        );
+        expect(commands).toEqual([
+          'skills add git@git.example.com:owner/repo.git --skill nested-skill --full-depth -y',
+        ]);
+      });
+
+      it('should skip ambiguous legacy git sources', () => {
+        const { commands, skipped } = buildExportCommands(
+          [makeSkill('legacy-skill')],
+          lockLookup({
+            'legacy-skill': { source: 'acme/skills', sourceType: 'git' },
+          }),
+          false
+        );
+        expect(commands).toEqual([]);
+        expect(skipped).toEqual(['legacy-skill (missing source URL)']);
+      });
+
+      it('should skip local and node_modules sources, explaining why', () => {
+        const { commands, skipped } = buildExportCommands(
+          [makeSkill('local-skill'), makeSkill('nm-skill')],
+          lockLookup({
+            'local-skill': { source: '/some/path', sourceType: 'local' },
+            'nm-skill': { source: '@scope/pkg', sourceType: 'node_modules' },
+          }),
+          false
+        );
+        expect(commands).toEqual([]);
+        expect(skipped).toEqual([
+          'local-skill (local path: /some/path)',
+          'nm-skill (node_modules: @scope/pkg)',
+        ]);
+      });
+
+      it('should skip skills with no lock entry', () => {
+        const { commands, skipped } = buildExportCommands(
+          [makeSkill('orphan')],
+          () => undefined,
+          false
+        );
+        expect(commands).toEqual([]);
+        expect(skipped).toEqual(['orphan (no recorded source)']);
+      });
+
+      it('should include -g for global scope', () => {
+        const { commands } = buildExportCommands(
+          [makeSkill('skill-a')],
+          lockLookup({ 'skill-a': { source: 'owner/repo', sourceType: 'github' } }),
+          true
+        );
+        expect(commands).toEqual(['skills add owner/repo --skill skill-a -g -y']);
+      });
+    });
+
+    it('should output nothing on stdout when no skills are installed', () => {
+      const result = runCli(['list', '--export'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('');
+    });
+
+    it('should output only commands, one per line', () => {
+      createTestSkill(testDir, 'skill-alpha', 'Alpha');
+      createTestSkill(testDir, 'skill-beta', 'Beta');
+      writeProjectLock({
+        'skill-alpha': {
+          source: 'owner/team-skills',
+          sourceUrl: 'https://github.com/owner/team-skills.git',
+          sourceType: 'github',
+          computedHash: 'hash-a',
+        },
+        'skill-beta': {
+          source: 'owner/team-skills',
+          sourceUrl: 'https://github.com/owner/team-skills.git',
+          sourceType: 'github',
+          computedHash: 'hash-b',
+        },
+      });
+
+      const result = runCli(['list', '--export'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(
+        'skills add owner/team-skills --skill skill-alpha skill-beta -y'
+      );
+    });
+
+    it('should use github shorthand for github.com and full URLs otherwise', () => {
+      createTestSkill(testDir, 'hub-skill', 'GitHub skill');
+      createTestSkill(testDir, 'ghe-skill', 'Enterprise skill');
+      writeProjectLock({
+        'hub-skill': {
+          source: 'owner/repo',
+          sourceUrl: 'https://github.com/owner/repo.git',
+          sourceType: 'github',
+          computedHash: 'hash-a',
+        },
+        'ghe-skill': {
+          source: 'team/repo',
+          sourceUrl: 'https://ghe.acme.com/team/repo.git',
+          sourceType: 'github',
+          computedHash: 'hash-b',
+        },
+      });
+
+      const result = runCli(['list', '--export'], testDir);
+      expect(result.stdout).toContain('skills add owner/repo --skill hub-skill -y');
+      expect(result.stdout).toContain(
+        'skills add https://ghe.acme.com/team/repo.git --skill ghe-skill -y'
+      );
+    });
+
+    it('should append the ref as a quoted fragment', () => {
+      createTestSkill(testDir, 'ref-skill', 'Pinned skill');
+      writeProjectLock({
+        'ref-skill': {
+          source: 'owner/repo',
+          sourceUrl: 'https://github.com/owner/repo.git',
+          sourceType: 'github',
+          ref: 'v2',
+          computedHash: 'hash-a',
+        },
+      });
+
+      const result = runCli(['list', '--export'], testDir);
+      expect(result.stdout).toContain("skills add 'owner/repo#v2' --skill ref-skill -y");
+    });
+
+    it('should keep skipped local skills out of the command output', () => {
+      createTestSkill(testDir, 'local-skill', 'Local skill');
+      writeProjectLock({
+        'local-skill': {
+          source: '/some/path/on/this/machine',
+          sourceType: 'local',
+          computedHash: 'hash-a',
+        },
+      });
+
+      const result = runCli(['list', '--export'], testDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('skills add');
+      expect(result.stdout).not.toContain('local-skill');
+    });
+
+    it('should include -g when exporting global skills', () => {
+      const testHome = join(testDir, 'home');
+      createTestSkill(testHome, 'global-skill', 'A global skill');
+      const lockDir = join(testHome, '.local', 'state', 'skills');
+      mkdirSync(lockDir, { recursive: true });
+      writeFileSync(
+        join(lockDir, '.skill-lock.json'),
+        JSON.stringify({
+          version: 3,
+          skills: {
+            'global-skill': {
+              source: 'owner/global-skills',
+              sourceUrl: 'https://github.com/owner/global-skills.git',
+              sourceType: 'github',
+              skillFolderHash: 'global-hash',
+              installedAt: '2026-07-01T00:00:00.000Z',
+              updatedAt: '2026-07-01T00:00:00.000Z',
+            },
+          },
+        })
+      );
+
+      const result = runCli(['list', '-g', '--export'], testDir, { HOME: testHome });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(
+        'skills add owner/global-skills --skill global-skill -g -y'
+      );
+    });
+
+    it('should reject --export combined with --json', () => {
+      const result = runCli(['list', '--export', '--json'], testDir);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('--export cannot be combined with --json');
     });
   });
 

--- a/src/list.ts
+++ b/src/list.ts
@@ -5,6 +5,7 @@ import { listInstalledSkills, sanitizeName, type InstalledSkill } from './instal
 import { sanitizeMetadata } from './sanitize.ts';
 import { getAllLockedSkills } from './skill-lock.ts';
 import { readLocalLock } from './local-lock.ts';
+import { buildUpdateInstallSource, shouldUseFullDepthForUpdate } from './update-source.ts';
 
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
@@ -17,6 +18,7 @@ interface ListOptions {
   global?: boolean;
   agent?: string[];
   json?: boolean;
+  export?: boolean;
 }
 
 interface ListLockEntry {
@@ -24,6 +26,8 @@ interface ListLockEntry {
   sourceUrl?: string;
   sourceType: string;
   pluginName?: string;
+  ref?: string;
+  skillPath?: string;
 }
 
 /**
@@ -61,6 +65,8 @@ export function parseListOptions(args: string[]): ListOptions {
       options.global = true;
     } else if (arg === '--json') {
       options.json = true;
+    } else if (arg === '--export') {
+      options.export = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       // Collect all following arguments until next flag
@@ -73,11 +79,90 @@ export function parseListOptions(args: string[]): ListOptions {
   return options;
 }
 
+/** Quote a token for POSIX shells while keeping each command on one line. */
+function shellQuote(value: string): string {
+  const clean = value.replace(/[\x00-\x1f\x7f]/g, '');
+  if (/^[A-Za-z0-9-._/:@]+$/.test(clean)) return clean;
+  return `'${clean.replace(/'/g, `'\\''`)}'`;
+}
+
+function getExportSourceArg(entry: ListLockEntry): string {
+  if (entry.sourceType === 'github') {
+    const url = entry.sourceUrl ?? '';
+    if (!url || /^https?:\/\/github\.com\//i.test(url)) {
+      return entry.source;
+    }
+  }
+  return entry.sourceUrl ?? entry.source;
+}
+
+export function buildExportCommands(
+  installedSkills: InstalledSkill[],
+  getLockEntry: (skillName: string) => ListLockEntry | undefined,
+  scope: boolean
+): { commands: string[]; skipped: string[] } {
+  const groups = new Map<string, Map<boolean, string[]>>();
+  const skipped: string[] = [];
+
+  for (const skill of installedSkills) {
+    const entry = getLockEntry(skill.name);
+    if (!entry) {
+      skipped.push(`${sanitizeMetadata(skill.name)} (no recorded source)`);
+      continue;
+    }
+    if (entry.sourceType === 'local' || entry.sourceType === 'node_modules') {
+      skipped.push(
+        `${sanitizeMetadata(skill.name)} (${entry.sourceType === 'local' ? 'local path' : 'node_modules'}: ${sanitizeMetadata(entry.source)})`
+      );
+      continue;
+    }
+
+    const exportEntry = {
+      ...entry,
+      source: getExportSourceArg(entry),
+      sourceUrl: undefined,
+    };
+    const sourceArg = buildUpdateInstallSource(exportEntry);
+    if (!sourceArg) {
+      skipped.push(`${sanitizeMetadata(skill.name)} (missing source URL)`);
+      continue;
+    }
+
+    const fullDepth = shouldUseFullDepthForUpdate(exportEntry);
+    const sourceGroups = groups.get(sourceArg) ?? new Map<boolean, string[]>();
+    const group = sourceGroups.get(fullDepth) ?? [];
+    group.push(skill.name);
+    sourceGroups.set(fullDepth, group);
+    groups.set(sourceArg, sourceGroups);
+  }
+
+  const commands: string[] = [];
+  const sortedSources = [...groups.keys()].sort((a, b) => a.localeCompare(b));
+  for (const sourceArg of sortedSources) {
+    const sourceGroups = groups.get(sourceArg);
+    if (!sourceGroups) continue;
+    for (const fullDepth of [false, true]) {
+      const names = sourceGroups.get(fullDepth)?.sort();
+      if (!names) continue;
+      commands.push(
+        `skills add ${shellQuote(sourceArg)} --skill ${names.map(shellQuote).join(' ')}${fullDepth ? ' --full-depth' : ''}${scope ? ' -g' : ''} -y`
+      );
+    }
+  }
+
+  return { commands, skipped: skipped.sort() };
+}
+
 export async function runList(args: string[]): Promise<void> {
   const options = parseListOptions(args);
 
   // Default to project only (local), use -g for global
   const scope = options.global === true ? true : false;
+
+  if (options.export && options.json) {
+    console.log(`${YELLOW}--export cannot be combined with --json${RESET}`);
+    process.exit(1);
+  }
 
   // Validate agent filter if provided
   let agentFilter: AgentType[] | undefined;
@@ -109,6 +194,21 @@ export async function runList(args: string[]): Promise<void> {
   );
   const getLockEntry = (skillName: string): ListLockEntry | undefined =>
     lockedSkills[skillName] ?? lockEntriesBySanitizedName.get(sanitizeName(skillName));
+
+  // Keep stdout pipeable into sh.
+  if (options.export) {
+    const { commands, skipped } = buildExportCommands(installedSkills, getLockEntry, scope);
+    for (const command of commands) {
+      console.log(command);
+    }
+    for (const note of skipped) {
+      console.error(`${YELLOW}Skipped ${note} — not portable to another machine${RESET}`);
+    }
+    if (commands.length === 0 && skipped.length === 0) {
+      console.error(`${DIM}No ${scope ? 'global' : 'project'} skills found.${RESET}`);
+    }
+    return;
+  }
 
   // JSON output mode: structured, no ANSI, untruncated agent lists
   if (options.json) {


### PR DESCRIPTION
## Why

`skills ls --json` exposes installation metadata, but using it to move skills between computers requires parsing JSON, rebuilding `skills add` commands, handling refs and paths, and quoting shell arguments.

`--export` provides executable install commands directly.

## What

- Adds `skills ls --export` for project skills and `skills ls -g --export` for global skills.
- Prints one `skills add` command per source.
- Groups skills from the same source into one command.
- Preserves refs, nested skill paths, global scope, and `--full-depth` when needed.
- Writes commands only to stdout. Skipped local, `node_modules`, untracked, or ambiguous legacy sources are reported on stderr.
- Rejects combining `--export` with `--json`.
- Quotes generated arguments for POSIX shells.

Export to a file and copy it to another computer:

```bash
skills ls -g --export > skills.sh
scp skills.sh user@other-machine:~
ssh user@other-machine 'sh ~/skills.sh'
```

Pipe directly over SSH:

```bash
skills ls -g --export | ssh user@other-machine 'sh -s'
```

Transfer project skills:

```bash
skills ls --export > bootstrap-skills.sh
sh bootstrap-skills.sh
```

Preview or edit the commands before running them:

```bash
skills ls -g --export | less
```

The destination computer must have the `skills` CLI available.

## Testing

- Added coverage for flag parsing, command grouping, refs, GitHub and non-GitHub sources, global scope, nested skill paths, full-depth installs, skipped sources, empty output, and `--json` conflicts.
- 79 targeted tests passing.
- TypeScript check passing.
- Prettier and `git diff --check` passing.