### PR TITLE
fix: treat Droid as a universal agent to stop duplicate skill definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Skills can be installed to any of these agents:
 | Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
 | Deep Agents | `deepagents` | `.agents/skills/` | `~/.deepagents/agent/skills/` |
 | Devin for Terminal | `devin` | `.devin/skills/` | `~/.config/devin/skills/` |
-| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
+| Droid | `droid` | `.agents/skills/` | `~/.factory/skills/` |
 | Eve | `eve` | `agent/skills/` | N/A (project-only) |
 | Firebender | `firebender` | `.agents/skills/` | `~/.firebender/skills/` |
 | ForgeCode | `forgecode` | `.forge/skills/` | `~/.forge/skills/` |
@@ -430,7 +430,6 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.cortex/skills/`
 - `.crush/skills/`
 - `.devin/skills/`
-- `.factory/skills/`
 - `agent/skills/`
 - `.forge/skills/`
 - `.goose/skills/`

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -301,7 +301,11 @@ export const agents: Record<AgentType, AgentConfig> = {
   droid: {
     name: 'droid',
     displayName: 'Droid',
-    skillsDir: '.factory/skills',
+    // Droid reads .agents/skills and ~/.agents/skills as compatibility
+    // locations, so installing there avoids defining the same skill twice.
+    // globalSkillsDir stays on ~/.factory/skills so `remove` still cleans up
+    // skills placed there by earlier versions.
+    skillsDir: '.agents/skills',
     globalSkillsDir: join(home, '.factory/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.factory'));

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -316,6 +316,7 @@ const PRIORITY_PREFIXES = [
   '.codex/skills/',
   '.commandcode/skills/',
   '.continue/skills/',
+  '.factory/skills/',
   '.github/skills/',
   '.goose/skills/',
   '.grok/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -17,6 +17,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.codex/skills',
   '.commandcode/skills',
   '.continue/skills',
+  '.factory/skills',
   '.github/skills',
   '.goose/skills',
   '.grok/skills',


### PR DESCRIPTION
Closes #1969.

Universal membership is derived from `skillsDir === '.agents/skills'`, and Droid's entry uses `.factory/skills`, so it falls outside. A global install writes to the canonical `~/.agents/skills` and symlinks into `~/.factory/skills`; Droid reads both and surfaces a config diagnostic saying the skill is defined multiple times at the same level. The same happens at project level whenever a `.factory/` directory exists.

Factory documents `<repo>/.agents/skills/**/SKILL.md` and `~/.agents/skills/**/SKILL.md` as compatible discovery locations, so `.agents/skills` is a supported home at both scopes.

## Fix

`droid.skillsDir` becomes `.agents/skills`, which makes `isUniversalAgent('droid')` true, after which `getAgentBaseDir` returns the canonical directory and the installer's `isGlobal && isUniversalAgent(agentType)` branch skips the second write. This is the shape GitHub Copilot already uses.

`globalSkillsDir` stays on `~/.factory/skills` rather than moving to canonical: `src/remove.ts` scans every agent's `globalSkillsDir` for cleanup, so keeping the value means anyone with the duplicate today can clear it with `skills remove -g`.

`PRIORITY_PREFIXES` in `src/blob.ts` and `AGENT_PROJECT_SKILL_DIRS` in `src/skills.ts` both gain `.factory/skills/`. Neither list ever had it, so the CLI did not find skills shipped at that path inside a source repository, while the README's generated skill-discovery block listed it anyway. That was wrong before this change and would have silently become right for the wrong reason after it. `README.md` regenerated with `node scripts/sync-agents.ts` per AGENTS.md; `package.json` keywords regenerated unchanged.

Resolved paths after the change:

```
                  universal  project                    global              declared global
droid             true       /tmp/proj/.agents/skills   ~/.agents/skills    ~/.factory/skills
github-copilot    true       /tmp/proj/.agents/skills   ~/.agents/skills    ~/.copilot/skills
```

## Interaction with #1883

#1883 is open and mergeable and rewrites this exact branch, replacing the `isGlobal && isUniversalAgent` skip with an `agentReadsCanonicalGlobally()` helper that returns true only when `globalSkillsDir` is canonical or the agent is GitHub Copilot. Under that helper Droid gets a `~/.factory/skills` symlink again and #1969 comes back.

Whichever lands second should account for the other: if #1883 goes first, Droid needs to join the Copilot case in that helper. Happy to rebase onto #1883 and make the edit here instead.

```
node scripts/validate-agents.ts   All agents valid.
pnpm type-check                   clean
pnpm format:check                 All matched files use Prettier code style!
pnpm test                         58 files, 776 tests, all passing
pnpm build                        obuild finished, 20 files
```

A clean `main` checkout produces the same 776 passing. No other open PR touches the `droid` entry.
