### PR TITLE
feat: add Nexrall Code as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [74 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -335,6 +335,7 @@ Skills can be installed to any of these agents:
 | ZCode | `zcode` | `.zcode/skills/` | `~/.zcode/skills/` |
 | Zencoder, Zenflow | `zencoder`, `zenflow` | `.zencoder/skills/` | `~/.zencoder/skills/` |
 | Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
+| Nexrall Code | `nexrall-code` | `.nexrall/skills/` | `~/.nexrall/skills/` |
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
 | PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
@@ -467,6 +468,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.zcode/skills/`
 - `.zencoder/skills/`
 - `.neovate/skills/`
+- `.nexrall/skills/`
 - `.pochi/skills/`
 - `.adal/skills/`
 <!-- skill-discovery:end -->

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "zencoder",
     "zenflow",
     "neovate",
+    "nexrall-code",
     "pochi",
     "promptscript",
     "adal",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -750,6 +750,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.neovate'));
     },
   },
+  'nexrall-code': {
+    name: 'nexrall-code',
+    displayName: 'Nexrall Code',
+    skillsDir: '.nexrall/skills',
+    globalSkillsDir: join(home, '.nexrall/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.nexrall'));
+    },
+  },
   pochi: {
     name: 'pochi',
     displayName: 'Pochi',

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type AgentType =
   | 'moxby'
   | 'mux'
   | 'neovate'
+  | 'nexrall-code'
   | 'opencode'
   | 'openhands'
   | 'ona'


### PR DESCRIPTION
Closes #2002.

Adds **Nexrall Code** (`nexrall-code`) — an AI coding agent (CLI `nex` + VS Code extension) built on the `agentskills.io` format — as a supported install target.

### Agent details

| Field | Value |
|---|---|
| Agent Name | Nexrall Code |
| Skills Documentation | https://docs.nexrall.com/developers/sub-agents-and-skills |
| Project Skills Directory | `.nexrall/skills` |
| Global Skills Directory | `~/.nexrall/skills` |
| Detection Path | `~/.nexrall` |

Nexrall Code also scans the cross-client `.agents/skills/` convention (project + global) — a skill installed by any compliant tool works in Nexrall too, with `.nexrall/skills` and `.nexrall/commands/*.md` always winning a name collision on that path.

### What changed

- `src/types.ts` — added `'nexrall-code'` to `AgentType`
- `src/agents.ts` — added the `nexrall-code` entry (same shape as `neovate`/`pochi`/`adal`)
- `README.md` / `package.json` — regenerated by `pnpm run -C scripts sync-agents.ts`, not hand-edited

### Verification (all run locally on this branch)

- `pnpm run -C scripts validate-agents.ts` → `All agents valid.`
- `pnpm run -C scripts sync-agents.ts` → regenerated README + package.json keywords
- `pnpm type-check` → clean
- `pnpm format:check` → clean
- `pnpm test -- --run` → **58 test files, 776 tests, all passing**

We also maintain a public skills pack, [`Maxrall-Inc/nexrall-skills`](https://github.com/Maxrall-Inc/nexrall-skills) (11 skills: reliability, security, blockchain), which already installs cleanly via `npx skills add Maxrall-Inc/nexrall-skills --list` ("Found 11 skills").