### PR TITLE
fix: point Kilo Code at .agents/skills and ~/.kilo/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Skills can be installed to any of these agents:
 | Jazz | `jazz` | `.jazz/skills/` | `~/.jazz/skills/` |
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
-| Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
+| Kilo Code | `kilo` | `.agents/skills/` | `~/.kilo/skills/` |
 | Kimchi | `kimchi` | `.kimchi/skills/` | `~/.config/kimchi/harness/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
@@ -440,7 +440,6 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.jazz/skills/`
 - `.junie/skills/`
 - `.iflow/skills/`
-- `.kilocode/skills/`
 - `.kimchi/skills/`
 - `.kiro/skills/`
 - `.kode/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -422,10 +422,12 @@ export const agents: Record<AgentType, AgentConfig> = {
   kilo: {
     name: 'kilo',
     displayName: 'Kilo Code',
-    skillsDir: '.kilocode/skills',
-    globalSkillsDir: join(home, '.kilocode/skills'),
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(home, '.kilo/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.kilocode'));
+      // `.kilocode` is the legacy config directory, kept here so existing
+      // installs are still detected.
+      return existsSync(join(home, '.kilo')) || existsSync(join(home, '.kilocode'));
     },
   },
   kimchi: {

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -321,6 +321,7 @@ const PRIORITY_PREFIXES = [
   '.grok/skills/',
   '.iflow/skills/',
   '.junie/skills/',
+  '.kilo/skills/',
   '.kilocode/skills/',
   '.kimchi/skills/',
   '.kiro/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -22,6 +22,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.grok/skills',
   '.iflow/skills',
   '.junie/skills',
+  '.kilo/skills',
   '.kilocode/skills',
   '.kimchi/skills',
   '.kiro/skills',


### PR DESCRIPTION
Closes #1997.

The `kilo` entry in `src/agents.ts` still points at the legacy `.kilocode` paths. The reporter picked the target in the issue thread: `.agents/skills` for the project directory, `~/.kilo/skills` for the global one. This implements that, which matches the existing GitHub Copilot entry (`.agents/skills` project, `~/.copilot/skills` global). Kilo's docs list `.agents/skills/` as a default-loaded compatibility location at both scopes, so a universal install is discoverable either way.

## Sites touched

- `kilo.skillsDir` to `.agents/skills`, which also makes `isUniversalAgent('kilo')` true, since universal membership is derived from `skillsDir` rather than a separate list.
- `kilo.globalSkillsDir` to `~/.kilo/skills`.
- `kilo.detectInstalled` accepts `~/.kilo` or `~/.kilocode`, so people on the legacy directory stay detected.
- `PRIORITY_PREFIXES` in `src/blob.ts` and `AGENT_PROJECT_SKILL_DIRS` in `src/skills.ts` both gain `.kilo/skills` and keep `.kilocode/skills`. These control where the CLI looks for `SKILL.md` inside a source repository, so dropping the legacy entry would make repositories that ship skills there undiscoverable for no gain.
- `README.md` regenerated by `node scripts/sync-agents.ts` per AGENTS.md; `package.json` keywords regenerated unchanged.

One note on the regenerated README: the skill-discovery block is derived from agent `skillsDir` values, so `.kilocode/skills/` drops out of it while `src/blob.ts` and `src/skills.ts` keep discovering it. It is generated, so I left it as the script produced it. Happy to reshape the generator in a follow-up.

## Relationship to #1133 and #428

Both are open, both conflict with main, neither updated since 2026-06-20. #1133 moves Kilo to `.kilo/skills` and `~/.kilo/skills` but misses `AGENT_PROJECT_SKILL_DIRS`, so project discovery would keep looking only at `.kilocode/skills`, and its project directory is not what the reporter asked for. #428 switches Cline, Roo Code and Kilo to `.agents/skills` together, agreeing on the project directory but bundling three agents and leaving Kilo's global path on `.kilocode`.

This takes the project directory from #428, the global from #1133, scopes to Kilo alone, and adds the `src/skills.ts` site neither covers. Both predate the reporter's answer; if either author would rather land theirs, close this one.

```
node scripts/validate-agents.ts   All agents valid.
pnpm type-check                   clean
pnpm format:check                 All matched files use Prettier code style!
pnpm test                         58 files, 776 tests, all passing
pnpm build                        obuild finished, 20 files
```

Same 776 passing on a clean `main` checkout. Resolved paths after the change:

```
isUniversalAgent('kilo')                      true
getAgentBaseDir('kilo', false, '/tmp/proj')   /tmp/proj/.agents/skills
getAgentBaseDir('kilo', true)                 ~/.agents/skills
getAgentBaseDir('github-copilot', true)       ~/.agents/skills
```
