### PR TITLE
feat: add fx agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [74 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -296,6 +296,7 @@ Skills can be installed to any of these agents:
 | Eve | `eve` | `agent/skills/` | N/A (project-only) |
 | Firebender | `firebender` | `.agents/skills/` | `~/.firebender/skills/` |
 | ForgeCode | `forgecode` | `.forge/skills/` | `~/.forge/skills/` |
+| fx | `fx` | `.fx/skills/` | `~/.fx/skills/` |
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
@@ -433,6 +434,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.factory/skills/`
 - `agent/skills/`
 - `.forge/skills/`
+- `.fx/skills/`
 - `.goose/skills/`
 - `.grok/skills/`
 - `.hermes/skills/`

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eve",
     "firebender",
     "forgecode",
+    "fx",
     "gemini-cli",
     "github-copilot",
     "goose",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -338,6 +338,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.forge'));
     },
   },
+  fx: {
+    name: 'fx',
+    displayName: 'fx',
+    skillsDir: '.fx/skills',
+    globalSkillsDir: join(home, '.fx/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.fx'));
+    },
+  },
   'gemini-cli': {
     name: 'gemini-cli',
     displayName: 'Gemini CLI',

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type AgentType =
   | 'eve'
   | 'firebender'
   | 'forgecode'
+  | 'fx'
   | 'gemini-cli'
   | 'github-copilot'
   | 'goose'


### PR DESCRIPTION
## What

Add `fx` (the coding CLI at [fx.sh](https://fx.sh)) to the supported agents registry of the skills CLI.

## Why

fx uses `~/.fx/skills` as its skills directory, but it was not registered in the static agents registry. As a result, `skills` CLI could not install or route skills to fx:

- `--agent fx` was not a valid target
- `skills list` did not include fx
- fx was absent from the README supported-agents table and `package.json` keywords

## Changes

- **`src/types.ts`** — add `'fx'` to the `AgentType` union
- **`src/agents.ts`** — add the `fx` agent config:
  - `skillsDir`: `.fx/skills`
  - `globalSkillsDir`: `~/.fx/skills`
  - `detectInstalled`: checks for `~/.fx`
- **`README.md`** — auto-synced via `scripts/sync-agents.ts` (supported-agents table + skill discovery paths)
- **`package.json`** — auto-synced (`fx` keyword added)

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Validate agents | `node scripts/validate-agents.ts` | ✅ All agents valid |
| Sync agents | `node scripts/sync-agents.ts` | ✅ README + package.json updated |
| Type check | `pnpm type-check` | ✅ Exit 0 |
| Format | `pnpm format` | ✅ Exit 0 |
| Tests (agents-related) | `pnpm test --run src/detect-agent.test.ts src/cli.test.ts src/list.test.ts` | ✅ 65/65 pass |
| End-to-end install | `pnpm dev add vercel-labs/agent-skills --agent fx -g -s vercel-cli-with-tokens -y` | ✅ Installed to `~/.fx/skills/vercel-cli-with-tokens/` |
| End-to-end remove | `pnpm dev remove vercel-cli-with-tokens -g -y` | ✅ Removed |
| Code review | `ocr review --audience agent` | ✅ 0 findings across 3 files |

## Notes

- Follows the same pattern as the existing Posit Assistant support (#1885).
- Generated files (`README.md`, `package.json`) are produced by `scripts/sync-agents.ts` and included to keep the published registry consistent.