### PR TITLE
feat: add Sarvam Code agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Skills can be installed to any of these agents:
 | IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
+| Cline, Dexto, Kimi Code CLI, Loaf, Sarvam Code, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `sarvam-code`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codemaker | `codemaker` | `.codemaker/skills/` | `~/.codemaker/skills/` |
@@ -326,7 +326,6 @@ Skills can be installed to any of these agents:
 | Reasonix | `reasonix` | `.reasonix/skills/` | `~/.reasonix/skills/` |
 | Rovo Dev | `rovodev` | `.rovodev/skills/` | `~/.rovodev/skills/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
-| Sarvam Code | `sarvam-code` | `.sarvam/skills/` | `~/.sarvam/skills/` |
 | Tabnine CLI | `tabnine-cli` | `.tabnine/agent/skills/` | `~/.tabnine/agent/skills/` |
 | Terramind | `terramind` | `.terramind/skills/` | `~/.terramind/skills/` |
 | Tinycloud | `tinycloud` | `.tinycloud/skills/` | `~/.tinycloud/skills/` |
@@ -460,7 +459,6 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.reasonix/skills/`
 - `.rovodev/skills/`
 - `.roo/skills/`
-- `.sarvam/skills/`
 - `.tabnine/agent/skills/`
 - `.terramind/skills/`
 - `.tinycloud/skills/`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [74 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -326,6 +326,7 @@ Skills can be installed to any of these agents:
 | Reasonix | `reasonix` | `.reasonix/skills/` | `~/.reasonix/skills/` |
 | Rovo Dev | `rovodev` | `.rovodev/skills/` | `~/.rovodev/skills/` |
 | Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
+| Sarvam Code | `sarvam-code` | `.sarvam/skills/` | `~/.sarvam/skills/` |
 | Tabnine CLI | `tabnine-cli` | `.tabnine/agent/skills/` | `~/.tabnine/agent/skills/` |
 | Terramind | `terramind` | `.terramind/skills/` | `~/.terramind/skills/` |
 | Tinycloud | `tinycloud` | `.tinycloud/skills/` | `~/.tinycloud/skills/` |
@@ -459,6 +460,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.reasonix/skills/`
 - `.rovodev/skills/`
 - `.roo/skills/`
+- `.sarvam/skills/`
 - `.tabnine/agent/skills/`
 - `.terramind/skills/`
 - `.tinycloud/skills/`

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "reasonix",
     "rovodev",
     "roo",
+    "sarvam-code",
     "tabnine-cli",
     "terramind",
     "tinycloud",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -641,8 +641,8 @@ export const agents: Record<AgentType, AgentConfig> = {
   'sarvam-code': {
     name: 'sarvam-code',
     displayName: 'Sarvam Code',
-    skillsDir: '.sarvam/skills',
-    globalSkillsDir: join(sarvamHome, 'skills'),
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.agents/skills'),
     detectInstalled: async () => {
       return existsSync(sarvamHome);
     },

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -13,6 +13,7 @@ const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 const grokHome = process.env.GROK_HOME?.trim() || join(home, '.grok');
+const sarvamHome = process.env.SARVAM_HOME?.trim() || join(home, '.sarvam');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
 
@@ -635,6 +636,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.roo/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.roo'));
+    },
+  },
+  'sarvam-code': {
+    name: 'sarvam-code',
+    displayName: 'Sarvam Code',
+    skillsDir: '.sarvam/skills',
+    globalSkillsDir: join(sarvamHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(sarvamHome);
     },
   },
   'tabnine-cli': {

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -51,6 +51,7 @@ const agentNameToType: Record<string, AgentType> = {
   'augment-cli': 'augment',
   opencode: 'opencode',
   'github-copilot': 'github-copilot',
+  'sarvam-code': 'sarvam-code',
 };
 
 /**

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -51,7 +51,6 @@ const agentNameToType: Record<string, AgentType> = {
   'augment-cli': 'augment',
   opencode: 'opencode',
   'github-copilot': 'github-copilot',
-  'sarvam-code': 'sarvam-code',
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type AgentType =
   | 'reasonix'
   | 'roo'
   | 'rovodev'
+  | 'sarvam-code'
   | 'tabnine-cli'
   | 'terramind'
   | 'tinycloud'

--- a/src/use.ts
+++ b/src/use.ts
@@ -83,6 +83,7 @@ const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 const USE_AGENT_CONFIGS: Partial<Record<AgentType, UseAgentConfig>> = {
   'claude-code': { command: 'claude', args: [] },
   codex: { command: 'codex', args: [] },
+  'sarvam-code': { command: 'sarvam-code', args: [] },
 };
 const SUPPORTED_USE_AGENTS = Object.keys(USE_AGENT_CONFIGS) as AgentType[];
 

--- a/tests/sarvam-code-agent.test.ts
+++ b/tests/sarvam-code-agent.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, rmSync } from 'fs';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
-import { tmpdir } from 'os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('Sarvam Code agent support', () => {
@@ -9,16 +9,14 @@ describe('Sarvam Code agent support', () => {
     vi.resetModules();
   });
 
-  it('uses .sarvam/skills and respects SARVAM_HOME for global skills', async () => {
-    const sarvamHome = join(tmpdir(), 'custom-sarvam-home');
-    vi.stubEnv('SARVAM_HOME', sarvamHome);
-
-    const { agents } = await import('../src/agents.ts');
+  it('installs into the universal .agents/skills directory', async () => {
+    const { agents, isUniversalAgent } = await import('../src/agents.ts');
 
     expect(agents['sarvam-code'].name).toBe('sarvam-code');
     expect(agents['sarvam-code'].displayName).toBe('Sarvam Code');
-    expect(agents['sarvam-code'].skillsDir).toBe('.sarvam/skills');
-    expect(agents['sarvam-code'].globalSkillsDir).toBe(join(sarvamHome, 'skills'));
+    expect(agents['sarvam-code'].skillsDir).toBe('.agents/skills');
+    expect(agents['sarvam-code'].globalSkillsDir).toBe(join(homedir(), '.agents', 'skills'));
+    expect(isUniversalAgent('sarvam-code')).toBe(true);
   });
 
   it('detects Sarvam Code from its resolved home directory', async () => {
@@ -51,11 +49,5 @@ describe('Sarvam Code agent support', () => {
 
     expect(result.options.agent).toEqual(['sarvam-code']);
     expect(result.errors).toEqual([]);
-  });
-
-  it('maps the sarvam-code detect-agent name to the sarvam-code type', async () => {
-    const { getAgentType } = await import('../src/detect-agent.ts');
-
-    expect(getAgentType('sarvam-code')).toBe('sarvam-code');
   });
 });

--- a/tests/sarvam-code-agent.test.ts
+++ b/tests/sarvam-code-agent.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('Sarvam Code agent support', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses .sarvam/skills and respects SARVAM_HOME for global skills', async () => {
+    const sarvamHome = join(tmpdir(), 'custom-sarvam-home');
+    vi.stubEnv('SARVAM_HOME', sarvamHome);
+
+    const { agents } = await import('../src/agents.ts');
+
+    expect(agents['sarvam-code'].name).toBe('sarvam-code');
+    expect(agents['sarvam-code'].displayName).toBe('Sarvam Code');
+    expect(agents['sarvam-code'].skillsDir).toBe('.sarvam/skills');
+    expect(agents['sarvam-code'].globalSkillsDir).toBe(join(sarvamHome, 'skills'));
+  });
+
+  it('detects Sarvam Code from its resolved home directory', async () => {
+    const sarvamHome = join(tmpdir(), `sarvam-home-${Date.now()}`);
+    mkdirSync(sarvamHome);
+    vi.stubEnv('SARVAM_HOME', sarvamHome);
+
+    try {
+      const { agents } = await import('../src/agents.ts');
+
+      await expect(agents['sarvam-code'].detectInstalled()).resolves.toBe(true);
+    } finally {
+      rmSync(sarvamHome, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false when the resolved Sarvam home does not exist', async () => {
+    const sarvamHome = join(tmpdir(), `missing-sarvam-home-${Date.now()}`);
+    vi.stubEnv('SARVAM_HOME', sarvamHome);
+
+    const { agents } = await import('../src/agents.ts');
+
+    await expect(agents['sarvam-code'].detectInstalled()).resolves.toBe(false);
+  });
+
+  it('accepts sarvam-code as a valid --agent for skills use', async () => {
+    const { parseUseOptions } = await import('../src/use.ts');
+
+    const result = parseUseOptions(['vercel-labs/agent-skills', '--agent', 'sarvam-code']);
+
+    expect(result.options.agent).toEqual(['sarvam-code']);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('maps the sarvam-code detect-agent name to the sarvam-code type', async () => {
+    const { getAgentType } = await import('../src/detect-agent.ts');
+
+    expect(getAgentType('sarvam-code')).toBe('sarvam-code');
+  });
+});


### PR DESCRIPTION
Adds [Sarvam Code](https://indus.sarvam.ai/code/install-guide) as a supported agent. `skills add --agent sarvam-code` installs into `.agents/skills`, the shared universal directory, and `skills use --agent sarvam-code` launches the `sarvam-code` CLI.

Sarvam Code v0.46.4 and later discover skills in `.agents/` on their own and tag them with a `skill_source` field, so the universal directory is the right target and no symlinks are needed.

## What changed

- `src/types.ts`: added `'sarvam-code'` to the `AgentType` union, between `'rovodev'` and `'tabnine-cli'`.
- `src/agents.ts`: new agent entry. `skillsDir` is `.agents/skills` and `globalSkillsDir` is `~/.agents/skills`, the same group as Cline, Warp, Zed, and the other universal agents, so installs are plain copies. `detectInstalled` checks `SARVAM_HOME` (default `~/.sarvam`), which locates the installation.
- `src/use.ts`: added `sarvam-code` to `USE_AGENT_CONFIGS`, so the launch command is `sarvam-code <prompt>`, same as `claude` and `codex`.
- `README.md` and `package.json`: regenerated with `sync-agents.ts`. Sarvam Code joins the `.agents/skills/` row and the keyword list.
- `tests/sarvam-code-agent.test.ts`: four tests covering the config fields, `detectInstalled` with and without `SARVAM_HOME`, and `--agent sarvam-code` parsing.

## How the paths were checked

I placed a test skill in `~/.agents/skills/<name>/SKILL.md` and ran `sarvam-code debug prompt-input` with the shipped CLI (0.47.0). The skill appeared in the model-visible skill list, which confirms the global path.

## Tests

- `tests/sarvam-code-agent.test.ts`: 4/4 pass
- Full suite: 780/781. The one failure is `tests/dist.test.ts`, which runs `pnpm build`; pnpm refuses to start here because it cannot fetch registry signatures. I ran the build directly instead: `obuild` succeeds and the resulting `dist/cli.mjs` contains the new agent entry.
- `tsc --noEmit`, prettier, and `validate-agents.ts` all clean
- Cyclomatic complexity of every function this PR adds or edits is 1 (threshold 10). The two functions in `src/use.ts` above the threshold, `parseUseOptions` and `runUse`, are unchanged from main.

🪷 Generated with Sarvam Code
