### PR TITLE
feat: add claude-managed-agents install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [72 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -337,6 +337,7 @@ Skills can be installed to any of these agents:
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
 | PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
+| Claude Managed Agents | `claude-managed-agents` | Uploads to the Anthropic Skills API | Uploads to the Anthropic Skills API |
 <!-- supported-agents:end -->
 
 > [!NOTE]
@@ -351,6 +352,33 @@ Skills can be installed to any of these agents:
 
 The CLI automatically detects which coding agents you have installed. If none are detected, you'll be prompted to select
 which agents to install to.
+
+### Claude Managed Agents
+
+`claude-managed-agents` is an API target rather than a directory: each selected skill is uploaded to the
+[Anthropic Skills API](https://platform.claude.com/docs/en/agents-and-tools/agent-skills), where it becomes available
+to your [Claude managed agents](https://platform.claude.com/docs/en/agents-and-tools/managed-agents) (and to the
+Messages API code-execution container) as a custom skill.
+
+```bash
+npx skills add vercel-labs/agent-skills --agent claude-managed-agents
+```
+
+Credentials are resolved in this order:
+
+1. `ANTHROPIC_API_KEY` environment variable
+2. `ANTHROPIC_AUTH_TOKEN` environment variable
+3. The Anthropic CLI's stored login (run `ant auth login`); expired tokens are refreshed automatically
+4. The Anthropic CLI credentials file (`~/.config/anthropic`), when the `ant` binary isn't on `PATH`
+
+Behavior notes:
+
+- Adding a skill that already exists in your organization (matched by display title) uploads a new version of that
+  skill instead of failing.
+- This target is never auto-detected and is excluded from `--agent '*'` and `--all`, so bulk installs can't upload to
+  your Anthropic organization by accident. Select it explicitly with `--agent claude-managed-agents` or in the
+  interactive prompt.
+- `ANTHROPIC_BASE_URL` is honored for non-default API endpoints.
 
 ## Creating Skills
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Skills can be installed to any of these agents:
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
 | IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
+| Claude Managed Agents | `claude-managed-agents` | Uploads to the Anthropic Skills API | Uploads to the Anthropic Skills API |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
 | Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
@@ -337,7 +338,6 @@ Skills can be installed to any of these agents:
 | Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
 | PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
 | AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
-| Claude Managed Agents | `claude-managed-agents` | Uploads to the Anthropic Skills API | Uploads to the Anthropic Skills API |
 <!-- supported-agents:end -->
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -356,8 +356,8 @@ which agents to install to.
 ### Claude Managed Agents
 
 `claude-managed-agents` is an API target rather than a directory: each selected skill is uploaded to the
-[Anthropic Skills API](https://platform.claude.com/docs/en/agents-and-tools/agent-skills), where it becomes available
-to your [Claude managed agents](https://platform.claude.com/docs/en/agents-and-tools/managed-agents) (and to the
+[Anthropic Skills API](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview), where it becomes available
+to your [Claude managed agents](https://platform.claude.com/docs/en/managed-agents/skills) (and to the
 Messages API code-execution container) as a custom skill.
 
 ```bash
@@ -373,10 +373,10 @@ Credentials are resolved in this order:
 
 Behavior notes:
 
-- Adding a skill that already exists in your organization (matched by display title) uploads a new version of that
-  skill instead of failing.
+- Adding a skill that already exists in your workspace (matched by the id recorded in the lock file, otherwise by
+  display name) uploads a new version of that skill instead of creating a duplicate.
 - This target is never auto-detected and is excluded from `--agent '*'` and `--all`, so bulk installs can't upload to
-  your Anthropic organization by accident. Select it explicitly with `--agent claude-managed-agents` or in the
+  your Anthropic workspace by accident. Select it explicitly with `--agent claude-managed-agents` or in the
   interactive prompt.
 - `ANTHROPIC_BASE_URL` is honored for non-default API endpoints.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [74 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "augment",
     "bob",
     "claude-code",
+    "claude-managed-agents",
     "openclaw",
     "cline",
     "codearts-agent",

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -31,7 +31,13 @@ function generateAvailableAgentsTable(): string {
     }
   >();
 
+  const virtualRows: string[] = [];
+
   for (const [key, a] of Object.entries(agents)) {
+    if (a.virtual) {
+      virtualRows.push(`| ${a.displayName} | \`${key}\` | ${a.installHint} | ${a.installHint} |`);
+      continue;
+    }
     const pathKey = `${a.skillsDir}|${a.globalSkillsDir}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
@@ -58,6 +64,7 @@ function generateAvailableAgentsTable(): string {
     '| Agent | `--agent` | Project Path | Global Path |',
     '|-------|-----------|--------------|-------------|',
     ...rows,
+    ...virtualRows,
   ].join('\n');
 }
 
@@ -70,7 +77,13 @@ function generateSkillDiscoveryPaths(): string {
     '- `skills/.system/`',
   ];
 
-  const agentPaths = [...new Set(Object.values(agents).map((a) => a.skillsDir))]
+  const agentPaths = [
+    ...new Set(
+      Object.values(agents)
+        .filter((a) => !a.virtual)
+        .map((a) => a.skillsDir)
+    ),
+  ]
     .filter((p) => p !== 'skills') // Filter out the standard `skills/` path
     .map((p) => `- \`${p}/\``);
 

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -20,7 +20,8 @@ function generateAgentNames(): string {
 }
 
 function generateAvailableAgentsTable(): string {
-  // Group agents by their paths
+  // Group agents by their paths. Virtual agents (API upload targets) have no
+  // paths; each gets its own group so it stays in registry order.
   const pathGroups = new Map<
     string,
     {
@@ -28,23 +29,19 @@ function generateAvailableAgentsTable(): string {
       displayNames: string[];
       skillsDir: string;
       globalSkillsDir: string | undefined;
+      installHint?: string;
     }
   >();
 
-  const virtualRows: string[] = [];
-
   for (const [key, a] of Object.entries(agents)) {
-    if (a.virtual) {
-      virtualRows.push(`| ${a.displayName} | \`${key}\` | ${a.installHint} | ${a.installHint} |`);
-      continue;
-    }
-    const pathKey = `${a.skillsDir}|${a.globalSkillsDir}`;
+    const pathKey = a.virtual ? `virtual|${key}` : `${a.skillsDir}|${a.globalSkillsDir}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
         keys: [],
         displayNames: [],
         skillsDir: a.skillsDir,
         globalSkillsDir: a.globalSkillsDir,
+        ...(a.virtual && { installHint: a.installHint }),
       });
     }
     const group = pathGroups.get(pathKey)!;
@@ -53,18 +50,20 @@ function generateAvailableAgentsTable(): string {
   }
 
   const rows = Array.from(pathGroups.values()).map((group) => {
+    const names = group.displayNames.join(', ');
+    const keys = group.keys.map((k) => `\`${k}\``).join(', ');
+    if (group.installHint) {
+      return `| ${names} | ${keys} | ${group.installHint} | ${group.installHint} |`;
+    }
     const globalPath = group.globalSkillsDir
       ? `\`${group.globalSkillsDir.replace(homedir(), '~')}/\``
       : 'N/A (project-only)';
-    const names = group.displayNames.join(', ');
-    const keys = group.keys.map((k) => `\`${k}\``).join(', ');
     return `| ${names} | ${keys} | \`${group.skillsDir}/\` | ${globalPath} |`;
   });
   return [
     '| Agent | `--agent` | Project Path | Global Path |',
     '|-------|-----------|--------------|-------------|',
     ...rows,
-    ...virtualRows,
   ].join('\n');
 }
 

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -20,8 +20,8 @@ function generateAgentNames(): string {
 }
 
 function generateAvailableAgentsTable(): string {
-  // Group agents by their paths. Virtual agents (API upload targets) have no
-  // paths; each gets its own group so it stays in registry order.
+  // Group agents by their paths. API-upload agents have no paths; each gets
+  // its own group so it stays in registry order.
   const pathGroups = new Map<
     string,
     {
@@ -34,14 +34,15 @@ function generateAvailableAgentsTable(): string {
   >();
 
   for (const [key, a] of Object.entries(agents)) {
-    const pathKey = a.virtual ? `virtual|${key}` : `${a.skillsDir}|${a.globalSkillsDir}`;
+    const pathKey =
+      a.install === 'api-upload' ? `api-upload|${key}` : `${a.skillsDir}|${a.globalSkillsDir}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
         keys: [],
         displayNames: [],
         skillsDir: a.skillsDir,
         globalSkillsDir: a.globalSkillsDir,
-        ...(a.virtual && { installHint: a.installHint }),
+        ...(a.install === 'api-upload' && { installHint: a.installHint }),
       });
     }
     const group = pathGroups.get(pathKey)!;
@@ -79,7 +80,7 @@ function generateSkillDiscoveryPaths(): string {
   const agentPaths = [
     ...new Set(
       Object.values(agents)
-        .filter((a) => !a.virtual)
+        .filter((a) => (a.install ?? 'filesystem') === 'filesystem')
         .map((a) => a.skillsDir)
     ),
   ]

--- a/scripts/sync-agents.ts
+++ b/scripts/sync-agents.ts
@@ -20,8 +20,7 @@ function generateAgentNames(): string {
 }
 
 function generateAvailableAgentsTable(): string {
-  // Group agents by their paths. API-upload agents have no paths; each gets
-  // its own group so it stays in registry order.
+  // Group agents by their paths (API-upload agents by their install hint).
   const pathGroups = new Map<
     string,
     {
@@ -34,15 +33,14 @@ function generateAvailableAgentsTable(): string {
   >();
 
   for (const [key, a] of Object.entries(agents)) {
-    const pathKey =
-      a.install === 'api-upload' ? `api-upload|${key}` : `${a.skillsDir}|${a.globalSkillsDir}`;
+    const pathKey = `${a.skillsDir}|${a.globalSkillsDir}|${a.installHint ?? ''}`;
     if (!pathGroups.has(pathKey)) {
       pathGroups.set(pathKey, {
         keys: [],
         displayNames: [],
         skillsDir: a.skillsDir,
         globalSkillsDir: a.globalSkillsDir,
-        ...(a.install === 'api-upload' && { installHint: a.installHint }),
+        installHint: a.installHint,
       });
     }
     const group = pathGroups.get(pathKey)!;
@@ -80,7 +78,7 @@ function generateSkillDiscoveryPaths(): string {
   const agentPaths = [
     ...new Set(
       Object.values(agents)
-        .filter((a) => (a.install ?? 'filesystem') === 'filesystem')
+        .filter((a) => a.install !== 'api-upload')
         .map((a) => a.skillsDir)
     ),
   ]

--- a/src/add.ts
+++ b/src/add.ts
@@ -51,13 +51,14 @@ import {
 import { downloadSource } from './download-source.ts';
 import {
   addSkillToLock,
+  readSkillLock,
   getGitHubToken,
   isPromptDismissed,
   dismissPrompt,
   getLastSelectedAgents,
   saveSelectedAgents,
 } from './skill-lock.ts';
-import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
+import { addSkillToLocalLock, readLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import {
   tryBlobInstall,
@@ -424,6 +425,65 @@ async function resolveManagedAgentsAuth(
   return { auth, required: true };
 }
 
+/**
+ * Fold the additive `--managed-agents` flag into the target list and resolve
+ * API credentials when any target is virtual. An explicitly requested virtual
+ * agent still aborts on missing credentials (shouldAbort); a target added
+ * only by the flag is dropped with a warning instead so filesystem installs
+ * proceed — `update` passes the flag on every refresh of a previously
+ * uploaded skill, and must not fail the whole update over a missing login.
+ */
+async function resolveManagedAgentsTargets(
+  targetAgents: AgentType[],
+  options: AddOptions | undefined,
+  spinner: ReturnType<typeof p.spinner>
+): Promise<{ targetAgents: AgentType[]; auth: AnthropicAuth | null; shouldAbort: boolean }> {
+  const additiveOnly =
+    Boolean(options?.managedAgents) && !targetAgents.some((a) => isVirtualAgent(a));
+  const resolved =
+    options?.managedAgents && !targetAgents.includes('claude-managed-agents')
+      ? [...targetAgents, 'claude-managed-agents' as AgentType]
+      : targetAgents;
+
+  const { auth, required } = await resolveManagedAgentsAuth(resolved, spinner);
+  if (required && !auth) {
+    if (additiveOnly) {
+      p.log.warn('Skipping the Claude Managed Agents upload; other installs continue.');
+      return {
+        targetAgents: resolved.filter((a) => !isVirtualAgent(a)),
+        auth: null,
+        shouldAbort: false,
+      };
+    }
+    return { targetAgents: resolved, auth: null, shouldAbort: true };
+  }
+  return { targetAgents: resolved, auth, shouldAbort: false };
+}
+
+/**
+ * Read previously recorded Skills API ids from the lock file for the scope
+ * being installed to, so re-uploads go straight to the right skill instead of
+ * re-resolving it by display title (and so a re-add that doesn't touch the
+ * upload preserves the recorded id).
+ */
+async function getKnownManagedSkillIds(
+  installGlobally: boolean,
+  cwd?: string
+): Promise<Map<string, string>> {
+  const ids = new Map<string, string>();
+  try {
+    const skills = installGlobally
+      ? (await readSkillLock()).skills
+      : (await readLocalLock(cwd)).skills;
+    for (const [name, entry] of Object.entries(skills)) {
+      if (entry.managedSkillId) ids.set(name, entry.managedSkillId);
+    }
+  } catch {
+    // Unreadable lock — uploads fall back to display-title resolution.
+  }
+  return ids;
+}
+
 interface ManagedUploadOutcome {
   skill: string;
   success: boolean;
@@ -439,13 +499,13 @@ interface ManagedUploadOutcome {
  * stop the rest.
  */
 async function uploadSkillsToManagedAgents(
-  skills: Array<{ name: string; files: SkillUploadFile[] }>,
+  skills: Array<{ name: string; files: SkillUploadFile[]; knownSkillId?: string }>,
   auth: AnthropicAuth
 ): Promise<ManagedUploadOutcome[]> {
   const outcomes: ManagedUploadOutcome[] = [];
   for (const skill of skills) {
     try {
-      const result = await uploadSkillToManagedAgents(skill, auth);
+      const result = await uploadSkillToManagedAgents(skill, auth, skill.knownSkillId);
       outcomes.push({ skill: skill.name, success: true, ...result });
     } catch (error) {
       outcomes.push({
@@ -690,6 +750,13 @@ export interface AddOptions {
    * selects the root agent. Implies installing for Eve.
    */
   subagent?: string[];
+  /**
+   * Additionally upload to Claude Managed Agents on top of the selected or
+   * detected agents. Unlike an explicit `--agent claude-managed-agents`,
+   * missing credentials skip the upload with a warning instead of aborting.
+   * Used by `update` to refresh skills whose lock entry records an upload.
+   */
+  managedAgents?: boolean;
 }
 
 /**
@@ -879,12 +946,13 @@ async function handleWellKnownSkills(
 
   // Resolve API credentials up front when Claude Managed Agents is targeted,
   // so a missing login fails before anything is installed.
-  const { auth: managedAgentsAuth, required: managedAgentsRequired } =
-    await resolveManagedAgentsAuth(targetAgents, spinner);
-  if (managedAgentsRequired && !managedAgentsAuth) {
+  const managedResolution = await resolveManagedAgentsTargets(targetAgents, options, spinner);
+  if (managedResolution.shouldAbort) {
     p.outro(pc.red('Installation failed'));
     process.exit(1);
   }
+  targetAgents = managedResolution.targetAgents;
+  const managedAgentsAuth = managedResolution.auth;
 
   let installGlobally = options.global ?? false;
 
@@ -1046,6 +1114,7 @@ async function handleWellKnownSkills(
     }
   }
 
+  const knownManagedIds = await getKnownManagedSkillIds(installGlobally, cwd);
   let uploadOutcomes: ManagedUploadOutcome[] = [];
   if (managedAgentsAuth) {
     uploadOutcomes = await uploadSkillsToManagedAgents(
@@ -1054,6 +1123,7 @@ async function handleWellKnownSkills(
       selectedSkills.map((skill) => ({
         name: skill.installName,
         files: Array.from(skill.files, ([path, content]) => ({ path, content })),
+        knownSkillId: knownManagedIds.get(skill.installName),
       })),
       managedAgentsAuth
     );
@@ -1087,12 +1157,24 @@ async function handleWellKnownSkills(
     });
   }
 
+  // A skill counts as installed for lock purposes when it reached the
+  // filesystem or the Skills API. Keep a previously recorded API id when this
+  // run didn't touch the upload, so a filesystem-only re-add doesn't drop it.
+  const uploadedManagedIds = new Map(
+    uploadOutcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
+  );
+  const managedIdFor = (name: string) => uploadedManagedIds.get(name) ?? knownManagedIds.get(name);
+
   // Add to skill lock file for update tracking (only for global installs)
-  if (successful.length > 0 && installGlobally) {
+  if ((successful.length > 0 || uploadedManagedIds.size > 0) && installGlobally) {
     const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
-      if (successfulSkillNames.has(skill.installName)) {
+      if (
+        successfulSkillNames.has(skill.installName) ||
+        uploadedManagedIds.has(skill.installName)
+      ) {
         try {
+          const managedSkillId = managedIdFor(skill.installName);
           await addSkillToLock(skill.installName, {
             source: sourceIdentifier,
             sourceType: 'well-known',
@@ -1100,6 +1182,7 @@ async function handleWellKnownSkills(
             skillFolderHash: '',
             sourceBaseUrl: url,
             wellKnownDigest: computeWellKnownSkillDigest(skill),
+            ...(managedSkillId && { managedSkillId }),
           });
         } catch {
           // Don't fail installation if lock file update fails
@@ -1109,15 +1192,21 @@ async function handleWellKnownSkills(
   }
 
   // Add to local lock file for project-scoped installs
-  if (successful.length > 0 && !installGlobally) {
+  if ((successful.length > 0 || uploadedManagedIds.size > 0) && !installGlobally) {
     const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
-      if (successfulSkillNames.has(skill.installName)) {
+      if (
+        successfulSkillNames.has(skill.installName) ||
+        uploadedManagedIds.has(skill.installName)
+      ) {
         try {
           const matchingResult = successful.find((r) => r.skill === skill.installName);
           const installDir = matchingResult?.canonicalPath || matchingResult?.path;
-          if (installDir) {
-            const computedHash = await computeSkillFolderHash(installDir);
+          const managedSkillId = managedIdFor(skill.installName);
+          if (installDir || managedSkillId) {
+            // Upload-only installs have no local files to hash; well-known
+            // update detection runs off wellKnownDigest, not computedHash.
+            const computedHash = installDir ? await computeSkillFolderHash(installDir) : '';
             await addSkillToLocalLock(
               skill.installName,
               {
@@ -1126,6 +1215,7 @@ async function handleWellKnownSkills(
                 sourceType: 'well-known',
                 computedHash,
                 wellKnownDigest: computeWellKnownSkillDigest(skill),
+                ...(managedSkillId && { managedSkillId }),
               },
               cwd
             );
@@ -1710,13 +1800,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     // Resolve API credentials up front when Claude Managed Agents is targeted,
     // so a missing login fails before anything is installed.
-    const { auth: managedAgentsAuth, required: managedAgentsRequired } =
-      await resolveManagedAgentsAuth(targetAgents, spinner);
-    if (managedAgentsRequired && !managedAgentsAuth) {
+    const managedResolution = await resolveManagedAgentsTargets(targetAgents, options, spinner);
+    if (managedResolution.shouldAbort) {
       await cleanup(tempDir);
       p.outro(pc.red('Installation failed'));
       process.exit(1);
     }
+    targetAgents = managedResolution.targetAgents;
+    const managedAgentsAuth = managedResolution.auth;
 
     const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
 
@@ -1971,19 +2062,26 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // API upload pass for Claude Managed Agents.
+    const knownManagedIds = await getKnownManagedSkillIds(installGlobally, cwd);
     const uploadOutcomes: ManagedUploadOutcome[] = [];
     if (managedAgentsAuth) {
-      const uploads: Array<{ name: string; files: SkillUploadFile[] }> = [];
+      const uploads: Array<{ name: string; files: SkillUploadFile[]; knownSkillId?: string }> = [];
       for (const skill of selectedSkills) {
+        const knownSkillId = knownManagedIds.get(skill.name);
         try {
           if (blobResult && 'files' in skill) {
             const blobSkill = skill as BlobSkill;
             uploads.push({
               name: skill.name,
               files: blobSkill.files.map((f) => ({ path: f.path, content: f.contents })),
+              knownSkillId,
             });
           } else {
-            uploads.push({ name: skill.name, files: await collectSkillFiles(skill.path) });
+            uploads.push({
+              name: skill.name,
+              files: await collectSkillFiles(skill.path),
+              knownSkillId,
+            });
           }
         } catch (error) {
           uploadOutcomes.push({
@@ -2067,8 +2165,22 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    // A skill counts as installed for lock purposes when it reached the
+    // filesystem or the Skills API. Keep a previously recorded API id when
+    // this run didn't touch the upload, so a filesystem-only re-add doesn't
+    // drop it.
+    const uploadedManagedIds = new Map(
+      uploadOutcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
+    );
+    const managedIdFor = (name: string) =>
+      uploadedManagedIds.get(name) ?? knownManagedIds.get(name);
+
     // Add to skill lock file for update tracking (only for global installs)
-    if (successful.length > 0 && installGlobally && normalizedSource) {
+    if (
+      (successful.length > 0 || uploadedManagedIds.size > 0) &&
+      installGlobally &&
+      normalizedSource
+    ) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
 
       // For GitHub clone installs, fetch the repo tree once and reuse it
@@ -2080,7 +2192,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
-        if (successfulSkillNames.has(skillDisplayName)) {
+        if (successfulSkillNames.has(skillDisplayName) || uploadedManagedIds.has(skill.name)) {
           try {
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
@@ -2097,6 +2209,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               if (hash) skillFolderHash = hash;
             }
 
+            const managedSkillId = managedIdFor(skill.name);
             await addSkillToLock(skill.name, {
               source: lockSource || normalizedSource,
               sourceType: parsed.type,
@@ -2105,6 +2218,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
+              ...(managedSkillId && { managedSkillId }),
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -2114,7 +2228,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Add to local lock file for project-scoped installs
-    if (successful.length > 0 && !installGlobally && !directDownload) {
+    if (
+      (successful.length > 0 || uploadedManagedIds.size > 0) &&
+      !installGlobally &&
+      !directDownload
+    ) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
       // Record Eve subagent placement (root = '') so `update` can restore it.
       // Only meaningful when Eve is among the targets and a non-root subagent
@@ -2126,7 +2244,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         eveSubagents && (eveSubagents.length > 1 || eveSubagents.some((s) => s !== ''));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
-        if (successfulSkillNames.has(skillDisplayName)) {
+        if (successfulSkillNames.has(skillDisplayName) || uploadedManagedIds.has(skill.name)) {
           try {
             // For blob skills, use the snapshot hash; for disk skills, compute from files
             const computedHash =
@@ -2134,6 +2252,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
             const skillPathValue = skillFiles[skill.name];
+            const managedSkillId = managedIdFor(skill.name);
             await addSkillToLocalLock(
               skill.name,
               {
@@ -2144,6 +2263,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
                 ...(recordSubagents && { subagents: eveSubagents }),
+                ...(managedSkillId && { managedSkillId }),
               },
               cwd
             );
@@ -2392,6 +2512,8 @@ export function parseAddOptions(args: string[]): {
       options.list = true;
     } else if (arg === '--all') {
       options.all = true;
+    } else if (arg === '--managed-agents') {
+      options.managedAgents = true;
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       i++;

--- a/src/add.ts
+++ b/src/add.ts
@@ -24,18 +24,16 @@ import {
   getNonUniversalAgents,
   isUniversalAgent,
   isApiUploadAgent,
-  isFilesystemAgent,
   getWildcardAgents,
   getEveSubagents,
 } from './agents.ts';
 import {
   resolveAnthropicAuth,
-  uploadSkillToManagedAgents,
-  createManagedSkillLookup,
+  runManagedUploads,
   collectSkillFiles,
   MANAGED_AGENTS_AUTH_GUIDANCE,
   type AnthropicAuth,
-  type SkillUploadFile,
+  type ManagedUploadOutcome,
 } from './managed-agents.ts';
 import {
   track,
@@ -53,14 +51,13 @@ import {
 import { downloadSource } from './download-source.ts';
 import {
   addSkillToLock,
-  readSkillLock,
   getGitHubToken,
   isPromptDismissed,
   dismissPrompt,
   getLastSelectedAgents,
   saveSelectedAgents,
 } from './skill-lock.ts';
-import { addSkillToLocalLock, readLocalLock, computeSkillFolderHash } from './local-lock.ts';
+import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import {
   tryBlobInstall,
@@ -242,29 +239,25 @@ export function formatEveInstallPromptMessage(skills: Skill[]): string {
 }
 
 /**
- * Splits agents into universal, non-universal (symlinked), and API-upload
- * (API upload) groups. Returns display names for each group.
+ * Splits agents into universal and non-universal (symlinked) groups.
+ * Returns display names for each group.
  */
 function splitAgentsByType(agentTypes: AgentType[]): {
   universal: string[];
   symlinked: string[];
-  apiUpload: string[];
 } {
   const universal: string[] = [];
   const symlinked: string[] = [];
-  const apiUpload: string[] = [];
 
   for (const a of agentTypes) {
-    if (isApiUploadAgent(a)) {
-      apiUpload.push(agents[a].displayName);
-    } else if (isUniversalAgent(a)) {
+    if (isUniversalAgent(a)) {
       universal.push(agents[a].displayName);
     } else {
       symlinked.push(agents[a].displayName);
     }
   }
 
-  return { universal, symlinked, apiUpload };
+  return { universal, symlinked };
 }
 
 /**
@@ -272,7 +265,7 @@ function splitAgentsByType(agentTypes: AgentType[]): {
  */
 function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallMode): string[] {
   const lines: string[] = [];
-  const { universal, symlinked, apiUpload } = splitAgentsByType(targetAgents);
+  const { universal, symlinked } = splitAgentsByType(targetAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -282,17 +275,9 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
       lines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
     }
   } else {
-    // Copy mode - all filesystem agents get copies
-    const allNames = targetAgents
-      .filter((a) => isFilesystemAgent(a))
-      .map((a) => agents[a].displayName);
-    if (allNames.length > 0) {
-      lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
-    }
-  }
-
-  if (apiUpload.length > 0) {
-    lines.push(`  ${pc.dim('upload →')} ${formatList(apiUpload)}`);
+    // Copy mode - all agents get copies
+    const allNames = targetAgents.map((a) => agents[a].displayName);
+    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
   }
 
   return lines;
@@ -348,7 +333,7 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
   const lines: string[] = [];
   const rootAgents = targets.filter((t) => !t.subagent).map((t) => t.agent);
   const subagentNames = targets.filter((t) => t.subagent).map(targetDisplayName);
-  const { universal, symlinked, apiUpload } = splitAgentsByType(rootAgents);
+  const { universal, symlinked } = splitAgentsByType(rootAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -361,14 +346,8 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
       lines.push(`  ${pc.dim('copy →')} ${formatList(subagentNames)}`);
     }
   } else {
-    const allNames = targets.filter((t) => isFilesystemAgent(t.agent)).map(targetDisplayName);
-    if (allNames.length > 0) {
-      lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
-    }
-  }
-
-  if (apiUpload.length > 0) {
-    lines.push(`  ${pc.dim('upload →')} ${formatList(apiUpload)}`);
+    const allNames = targets.map(targetDisplayName);
+    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
   }
 
   return lines;
@@ -397,169 +376,73 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
  */
 function expandWildcardAgents(requested: string[]): AgentType[] {
   const explicitApiUpload = requested.filter(
-    (a): a is AgentType => a !== '*' && a in agents && isApiUploadAgent(a as AgentType)
+    (a): a is AgentType => a in agents && isApiUploadAgent(a as AgentType)
   );
   return [...new Set([...getWildcardAgents(), ...explicitApiUpload])];
 }
 
+const UPLOAD_AGENT: AgentType = 'claude-managed-agents';
+
 interface ManagedResolution {
+  /** Filesystem targets only; the API-upload agent is split off into `auth`. */
   targetAgents: AgentType[];
+  fsRequested: boolean;
+  /** Credentials for this run's upload, or null when nothing will be uploaded. */
   auth: AnthropicAuth | null;
   /** An upload is part of this run: attempted, or skipped for missing credentials. */
   uploadRequested: boolean;
+  /** Every target the run addresses (filesystem and upload), for telemetry. */
+  reportedAgents: string;
 }
 
 /**
- * Fold the additive `--managed-agents` flag into the target list and resolve
- * API credentials up front when any target is an API-upload agent, so a
- * missing login fails before anything is installed. Returns null when the
- * install should abort: an explicitly requested API-upload agent with no
- * credentials. With `--managed-agents` the run is an automated refresh
- * (`update` passes it for every previously uploaded skill), so a missing
- * login drops the upload with a warning instead of failing the whole run.
+ * Split the API-upload agent (or the additive `--managed-agents` flag) off
+ * the target list and resolve API credentials up front, so a missing login
+ * fails before anything is installed. Returns null when the install should
+ * abort: an explicitly requested API-upload agent with no credentials. With
+ * `--managed-agents` the run is an automated refresh (`update` passes it for
+ * every previously uploaded skill), so a missing login drops the upload with
+ * a warning instead of failing the whole run.
  */
 async function resolveManagedAgentsTargets(
-  targetAgents: AgentType[],
+  requested: AgentType[],
   options: AddOptions | undefined,
   spinner: ReturnType<typeof p.spinner>
 ): Promise<ManagedResolution | null> {
+  const targetAgents = requested.filter((a) => !isApiUploadAgent(a));
+  const resolution = (auth: AnthropicAuth | null, uploadRequested: boolean) => ({
+    targetAgents,
+    fsRequested: targetAgents.length > 0,
+    auth,
+    uploadRequested,
+    reportedAgents: [...targetAgents, ...(auth ? [UPLOAD_AGENT] : [])].join(','),
+  });
   const soft = Boolean(options?.managedAgents);
-  if (soft && !targetAgents.includes('claude-managed-agents')) {
-    targetAgents = [...targetAgents, 'claude-managed-agents'];
-  }
-  if (!targetAgents.some((a) => isApiUploadAgent(a))) {
-    return { targetAgents, auth: null, uploadRequested: false };
-  }
+  if (!soft && targetAgents.length === requested.length) return resolution(null, false);
 
   spinner.start('Checking Anthropic credentials…');
   const auth = await resolveAnthropicAuth();
   if (auth) {
     spinner.stop(`Anthropic credentials: ${pc.cyan(auth.source)}`);
-    return { targetAgents, auth, uploadRequested: true };
+    return resolution(auth, true);
   }
   spinner.stop(pc.red('No Anthropic credentials found'));
   p.log.error('Claude Managed Agents requires Anthropic API credentials.');
   p.log.message(pc.dim(`  ${MANAGED_AGENTS_AUTH_GUIDANCE}`));
   if (!soft) return null;
   p.log.warn('Skipping the Claude Managed Agents upload; other installs continue.');
-  return {
-    targetAgents: targetAgents.filter((a) => isFilesystemAgent(a)),
-    auth: null,
-    uploadRequested: true,
-  };
+  return resolution(null, true);
 }
 
-/**
- * Sentinel written in place of a content hash or digest when part of a
- * requested install (filesystem copy or managed upload) did not complete.
- * Never equal to a real hash, so a later `update` sees the entry as changed
- * and retries the whole install instead of treating the skill as current.
- */
-export const PENDING_INSTALL_HASH = 'pending-install';
-
-interface ManagedUploadOutcome {
-  skill: string;
-  success: boolean;
-  skillId?: string;
-  action?: 'created' | 'updated';
-  error?: string;
-}
-
-/** Result of one run's Claude Managed Agents upload pass, shaped for the lock writes. */
-interface ManagedUploadPass {
-  outcomes: ManagedUploadOutcome[];
-  /** Skills API ids from this run's successful uploads, by skill name. */
-  uploadedManagedIds: Map<string, string>;
-  /** Id to record: this run's upload, else the id already recorded for this source. */
-  managedIdFor(name: string): string | undefined;
-  /**
-   * Whether every requested part of the install reached its destination. An
-   * incomplete skill gets PENDING_INSTALL_HASH so `update` retries it.
-   */
-  isComplete(name: string, fsSucceeded: boolean): boolean;
-}
-
-/**
- * Skills API ids a previous run recorded in the lock, restricted to entries
- * whose source matches this run's. A same-named skill from another source
- * doesn't get the recorded id as a direct-version shortcut; it goes through
- * the workspace display-name lookup like any first upload.
- */
-export function knownManagedIds(
-  entries: Record<string, { source: string; managedSkillId?: string }>,
-  sourceKey: string | null
-): Map<string, string> {
-  const ids = new Map<string, string>();
-  for (const [name, entry] of Object.entries(entries)) {
-    if (entry.managedSkillId && entry.source === sourceKey) ids.set(name, entry.managedSkillId);
-  }
-  return ids;
-}
-
-export function summarizeManagedUploads(
-  outcomes: ManagedUploadOutcome[],
-  knownIds: Map<string, string>,
-  requested: { upload: boolean; fs: boolean }
-): ManagedUploadPass {
-  const uploadedManagedIds = new Map(
-    outcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
-  );
-  return {
-    outcomes,
-    uploadedManagedIds,
-    managedIdFor: (name) => uploadedManagedIds.get(name) ?? knownIds.get(name),
-    isComplete: (name, fsSucceeded) =>
-      (!requested.fs || fsSucceeded) && (!requested.upload || uploadedManagedIds.has(name)),
-  };
-}
-
-/**
- * Upload pass for the Claude Managed Agents target. Skills with an id
- * recorded in this scope's lock are versioned directly; the rest are matched
- * by display name or created. One skill at a time; a failure doesn't stop
- * the rest. Without credentials nothing is uploaded, but recorded ids are
- * still returned so a filesystem-only re-add keeps them in the lock.
- */
-async function runManagedUploads(
-  resolution: ManagedResolution,
-  skills: Array<{ name: string; files: () => SkillUploadFile[] | Promise<SkillUploadFile[]> }>,
-  scope: { installGlobally: boolean; cwd: string; sourceKey: string | null }
-): Promise<ManagedUploadPass> {
-  const lock = scope.installGlobally ? await readSkillLock() : await readLocalLock(scope.cwd);
-  const knownIds = knownManagedIds(lock.skills, scope.sourceKey);
-
-  const outcomes: ManagedUploadOutcome[] = [];
-  if (resolution.auth) {
-    const lookup = createManagedSkillLookup(resolution.auth);
-    for (const skill of skills) {
-      try {
-        const result = await uploadSkillToManagedAgents(
-          { name: skill.name, files: await skill.files() },
-          resolution.auth,
-          { knownSkillId: knownIds.get(skill.name), lookup }
-        );
-        outcomes.push({ skill: skill.name, success: true, ...result });
-      } catch (error) {
-        outcomes.push({
-          skill: skill.name,
-          success: false,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-      }
-    }
-  }
-  return summarizeManagedUploads(outcomes, knownIds, {
-    upload: resolution.uploadRequested,
-    fs: resolution.targetAgents.some((a) => isFilesystemAgent(a)),
-  });
+/** Summary line for the upload half of a run, if any. */
+function uploadSummaryLines(resolution: ManagedResolution): string[] {
+  return resolution.auth ? [`  ${pc.dim('upload →')} ${agents[UPLOAD_AGENT].displayName}`] : [];
 }
 
 /**
  * Render upload outcomes for the Claude Managed Agents target.
  */
 function printManagedUploadOutcomes(outcomes: ManagedUploadOutcome[]): void {
-  if (outcomes.length === 0) return;
-
   const successful = outcomes.filter((o) => o.success);
   const failed = outcomes.filter((o) => !o.success);
 
@@ -980,15 +863,15 @@ async function handleWellKnownSkills(
     }
   }
 
-  // Resolve API credentials up front when Claude Managed Agents is targeted,
-  // so a missing login fails before anything is installed.
+  // From here on targetAgents holds filesystem agents only; the Claude
+  // Managed Agents upload, if requested, rides along in managedResolution.
   const managedResolution = await resolveManagedAgentsTargets(targetAgents, options, spinner);
   if (!managedResolution) {
     p.outro(pc.red('Installation failed'));
     process.exit(1);
   }
   targetAgents = managedResolution.targetAgents;
-  if (targetAgents.length === 0) {
+  if (targetAgents.length === 0 && !managedResolution.auth) {
     // Upload-only run whose upload was credential-skipped: nothing left to do,
     // but the well-known source was handled.
     p.outro('Nothing to install (Claude Managed Agents upload skipped)');
@@ -1030,10 +913,7 @@ async function handleWellKnownSkills(
 
   // Only prompt for install mode when there are multiple unique target directories.
   // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-  // API-upload agents have no target directory and don't participate in the choice.
-  const uniqueDirs = new Set(
-    targetAgents.filter((a) => isFilesystemAgent(a)).map((a) => agents[a].skillsDir)
-  );
+  const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
 
   if (!options.copy && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
@@ -1083,20 +963,19 @@ async function handleWellKnownSkills(
     overwriteStatus.get(skillName)!.set(agent, installed);
   }
 
-  const allApiUploadTargets = targetAgents.every((a) => isApiUploadAgent(a));
-
   for (const skill of selectedSkills) {
     if (summaryLines.length > 0) summaryLines.push('');
 
-    // API-only installs have no local path to show
-    if (allApiUploadTargets) {
+    if (targetAgents.length === 0) {
+      // Upload-only installs have no local path to show
       summaryLines.push(`${pc.cyan(skill.installName)}`);
     } else {
       const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
       const shortCanonical = shortenPath(canonicalPath, cwd);
       summaryLines.push(`${pc.cyan(shortCanonical)}`);
+      summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
     }
-    summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
+    summaryLines.push(...uploadSummaryLines(managedResolution));
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
     }
@@ -1142,7 +1021,6 @@ async function handleWellKnownSkills(
 
   for (const skill of selectedSkills) {
     for (const agent of targetAgents) {
-      if (isApiUploadAgent(agent)) continue;
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
@@ -1161,7 +1039,7 @@ async function handleWellKnownSkills(
     // names may collide across entries.
     selectedSkills.map((skill) => ({
       name: skill.installName,
-      files: () => Array.from(skill.files, ([path, content]) => ({ path, content })),
+      files: () => Array.from(skill.files, ([path, contents]) => ({ path, contents })),
     })),
     { installGlobally, cwd, sourceKey: sourceIdentifier }
   );
@@ -1185,7 +1063,7 @@ async function handleWellKnownSkills(
       event: 'install',
       source: sourceIdentifier,
       skills: selectedSkills.map((s) => s.installName).join(','),
-      agents: targetAgents.join(','),
+      agents: managedResolution.reportedAgents,
       ...(installGlobally && { global: '1' }),
       skillFiles: JSON.stringify(skillFiles),
       installUrl: url,
@@ -1194,30 +1072,24 @@ async function handleWellKnownSkills(
     });
   }
 
-  // A skill counts as installed for lock purposes when it reached the
-  // filesystem or the Skills API.
-  const { uploadedManagedIds, managedIdFor, isComplete } = managed;
-
   // Add to skill lock file for update tracking (only for global installs)
-  if ((successful.length > 0 || uploadedManagedIds.size > 0) && installGlobally) {
+  if ((successful.length > 0 || managed.uploads > 0) && installGlobally) {
     const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
-      const fsSucceeded = successfulSkillNames.has(skill.installName);
-      if (fsSucceeded || uploadedManagedIds.has(skill.installName)) {
+      const lock = managed.lockEntry(
+        skill.installName,
+        successfulSkillNames.has(skill.installName)
+      );
+      if (lock) {
         try {
-          const managedSkillId = managedIdFor(skill.installName);
           await addSkillToLock(skill.installName, {
             source: sourceIdentifier,
             sourceType: 'well-known',
             sourceUrl: skill.sourceUrl,
             skillFolderHash: '',
             sourceBaseUrl: url,
-            // A pending digest keeps the entry "changed" so update retries
-            // the part of the install that didn't complete.
-            wellKnownDigest: isComplete(skill.installName, fsSucceeded)
-              ? computeWellKnownSkillDigest(skill)
-              : PENDING_INSTALL_HASH,
-            ...(managedSkillId && { managedSkillId }),
+            wellKnownDigest: lock.hash(computeWellKnownSkillDigest(skill)),
+            managedSkillId: lock.managedSkillId,
           });
         } catch {
           // Don't fail installation if lock file update fails
@@ -1227,34 +1099,32 @@ async function handleWellKnownSkills(
   }
 
   // Add to local lock file for project-scoped installs
-  if ((successful.length > 0 || uploadedManagedIds.size > 0) && !installGlobally) {
+  if ((successful.length > 0 || managed.uploads > 0) && !installGlobally) {
     const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
-      const fsSucceeded = successfulSkillNames.has(skill.installName);
-      if (fsSucceeded || uploadedManagedIds.has(skill.installName)) {
+      const lock = managed.lockEntry(
+        skill.installName,
+        successfulSkillNames.has(skill.installName)
+      );
+      if (lock) {
         try {
           const matchingResult = successful.find((r) => r.skill === skill.installName);
           const installDir = matchingResult?.canonicalPath || matchingResult?.path;
-          const managedSkillId = managedIdFor(skill.installName);
-          if (installDir || managedSkillId) {
-            // Upload-only installs have no local files to hash; well-known
-            // update detection runs off wellKnownDigest, not computedHash.
-            const computedHash = installDir ? await computeSkillFolderHash(installDir) : '';
-            await addSkillToLocalLock(
-              skill.installName,
-              {
-                source: sourceIdentifier,
-                sourceUrl: url,
-                sourceType: 'well-known',
-                computedHash,
-                wellKnownDigest: isComplete(skill.installName, fsSucceeded)
-                  ? computeWellKnownSkillDigest(skill)
-                  : PENDING_INSTALL_HASH,
-                ...(managedSkillId && { managedSkillId }),
-              },
-              cwd
-            );
-          }
+          // Upload-only installs have no local files to hash; well-known
+          // update detection runs off wellKnownDigest, not computedHash.
+          const computedHash = installDir ? await computeSkillFolderHash(installDir) : '';
+          await addSkillToLocalLock(
+            skill.installName,
+            {
+              source: sourceIdentifier,
+              sourceUrl: url,
+              sourceType: 'well-known',
+              computedHash,
+              wellKnownDigest: lock.hash(computeWellKnownSkillDigest(skill)),
+              managedSkillId: lock.managedSkillId,
+            },
+            cwd
+          );
         } catch {
           // Don't fail installation if lock file update fails
         }
@@ -1832,8 +1702,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Resolve API credentials up front when Claude Managed Agents is targeted,
-    // so a missing login fails before anything is installed.
+    // From here on targetAgents holds filesystem agents only; the Claude
+    // Managed Agents upload, if requested, rides along in managedResolution.
     const managedResolution = await resolveManagedAgentsTargets(targetAgents, options, spinner);
     if (!managedResolution) {
       await cleanup(tempDir);
@@ -1841,7 +1711,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       process.exit(1);
     }
     targetAgents = managedResolution.targetAgents;
-    if (targetAgents.length === 0) {
+    if (targetAgents.length === 0 && !managedResolution.auth) {
       // Upload-only run whose upload was credential-skipped: nothing left to do.
       await cleanup(tempDir);
       p.outro('Nothing to install (Claude Managed Agents upload skipped)');
@@ -1890,9 +1760,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // never meaningful when every target is Eve.
     const allEve = installTargets.every((t) => t.agent === 'eve');
     const uniqueDirs = new Set(
-      installTargets
-        .filter((t) => isFilesystemAgent(t.agent))
-        .map((t) => (t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir))
+      installTargets.map((t) =>
+        t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir
+      )
     );
 
     if (!options.copy && !options.yes && uniqueDirs.size > 1 && !allEve) {
@@ -1962,13 +1832,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Helper to print summary lines for a list of skills
-    const allApiUploadTargets = installTargets.every((t) => isApiUploadAgent(t.agent));
     const printSkillSummary = (skills: Skill[]) => {
       for (const skill of skills) {
         if (summaryLines.length > 0) summaryLines.push('');
 
-        // API-only installs have no local path to show
-        if (allApiUploadTargets) {
+        if (installTargets.length === 0) {
+          // Upload-only installs have no local path to show
           summaryLines.push(`${pc.cyan(getSkillDisplayName(skill))}`);
         } else {
           const canonicalPath =
@@ -1981,8 +1850,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               : getCanonicalPath(skill.name, { global: installGlobally });
           const shortCanonical = shortenPath(canonicalPath, cwd);
           summaryLines.push(`${pc.cyan(shortCanonical)}`);
+          summaryLines.push(...buildTargetSummaryLines(installTargets, installMode));
         }
-        summaryLines.push(...buildTargetSummaryLines(installTargets, installMode));
+        summaryLines.push(...uploadSummaryLines(managedResolution));
 
         const skillOverwrites = overwriteStatus.get(skill.name);
         const overwriteAgents = installTargets
@@ -2068,8 +1938,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     for (const skill of selectedSkills) {
       for (const target of installTargets) {
         const { agent, subagent } = target;
-        // API-upload agents are handled by the API upload pass below.
-        if (isApiUploadAgent(agent)) continue;
         let result;
         if (blobResult && 'files' in skill) {
           // Blob-based install: write files from snapshot
@@ -2109,10 +1977,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         name: skill.name,
         files: () =>
           blobResult && 'files' in skill
-            ? (skill as BlobSkill).files.map((f) => ({ path: f.path, content: f.contents }))
+            ? (skill as BlobSkill).files
             : collectSkillFiles(skill.path),
       })),
-      // sourceKey must match the `source` the lock writes below record for this scope.
+      // sourceKey mirrors the `source` each lock write below records for its scope.
       {
         installGlobally,
         cwd,
@@ -2167,7 +2035,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             event: 'install',
             source: normalizedSource,
             skills: selectedSkills.map((s) => s.name).join(','),
-            agents: targetAgents.join(','),
+            agents: managedResolution.reportedAgents,
             ...(installGlobally && { global: '1' }),
             skillFiles: JSON.stringify(skillFiles),
             metadata: options.metadata,
@@ -2179,7 +2047,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           event: 'install',
           source: normalizedSource,
           skills: selectedSkills.map((s) => s.name).join(','),
-          agents: targetAgents.join(','),
+          agents: managedResolution.reportedAgents,
           ...(installGlobally && { global: '1' }),
           skillFiles: JSON.stringify(skillFiles),
           metadata: options.metadata,
@@ -2187,16 +2055,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // A skill counts as installed for lock purposes when it reached the
-    // filesystem or the Skills API.
-    const { uploadedManagedIds, managedIdFor, isComplete } = managed;
-
     // Add to skill lock file for update tracking (only for global installs)
-    if (
-      (successful.length > 0 || uploadedManagedIds.size > 0) &&
-      installGlobally &&
-      normalizedSource
-    ) {
+    if ((successful.length > 0 || managed.uploads > 0) && installGlobally && normalizedSource) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
 
       // For GitHub clone installs, fetch the repo tree once and reuse it
@@ -2208,8 +2068,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
-        const fsSucceeded = successfulSkillNames.has(skillDisplayName);
-        if (fsSucceeded || uploadedManagedIds.has(skill.name)) {
+        const lock = managed.lockEntry(skill.name, successfulSkillNames.has(skillDisplayName));
+        if (lock) {
           try {
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
@@ -2226,20 +2086,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               if (hash) skillFolderHash = hash;
             }
 
-            const managedSkillId = managedIdFor(skill.name);
             await addSkillToLock(skill.name, {
               source: lockSource || normalizedSource,
               sourceType: parsed.type,
               sourceUrl: parsed.url,
               ref: parsed.ref,
               skillPath: skillPathValue,
-              // A pending hash keeps the entry "changed" so update retries
-              // the part of the install that didn't complete.
-              skillFolderHash: isComplete(skill.name, fsSucceeded)
-                ? skillFolderHash
-                : PENDING_INSTALL_HASH,
+              skillFolderHash: lock.hash(skillFolderHash),
               pluginName: skill.pluginName,
-              ...(managedSkillId && { managedSkillId }),
+              managedSkillId: lock.managedSkillId,
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -2249,11 +2104,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Add to local lock file for project-scoped installs
-    if (
-      (successful.length > 0 || uploadedManagedIds.size > 0) &&
-      !installGlobally &&
-      !directDownload
-    ) {
+    if ((successful.length > 0 || managed.uploads > 0) && !installGlobally && !directDownload) {
       const successfulSkillNames = new Set(successful.map((r) => r.skill));
       // Record Eve subagent placement (root = '') so `update` can restore it.
       // Only meaningful when Eve is among the targets and a non-root subagent
@@ -2265,8 +2116,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         eveSubagents && (eveSubagents.length > 1 || eveSubagents.some((s) => s !== ''));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
-        const fsSucceeded = successfulSkillNames.has(skillDisplayName);
-        if (fsSucceeded || uploadedManagedIds.has(skill.name)) {
+        const lock = managed.lockEntry(skill.name, successfulSkillNames.has(skillDisplayName));
+        if (lock) {
           try {
             // For blob skills, use the snapshot hash; for disk skills, compute from files
             const computedHash =
@@ -2274,7 +2125,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
             const skillPathValue = skillFiles[skill.name];
-            const managedSkillId = managedIdFor(skill.name);
             await addSkillToLocalLock(
               skill.name,
               {
@@ -2283,13 +2133,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ref: parsed.ref,
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),
-                // A pending hash keeps the entry "changed" so update retries
-                // the part of the install that didn't complete.
-                computedHash: isComplete(skill.name, fsSucceeded)
-                  ? computedHash
-                  : PENDING_INSTALL_HASH,
+                computedHash: lock.hash(computedHash),
                 ...(recordSubagents && { subagents: eveSubagents }),
-                ...(managedSkillId && { managedSkillId }),
+                managedSkillId: lock.managedSkillId,
               },
               cwd
             );

--- a/src/add.ts
+++ b/src/add.ts
@@ -23,8 +23,18 @@ import {
   getVisibleUniversalAgents,
   getNonUniversalAgents,
   isUniversalAgent,
+  isVirtualAgent,
+  getWildcardAgents,
   getEveSubagents,
 } from './agents.ts';
+import {
+  resolveAnthropicAuth,
+  uploadSkillToManagedAgents,
+  collectSkillFiles,
+  MANAGED_AGENTS_AUTH_GUIDANCE,
+  type AnthropicAuth,
+  type SkillUploadFile,
+} from './managed-agents.ts';
 import {
   track,
   setVersion,
@@ -229,25 +239,29 @@ export function formatEveInstallPromptMessage(skills: Skill[]): string {
 }
 
 /**
- * Splits agents into universal and non-universal (symlinked) groups.
- * Returns display names for each group.
+ * Splits agents into universal, non-universal (symlinked), and virtual
+ * (API upload) groups. Returns display names for each group.
  */
 function splitAgentsByType(agentTypes: AgentType[]): {
   universal: string[];
   symlinked: string[];
+  virtual: string[];
 } {
   const universal: string[] = [];
   const symlinked: string[] = [];
+  const virtual: string[] = [];
 
   for (const a of agentTypes) {
-    if (isUniversalAgent(a)) {
+    if (isVirtualAgent(a)) {
+      virtual.push(agents[a].displayName);
+    } else if (isUniversalAgent(a)) {
       universal.push(agents[a].displayName);
     } else {
       symlinked.push(agents[a].displayName);
     }
   }
 
-  return { universal, symlinked };
+  return { universal, symlinked, virtual };
 }
 
 /**
@@ -255,7 +269,7 @@ function splitAgentsByType(agentTypes: AgentType[]): {
  */
 function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallMode): string[] {
   const lines: string[] = [];
-  const { universal, symlinked } = splitAgentsByType(targetAgents);
+  const { universal, symlinked, virtual } = splitAgentsByType(targetAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -265,9 +279,17 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
       lines.push(`  ${pc.dim('symlink →')} ${formatList(symlinked)}`);
     }
   } else {
-    // Copy mode - all agents get copies
-    const allNames = targetAgents.map((a) => agents[a].displayName);
-    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    // Copy mode - all filesystem agents get copies
+    const allNames = targetAgents
+      .filter((a) => !isVirtualAgent(a))
+      .map((a) => agents[a].displayName);
+    if (allNames.length > 0) {
+      lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    }
+  }
+
+  if (virtual.length > 0) {
+    lines.push(`  ${pc.dim('upload →')} ${formatList(virtual)}`);
   }
 
   return lines;
@@ -323,7 +345,7 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
   const lines: string[] = [];
   const rootAgents = targets.filter((t) => !t.subagent).map((t) => t.agent);
   const subagentNames = targets.filter((t) => t.subagent).map(targetDisplayName);
-  const { universal, symlinked } = splitAgentsByType(rootAgents);
+  const { universal, symlinked, virtual } = splitAgentsByType(rootAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -336,8 +358,14 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
       lines.push(`  ${pc.dim('copy →')} ${formatList(subagentNames)}`);
     }
   } else {
-    const allNames = targets.map(targetDisplayName);
-    lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    const allNames = targets.filter((t) => !isVirtualAgent(t.agent)).map(targetDisplayName);
+    if (allNames.length > 0) {
+      lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
+    }
+  }
+
+  if (virtual.length > 0) {
+    lines.push(`  ${pc.dim('upload →')} ${formatList(virtual)}`);
   }
 
   return lines;
@@ -358,6 +386,96 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
   }
 
   return result;
+}
+
+/**
+ * Resolve Anthropic API credentials when any selected target is a virtual
+ * (API upload) agent. Prints guidance and returns null when no credential is
+ * available; callers should abort the install in that case.
+ */
+async function resolveManagedAgentsAuth(
+  targetAgents: AgentType[],
+  spinner: ReturnType<typeof p.spinner>
+): Promise<{ auth: AnthropicAuth | null; required: boolean }> {
+  if (!targetAgents.some((a) => isVirtualAgent(a))) {
+    return { auth: null, required: false };
+  }
+
+  spinner.start('Checking Anthropic credentials…');
+  const auth = await resolveAnthropicAuth();
+  if (!auth) {
+    spinner.stop(pc.red('No Anthropic credentials found'));
+    p.log.error('Claude Managed Agents requires Anthropic API credentials.');
+    p.log.message(pc.dim(`  ${MANAGED_AGENTS_AUTH_GUIDANCE}`));
+    return { auth: null, required: true };
+  }
+  spinner.stop(`Anthropic credentials: ${pc.cyan(auth.source)}`);
+  return { auth, required: true };
+}
+
+interface ManagedUploadOutcome {
+  skill: string;
+  success: boolean;
+  skillId?: string;
+  version?: string;
+  action?: 'created' | 'updated';
+  error?: string;
+}
+
+/**
+ * Upload skills to the Anthropic Skills API for the Claude Managed Agents
+ * target. Uploads happen one skill at a time; a failure on one skill doesn't
+ * stop the rest.
+ */
+async function uploadSkillsToManagedAgents(
+  skills: Array<{ name: string; files: SkillUploadFile[] }>,
+  auth: AnthropicAuth
+): Promise<ManagedUploadOutcome[]> {
+  const outcomes: ManagedUploadOutcome[] = [];
+  for (const skill of skills) {
+    try {
+      const result = await uploadSkillToManagedAgents(skill, auth);
+      outcomes.push({ skill: skill.name, success: true, ...result });
+    } catch (error) {
+      outcomes.push({
+        skill: skill.name,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+  return outcomes;
+}
+
+/**
+ * Render upload outcomes for the Claude Managed Agents target.
+ */
+function printManagedUploadOutcomes(outcomes: ManagedUploadOutcome[]): void {
+  if (outcomes.length === 0) return;
+
+  const successful = outcomes.filter((o) => o.success);
+  const failed = outcomes.filter((o) => !o.success);
+
+  if (successful.length > 0) {
+    const lines = successful.map((o) => {
+      const label = o.action === 'updated' ? 'new version' : 'created';
+      return `${pc.green('✓')} ${o.skill} ${pc.dim(`(${label}: ${o.skillId})`)}`;
+    });
+    p.note(
+      lines.join('\n'),
+      pc.green(
+        `Uploaded ${successful.length} skill${successful.length !== 1 ? 's' : ''} to Claude Managed Agents`
+      )
+    );
+  }
+
+  if (failed.length > 0) {
+    console.log();
+    p.log.error(pc.red(`Failed to upload ${failed.length} to Claude Managed Agents`));
+    for (const o of failed) {
+      p.log.message(`  ${pc.red('✗')} ${o.skill}: ${pc.dim(o.error)}`);
+    }
+  }
 }
 
 /**
@@ -475,8 +593,10 @@ export async function promptForAgents(
 async function selectAgentsInteractive(options: {
   global?: boolean;
 }): Promise<AgentType[] | symbol> {
-  // Filter out agents that don't support global installation when --global is used
-  const supportsGlobalFilter = (a: AgentType) => !options.global || agents[a].globalSkillsDir;
+  // Filter out agents that don't support global installation when --global is used.
+  // Virtual agents (API uploads) are scope-independent, so they always remain.
+  const supportsGlobalFilter = (a: AgentType) =>
+    !options.global || agents[a].globalSkillsDir || isVirtualAgent(a);
 
   const universalAgents = getUniversalAgents().filter(supportsGlobalFilter);
   const visibleUniversalAgents = getVisibleUniversalAgents().filter(supportsGlobalFilter);
@@ -498,7 +618,8 @@ async function selectAgentsInteractive(options: {
   const otherChoices = otherAgents.map((a) => ({
     value: a,
     label: agents[a].displayName,
-    hint: options.global ? agents[a].globalSkillsDir! : agents[a].skillsDir,
+    hint:
+      agents[a].installHint ?? (options.global ? agents[a].globalSkillsDir! : agents[a].skillsDir),
   }));
 
   // Get last selected agents (filter to only non-universal ones for initial selection)
@@ -671,8 +792,9 @@ async function handleWellKnownSkills(
   const validAgents = Object.keys(agents);
 
   if (options.agent?.includes('*')) {
-    // --agent '*' selects all agents
-    targetAgents = validAgents as AgentType[];
+    // --agent '*' selects all filesystem agents; virtual agents (API uploads)
+    // must be requested explicitly.
+    targetAgents = getWildcardAgents();
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -692,7 +814,8 @@ async function handleWellKnownSkills(
 
     if (installedAgents.length === 0) {
       if (options.yes) {
-        targetAgents = validAgents as AgentType[];
+        // Covers filesystem agents only; virtual agents need an explicit -a.
+        targetAgents = getWildcardAgents();
         p.log.info('Installing to all agents');
       } else {
         p.log.info('Select agents to install skills to');
@@ -738,6 +861,15 @@ async function handleWellKnownSkills(
     }
   }
 
+  // Resolve API credentials up front when Claude Managed Agents is targeted,
+  // so a missing login fails before anything is installed.
+  const { auth: managedAgentsAuth, required: managedAgentsRequired } =
+    await resolveManagedAgentsAuth(targetAgents, spinner);
+  if (managedAgentsRequired && !managedAgentsAuth) {
+    p.outro(pc.red('Installation failed'));
+    process.exit(1);
+  }
+
   let installGlobally = options.global ?? false;
 
   // Check if any selected agents support global installation
@@ -773,7 +905,10 @@ async function handleWellKnownSkills(
 
   // Only prompt for install mode when there are multiple unique target directories.
   // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-  const uniqueDirs = new Set(targetAgents.map((a) => agents[a].skillsDir));
+  // Virtual agents have no target directory and don't participate in the choice.
+  const uniqueDirs = new Set(
+    targetAgents.filter((a) => !isVirtualAgent(a)).map((a) => agents[a].skillsDir)
+  );
 
   if (!options.copy && !options.yes && uniqueDirs.size > 1) {
     const modeChoice = await p.select({
@@ -823,12 +958,19 @@ async function handleWellKnownSkills(
     overwriteStatus.get(skillName)!.set(agent, installed);
   }
 
+  const allVirtualTargets = targetAgents.every((a) => isVirtualAgent(a));
+
   for (const skill of selectedSkills) {
     if (summaryLines.length > 0) summaryLines.push('');
 
-    const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
-    const shortCanonical = shortenPath(canonicalPath, cwd);
-    summaryLines.push(`${pc.cyan(shortCanonical)}`);
+    // API-only installs have no local path to show
+    if (allVirtualTargets) {
+      summaryLines.push(`${pc.cyan(skill.installName)}`);
+    } else {
+      const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
+      const shortCanonical = shortenPath(canonicalPath, cwd);
+      summaryLines.push(`${pc.cyan(shortCanonical)}`);
+    }
     summaryLines.push(...buildAgentSummaryLines(targetAgents, installMode));
     if (skill.files.size > 1) {
       summaryLines.push(`  ${pc.dim('files:')} ${skill.files.size}`);
@@ -875,6 +1017,7 @@ async function handleWellKnownSkills(
 
   for (const skill of selectedSkills) {
     for (const agent of targetAgents) {
+      if (isVirtualAgent(agent)) continue;
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
@@ -885,6 +1028,17 @@ async function handleWellKnownSkills(
         ...result,
       });
     }
+  }
+
+  let uploadOutcomes: ManagedUploadOutcome[] = [];
+  if (managedAgentsAuth) {
+    uploadOutcomes = await uploadSkillsToManagedAgents(
+      selectedSkills.map((skill) => ({
+        name: skill.name,
+        files: Array.from(skill.files, ([path, content]) => ({ path, content })),
+      })),
+      managedAgentsAuth
+    );
   }
 
   spinner.stop('Installation complete');
@@ -1025,6 +1179,8 @@ async function handleWellKnownSkills(
       p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
     }
   }
+
+  printManagedUploadOutcomes(uploadOutcomes);
 
   console.log();
   p.outro(
@@ -1387,8 +1543,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const validAgents = Object.keys(agents);
 
     if (options.agent?.includes('*')) {
-      // --agent '*' selects all agents
-      targetAgents = validAgents as AgentType[];
+      // --agent '*' selects all filesystem agents; virtual agents (API
+      // uploads) must be requested explicitly.
+      targetAgents = getWildcardAgents();
       p.log.info(`Installing to all ${targetAgents.length} agents`);
     } else if (options.agent && options.agent.length > 0) {
       const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -1437,7 +1594,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
       } else if (installedAgents.length === 0) {
         if (options.yes) {
-          targetAgents = validAgents as AgentType[];
+          // Covers filesystem agents only; virtual agents need an explicit -a.
+          targetAgents = getWildcardAgents();
           p.log.info('Installing to all agents');
         } else {
           p.log.info('Select agents to install skills to');
@@ -1531,6 +1689,16 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    // Resolve API credentials up front when Claude Managed Agents is targeted,
+    // so a missing login fails before anything is installed.
+    const { auth: managedAgentsAuth, required: managedAgentsRequired } =
+      await resolveManagedAgentsAuth(targetAgents, spinner);
+    if (managedAgentsRequired && !managedAgentsAuth) {
+      await cleanup(tempDir);
+      p.outro(pc.red('Installation failed'));
+      process.exit(1);
+    }
+
     const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
 
     let installGlobally = options.global ?? false;
@@ -1573,9 +1741,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // never meaningful when every target is Eve.
     const allEve = installTargets.every((t) => t.agent === 'eve');
     const uniqueDirs = new Set(
-      installTargets.map((t) =>
-        t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir
-      )
+      installTargets
+        .filter((t) => !isVirtualAgent(t.agent))
+        .map((t) => (t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir))
     );
 
     if (!options.copy && !options.yes && uniqueDirs.size > 1 && !allEve) {
@@ -1645,20 +1813,26 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Helper to print summary lines for a list of skills
+    const allVirtualTargets = installTargets.every((t) => isVirtualAgent(t.agent));
     const printSkillSummary = (skills: Skill[]) => {
       for (const skill of skills) {
         if (summaryLines.length > 0) summaryLines.push('');
 
-        const canonicalPath =
-          installTargets.length === 1
-            ? getCanonicalPath(skill.name, {
-                global: installGlobally,
-                agent: installTargets[0]!.agent,
-                eveSubagent: installTargets[0]!.subagent,
-              })
-            : getCanonicalPath(skill.name, { global: installGlobally });
-        const shortCanonical = shortenPath(canonicalPath, cwd);
-        summaryLines.push(`${pc.cyan(shortCanonical)}`);
+        // API-only installs have no local path to show
+        if (allVirtualTargets) {
+          summaryLines.push(`${pc.cyan(getSkillDisplayName(skill))}`);
+        } else {
+          const canonicalPath =
+            installTargets.length === 1
+              ? getCanonicalPath(skill.name, {
+                  global: installGlobally,
+                  agent: installTargets[0]!.agent,
+                  eveSubagent: installTargets[0]!.subagent,
+                })
+              : getCanonicalPath(skill.name, { global: installGlobally });
+          const shortCanonical = shortenPath(canonicalPath, cwd);
+          summaryLines.push(`${pc.cyan(shortCanonical)}`);
+        }
         summaryLines.push(...buildTargetSummaryLines(installTargets, installMode));
 
         const skillOverwrites = overwriteStatus.get(skill.name);
@@ -1745,6 +1919,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     for (const skill of selectedSkills) {
       for (const target of installTargets) {
         const { agent, subagent } = target;
+        // Virtual agents are handled by the API upload pass below.
+        if (isVirtualAgent(agent)) continue;
         let result;
         if (blobResult && 'files' in skill) {
           // Blob-based install: write files from snapshot
@@ -1773,6 +1949,32 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           ...result,
         });
       }
+    }
+
+    // API upload pass for Claude Managed Agents.
+    const uploadOutcomes: ManagedUploadOutcome[] = [];
+    if (managedAgentsAuth) {
+      const uploads: Array<{ name: string; files: SkillUploadFile[] }> = [];
+      for (const skill of selectedSkills) {
+        try {
+          if (blobResult && 'files' in skill) {
+            const blobSkill = skill as BlobSkill;
+            uploads.push({
+              name: skill.name,
+              files: blobSkill.files.map((f) => ({ path: f.path, content: f.contents })),
+            });
+          } else {
+            uploads.push({ name: skill.name, files: await collectSkillFiles(skill.path) });
+          }
+        } catch (error) {
+          uploadOutcomes.push({
+            skill: skill.name,
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+      uploadOutcomes.push(...(await uploadSkillsToManagedAgents(uploads, managedAgentsAuth)));
     }
 
     spinner.stop('Installation complete');
@@ -2035,6 +2237,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         p.log.message(`  ${pc.red('✗')} ${r.skill} → ${r.agent}: ${pc.dim(r.error)}`);
       }
     }
+
+    printManagedUploadOutcomes(uploadOutcomes);
 
     console.log();
     p.outro(

--- a/src/add.ts
+++ b/src/add.ts
@@ -31,6 +31,7 @@ import {
 import {
   resolveAnthropicAuth,
   uploadSkillToManagedAgents,
+  createManagedSkillLookup,
   collectSkillFiles,
   MANAGED_AGENTS_AUTH_GUIDANCE,
   type AnthropicAuth,
@@ -460,7 +461,6 @@ interface ManagedUploadOutcome {
   skill: string;
   success: boolean;
   skillId?: string;
-  versionId?: string;
   action?: 'created' | 'updated';
   error?: string;
 }
@@ -481,8 +481,9 @@ interface ManagedUploadPass {
 
 /**
  * Skills API ids a previous run recorded in the lock, restricted to entries
- * whose source matches this run's: a same-named skill installed from another
- * source must not inherit (and version over) the earlier upload.
+ * whose source matches this run's. A same-named skill from another source
+ * doesn't get the recorded id as a direct-version shortcut; it goes through
+ * the workspace display-name lookup like any first upload.
  */
 export function knownManagedIds(
   entries: Record<string, { source: string; managedSkillId?: string }>,
@@ -529,12 +530,13 @@ async function runManagedUploads(
 
   const outcomes: ManagedUploadOutcome[] = [];
   if (resolution.auth) {
+    const lookup = createManagedSkillLookup(resolution.auth);
     for (const skill of skills) {
       try {
         const result = await uploadSkillToManagedAgents(
           { name: skill.name, files: await skill.files() },
           resolution.auth,
-          knownIds.get(skill.name)
+          { knownSkillId: knownIds.get(skill.name), lookup }
         );
         outcomes.push({ skill: skill.name, success: true, ...result });
       } catch (error) {

--- a/src/add.ts
+++ b/src/add.ts
@@ -23,7 +23,8 @@ import {
   getVisibleUniversalAgents,
   getNonUniversalAgents,
   isUniversalAgent,
-  isVirtualAgent,
+  isApiUploadAgent,
+  isFilesystemAgent,
   getWildcardAgents,
   getEveSubagents,
 } from './agents.ts';
@@ -240,21 +241,21 @@ export function formatEveInstallPromptMessage(skills: Skill[]): string {
 }
 
 /**
- * Splits agents into universal, non-universal (symlinked), and virtual
+ * Splits agents into universal, non-universal (symlinked), and API-upload
  * (API upload) groups. Returns display names for each group.
  */
 function splitAgentsByType(agentTypes: AgentType[]): {
   universal: string[];
   symlinked: string[];
-  virtual: string[];
+  apiUpload: string[];
 } {
   const universal: string[] = [];
   const symlinked: string[] = [];
-  const virtual: string[] = [];
+  const apiUpload: string[] = [];
 
   for (const a of agentTypes) {
-    if (isVirtualAgent(a)) {
-      virtual.push(agents[a].displayName);
+    if (isApiUploadAgent(a)) {
+      apiUpload.push(agents[a].displayName);
     } else if (isUniversalAgent(a)) {
       universal.push(agents[a].displayName);
     } else {
@@ -262,7 +263,7 @@ function splitAgentsByType(agentTypes: AgentType[]): {
     }
   }
 
-  return { universal, symlinked, virtual };
+  return { universal, symlinked, apiUpload };
 }
 
 /**
@@ -270,7 +271,7 @@ function splitAgentsByType(agentTypes: AgentType[]): {
  */
 function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallMode): string[] {
   const lines: string[] = [];
-  const { universal, symlinked, virtual } = splitAgentsByType(targetAgents);
+  const { universal, symlinked, apiUpload } = splitAgentsByType(targetAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -282,15 +283,15 @@ function buildAgentSummaryLines(targetAgents: AgentType[], installMode: InstallM
   } else {
     // Copy mode - all filesystem agents get copies
     const allNames = targetAgents
-      .filter((a) => !isVirtualAgent(a))
+      .filter((a) => isFilesystemAgent(a))
       .map((a) => agents[a].displayName);
     if (allNames.length > 0) {
       lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
     }
   }
 
-  if (virtual.length > 0) {
-    lines.push(`  ${pc.dim('upload →')} ${formatList(virtual)}`);
+  if (apiUpload.length > 0) {
+    lines.push(`  ${pc.dim('upload →')} ${formatList(apiUpload)}`);
   }
 
   return lines;
@@ -346,7 +347,7 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
   const lines: string[] = [];
   const rootAgents = targets.filter((t) => !t.subagent).map((t) => t.agent);
   const subagentNames = targets.filter((t) => t.subagent).map(targetDisplayName);
-  const { universal, symlinked, virtual } = splitAgentsByType(rootAgents);
+  const { universal, symlinked, apiUpload } = splitAgentsByType(rootAgents);
 
   if (installMode === 'symlink') {
     if (universal.length > 0) {
@@ -359,14 +360,14 @@ function buildTargetSummaryLines(targets: InstallTarget[], installMode: InstallM
       lines.push(`  ${pc.dim('copy →')} ${formatList(subagentNames)}`);
     }
   } else {
-    const allNames = targets.filter((t) => !isVirtualAgent(t.agent)).map(targetDisplayName);
+    const allNames = targets.filter((t) => isFilesystemAgent(t.agent)).map(targetDisplayName);
     if (allNames.length > 0) {
       lines.push(`  ${pc.dim('copy →')} ${formatList(allNames)}`);
     }
   }
 
-  if (virtual.length > 0) {
-    lines.push(`  ${pc.dim('upload →')} ${formatList(virtual)}`);
+  if (apiUpload.length > 0) {
+    lines.push(`  ${pc.dim('upload →')} ${formatList(apiUpload)}`);
   }
 
   return lines;
@@ -390,18 +391,18 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
 }
 
 /**
- * Expand `--agent '*'` to all filesystem agents, keeping any virtual agents
+ * Expand `--agent '*'` to all filesystem agents, keeping any API-upload agents
  * the user listed explicitly alongside the wildcard.
  */
 function expandWildcardAgents(requested: string[]): AgentType[] {
-  const explicitVirtual = requested.filter(
-    (a): a is AgentType => a !== '*' && a in agents && isVirtualAgent(a as AgentType)
+  const explicitApiUpload = requested.filter(
+    (a): a is AgentType => a !== '*' && a in agents && isApiUploadAgent(a as AgentType)
   );
-  return [...new Set([...getWildcardAgents(), ...explicitVirtual])];
+  return [...new Set([...getWildcardAgents(), ...explicitApiUpload])];
 }
 
 /**
- * Resolve Anthropic API credentials when any selected target is a virtual
+ * Resolve Anthropic API credentials when any selected target is an API-upload
  * (API upload) agent. Prints guidance and returns null when no credential is
  * available; callers should abort the install in that case.
  */
@@ -409,7 +410,7 @@ async function resolveManagedAgentsAuth(
   targetAgents: AgentType[],
   spinner: ReturnType<typeof p.spinner>
 ): Promise<{ auth: AnthropicAuth | null; required: boolean }> {
-  if (!targetAgents.some((a) => isVirtualAgent(a))) {
+  if (!targetAgents.some((a) => isApiUploadAgent(a))) {
     return { auth: null, required: false };
   }
 
@@ -427,13 +428,13 @@ async function resolveManagedAgentsAuth(
 
 /**
  * Fold the additive `--managed-agents` flag into the target list and resolve
- * API credentials when any target is virtual. An explicitly requested virtual
- * agent aborts on missing credentials (shouldAbort) — unless the
- * `--managed-agents` flag is also present, which marks the run as an
- * automated refresh: virtual targets are then dropped with a warning and
+ * API credentials when any target is an API-upload agent. An explicitly
+ * requested API-upload agent aborts on missing credentials (shouldAbort) —
+ * unless the `--managed-agents` flag is also present, which marks the run as an
+ * automated refresh: API-upload targets are then dropped with a warning and
  * reported as uploadSkipped, so `update` never fails the whole run over a
  * missing login (it passes the flag on every refresh of a previously
- * uploaded skill, including upload-only ones where the virtual agent is
+ * uploaded skill, including upload-only ones where the API-upload agent is
  * named explicitly).
  */
 async function resolveManagedAgentsTargets(
@@ -457,7 +458,7 @@ async function resolveManagedAgentsTargets(
     if (soft) {
       p.log.warn('Skipping the Claude Managed Agents upload; other installs continue.');
       return {
-        targetAgents: resolved.filter((a) => !isVirtualAgent(a)),
+        targetAgents: resolved.filter((a) => isFilesystemAgent(a)),
         auth: null,
         shouldAbort: false,
         uploadSkipped: true,
@@ -727,9 +728,9 @@ async function selectAgentsInteractive(options: {
   global?: boolean;
 }): Promise<AgentType[] | symbol> {
   // Filter out agents that don't support global installation when --global is used.
-  // Virtual agents (API uploads) are scope-independent, so they always remain.
+  // API-upload agents are scope-independent, so they always remain.
   const supportsGlobalFilter = (a: AgentType) =>
-    !options.global || agents[a].globalSkillsDir || isVirtualAgent(a);
+    !options.global || agents[a].globalSkillsDir || isApiUploadAgent(a);
 
   const universalAgents = getUniversalAgents().filter(supportsGlobalFilter);
   const visibleUniversalAgents = getVisibleUniversalAgents().filter(supportsGlobalFilter);
@@ -932,8 +933,8 @@ async function handleWellKnownSkills(
   const validAgents = Object.keys(agents);
 
   if (options.agent?.includes('*')) {
-    // --agent '*' selects all filesystem agents; virtual agents (API uploads)
-    // are included only when listed explicitly alongside the wildcard.
+    // --agent '*' selects all filesystem agents; API-upload agents are
+    // included only when listed explicitly alongside the wildcard.
     targetAgents = expandWildcardAgents(options.agent);
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
@@ -954,7 +955,7 @@ async function handleWellKnownSkills(
 
     if (installedAgents.length === 0) {
       if (options.yes) {
-        // Covers filesystem agents only; virtual agents need an explicit -a.
+        // Covers filesystem agents only; API-upload agents need an explicit -a.
         targetAgents = getWildcardAgents();
         p.log.info('Installing to all agents');
       } else {
@@ -1052,9 +1053,9 @@ async function handleWellKnownSkills(
 
   // Only prompt for install mode when there are multiple unique target directories.
   // When all selected agents share the same skillsDir, symlink vs copy is meaningless.
-  // Virtual agents have no target directory and don't participate in the choice.
+  // API-upload agents have no target directory and don't participate in the choice.
   const uniqueDirs = new Set(
-    targetAgents.filter((a) => !isVirtualAgent(a)).map((a) => agents[a].skillsDir)
+    targetAgents.filter((a) => isFilesystemAgent(a)).map((a) => agents[a].skillsDir)
   );
 
   if (!options.copy && !options.yes && uniqueDirs.size > 1) {
@@ -1105,13 +1106,13 @@ async function handleWellKnownSkills(
     overwriteStatus.get(skillName)!.set(agent, installed);
   }
 
-  const allVirtualTargets = targetAgents.every((a) => isVirtualAgent(a));
+  const allApiUploadTargets = targetAgents.every((a) => isApiUploadAgent(a));
 
   for (const skill of selectedSkills) {
     if (summaryLines.length > 0) summaryLines.push('');
 
     // API-only installs have no local path to show
-    if (allVirtualTargets) {
+    if (allApiUploadTargets) {
       summaryLines.push(`${pc.cyan(skill.installName)}`);
     } else {
       const canonicalPath = getCanonicalPath(skill.installName, { global: installGlobally });
@@ -1164,7 +1165,7 @@ async function handleWellKnownSkills(
 
   for (const skill of selectedSkills) {
     for (const agent of targetAgents) {
-      if (isVirtualAgent(agent)) continue;
+      if (isApiUploadAgent(agent)) continue;
       const result = await installWellKnownSkillForAgent(skill, agent, {
         global: installGlobally,
         mode: installMode,
@@ -1232,7 +1233,7 @@ async function handleWellKnownSkills(
     knownManagedIds,
     sourceKey: sourceIdentifier,
     uploadRequested: Boolean(managedAgentsAuth) || managedResolution.uploadSkipped,
-    fsRequested: targetAgents.some((a) => !isVirtualAgent(a)),
+    fsRequested: targetAgents.some((a) => isFilesystemAgent(a)),
   });
 
   // Add to skill lock file for update tracking (only for global installs)
@@ -1723,9 +1724,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const validAgents = Object.keys(agents);
 
     if (options.agent?.includes('*')) {
-      // --agent '*' selects all filesystem agents; virtual agents (API
-      // uploads) are included only when listed explicitly alongside the
-      // wildcard.
+      // --agent '*' selects all filesystem agents; API-upload agents are
+      // included only when listed explicitly alongside the wildcard.
       targetAgents = expandWildcardAgents(options.agent);
       p.log.info(`Installing to all ${targetAgents.length} agents`);
     } else if (options.agent && options.agent.length > 0) {
@@ -1775,7 +1775,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
       } else if (installedAgents.length === 0) {
         if (options.yes) {
-          // Covers filesystem agents only; virtual agents need an explicit -a.
+          // Covers filesystem agents only; API-upload agents need an explicit -a.
           targetAgents = getWildcardAgents();
           p.log.info('Installing to all agents');
         } else {
@@ -1930,7 +1930,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const allEve = installTargets.every((t) => t.agent === 'eve');
     const uniqueDirs = new Set(
       installTargets
-        .filter((t) => !isVirtualAgent(t.agent))
+        .filter((t) => isFilesystemAgent(t.agent))
         .map((t) => (t.subagent ? `eve:subagent:${t.subagent}` : agents[t.agent].skillsDir))
     );
 
@@ -2001,13 +2001,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // Helper to print summary lines for a list of skills
-    const allVirtualTargets = installTargets.every((t) => isVirtualAgent(t.agent));
+    const allApiUploadTargets = installTargets.every((t) => isApiUploadAgent(t.agent));
     const printSkillSummary = (skills: Skill[]) => {
       for (const skill of skills) {
         if (summaryLines.length > 0) summaryLines.push('');
 
         // API-only installs have no local path to show
-        if (allVirtualTargets) {
+        if (allApiUploadTargets) {
           summaryLines.push(`${pc.cyan(getSkillDisplayName(skill))}`);
         } else {
           const canonicalPath =
@@ -2107,8 +2107,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     for (const skill of selectedSkills) {
       for (const target of installTargets) {
         const { agent, subagent } = target;
-        // Virtual agents are handled by the API upload pass below.
-        if (isVirtualAgent(agent)) continue;
+        // API-upload agents are handled by the API upload pass below.
+        if (isApiUploadAgent(agent)) continue;
         let result;
         if (blobResult && 'files' in skill) {
           // Blob-based install: write files from snapshot
@@ -2258,7 +2258,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       knownManagedIds,
       sourceKey: managedSourceKey,
       uploadRequested: Boolean(managedAgentsAuth) || managedResolution.uploadSkipped,
-      fsRequested: targetAgents.some((a) => !isVirtualAgent(a)),
+      fsRequested: targetAgents.some((a) => isFilesystemAgent(a)),
     });
 
     // Add to skill lock file for update tracking (only for global installs)

--- a/src/add.ts
+++ b/src/add.ts
@@ -460,7 +460,7 @@ interface ManagedUploadOutcome {
   skill: string;
   success: boolean;
   skillId?: string;
-  version?: string;
+  versionId?: string;
   action?: 'created' | 'updated';
   error?: string;
 }
@@ -514,8 +514,8 @@ export function summarizeManagedUploads(
 
 /**
  * Upload pass for the Claude Managed Agents target. Skills with an id
- * recorded in this scope's lock are versioned directly; the rest are created
- * or resolved by display title. One skill at a time; a failure doesn't stop
+ * recorded in this scope's lock are versioned directly; the rest are matched
+ * by display name or created. One skill at a time; a failure doesn't stop
  * the rest. Without credentials nothing is uploaded, but recorded ids are
  * still returned so a filesystem-only re-add keeps them in the lock.
  */

--- a/src/add.ts
+++ b/src/add.ts
@@ -428,18 +428,25 @@ async function resolveManagedAgentsAuth(
 /**
  * Fold the additive `--managed-agents` flag into the target list and resolve
  * API credentials when any target is virtual. An explicitly requested virtual
- * agent still aborts on missing credentials (shouldAbort); a target added
- * only by the flag is dropped with a warning instead so filesystem installs
- * proceed — `update` passes the flag on every refresh of a previously
- * uploaded skill, and must not fail the whole update over a missing login.
+ * agent aborts on missing credentials (shouldAbort) — unless the
+ * `--managed-agents` flag is also present, which marks the run as an
+ * automated refresh: virtual targets are then dropped with a warning and
+ * reported as uploadSkipped, so `update` never fails the whole run over a
+ * missing login (it passes the flag on every refresh of a previously
+ * uploaded skill, including upload-only ones where the virtual agent is
+ * named explicitly).
  */
 async function resolveManagedAgentsTargets(
   targetAgents: AgentType[],
   options: AddOptions | undefined,
   spinner: ReturnType<typeof p.spinner>
-): Promise<{ targetAgents: AgentType[]; auth: AnthropicAuth | null; shouldAbort: boolean }> {
-  const additiveOnly =
-    Boolean(options?.managedAgents) && !targetAgents.some((a) => isVirtualAgent(a));
+): Promise<{
+  targetAgents: AgentType[];
+  auth: AnthropicAuth | null;
+  shouldAbort: boolean;
+  uploadSkipped: boolean;
+}> {
+  const soft = Boolean(options?.managedAgents);
   const resolved =
     options?.managedAgents && !targetAgents.includes('claude-managed-agents')
       ? [...targetAgents, 'claude-managed-agents' as AgentType]
@@ -447,41 +454,91 @@ async function resolveManagedAgentsTargets(
 
   const { auth, required } = await resolveManagedAgentsAuth(resolved, spinner);
   if (required && !auth) {
-    if (additiveOnly) {
+    if (soft) {
       p.log.warn('Skipping the Claude Managed Agents upload; other installs continue.');
       return {
         targetAgents: resolved.filter((a) => !isVirtualAgent(a)),
         auth: null,
         shouldAbort: false,
+        uploadSkipped: true,
       };
     }
-    return { targetAgents: resolved, auth: null, shouldAbort: true };
+    return { targetAgents: resolved, auth: null, shouldAbort: true, uploadSkipped: false };
   }
-  return { targetAgents: resolved, auth, shouldAbort: false };
+  return { targetAgents: resolved, auth, shouldAbort: false, uploadSkipped: false };
+}
+
+/**
+ * Sentinel written in place of a content hash or digest when part of a
+ * requested install (filesystem copy or managed upload) did not complete.
+ * Never equal to a real hash, so a later `update` sees the entry as changed
+ * and retries the whole install instead of treating the skill as current.
+ */
+export const PENDING_INSTALL_HASH = 'pending-install';
+
+interface KnownManagedSkill {
+  managedSkillId: string;
+  /** The lock entry's source, so ids never leak across sources. */
+  source: string;
 }
 
 /**
  * Read previously recorded Skills API ids from the lock file for the scope
  * being installed to, so re-uploads go straight to the right skill instead of
  * re-resolving it by display title (and so a re-add that doesn't touch the
- * upload preserves the recorded id).
+ * upload preserves the recorded id). Ids are keyed by skill name but carry
+ * their entry's source: a same-named skill installed from a different source
+ * must not inherit the previous source's uploaded skill.
  */
 async function getKnownManagedSkillIds(
   installGlobally: boolean,
   cwd?: string
-): Promise<Map<string, string>> {
-  const ids = new Map<string, string>();
+): Promise<Map<string, KnownManagedSkill>> {
+  const ids = new Map<string, KnownManagedSkill>();
   try {
     const skills = installGlobally
       ? (await readSkillLock()).skills
       : (await readLocalLock(cwd)).skills;
     for (const [name, entry] of Object.entries(skills)) {
-      if (entry.managedSkillId) ids.set(name, entry.managedSkillId);
+      if (entry.managedSkillId) {
+        ids.set(name, { managedSkillId: entry.managedSkillId, source: entry.source });
+      }
     }
   } catch {
     // Unreadable lock — uploads fall back to display-title resolution.
   }
   return ids;
+}
+
+/**
+ * Per-run bookkeeping for lock writes after the install + upload passes.
+ * `managedIdFor` resolves the id to record (fresh upload first, then the
+ * previously recorded id when it belongs to the same source), and
+ * `isComplete` says whether every requested part of the install reached its
+ * destination — an incomplete skill gets `PENDING_INSTALL_HASH` in place of
+ * its content hash so `update` retries it.
+ */
+export function buildManagedLockBookkeeping(opts: {
+  uploadOutcomes: ManagedUploadOutcome[];
+  knownManagedIds: Map<string, KnownManagedSkill>;
+  sourceKey: string | null;
+  /** Uploads were part of this install (attempted, or skipped for missing credentials). */
+  uploadRequested: boolean;
+  /** Any filesystem agent was targeted. */
+  fsRequested: boolean;
+}) {
+  const uploadedManagedIds = new Map(
+    opts.uploadOutcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
+  );
+  const managedIdFor = (name: string): string | undefined => {
+    const uploaded = uploadedManagedIds.get(name);
+    if (uploaded) return uploaded;
+    const known = opts.knownManagedIds.get(name);
+    return known && known.source === opts.sourceKey ? known.managedSkillId : undefined;
+  };
+  const isComplete = (name: string, fsSucceeded: boolean): boolean =>
+    (!opts.fsRequested || fsSucceeded) && (!opts.uploadRequested || uploadedManagedIds.has(name));
+  return { uploadedManagedIds, managedIdFor, isComplete };
 }
 
 interface ManagedUploadOutcome {
@@ -953,6 +1010,12 @@ async function handleWellKnownSkills(
   }
   targetAgents = managedResolution.targetAgents;
   const managedAgentsAuth = managedResolution.auth;
+  if (targetAgents.length === 0) {
+    // Upload-only run whose upload was credential-skipped: nothing left to do,
+    // but the well-known source was handled.
+    p.outro('Nothing to install (Claude Managed Agents upload skipped)');
+    return true;
+  }
 
   let installGlobally = options.global ?? false;
 
@@ -1115,6 +1178,10 @@ async function handleWellKnownSkills(
   }
 
   const knownManagedIds = await getKnownManagedSkillIds(installGlobally, cwd);
+  const knownIdForUpload = (name: string): string | undefined => {
+    const known = knownManagedIds.get(name);
+    return known && known.source === sourceIdentifier ? known.managedSkillId : undefined;
+  };
   let uploadOutcomes: ManagedUploadOutcome[] = [];
   if (managedAgentsAuth) {
     uploadOutcomes = await uploadSkillsToManagedAgents(
@@ -1123,7 +1190,7 @@ async function handleWellKnownSkills(
       selectedSkills.map((skill) => ({
         name: skill.installName,
         files: Array.from(skill.files, ([path, content]) => ({ path, content })),
-        knownSkillId: knownManagedIds.get(skill.installName),
+        knownSkillId: knownIdForUpload(skill.installName),
       })),
       managedAgentsAuth
     );
@@ -1160,19 +1227,20 @@ async function handleWellKnownSkills(
   // A skill counts as installed for lock purposes when it reached the
   // filesystem or the Skills API. Keep a previously recorded API id when this
   // run didn't touch the upload, so a filesystem-only re-add doesn't drop it.
-  const uploadedManagedIds = new Map(
-    uploadOutcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
-  );
-  const managedIdFor = (name: string) => uploadedManagedIds.get(name) ?? knownManagedIds.get(name);
+  const { uploadedManagedIds, managedIdFor, isComplete } = buildManagedLockBookkeeping({
+    uploadOutcomes,
+    knownManagedIds,
+    sourceKey: sourceIdentifier,
+    uploadRequested: Boolean(managedAgentsAuth) || managedResolution.uploadSkipped,
+    fsRequested: targetAgents.some((a) => !isVirtualAgent(a)),
+  });
 
   // Add to skill lock file for update tracking (only for global installs)
   if ((successful.length > 0 || uploadedManagedIds.size > 0) && installGlobally) {
     const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
-      if (
-        successfulSkillNames.has(skill.installName) ||
-        uploadedManagedIds.has(skill.installName)
-      ) {
+      const fsSucceeded = successfulSkillNames.has(skill.installName);
+      if (fsSucceeded || uploadedManagedIds.has(skill.installName)) {
         try {
           const managedSkillId = managedIdFor(skill.installName);
           await addSkillToLock(skill.installName, {
@@ -1181,7 +1249,11 @@ async function handleWellKnownSkills(
             sourceUrl: skill.sourceUrl,
             skillFolderHash: '',
             sourceBaseUrl: url,
-            wellKnownDigest: computeWellKnownSkillDigest(skill),
+            // A pending digest keeps the entry "changed" so update retries
+            // the part of the install that didn't complete.
+            wellKnownDigest: isComplete(skill.installName, fsSucceeded)
+              ? computeWellKnownSkillDigest(skill)
+              : PENDING_INSTALL_HASH,
             ...(managedSkillId && { managedSkillId }),
           });
         } catch {
@@ -1195,10 +1267,8 @@ async function handleWellKnownSkills(
   if ((successful.length > 0 || uploadedManagedIds.size > 0) && !installGlobally) {
     const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
-      if (
-        successfulSkillNames.has(skill.installName) ||
-        uploadedManagedIds.has(skill.installName)
-      ) {
+      const fsSucceeded = successfulSkillNames.has(skill.installName);
+      if (fsSucceeded || uploadedManagedIds.has(skill.installName)) {
         try {
           const matchingResult = successful.find((r) => r.skill === skill.installName);
           const installDir = matchingResult?.canonicalPath || matchingResult?.path;
@@ -1214,7 +1284,9 @@ async function handleWellKnownSkills(
                 sourceUrl: url,
                 sourceType: 'well-known',
                 computedHash,
-                wellKnownDigest: computeWellKnownSkillDigest(skill),
+                wellKnownDigest: isComplete(skill.installName, fsSucceeded)
+                  ? computeWellKnownSkillDigest(skill)
+                  : PENDING_INSTALL_HASH,
                 ...(managedSkillId && { managedSkillId }),
               },
               cwd
@@ -1808,6 +1880,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
     targetAgents = managedResolution.targetAgents;
     const managedAgentsAuth = managedResolution.auth;
+    if (targetAgents.length === 0) {
+      // Upload-only run whose upload was credential-skipped: nothing left to do.
+      await cleanup(tempDir);
+      p.outro('Nothing to install (Claude Managed Agents upload skipped)');
+      return;
+    }
 
     const installTargets = buildInstallTargets(targetAgents, eveSubagentTargets);
 
@@ -2062,12 +2140,22 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // API upload pass for Claude Managed Agents.
+    const normalizedSource = directDownload ? null : getOwnerRepo(parsed);
+    const lockSource = directDownload ? null : getLockSource(parsed.url, normalizedSource);
+    // Must match the `source` value the lock write below records for this scope.
+    const managedSourceKey = installGlobally
+      ? lockSource || normalizedSource
+      : lockSource || parsed.url;
     const knownManagedIds = await getKnownManagedSkillIds(installGlobally, cwd);
+    const knownIdForUpload = (name: string): string | undefined => {
+      const known = knownManagedIds.get(name);
+      return known && known.source === managedSourceKey ? known.managedSkillId : undefined;
+    };
     const uploadOutcomes: ManagedUploadOutcome[] = [];
     if (managedAgentsAuth) {
       const uploads: Array<{ name: string; files: SkillUploadFile[]; knownSkillId?: string }> = [];
       for (const skill of selectedSkills) {
-        const knownSkillId = knownManagedIds.get(skill.name);
+        const knownSkillId = knownIdForUpload(skill.name);
         try {
           if (blobResult && 'files' in skill) {
             const blobSkill = skill as BlobSkill;
@@ -2123,10 +2211,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    // Normalize source to owner/repo format for telemetry
-    const normalizedSource = directDownload ? null : getOwnerRepo(parsed);
-
-    const lockSource = directDownload ? null : getLockSource(parsed.url, normalizedSource);
     const projectLockSourceUrl = directDownload
       ? undefined
       : getProjectLockSourceUrl(parsed.type, parsed.url);
@@ -2169,11 +2253,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // filesystem or the Skills API. Keep a previously recorded API id when
     // this run didn't touch the upload, so a filesystem-only re-add doesn't
     // drop it.
-    const uploadedManagedIds = new Map(
-      uploadOutcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
-    );
-    const managedIdFor = (name: string) =>
-      uploadedManagedIds.get(name) ?? knownManagedIds.get(name);
+    const { uploadedManagedIds, managedIdFor, isComplete } = buildManagedLockBookkeeping({
+      uploadOutcomes,
+      knownManagedIds,
+      sourceKey: managedSourceKey,
+      uploadRequested: Boolean(managedAgentsAuth) || managedResolution.uploadSkipped,
+      fsRequested: targetAgents.some((a) => !isVirtualAgent(a)),
+    });
 
     // Add to skill lock file for update tracking (only for global installs)
     if (
@@ -2192,7 +2278,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
-        if (successfulSkillNames.has(skillDisplayName) || uploadedManagedIds.has(skill.name)) {
+        const fsSucceeded = successfulSkillNames.has(skillDisplayName);
+        if (fsSucceeded || uploadedManagedIds.has(skill.name)) {
           try {
             let skillFolderHash = '';
             const skillPathValue = skillFiles[skill.name];
@@ -2216,7 +2303,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               sourceUrl: parsed.url,
               ref: parsed.ref,
               skillPath: skillPathValue,
-              skillFolderHash,
+              // A pending hash keeps the entry "changed" so update retries
+              // the part of the install that didn't complete.
+              skillFolderHash: isComplete(skill.name, fsSucceeded)
+                ? skillFolderHash
+                : PENDING_INSTALL_HASH,
               pluginName: skill.pluginName,
               ...(managedSkillId && { managedSkillId }),
             });
@@ -2244,7 +2335,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         eveSubagents && (eveSubagents.length > 1 || eveSubagents.some((s) => s !== ''));
       for (const skill of selectedSkills) {
         const skillDisplayName = getSkillDisplayName(skill);
-        if (successfulSkillNames.has(skillDisplayName) || uploadedManagedIds.has(skill.name)) {
+        const fsSucceeded = successfulSkillNames.has(skillDisplayName);
+        if (fsSucceeded || uploadedManagedIds.has(skill.name)) {
           try {
             // For blob skills, use the snapshot hash; for disk skills, compute from files
             const computedHash =
@@ -2261,7 +2353,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ref: parsed.ref,
                 sourceType: parsed.type,
                 ...(skillPathValue && { skillPath: skillPathValue }),
-                computedHash,
+                // A pending hash keeps the entry "changed" so update retries
+                // the part of the install that didn't complete.
+                computedHash: isComplete(skill.name, fsSucceeded)
+                  ? computedHash
+                  : PENDING_INSTALL_HASH,
                 ...(recordSubagents && { subagents: eveSubagents }),
                 ...(managedSkillId && { managedSkillId }),
               },

--- a/src/add.ts
+++ b/src/add.ts
@@ -389,6 +389,17 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
 }
 
 /**
+ * Expand `--agent '*'` to all filesystem agents, keeping any virtual agents
+ * the user listed explicitly alongside the wildcard.
+ */
+function expandWildcardAgents(requested: string[]): AgentType[] {
+  const explicitVirtual = requested.filter(
+    (a): a is AgentType => a !== '*' && a in agents && isVirtualAgent(a as AgentType)
+  );
+  return [...new Set([...getWildcardAgents(), ...explicitVirtual])];
+}
+
+/**
  * Resolve Anthropic API credentials when any selected target is a virtual
  * (API upload) agent. Prints guidance and returns null when no credential is
  * available; callers should abort the install in that case.
@@ -474,6 +485,11 @@ function printManagedUploadOutcomes(outcomes: ManagedUploadOutcome[]): void {
     p.log.error(pc.red(`Failed to upload ${failed.length} to Claude Managed Agents`));
     for (const o of failed) {
       p.log.message(`  ${pc.red('✗')} ${o.skill}: ${pc.dim(o.error)}`);
+    }
+    // The upload was explicitly requested; if nothing reached the API, make
+    // that visible to scripts via the exit code.
+    if (successful.length === 0) {
+      process.exitCode = 1;
     }
   }
 }
@@ -793,8 +809,8 @@ async function handleWellKnownSkills(
 
   if (options.agent?.includes('*')) {
     // --agent '*' selects all filesystem agents; virtual agents (API uploads)
-    // must be requested explicitly.
-    targetAgents = getWildcardAgents();
+    // are included only when listed explicitly alongside the wildcard.
+    targetAgents = expandWildcardAgents(options.agent);
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -1033,8 +1049,10 @@ async function handleWellKnownSkills(
   let uploadOutcomes: ManagedUploadOutcome[] = [];
   if (managedAgentsAuth) {
     uploadOutcomes = await uploadSkillsToManagedAgents(
+      // installName is the unique identifier for well-known skills; frontmatter
+      // names may collide across entries.
       selectedSkills.map((skill) => ({
-        name: skill.name,
+        name: skill.installName,
         files: Array.from(skill.files, ([path, content]) => ({ path, content })),
       })),
       managedAgentsAuth
@@ -1544,8 +1562,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     if (options.agent?.includes('*')) {
       // --agent '*' selects all filesystem agents; virtual agents (API
-      // uploads) must be requested explicitly.
-      targetAgents = getWildcardAgents();
+      // uploads) are included only when listed explicitly alongside the
+      // wildcard.
+      targetAgents = expandWildcardAgents(options.agent);
       p.log.info(`Installing to all ${targetAgents.length} agents`);
     } else if (options.agent && options.agent.length > 0) {
       const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));

--- a/src/add.ts
+++ b/src/add.ts
@@ -401,72 +401,51 @@ function expandWildcardAgents(requested: string[]): AgentType[] {
   return [...new Set([...getWildcardAgents(), ...explicitApiUpload])];
 }
 
-/**
- * Resolve Anthropic API credentials when any selected target is an API-upload
- * (API upload) agent. Prints guidance and returns null when no credential is
- * available; callers should abort the install in that case.
- */
-async function resolveManagedAgentsAuth(
-  targetAgents: AgentType[],
-  spinner: ReturnType<typeof p.spinner>
-): Promise<{ auth: AnthropicAuth | null; required: boolean }> {
-  if (!targetAgents.some((a) => isApiUploadAgent(a))) {
-    return { auth: null, required: false };
-  }
-
-  spinner.start('Checking Anthropic credentials…');
-  const auth = await resolveAnthropicAuth();
-  if (!auth) {
-    spinner.stop(pc.red('No Anthropic credentials found'));
-    p.log.error('Claude Managed Agents requires Anthropic API credentials.');
-    p.log.message(pc.dim(`  ${MANAGED_AGENTS_AUTH_GUIDANCE}`));
-    return { auth: null, required: true };
-  }
-  spinner.stop(`Anthropic credentials: ${pc.cyan(auth.source)}`);
-  return { auth, required: true };
+interface ManagedResolution {
+  targetAgents: AgentType[];
+  auth: AnthropicAuth | null;
+  /** An upload is part of this run: attempted, or skipped for missing credentials. */
+  uploadRequested: boolean;
 }
 
 /**
  * Fold the additive `--managed-agents` flag into the target list and resolve
- * API credentials when any target is an API-upload agent. An explicitly
- * requested API-upload agent aborts on missing credentials (shouldAbort) —
- * unless the `--managed-agents` flag is also present, which marks the run as an
- * automated refresh: API-upload targets are then dropped with a warning and
- * reported as uploadSkipped, so `update` never fails the whole run over a
- * missing login (it passes the flag on every refresh of a previously
- * uploaded skill, including upload-only ones where the API-upload agent is
- * named explicitly).
+ * API credentials up front when any target is an API-upload agent, so a
+ * missing login fails before anything is installed. Returns null when the
+ * install should abort: an explicitly requested API-upload agent with no
+ * credentials. With `--managed-agents` the run is an automated refresh
+ * (`update` passes it for every previously uploaded skill), so a missing
+ * login drops the upload with a warning instead of failing the whole run.
  */
 async function resolveManagedAgentsTargets(
   targetAgents: AgentType[],
   options: AddOptions | undefined,
   spinner: ReturnType<typeof p.spinner>
-): Promise<{
-  targetAgents: AgentType[];
-  auth: AnthropicAuth | null;
-  shouldAbort: boolean;
-  uploadSkipped: boolean;
-}> {
+): Promise<ManagedResolution | null> {
   const soft = Boolean(options?.managedAgents);
-  const resolved =
-    options?.managedAgents && !targetAgents.includes('claude-managed-agents')
-      ? [...targetAgents, 'claude-managed-agents' as AgentType]
-      : targetAgents;
-
-  const { auth, required } = await resolveManagedAgentsAuth(resolved, spinner);
-  if (required && !auth) {
-    if (soft) {
-      p.log.warn('Skipping the Claude Managed Agents upload; other installs continue.');
-      return {
-        targetAgents: resolved.filter((a) => isFilesystemAgent(a)),
-        auth: null,
-        shouldAbort: false,
-        uploadSkipped: true,
-      };
-    }
-    return { targetAgents: resolved, auth: null, shouldAbort: true, uploadSkipped: false };
+  if (soft && !targetAgents.includes('claude-managed-agents')) {
+    targetAgents = [...targetAgents, 'claude-managed-agents'];
   }
-  return { targetAgents: resolved, auth, shouldAbort: false, uploadSkipped: false };
+  if (!targetAgents.some((a) => isApiUploadAgent(a))) {
+    return { targetAgents, auth: null, uploadRequested: false };
+  }
+
+  spinner.start('Checking Anthropic credentials…');
+  const auth = await resolveAnthropicAuth();
+  if (auth) {
+    spinner.stop(`Anthropic credentials: ${pc.cyan(auth.source)}`);
+    return { targetAgents, auth, uploadRequested: true };
+  }
+  spinner.stop(pc.red('No Anthropic credentials found'));
+  p.log.error('Claude Managed Agents requires Anthropic API credentials.');
+  p.log.message(pc.dim(`  ${MANAGED_AGENTS_AUTH_GUIDANCE}`));
+  if (!soft) return null;
+  p.log.warn('Skipping the Claude Managed Agents upload; other installs continue.');
+  return {
+    targetAgents: targetAgents.filter((a) => isFilesystemAgent(a)),
+    auth: null,
+    uploadRequested: true,
+  };
 }
 
 /**
@@ -477,71 +456,6 @@ async function resolveManagedAgentsTargets(
  */
 export const PENDING_INSTALL_HASH = 'pending-install';
 
-interface KnownManagedSkill {
-  managedSkillId: string;
-  /** The lock entry's source, so ids never leak across sources. */
-  source: string;
-}
-
-/**
- * Read previously recorded Skills API ids from the lock file for the scope
- * being installed to, so re-uploads go straight to the right skill instead of
- * re-resolving it by display title (and so a re-add that doesn't touch the
- * upload preserves the recorded id). Ids are keyed by skill name but carry
- * their entry's source: a same-named skill installed from a different source
- * must not inherit the previous source's uploaded skill.
- */
-async function getKnownManagedSkillIds(
-  installGlobally: boolean,
-  cwd?: string
-): Promise<Map<string, KnownManagedSkill>> {
-  const ids = new Map<string, KnownManagedSkill>();
-  try {
-    const skills = installGlobally
-      ? (await readSkillLock()).skills
-      : (await readLocalLock(cwd)).skills;
-    for (const [name, entry] of Object.entries(skills)) {
-      if (entry.managedSkillId) {
-        ids.set(name, { managedSkillId: entry.managedSkillId, source: entry.source });
-      }
-    }
-  } catch {
-    // Unreadable lock — uploads fall back to display-title resolution.
-  }
-  return ids;
-}
-
-/**
- * Per-run bookkeeping for lock writes after the install + upload passes.
- * `managedIdFor` resolves the id to record (fresh upload first, then the
- * previously recorded id when it belongs to the same source), and
- * `isComplete` says whether every requested part of the install reached its
- * destination — an incomplete skill gets `PENDING_INSTALL_HASH` in place of
- * its content hash so `update` retries it.
- */
-export function buildManagedLockBookkeeping(opts: {
-  uploadOutcomes: ManagedUploadOutcome[];
-  knownManagedIds: Map<string, KnownManagedSkill>;
-  sourceKey: string | null;
-  /** Uploads were part of this install (attempted, or skipped for missing credentials). */
-  uploadRequested: boolean;
-  /** Any filesystem agent was targeted. */
-  fsRequested: boolean;
-}) {
-  const uploadedManagedIds = new Map(
-    opts.uploadOutcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
-  );
-  const managedIdFor = (name: string): string | undefined => {
-    const uploaded = uploadedManagedIds.get(name);
-    if (uploaded) return uploaded;
-    const known = opts.knownManagedIds.get(name);
-    return known && known.source === opts.sourceKey ? known.managedSkillId : undefined;
-  };
-  const isComplete = (name: string, fsSucceeded: boolean): boolean =>
-    (!opts.fsRequested || fsSucceeded) && (!opts.uploadRequested || uploadedManagedIds.has(name));
-  return { uploadedManagedIds, managedIdFor, isComplete };
-}
-
 interface ManagedUploadOutcome {
   skill: string;
   success: boolean;
@@ -551,29 +465,91 @@ interface ManagedUploadOutcome {
   error?: string;
 }
 
+/** Result of one run's Claude Managed Agents upload pass, shaped for the lock writes. */
+interface ManagedUploadPass {
+  outcomes: ManagedUploadOutcome[];
+  /** Skills API ids from this run's successful uploads, by skill name. */
+  uploadedManagedIds: Map<string, string>;
+  /** Id to record: this run's upload, else the id already recorded for this source. */
+  managedIdFor(name: string): string | undefined;
+  /**
+   * Whether every requested part of the install reached its destination. An
+   * incomplete skill gets PENDING_INSTALL_HASH so `update` retries it.
+   */
+  isComplete(name: string, fsSucceeded: boolean): boolean;
+}
+
 /**
- * Upload skills to the Anthropic Skills API for the Claude Managed Agents
- * target. Uploads happen one skill at a time; a failure on one skill doesn't
- * stop the rest.
+ * Skills API ids a previous run recorded in the lock, restricted to entries
+ * whose source matches this run's: a same-named skill installed from another
+ * source must not inherit (and version over) the earlier upload.
  */
-async function uploadSkillsToManagedAgents(
-  skills: Array<{ name: string; files: SkillUploadFile[]; knownSkillId?: string }>,
-  auth: AnthropicAuth
-): Promise<ManagedUploadOutcome[]> {
+export function knownManagedIds(
+  entries: Record<string, { source: string; managedSkillId?: string }>,
+  sourceKey: string | null
+): Map<string, string> {
+  const ids = new Map<string, string>();
+  for (const [name, entry] of Object.entries(entries)) {
+    if (entry.managedSkillId && entry.source === sourceKey) ids.set(name, entry.managedSkillId);
+  }
+  return ids;
+}
+
+export function summarizeManagedUploads(
+  outcomes: ManagedUploadOutcome[],
+  knownIds: Map<string, string>,
+  requested: { upload: boolean; fs: boolean }
+): ManagedUploadPass {
+  const uploadedManagedIds = new Map(
+    outcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
+  );
+  return {
+    outcomes,
+    uploadedManagedIds,
+    managedIdFor: (name) => uploadedManagedIds.get(name) ?? knownIds.get(name),
+    isComplete: (name, fsSucceeded) =>
+      (!requested.fs || fsSucceeded) && (!requested.upload || uploadedManagedIds.has(name)),
+  };
+}
+
+/**
+ * Upload pass for the Claude Managed Agents target. Skills with an id
+ * recorded in this scope's lock are versioned directly; the rest are created
+ * or resolved by display title. One skill at a time; a failure doesn't stop
+ * the rest. Without credentials nothing is uploaded, but recorded ids are
+ * still returned so a filesystem-only re-add keeps them in the lock.
+ */
+async function runManagedUploads(
+  resolution: ManagedResolution,
+  skills: Array<{ name: string; files: () => SkillUploadFile[] | Promise<SkillUploadFile[]> }>,
+  scope: { installGlobally: boolean; cwd: string; sourceKey: string | null }
+): Promise<ManagedUploadPass> {
+  const lock = scope.installGlobally ? await readSkillLock() : await readLocalLock(scope.cwd);
+  const knownIds = knownManagedIds(lock.skills, scope.sourceKey);
+
   const outcomes: ManagedUploadOutcome[] = [];
-  for (const skill of skills) {
-    try {
-      const result = await uploadSkillToManagedAgents(skill, auth, skill.knownSkillId);
-      outcomes.push({ skill: skill.name, success: true, ...result });
-    } catch (error) {
-      outcomes.push({
-        skill: skill.name,
-        success: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+  if (resolution.auth) {
+    for (const skill of skills) {
+      try {
+        const result = await uploadSkillToManagedAgents(
+          { name: skill.name, files: await skill.files() },
+          resolution.auth,
+          knownIds.get(skill.name)
+        );
+        outcomes.push({ skill: skill.name, success: true, ...result });
+      } catch (error) {
+        outcomes.push({
+          skill: skill.name,
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
     }
   }
-  return outcomes;
+  return summarizeManagedUploads(outcomes, knownIds, {
+    upload: resolution.uploadRequested,
+    fs: resolution.targetAgents.some((a) => isFilesystemAgent(a)),
+  });
 }
 
 /**
@@ -1005,12 +981,11 @@ async function handleWellKnownSkills(
   // Resolve API credentials up front when Claude Managed Agents is targeted,
   // so a missing login fails before anything is installed.
   const managedResolution = await resolveManagedAgentsTargets(targetAgents, options, spinner);
-  if (managedResolution.shouldAbort) {
+  if (!managedResolution) {
     p.outro(pc.red('Installation failed'));
     process.exit(1);
   }
   targetAgents = managedResolution.targetAgents;
-  const managedAgentsAuth = managedResolution.auth;
   if (targetAgents.length === 0) {
     // Upload-only run whose upload was credential-skipped: nothing left to do,
     // but the well-known source was handled.
@@ -1178,24 +1153,16 @@ async function handleWellKnownSkills(
     }
   }
 
-  const knownManagedIds = await getKnownManagedSkillIds(installGlobally, cwd);
-  const knownIdForUpload = (name: string): string | undefined => {
-    const known = knownManagedIds.get(name);
-    return known && known.source === sourceIdentifier ? known.managedSkillId : undefined;
-  };
-  let uploadOutcomes: ManagedUploadOutcome[] = [];
-  if (managedAgentsAuth) {
-    uploadOutcomes = await uploadSkillsToManagedAgents(
-      // installName is the unique identifier for well-known skills; frontmatter
-      // names may collide across entries.
-      selectedSkills.map((skill) => ({
-        name: skill.installName,
-        files: Array.from(skill.files, ([path, content]) => ({ path, content })),
-        knownSkillId: knownIdForUpload(skill.installName),
-      })),
-      managedAgentsAuth
-    );
-  }
+  const managed = await runManagedUploads(
+    managedResolution,
+    // installName is the unique identifier for well-known skills; frontmatter
+    // names may collide across entries.
+    selectedSkills.map((skill) => ({
+      name: skill.installName,
+      files: () => Array.from(skill.files, ([path, content]) => ({ path, content })),
+    })),
+    { installGlobally, cwd, sourceKey: sourceIdentifier }
+  );
 
   spinner.stop('Installation complete');
 
@@ -1226,15 +1193,8 @@ async function handleWellKnownSkills(
   }
 
   // A skill counts as installed for lock purposes when it reached the
-  // filesystem or the Skills API. Keep a previously recorded API id when this
-  // run didn't touch the upload, so a filesystem-only re-add doesn't drop it.
-  const { uploadedManagedIds, managedIdFor, isComplete } = buildManagedLockBookkeeping({
-    uploadOutcomes,
-    knownManagedIds,
-    sourceKey: sourceIdentifier,
-    uploadRequested: Boolean(managedAgentsAuth) || managedResolution.uploadSkipped,
-    fsRequested: targetAgents.some((a) => isFilesystemAgent(a)),
-  });
+  // filesystem or the Skills API.
+  const { uploadedManagedIds, managedIdFor, isComplete } = managed;
 
   // Add to skill lock file for update tracking (only for global installs)
   if ((successful.length > 0 || uploadedManagedIds.size > 0) && installGlobally) {
@@ -1361,7 +1321,7 @@ async function handleWellKnownSkills(
     }
   }
 
-  printManagedUploadOutcomes(uploadOutcomes);
+  printManagedUploadOutcomes(managed.outcomes);
 
   console.log();
   p.outro(
@@ -1873,13 +1833,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Resolve API credentials up front when Claude Managed Agents is targeted,
     // so a missing login fails before anything is installed.
     const managedResolution = await resolveManagedAgentsTargets(targetAgents, options, spinner);
-    if (managedResolution.shouldAbort) {
+    if (!managedResolution) {
       await cleanup(tempDir);
       p.outro(pc.red('Installation failed'));
       process.exit(1);
     }
     targetAgents = managedResolution.targetAgents;
-    const managedAgentsAuth = managedResolution.auth;
     if (targetAgents.length === 0) {
       // Upload-only run whose upload was credential-skipped: nothing left to do.
       await cleanup(tempDir);
@@ -2142,45 +2101,22 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // API upload pass for Claude Managed Agents.
     const normalizedSource = directDownload ? null : getOwnerRepo(parsed);
     const lockSource = directDownload ? null : getLockSource(parsed.url, normalizedSource);
-    // Must match the `source` value the lock write below records for this scope.
-    const managedSourceKey = installGlobally
-      ? lockSource || normalizedSource
-      : lockSource || parsed.url;
-    const knownManagedIds = await getKnownManagedSkillIds(installGlobally, cwd);
-    const knownIdForUpload = (name: string): string | undefined => {
-      const known = knownManagedIds.get(name);
-      return known && known.source === managedSourceKey ? known.managedSkillId : undefined;
-    };
-    const uploadOutcomes: ManagedUploadOutcome[] = [];
-    if (managedAgentsAuth) {
-      const uploads: Array<{ name: string; files: SkillUploadFile[]; knownSkillId?: string }> = [];
-      for (const skill of selectedSkills) {
-        const knownSkillId = knownIdForUpload(skill.name);
-        try {
-          if (blobResult && 'files' in skill) {
-            const blobSkill = skill as BlobSkill;
-            uploads.push({
-              name: skill.name,
-              files: blobSkill.files.map((f) => ({ path: f.path, content: f.contents })),
-              knownSkillId,
-            });
-          } else {
-            uploads.push({
-              name: skill.name,
-              files: await collectSkillFiles(skill.path),
-              knownSkillId,
-            });
-          }
-        } catch (error) {
-          uploadOutcomes.push({
-            skill: skill.name,
-            success: false,
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-        }
+    const managed = await runManagedUploads(
+      managedResolution,
+      selectedSkills.map((skill) => ({
+        name: skill.name,
+        files: () =>
+          blobResult && 'files' in skill
+            ? (skill as BlobSkill).files.map((f) => ({ path: f.path, content: f.contents }))
+            : collectSkillFiles(skill.path),
+      })),
+      // sourceKey must match the `source` the lock writes below record for this scope.
+      {
+        installGlobally,
+        cwd,
+        sourceKey: installGlobally ? lockSource || normalizedSource : lockSource || parsed.url,
       }
-      uploadOutcomes.push(...(await uploadSkillsToManagedAgents(uploads, managedAgentsAuth)));
-    }
+    );
 
     spinner.stop('Installation complete');
 
@@ -2250,16 +2186,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // A skill counts as installed for lock purposes when it reached the
-    // filesystem or the Skills API. Keep a previously recorded API id when
-    // this run didn't touch the upload, so a filesystem-only re-add doesn't
-    // drop it.
-    const { uploadedManagedIds, managedIdFor, isComplete } = buildManagedLockBookkeeping({
-      uploadOutcomes,
-      knownManagedIds,
-      sourceKey: managedSourceKey,
-      uploadRequested: Boolean(managedAgentsAuth) || managedResolution.uploadSkipped,
-      fsRequested: targetAgents.some((a) => isFilesystemAgent(a)),
-    });
+    // filesystem or the Skills API.
+    const { uploadedManagedIds, managedIdFor, isComplete } = managed;
 
     // Add to skill lock file for update tracking (only for global installs)
     if (
@@ -2473,7 +2401,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
-    printManagedUploadOutcomes(uploadOutcomes);
+    printManagedUploadOutcomes(managed.outcomes);
 
     console.log();
     p.outro(

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -149,6 +149,19 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(claudeHome);
     },
   },
+  'claude-managed-agents': {
+    name: 'claude-managed-agents',
+    displayName: 'Claude Managed Agents',
+    // Placeholder path; never written to. Skills for this target are uploaded
+    // to the Anthropic Skills API (see managed-agents.ts).
+    skillsDir: '.claude-managed-agents/skills',
+    globalSkillsDir: undefined,
+    virtual: true,
+    installHint: 'Uploads to the Anthropic Skills API',
+    // Uploading to the user's Anthropic organization must be an explicit
+    // choice, so this target is never auto-detected.
+    detectInstalled: async () => false,
+  },
   openclaw: {
     name: 'openclaw',
     displayName: 'OpenClaw',
@@ -860,4 +873,20 @@ export function getNonUniversalAgents(): AgentType[] {
  */
 export function isUniversalAgent(type: AgentType): boolean {
   return agents[type].skillsDir === '.agents/skills';
+}
+
+/**
+ * Check if an agent is virtual (no filesystem skills directory; skills are
+ * delivered through a dedicated integration such as an API upload).
+ */
+export function isVirtualAgent(type: AgentType): boolean {
+  return agents[type].virtual === true;
+}
+
+/**
+ * Agent types that install to the filesystem. Virtual agents (API-backed
+ * targets) are excluded; they must be requested explicitly by name.
+ */
+export function getWildcardAgents(): AgentType[] {
+  return (Object.keys(agents) as AgentType[]).filter((type) => !isVirtualAgent(type));
 }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -2,7 +2,7 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { xdgConfig } from 'xdg-basedir';
-import type { AgentConfig, AgentType, AgentInstallMethod } from './types.ts';
+import type { AgentConfig, AgentType } from './types.ts';
 
 const home = homedir();
 // Use xdg-basedir (not env-paths) to match OpenCode/Amp/Goose behavior on all platforms.
@@ -875,14 +875,9 @@ export function isUniversalAgent(type: AgentType): boolean {
   return agents[type].skillsDir === '.agents/skills';
 }
 
-/** How skills reach an agent; defaults to a filesystem copy or symlink. */
-export function getInstallMethod(type: AgentType): AgentInstallMethod {
-  return agents[type].install ?? 'filesystem';
-}
-
-/** Agents whose skills are copied or symlinked into a local skills directory. */
+/** Agents whose skills are copied or symlinked into a local skills directory (the default). */
 export function isFilesystemAgent(type: AgentType): boolean {
-  return getInstallMethod(type) === 'filesystem';
+  return (agents[type].install ?? 'filesystem') === 'filesystem';
 }
 
 /**
@@ -890,7 +885,7 @@ export function isFilesystemAgent(type: AgentType): boolean {
  * They have no skills directory and must be selected explicitly.
  */
 export function isApiUploadAgent(type: AgentType): boolean {
-  return getInstallMethod(type) === 'api-upload';
+  return agents[type].install === 'api-upload';
 }
 
 /**

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -875,11 +875,6 @@ export function isUniversalAgent(type: AgentType): boolean {
   return agents[type].skillsDir === '.agents/skills';
 }
 
-/** Agents whose skills are copied or symlinked into a local skills directory (the default). */
-export function isFilesystemAgent(type: AgentType): boolean {
-  return (agents[type].install ?? 'filesystem') === 'filesystem';
-}
-
 /**
  * Agents whose skills are pushed through an API instead of written to disk.
  * They have no skills directory and must be selected explicitly.
@@ -893,5 +888,5 @@ export function isApiUploadAgent(type: AgentType): boolean {
  * they must be requested explicitly by name.
  */
 export function getWildcardAgents(): AgentType[] {
-  return (Object.keys(agents) as AgentType[]).filter((type) => isFilesystemAgent(type));
+  return (Object.keys(agents) as AgentType[]).filter((type) => !isApiUploadAgent(type));
 }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -158,7 +158,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: undefined,
     install: 'api-upload',
     installHint: 'Uploads to the Anthropic Skills API',
-    // Uploading to the user's Anthropic organization must be an explicit
+    // Uploading to the user's Anthropic workspace must be an explicit
     // choice, so this target is never auto-detected.
     detectInstalled: async () => false,
   },

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -2,7 +2,7 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { xdgConfig } from 'xdg-basedir';
-import type { AgentConfig, AgentType } from './types.ts';
+import type { AgentConfig, AgentType, AgentInstallMethod } from './types.ts';
 
 const home = homedir();
 // Use xdg-basedir (not env-paths) to match OpenCode/Amp/Goose behavior on all platforms.
@@ -156,7 +156,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     // to the Anthropic Skills API (see managed-agents.ts).
     skillsDir: '.claude-managed-agents/skills',
     globalSkillsDir: undefined,
-    virtual: true,
+    install: 'api-upload',
     installHint: 'Uploads to the Anthropic Skills API',
     // Uploading to the user's Anthropic organization must be an explicit
     // choice, so this target is never auto-detected.
@@ -875,18 +875,28 @@ export function isUniversalAgent(type: AgentType): boolean {
   return agents[type].skillsDir === '.agents/skills';
 }
 
-/**
- * Check if an agent is virtual (no filesystem skills directory; skills are
- * delivered through a dedicated integration such as an API upload).
- */
-export function isVirtualAgent(type: AgentType): boolean {
-  return agents[type].virtual === true;
+/** How skills reach an agent; defaults to a filesystem copy or symlink. */
+export function getInstallMethod(type: AgentType): AgentInstallMethod {
+  return agents[type].install ?? 'filesystem';
+}
+
+/** Agents whose skills are copied or symlinked into a local skills directory. */
+export function isFilesystemAgent(type: AgentType): boolean {
+  return getInstallMethod(type) === 'filesystem';
 }
 
 /**
- * Agent types that install to the filesystem. Virtual agents (API-backed
- * targets) are excluded; they must be requested explicitly by name.
+ * Agents whose skills are pushed through an API instead of written to disk.
+ * They have no skills directory and must be selected explicitly.
+ */
+export function isApiUploadAgent(type: AgentType): boolean {
+  return getInstallMethod(type) === 'api-upload';
+}
+
+/**
+ * Agent types that install to the filesystem. API-upload agents are excluded;
+ * they must be requested explicitly by name.
  */
 export function getWildcardAgents(): AgentType[] {
-  return (Object.keys(agents) as AgentType[]).filter((type) => !isVirtualAgent(type));
+  return (Object.keys(agents) as AgentType[]).filter((type) => isFilesystemAgent(type));
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,6 +135,8 @@ ${BOLD}Project:${RESET}
 ${BOLD}Add Options:${RESET}
   -g, --global           Install skill globally (user-level) instead of project-level
   -a, --agent <agents>   Specify agents to install to (use '*' for all agents)
+                         'claude-managed-agents' uploads to the Anthropic Skills API
+                         (requires \`ant auth login\` or ANTHROPIC_API_KEY)
   -s, --skill <skills>   Specify skill names to install (use '*' for all skills)
   -l, --list             List available skills in the repository without installing
   -y, --yes              Skip confirmation prompts

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,8 @@ ${BOLD}Add Options:${RESET}
   --copy                 Copy files instead of symlinking to agent directories
   --metadata <json>      Attach valid JSON to the install telemetry event
   --subagent <names>     Install to Eve subagents (use 'root' for the root agent)
+  --managed-agents       Also upload to Claude Managed Agents on top of the
+                         selected agents (skipped with a warning if no credentials)
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -41,6 +41,16 @@ interface InstallResult {
   error?: string;
 }
 
+function virtualAgentInstallError(agentType: AgentType, mode?: InstallMode): InstallResult {
+  const agent = agents[agentType];
+  return {
+    success: false,
+    path: '',
+    mode: mode ?? 'symlink',
+    error: `${agent.displayName} skills are uploaded through the Anthropic API and cannot be installed to a directory`,
+  };
+}
+
 /**
  * Sanitizes a filename/directory name to prevent path traversal attacks
  * and ensures it follows kebab-case convention
@@ -271,6 +281,12 @@ export async function installSkillForAgent(
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const eveSubagent = options.eveSubagent;
+
+  // Virtual agents have no filesystem install; their skills are delivered
+  // through a dedicated integration (see managed-agents.ts).
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -624,6 +640,12 @@ export async function installRemoteSkillForAgent(
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
 
+  // Virtual agents have no filesystem install; their skills are delivered
+  // through a dedicated integration (see managed-agents.ts).
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
+
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {
@@ -764,6 +786,12 @@ export async function installWellKnownSkillForAgent(
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
+
+  // Virtual agents have no filesystem install; their skills are delivered
+  // through a dedicated integration (see managed-agents.ts).
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -910,6 +938,10 @@ export async function installBlobSkillForAgent(
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
+
+  if (agent.virtual) {
+    return virtualAgentInstallError(agentType, options.mode);
+  }
 
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -436,8 +436,8 @@ export async function installSkillForAgent(
   }
 }
 
-const EXCLUDE_FILES = new Set(['metadata.json']);
-const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
+export const EXCLUDE_FILES = new Set(['metadata.json']);
+export const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 
 const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
   if (EXCLUDE_FILES.has(name)) return true;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -21,6 +21,7 @@ import type { WellKnownSkill } from './providers/wellknown.ts';
 import {
   agents,
   detectInstalledAgents,
+  isFilesystemAgent,
   isUniversalAgent,
   getEveSubagents,
   EVE_SUBAGENTS_DIR,
@@ -41,7 +42,7 @@ interface InstallResult {
   error?: string;
 }
 
-function virtualAgentInstallError(agentType: AgentType, mode?: InstallMode): InstallResult {
+function apiUploadAgentInstallError(agentType: AgentType, mode?: InstallMode): InstallResult {
   const agent = agents[agentType];
   return {
     success: false,
@@ -282,10 +283,10 @@ export async function installSkillForAgent(
   const cwd = options.cwd || process.cwd();
   const eveSubagent = options.eveSubagent;
 
-  // Virtual agents have no filesystem install; their skills are delivered
+  // API-upload agents have no filesystem install; their skills are delivered
   // through a dedicated integration (see managed-agents.ts).
-  if (agent.virtual) {
-    return virtualAgentInstallError(agentType, options.mode);
+  if (!isFilesystemAgent(agentType)) {
+    return apiUploadAgentInstallError(agentType, options.mode);
   }
 
   // Check if agent supports global installation
@@ -640,10 +641,10 @@ export async function installRemoteSkillForAgent(
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
 
-  // Virtual agents have no filesystem install; their skills are delivered
+  // API-upload agents have no filesystem install; their skills are delivered
   // through a dedicated integration (see managed-agents.ts).
-  if (agent.virtual) {
-    return virtualAgentInstallError(agentType, options.mode);
+  if (!isFilesystemAgent(agentType)) {
+    return apiUploadAgentInstallError(agentType, options.mode);
   }
 
   // Check if agent supports global installation
@@ -787,10 +788,10 @@ export async function installWellKnownSkillForAgent(
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
 
-  // Virtual agents have no filesystem install; their skills are delivered
+  // API-upload agents have no filesystem install; their skills are delivered
   // through a dedicated integration (see managed-agents.ts).
-  if (agent.virtual) {
-    return virtualAgentInstallError(agentType, options.mode);
+  if (!isFilesystemAgent(agentType)) {
+    return apiUploadAgentInstallError(agentType, options.mode);
   }
 
   // Check if agent supports global installation
@@ -939,8 +940,8 @@ export async function installBlobSkillForAgent(
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
 
-  if (agent.virtual) {
-    return virtualAgentInstallError(agentType, options.mode);
+  if (!isFilesystemAgent(agentType)) {
+    return apiUploadAgentInstallError(agentType, options.mode);
   }
 
   if (isGlobal && agent.globalSkillsDir === undefined) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -70,7 +70,7 @@ export function sanitizeName(name: string): string {
  * @param targetPath - The path to validate
  * @returns true if targetPath is within basePath
  */
-function isPathSafe(basePath: string, targetPath: string): boolean {
+export function isPathSafe(basePath: string, targetPath: string): boolean {
   const normalizedBase = normalize(resolve(basePath));
   const normalizedTarget = normalize(resolve(targetPath));
 
@@ -420,10 +420,10 @@ export async function installSkillForAgent(
   }
 }
 
-export const EXCLUDE_FILES = new Set(['metadata.json']);
-export const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
+const EXCLUDE_FILES = new Set(['metadata.json']);
+const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 
-const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
+export const isExcluded = (name: string, isDirectory: boolean = false): boolean => {
   if (EXCLUDE_FILES.has(name)) return true;
   if (isDirectory && EXCLUDE_DIRS.has(name)) return true;
   return false;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -21,7 +21,6 @@ import type { WellKnownSkill } from './providers/wellknown.ts';
 import {
   agents,
   detectInstalledAgents,
-  isFilesystemAgent,
   isUniversalAgent,
   getEveSubagents,
   EVE_SUBAGENTS_DIR,
@@ -40,16 +39,6 @@ interface InstallResult {
   symlinkFailed?: boolean;
   skipped?: boolean;
   error?: string;
-}
-
-function apiUploadAgentInstallError(agentType: AgentType, mode?: InstallMode): InstallResult {
-  const agent = agents[agentType];
-  return {
-    success: false,
-    path: '',
-    mode: mode ?? 'symlink',
-    error: `${agent.displayName} skills are uploaded through the Anthropic API and cannot be installed to a directory`,
-  };
 }
 
 /**
@@ -282,12 +271,6 @@ export async function installSkillForAgent(
   const isGlobal = options.global ?? false;
   const cwd = options.cwd || process.cwd();
   const eveSubagent = options.eveSubagent;
-
-  // API-upload agents have no filesystem install; their skills are delivered
-  // through a dedicated integration (see managed-agents.ts).
-  if (!isFilesystemAgent(agentType)) {
-    return apiUploadAgentInstallError(agentType, options.mode);
-  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -641,12 +624,6 @@ export async function installRemoteSkillForAgent(
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
 
-  // API-upload agents have no filesystem install; their skills are delivered
-  // through a dedicated integration (see managed-agents.ts).
-  if (!isFilesystemAgent(agentType)) {
-    return apiUploadAgentInstallError(agentType, options.mode);
-  }
-
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {
@@ -787,12 +764,6 @@ export async function installWellKnownSkillForAgent(
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
-
-  // API-upload agents have no filesystem install; their skills are delivered
-  // through a dedicated integration (see managed-agents.ts).
-  if (!isFilesystemAgent(agentType)) {
-    return apiUploadAgentInstallError(agentType, options.mode);
-  }
 
   // Check if agent supports global installation
   if (isGlobal && agent.globalSkillsDir === undefined) {
@@ -939,10 +910,6 @@ export async function installBlobSkillForAgent(
   const cwd = options.cwd || process.cwd();
   const installMode = options.mode ?? 'symlink';
   const eveSubagent = options.eveSubagent;
-
-  if (!isFilesystemAgent(agentType)) {
-    return apiUploadAgentInstallError(agentType, options.mode);
-  }
 
   if (isGlobal && agent.globalSkillsDir === undefined) {
     return {

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,6 +1,6 @@
 import { homedir } from 'os';
 import type { AgentType } from './types.ts';
-import { agents } from './agents.ts';
+import { agents, isApiUploadAgent } from './agents.ts';
 import { listInstalledSkills, sanitizeName, type InstalledSkill } from './installer.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { getAllLockedSkills } from './skill-lock.ts';
@@ -93,13 +93,13 @@ export async function runList(args: string[]): Promise<void> {
 
     agentFilter = options.agent as AgentType[];
 
-    // Claude Managed Agents skills live in the Anthropic API, not on disk,
-    // so a listing filtered to that agent would silently show the wrong thing.
-    if (agentFilter.includes('claude-managed-agents')) {
+    // API-upload agents' skills live in the Anthropic API, not on disk, so a
+    // listing filtered to them would silently show the wrong thing.
+    if (agentFilter.some((a) => isApiUploadAgent(a))) {
       console.log(
         `${YELLOW}Claude Managed Agents skills are managed through the Anthropic API and cannot be listed locally.${RESET}`
       );
-      agentFilter = agentFilter.filter((a) => a !== 'claude-managed-agents');
+      agentFilter = agentFilter.filter((a) => !isApiUploadAgent(a));
       if (agentFilter.length === 0) {
         process.exit(1);
       }

--- a/src/list.ts
+++ b/src/list.ts
@@ -92,6 +92,18 @@ export async function runList(args: string[]): Promise<void> {
     }
 
     agentFilter = options.agent as AgentType[];
+
+    // Claude Managed Agents skills live in the Anthropic API, not on disk,
+    // so a listing filtered to that agent would silently show the wrong thing.
+    if (agentFilter.includes('claude-managed-agents')) {
+      console.log(
+        `${YELLOW}Claude Managed Agents skills are managed through the Anthropic API and cannot be listed locally.${RESET}`
+      );
+      agentFilter = agentFilter.filter((a) => a !== 'claude-managed-agents');
+      if (agentFilter.length === 0) {
+        process.exit(1);
+      }
+    }
   }
 
   const installedSkills = await listInstalledSkills({

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -46,7 +46,7 @@ export interface LocalSkillLockEntry {
   /**
    * Anthropic Skills API id (e.g. "skill_01Ab…") recorded when this skill was
    * uploaded to the Claude Managed Agents target. Lets `update` re-upload a
-   * new version directly instead of re-resolving the skill by display title.
+   * new version directly instead of re-resolving the skill by display name.
    */
   managedSkillId?: string;
 }

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -43,6 +43,12 @@ export interface LocalSkillLockEntry {
    */
   subagents?: string[];
   wellKnownDigest?: string;
+  /**
+   * Anthropic Skills API id (e.g. "skill_01Ab…") recorded when this skill was
+   * uploaded to the Claude Managed Agents target. Lets `update` re-upload a
+   * new version directly instead of re-resolving the skill by display title.
+   */
+  managedSkillId?: string;
 }
 
 /**

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -273,11 +273,9 @@ function buildSkillForm(directory: string, displayName: string | null, files: Sk
 interface SkillResponse {
   id: string;
   display_name: string;
-  latest_version_id: string;
 }
 
 interface SkillVersionResponse {
-  id: string;
   skill_id: string;
 }
 
@@ -286,21 +284,37 @@ interface SkillListResponse {
   next_page: string | null;
 }
 
+const LIST_PAGE_SIZE = 1000; // the API maximum
+const MAX_LIST_PAGES = 10;
+
+/** Resolves a display name to the id of the newest custom skill carrying it. */
+export type ManagedSkillLookup = (displayName: string) => Promise<string | null>;
+
 /**
- * Find the workspace's most recently created custom skill with this display
- * name. Display names are not unique, so this is a best-effort match used
- * only when the lock has no recorded skill id; the list is newest-first.
+ * A lookup that lists the workspace's custom skills once, on first use, and
+ * answers every later query from that snapshot — one listing per run rather
+ * than one per uploaded skill.
  */
-async function findSkillByDisplayName(
-  displayName: string,
-  auth: AnthropicAuth
-): Promise<SkillResponse | null> {
+export function createManagedSkillLookup(auth: AnthropicAuth): ManagedSkillLookup {
+  let listing: Promise<Map<string, string>> | undefined;
+  return async (displayName) => {
+    listing ??= listSkillIdsByDisplayName(auth);
+    return (await listing).get(displayName) ?? null;
+  };
+}
+
+/**
+ * List the workspace's custom skills into a display name → skill id map.
+ * Display names are not unique; the API lists newest first and the map
+ * keeps the first (newest) id seen for each name.
+ */
+async function listSkillIdsByDisplayName(auth: AnthropicAuth): Promise<Map<string, string>> {
   const headers = buildHeaders(auth);
+  const ids = new Map<string, string>();
   let page: string | null = null;
 
-  // Paginate defensively; workspaces can accumulate many custom skills.
-  for (let i = 0; i < 20; i++) {
-    const params = new URLSearchParams({ source: 'custom', limit: '100' });
+  for (let i = 0; i < MAX_LIST_PAGES; i++) {
+    const params = new URLSearchParams({ source: 'custom', limit: String(LIST_PAGE_SIZE) });
     if (page) params.set('page', page);
 
     const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, {
@@ -310,18 +324,22 @@ async function findSkillByDisplayName(
     if (!response.ok) throw await ManagedAgentsApiError.from(response, 'Failed to list skills');
 
     const body = (await response.json()) as SkillListResponse;
-    const match = body.data.find((skill) => skill.display_name === displayName);
-    if (match) return match;
-    if (!body.next_page) return null;
+    for (const skill of body.data) {
+      if (!ids.has(skill.display_name)) ids.set(skill.display_name, skill.id);
+    }
+    if (!body.next_page) return ids;
     page = body.next_page;
   }
 
-  return null;
+  console.warn(
+    `Only the newest ${MAX_LIST_PAGES * LIST_PAGE_SIZE} custom skills were listed; ` +
+      'an older skill with a matching name would be re-created rather than versioned.'
+  );
+  return ids;
 }
 
 export interface ManagedSkillUploadResult {
   skillId: string;
-  versionId: string;
   action: 'created' | 'updated';
 }
 
@@ -345,7 +363,7 @@ async function uploadSkillVersion(
     throw await ManagedAgentsApiError.from(response, 'Failed to create skill version');
   }
   const version = (await response.json()) as SkillVersionResponse;
-  return { skillId: version.skill_id, versionId: version.id, action: 'updated' };
+  return { skillId: version.skill_id, action: 'updated' };
 }
 
 /**
@@ -368,20 +386,27 @@ async function tryUploadSkillVersion(
   }
 }
 
+export interface ManagedSkillUploadOptions {
+  /** Skill id recorded in the lock file by a previous upload of this skill. */
+  knownSkillId?: string;
+  /** Shared display-name lookup; pass one per run to list the workspace once. */
+  lookup?: ManagedSkillLookup;
+}
+
 /**
  * Upload a skill to the Anthropic Skills API as a new version of an existing
  * skill when one can be found, otherwise as a new skill.
  *
- * Candidates for versioning, in order: `knownSkillId` (recorded in the lock
- * file by a previous upload), then the newest workspace skill whose display
- * name equals the skill name. The API doesn't enforce unique names, so
- * without the display-name lookup every install from a project with no lock
- * entry would create a duplicate skill in the workspace.
+ * Candidates for versioning, in order: `knownSkillId`, then the newest
+ * workspace skill whose display name equals the skill name. The API doesn't
+ * enforce unique names, so without the display-name lookup every install
+ * from a project with no usable lock entry would create a duplicate skill in
+ * the workspace.
  */
 export async function uploadSkillToManagedAgents(
   skill: { name: string; files: SkillUploadFile[] },
   auth: AnthropicAuth,
-  knownSkillId?: string
+  options: ManagedSkillUploadOptions = {}
 ): Promise<ManagedSkillUploadResult> {
   // Case-insensitive filesystems discover a lowercase `skill.md`, but the
   // API requires the exact-case name — normalize instead of rejecting a
@@ -397,15 +422,16 @@ export async function uploadSkillToManagedAgents(
 
   const directory = sanitizeName(skill.name);
   const headers = buildHeaders(auth);
+  const { knownSkillId, lookup = createManagedSkillLookup(auth) } = options;
 
   if (knownSkillId) {
     const result = await tryUploadSkillVersion(knownSkillId, directory, files, headers);
     if (result) return result;
   }
 
-  const existing = await findSkillByDisplayName(skill.name, auth);
-  if (existing && existing.id !== knownSkillId) {
-    const result = await tryUploadSkillVersion(existing.id, directory, files, headers);
+  const existingId = await lookup(skill.name);
+  if (existingId && existingId !== knownSkillId) {
+    const result = await tryUploadSkillVersion(existingId, directory, files, headers);
     if (result) return result;
   }
 
@@ -417,5 +443,5 @@ export async function uploadSkillToManagedAgents(
   });
   if (!response.ok) throw await ManagedAgentsApiError.from(response, 'Failed to create skill');
   const created = (await response.json()) as SkillResponse;
-  return { skillId: created.id, versionId: created.latest_version_id, action: 'created' };
+  return { skillId: created.id, action: 'created' };
 }

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { readFile, readdir, stat } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
-import { sanitizeName } from './installer.ts';
+import { sanitizeName, EXCLUDE_FILES, EXCLUDE_DIRS } from './installer.ts';
 
 /**
  * Claude Managed Agents support.
@@ -26,6 +26,8 @@ import { sanitizeName } from './installer.ts';
 const SKILLS_BETA = 'skills-2025-10-02';
 const OAUTH_BETA = 'oauth-2025-04-20';
 const ANTHROPIC_VERSION = '2023-06-01';
+const FETCH_TIMEOUT_MS = 30000;
+const ANT_CLI_TIMEOUT_MS = 10000;
 
 export interface AnthropicAuth {
   /** Credential headers (x-api-key or Authorization, plus workspace binding). */
@@ -113,6 +115,9 @@ function readAntCliCredentials(): AnthropicAuth | null {
     const output = execFileSync('ant', ['auth', 'print-credentials'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      // Don't hang the CLI on an ant binary that prompts or stalls on a
+      // token refresh; the credentials-file fallback still gets a chance.
+      timeout: ANT_CLI_TIMEOUT_MS,
     });
     const credentials = JSON.parse(output) as AntCredentials;
     return authFromOAuthToken(credentials, 'ant CLI');
@@ -161,9 +166,6 @@ export interface SkillUploadFile {
   path: string;
   content: string | Uint8Array;
 }
-
-const EXCLUDE_FILES = new Set(['metadata.json']);
-const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 
 /**
  * Collect a skill directory's files for upload, applying the same exclusion
@@ -278,7 +280,10 @@ async function findSkillByDisplayTitle(
     const params = new URLSearchParams({ beta: 'true', source: 'custom', limit: '100' });
     if (afterId) params.set('after_id', afterId);
 
-    const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, { headers });
+    const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
     if (!response.ok) {
       throw new ManagedAgentsApiError(
         response.status,
@@ -324,6 +329,7 @@ export async function uploadSkillToManagedAgents(
     method: 'POST',
     headers,
     body: buildSkillForm(directory, skill.name, skill.files),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 
   if (createResponse.ok) {
@@ -351,6 +357,7 @@ export async function uploadSkillToManagedAgents(
       method: 'POST',
       headers,
       body: buildSkillForm(directory, null, skill.files),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     }
   );
 

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -338,9 +338,18 @@ export async function uploadSkillToManagedAgents(
   auth: AnthropicAuth,
   knownSkillId?: string
 ): Promise<ManagedSkillUploadResult> {
-  if (!skill.files.some((file) => file.path === 'SKILL.md')) {
+  // Case-insensitive filesystems discover a lowercase `skill.md`, but the
+  // API requires the exact-case name — normalize instead of rejecting a
+  // skill that installs fine to filesystem agents.
+  const files = skill.files.map((file) =>
+    file.path.toLowerCase() === 'skill.md' && file.path !== 'SKILL.md'
+      ? { ...file, path: 'SKILL.md' }
+      : file
+  );
+  if (!files.some((file) => file.path === 'SKILL.md')) {
     throw new Error('Skill is missing a SKILL.md at its root');
   }
+  skill = { ...skill, files };
 
   const directory = sanitizeName(skill.name);
   const headers = buildHeaders(auth);

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -221,24 +221,28 @@ async function collectSkillFilesWithin(
   return files;
 }
 
+/** A non-2xx response from the Skills API. */
 export class ManagedAgentsApiError extends Error {
   status: number;
-  apiMessage: string;
 
-  constructor(status: number, apiMessage: string, context: string) {
-    super(`${context}: ${apiMessage} (HTTP ${status})`);
+  constructor(status: number, message: string) {
+    super(message);
     this.name = 'ManagedAgentsApiError';
     this.status = status;
-    this.apiMessage = apiMessage;
   }
-}
 
-async function readApiError(response: Response): Promise<string> {
-  try {
-    const body = (await response.json()) as { error?: { message?: string } };
-    return body.error?.message || response.statusText;
-  } catch {
-    return response.statusText;
+  static async from(response: Response, context: string): Promise<ManagedAgentsApiError> {
+    let detail = response.statusText;
+    try {
+      const body = (await response.json()) as { error?: { message?: string } };
+      detail = body.error?.message || detail;
+    } catch {
+      // Non-JSON error body; the status text will do.
+    }
+    return new ManagedAgentsApiError(
+      response.status,
+      `${context}: ${detail} (HTTP ${response.status})`
+    );
   }
 }
 
@@ -301,13 +305,7 @@ async function findSkillByDisplayTitle(
       headers,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
-    if (!response.ok) {
-      throw new ManagedAgentsApiError(
-        response.status,
-        await readApiError(response),
-        'Failed to list skills'
-      );
-    }
+    if (!response.ok) throw await ManagedAgentsApiError.from(response, 'Failed to list skills');
 
     const body = (await response.json()) as SkillListResponse;
     const match = body.data.find((skill) => skill.display_title === displayTitle);
@@ -325,18 +323,27 @@ export interface ManagedSkillUploadResult {
   action: 'created' | 'updated';
 }
 
+/** Upload `files` as a new version of an existing skill. */
 async function uploadSkillVersion(
   skillId: string,
   directory: string,
   files: SkillUploadFile[],
   headers: Record<string, string>
-): Promise<Response> {
-  return fetch(`${getApiBaseUrl()}/v1/skills/${encodeURIComponent(skillId)}/versions?beta=true`, {
-    method: 'POST',
-    headers,
-    body: buildSkillForm(directory, null, files),
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
+): Promise<ManagedSkillUploadResult> {
+  const response = await fetch(
+    `${getApiBaseUrl()}/v1/skills/${encodeURIComponent(skillId)}/versions?beta=true`,
+    {
+      method: 'POST',
+      headers,
+      body: buildSkillForm(directory, null, files),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    }
+  );
+  if (!response.ok) {
+    throw await ManagedAgentsApiError.from(response, 'Failed to create skill version');
+  }
+  const version = (await response.json()) as SkillVersionResponse;
+  return { skillId: version.skill_id, version: version.version, action: 'updated' };
 }
 
 /**
@@ -370,64 +377,38 @@ export async function uploadSkillToManagedAgents(
 
   const directory = sanitizeName(skill.name);
   const headers = buildHeaders(auth);
-  const baseUrl = getApiBaseUrl();
 
   if (knownSkillId) {
-    const response = await uploadSkillVersion(knownSkillId, directory, skill.files, headers);
-    if (response.ok) {
-      const version = (await response.json()) as SkillVersionResponse;
-      return { skillId: version.skill_id, version: version.version, action: 'updated' };
-    }
-    // 404: the skill was deleted or the credentials point at a different
-    // org. 400: the recorded id is malformed (e.g. a hand-edited lock).
-    // Both mean the id is unusable — fall through to the create-or-version
-    // flow, which self-heals the lock; a 400 caused by the files themselves
-    // fails there identically and is surfaced then.
-    if (response.status !== 404 && response.status !== 400) {
-      throw new ManagedAgentsApiError(
-        response.status,
-        await readApiError(response),
-        'Failed to create skill version'
-      );
+    try {
+      return await uploadSkillVersion(knownSkillId, directory, skill.files, headers);
+    } catch (error) {
+      // 404: the skill was deleted or the credentials point at a different
+      // org. 400: the recorded id is malformed (e.g. a hand-edited lock).
+      // Both mean the id is unusable — fall through to the create-or-version
+      // flow, which self-heals the lock; a 400 caused by the files themselves
+      // fails there identically and is surfaced then.
+      const status = error instanceof ManagedAgentsApiError ? error.status : 0;
+      if (status !== 404 && status !== 400) throw error;
     }
   }
 
-  const createResponse = await fetch(`${baseUrl}/v1/skills?beta=true`, {
+  const createResponse = await fetch(`${getApiBaseUrl()}/v1/skills?beta=true`, {
     method: 'POST',
     headers,
     body: buildSkillForm(directory, skill.name, skill.files),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
-
   if (createResponse.ok) {
     const created = (await createResponse.json()) as SkillResponse;
     return { skillId: created.id, version: created.latest_version ?? 'latest', action: 'created' };
   }
 
-  const createError = await readApiError(createResponse);
-  const isDisplayTitleConflict =
-    createResponse.status === 400 && /display_title/i.test(createError);
-
-  if (!isDisplayTitleConflict) {
-    throw new ManagedAgentsApiError(createResponse.status, createError, 'Failed to create skill');
-  }
-
-  // A skill with this display title already exists — upload a new version.
-  const existing = await findSkillByDisplayTitle(skill.name, auth);
-  if (!existing) {
-    throw new ManagedAgentsApiError(createResponse.status, createError, 'Failed to create skill');
-  }
-
-  const versionResponse = await uploadSkillVersion(existing.id, directory, skill.files, headers);
-
-  if (!versionResponse.ok) {
-    throw new ManagedAgentsApiError(
-      versionResponse.status,
-      await readApiError(versionResponse),
-      'Failed to create skill version'
-    );
-  }
-
-  const version = (await versionResponse.json()) as SkillVersionResponse;
-  return { skillId: version.skill_id, version: version.version, action: 'updated' };
+  // A skill with this display title already exists — upload a new version of it.
+  const createError = await ManagedAgentsApiError.from(createResponse, 'Failed to create skill');
+  const existing =
+    createError.status === 400 && /display_title/i.test(createError.message)
+      ? await findSkillByDisplayTitle(skill.name, auth)
+      : null;
+  if (!existing) throw createError;
+  return uploadSkillVersion(existing.id, directory, skill.files, headers);
 }

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
-import { readFile, readdir, stat } from 'fs/promises';
+import { readFile, readdir, realpath, stat } from 'fs/promises';
 import { homedir } from 'os';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { sanitizeName, EXCLUDE_FILES, EXCLUDE_DIRS } from './installer.ts';
 
 /**
@@ -170,31 +170,48 @@ export interface SkillUploadFile {
 /**
  * Collect a skill directory's files for upload, applying the same exclusion
  * rules as filesystem installs (see installer.ts copyDirectory).
+ *
+ * Symlinks are followed only when they resolve inside the skill directory.
+ * Unlike a filesystem install, an upload sends file contents off the machine,
+ * so a cloned repo must not be able to smuggle local files (e.g. a symlink to
+ * an absolute path under the user's home) into the uploaded bundle.
  */
-export async function collectSkillFiles(
-  skillDir: string,
-  relativeDir = ''
+export async function collectSkillFiles(skillDir: string): Promise<SkillUploadFile[]> {
+  const rootReal = await realpath(skillDir);
+  return collectSkillFilesWithin(skillDir, rootReal, '');
+}
+
+async function collectSkillFilesWithin(
+  dir: string,
+  rootReal: string,
+  relativeDir: string
 ): Promise<SkillUploadFile[]> {
   const files: SkillUploadFile[] = [];
-  const entries = await readdir(skillDir, { withFileTypes: true });
+  const entries = await readdir(dir, { withFileTypes: true });
 
   for (const entry of entries) {
-    const entryPath = join(skillDir, entry.name);
+    const entryPath = join(dir, entry.name);
     const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
 
     let isDirectory = entry.isDirectory();
-    if (!isDirectory && entry.isSymbolicLink()) {
+    if (entry.isSymbolicLink()) {
+      let target: string;
       try {
-        isDirectory = (await stat(entryPath)).isDirectory();
+        target = await realpath(entryPath);
       } catch {
         // Broken symlink — skip, matching copyDirectory behavior
         continue;
       }
+      if (target !== rootReal && !target.startsWith(rootReal + sep)) {
+        console.warn(`Skipping symlink outside skill directory: ${relativePath}`);
+        continue;
+      }
+      isDirectory = (await stat(target)).isDirectory();
     }
 
     if (isDirectory) {
       if (EXCLUDE_DIRS.has(entry.name)) continue;
-      files.push(...(await collectSkillFiles(entryPath, relativePath)));
+      files.push(...(await collectSkillFilesWithin(entryPath, rootReal, relativePath)));
     } else {
       if (EXCLUDE_FILES.has(entry.name)) continue;
       files.push({ path: relativePath, content: await readFile(entryPath) });

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -1,38 +1,27 @@
 import { execFileSync } from 'child_process';
-import { existsSync } from 'fs';
 import { readFile, readdir, realpath, stat } from 'fs/promises';
 import { homedir } from 'os';
-import { join, sep } from 'path';
-import { sanitizeName, EXCLUDE_FILES, EXCLUDE_DIRS } from './installer.ts';
+import { join } from 'path';
+import { sanitizeName, isExcluded, isPathSafe } from './installer.ts';
+import { readLocalLock } from './local-lock.ts';
+import { readSkillLock } from './skill-lock.ts';
 
 /**
  * Claude Managed Agents support.
  *
  * Skills for the `claude-managed-agents` target are not copied to a directory;
- * they are uploaded to the Anthropic Skills API, where they become available
- * to the user's managed agents (and to the Messages API code-execution
- * container). See https://platform.claude.com/docs/en/managed-agents/skills
- *
- * Endpoints:
- *   POST /v1/skills                     create a skill (multipart `files[]`)
- *   GET  /v1/skills?source=custom       list the workspace's custom skills
- *   POST /v1/skills/{id}/versions       create a new version of a skill
- *
- * Each multipart file part is named `files[]` and its filename carries the
- * skill-relative path prefixed with the skill directory name, e.g.
- * `my-skill/SKILL.md`.
+ * they are uploaded to the Anthropic Skills API (`/v1/skills`), where they
+ * become available to the user's managed agents (and to the Messages API
+ * code-execution container). See https://platform.claude.com/docs/en/managed-agents/skills
  */
 
-const OAUTH_BETA = 'oauth-2025-04-20';
 const ANTHROPIC_VERSION = '2023-06-01';
 const FETCH_TIMEOUT_MS = 30000;
 const ANT_CLI_TIMEOUT_MS = 10000;
 
 export interface AnthropicAuth {
-  /** Credential headers (x-api-key or Authorization, plus workspace binding). */
+  /** Request headers this credential needs (key or bearer token, workspace, betas). */
   headers: Record<string, string>;
-  /** Extra anthropic-beta values required by this credential kind. */
-  betas: string[];
   /** Where the credential came from, for user-facing messages. */
   source: 'ANTHROPIC_API_KEY' | 'ANTHROPIC_AUTH_TOKEN' | 'ant CLI' | 'ant credentials file';
 }
@@ -57,13 +46,15 @@ function authFromOAuthToken(
   source: AnthropicAuth['source']
 ): AnthropicAuth | null {
   if (!credentials.access_token) return null;
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${credentials.access_token}`,
+  return {
+    headers: {
+      Authorization: `Bearer ${credentials.access_token}`,
+      // OAuth access tokens are accepted on the API behind this beta.
+      'anthropic-beta': 'oauth-2025-04-20',
+      ...(credentials.workspace_id && { 'anthropic-workspace-id': credentials.workspace_id }),
+    },
+    source,
   };
-  if (credentials.workspace_id) {
-    headers['anthropic-workspace-id'] = credentials.workspace_id;
-  }
-  return { headers, betas: [OAUTH_BETA], source };
 }
 
 /**
@@ -74,14 +65,10 @@ function authFromOAuthToken(
 async function readAntCredentialsFile(): Promise<AnthropicAuth | null> {
   try {
     const configDir = getAntConfigDir();
-    let profile = process.env.ANTHROPIC_PROFILE?.trim();
-    if (!profile) {
-      const activeConfigPath = join(configDir, 'active_config');
-      profile = existsSync(activeConfigPath)
-        ? (await readFile(activeConfigPath, 'utf-8')).trim() || 'default'
-        : 'default';
-    }
-
+    const profile =
+      process.env.ANTHROPIC_PROFILE?.trim() ||
+      (await readFile(join(configDir, 'active_config'), 'utf-8').catch(() => '')).trim() ||
+      'default';
     const credentialsPath = join(configDir, 'credentials', `${profile}.json`);
     const credentials = JSON.parse(await readFile(credentialsPath, 'utf-8')) as AntCredentials;
 
@@ -118,8 +105,7 @@ function readAntCliCredentials(): AnthropicAuth | null {
       // token refresh; the credentials-file fallback still gets a chance.
       timeout: ANT_CLI_TIMEOUT_MS,
     });
-    const credentials = JSON.parse(output) as AntCredentials;
-    return authFromOAuthToken(credentials, 'ant CLI');
+    return authFromOAuthToken(JSON.parse(output) as AntCredentials, 'ant CLI');
   } catch {
     // ant not installed or not logged in
     return null;
@@ -133,37 +119,23 @@ function readAntCliCredentials(): AnthropicAuth | null {
  */
 export async function resolveAnthropicAuth(): Promise<AnthropicAuth | null> {
   const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
-  if (apiKey) {
-    return { headers: { 'x-api-key': apiKey }, betas: [], source: 'ANTHROPIC_API_KEY' };
-  }
+  if (apiKey) return { headers: { 'x-api-key': apiKey }, source: 'ANTHROPIC_API_KEY' };
 
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN?.trim();
   if (authToken) {
-    return {
-      headers: { Authorization: `Bearer ${authToken}` },
-      betas: [],
-      source: 'ANTHROPIC_AUTH_TOKEN',
-    };
+    return { headers: { Authorization: `Bearer ${authToken}` }, source: 'ANTHROPIC_AUTH_TOKEN' };
   }
 
-  const fromCli = readAntCliCredentials();
-  if (fromCli) return fromCli;
-
-  return readAntCredentialsFile();
+  return readAntCliCredentials() ?? readAntCredentialsFile();
 }
 
 export const MANAGED_AGENTS_AUTH_GUIDANCE =
   'Log in with the Anthropic CLI (`ant auth login`) or set the ANTHROPIC_API_KEY environment variable.';
 
-function getApiBaseUrl(): string {
-  const base = process.env.ANTHROPIC_BASE_URL?.trim();
-  return (base || 'https://api.anthropic.com').replace(/\/+$/, '');
-}
-
 export interface SkillUploadFile {
   /** Path relative to the skill directory, using forward slashes. */
   path: string;
-  content: string | Uint8Array;
+  contents: string | Uint8Array;
 }
 
 /**
@@ -186,9 +158,7 @@ async function collectSkillFilesWithin(
   relativeDir: string
 ): Promise<SkillUploadFile[]> {
   const files: SkillUploadFile[] = [];
-  const entries = await readdir(dir, { withFileTypes: true });
-
-  for (const entry of entries) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
     const entryPath = join(dir, entry.name);
     const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
 
@@ -201,87 +171,59 @@ async function collectSkillFilesWithin(
         // Broken symlink — skip, matching copyDirectory behavior
         continue;
       }
-      if (target !== rootReal && !target.startsWith(rootReal + sep)) {
+      if (!isPathSafe(rootReal, target)) {
         console.warn(`Skipping symlink outside skill directory: ${relativePath}`);
         continue;
       }
       isDirectory = (await stat(target)).isDirectory();
     }
 
+    if (isExcluded(entry.name, isDirectory)) continue;
     if (isDirectory) {
-      if (EXCLUDE_DIRS.has(entry.name)) continue;
       files.push(...(await collectSkillFilesWithin(entryPath, rootReal, relativePath)));
     } else {
-      if (EXCLUDE_FILES.has(entry.name)) continue;
-      files.push({ path: relativePath, content: await readFile(entryPath) });
+      files.push({ path: relativePath, contents: await readFile(entryPath) });
     }
   }
-
   return files;
 }
 
-/** A non-2xx response from the Skills API. */
-export class ManagedAgentsApiError extends Error {
-  status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.name = 'ManagedAgentsApiError';
-    this.status = status;
-  }
-
-  static async from(response: Response, context: string): Promise<ManagedAgentsApiError> {
-    let detail = response.statusText;
-    try {
-      const body = (await response.json()) as { error?: { message?: string } };
-      detail = body.error?.message || detail;
-    } catch {
-      // Non-JSON error body; the status text will do.
-    }
-    return new ManagedAgentsApiError(
-      response.status,
-      `${context}: ${detail} (HTTP ${response.status})`
-    );
-  }
+/** Call the Anthropic API with this credential's headers and a timeout. */
+function skillsApi(auth: AnthropicAuth, path: string, init: RequestInit = {}): Promise<Response> {
+  const base = (process.env.ANTHROPIC_BASE_URL?.trim() || 'https://api.anthropic.com').replace(
+    /\/+$/,
+    ''
+  );
+  return fetch(`${base}${path}`, {
+    ...init,
+    headers: { ...auth.headers, 'anthropic-version': ANTHROPIC_VERSION },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
 }
 
-function buildHeaders(auth: AnthropicAuth): Record<string, string> {
-  const headers: Record<string, string> = {
-    ...auth.headers,
-    'anthropic-version': ANTHROPIC_VERSION,
-  };
-  if (auth.betas.length > 0) {
-    headers['anthropic-beta'] = auth.betas.join(',');
+async function apiError(response: Response, context: string): Promise<Error> {
+  let detail = response.statusText;
+  try {
+    const body = (await response.json()) as { error?: { message?: string } };
+    detail = body.error?.message || detail;
+  } catch {
+    // Non-JSON error body; the status text will do.
   }
-  return headers;
+  return new Error(`${context}: ${detail} (HTTP ${response.status})`);
 }
 
+/**
+ * Multipart body for a create or version upload. Each part is named
+ * `files[]`; its filename carries the file's path within the skill, prefixed
+ * with the skill's top-level directory name (e.g. `my-skill/SKILL.md`).
+ */
 function buildSkillForm(directory: string, displayName: string | null, files: SkillUploadFile[]) {
   const form = new FormData();
-  if (displayName !== null) {
-    form.append('display_name', displayName);
-  }
+  if (displayName !== null) form.append('display_name', displayName);
   for (const file of files) {
-    // The multipart filename carries the file's path within the skill,
-    // prefixed with the skill's top-level directory name.
-    const content = typeof file.content === 'string' ? file.content : new Uint8Array(file.content);
-    form.append('files[]', new File([content], `${directory}/${file.path}`));
+    form.append('files[]', new File([file.contents], `${directory}/${file.path}`));
   }
   return form;
-}
-
-interface SkillResponse {
-  id: string;
-  display_name: string;
-}
-
-interface SkillVersionResponse {
-  skill_id: string;
-}
-
-interface SkillListResponse {
-  data: SkillResponse[];
-  next_page: string | null;
 }
 
 const LIST_PAGE_SIZE = 1000; // the API maximum
@@ -309,7 +251,6 @@ export function createManagedSkillLookup(auth: AnthropicAuth): ManagedSkillLooku
  * keeps the first (newest) id seen for each name.
  */
 async function listSkillIdsByDisplayName(auth: AnthropicAuth): Promise<Map<string, string>> {
-  const headers = buildHeaders(auth);
   const ids = new Map<string, string>();
   let page: string | null = null;
 
@@ -317,13 +258,13 @@ async function listSkillIdsByDisplayName(auth: AnthropicAuth): Promise<Map<strin
     const params = new URLSearchParams({ source: 'custom', limit: String(LIST_PAGE_SIZE) });
     if (page) params.set('page', page);
 
-    const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, {
-      headers,
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!response.ok) throw await ManagedAgentsApiError.from(response, 'Failed to list skills');
+    const response = await skillsApi(auth, `/v1/skills?${params}`);
+    if (!response.ok) throw await apiError(response, 'Failed to list skills');
 
-    const body = (await response.json()) as SkillListResponse;
+    const body = (await response.json()) as {
+      data: Array<{ id: string; display_name: string }>;
+      next_page: string | null;
+    };
     for (const skill of body.data) {
       if (!ids.has(skill.display_name)) ids.set(skill.display_name, skill.id);
     }
@@ -343,70 +284,45 @@ export interface ManagedSkillUploadResult {
   action: 'created' | 'updated';
 }
 
-/** Upload `files` as a new version of an existing skill. */
-async function uploadSkillVersion(
-  skillId: string,
-  directory: string,
-  files: SkillUploadFile[],
-  headers: Record<string, string>
-): Promise<ManagedSkillUploadResult> {
-  const response = await fetch(
-    `${getApiBaseUrl()}/v1/skills/${encodeURIComponent(skillId)}/versions`,
-    {
-      method: 'POST',
-      headers,
-      body: buildSkillForm(directory, null, files),
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    }
-  );
-  if (!response.ok) {
-    throw await ManagedAgentsApiError.from(response, 'Failed to create skill version');
-  }
-  const version = (await response.json()) as SkillVersionResponse;
-  return { skillId: version.skill_id, action: 'updated' };
-}
-
 /**
- * Like uploadSkillVersion, but returns null when the target skill can't take
- * the upload: 404 (deleted, or credentials now point at another workspace)
- * or 400 (malformed id from a hand-edited lock, or a skill whose `name` slug
- * differs from this upload's). The caller then moves on to the next
- * candidate; a 400 caused by the files themselves fails identically at
+ * Upload `files` as a new version of `skillId`. Returns null when that skill
+ * can't take the upload: 404 (deleted, or credentials now point at another
+ * workspace) or 400 (malformed id from a hand-edited lock, or a skill whose
+ * `name` slug differs from this upload's). The caller then moves on to the
+ * next candidate; a 400 caused by the files themselves fails identically at
  * create time and is surfaced there.
  */
 async function tryUploadSkillVersion(
-  ...args: Parameters<typeof uploadSkillVersion>
+  auth: AnthropicAuth,
+  skillId: string,
+  directory: string,
+  files: SkillUploadFile[]
 ): Promise<ManagedSkillUploadResult | null> {
-  try {
-    return await uploadSkillVersion(...args);
-  } catch (error) {
-    const status = error instanceof ManagedAgentsApiError ? error.status : 0;
-    if (status === 404 || status === 400) return null;
-    throw error;
-  }
-}
-
-export interface ManagedSkillUploadOptions {
-  /** Skill id recorded in the lock file by a previous upload of this skill. */
-  knownSkillId?: string;
-  /** Shared display-name lookup; pass one per run to list the workspace once. */
-  lookup?: ManagedSkillLookup;
+  const response = await skillsApi(auth, `/v1/skills/${encodeURIComponent(skillId)}/versions`, {
+    method: 'POST',
+    body: buildSkillForm(directory, null, files),
+  });
+  if (response.status === 404 || response.status === 400) return null;
+  if (!response.ok) throw await apiError(response, 'Failed to create skill version');
+  const version = (await response.json()) as { skill_id: string };
+  return { skillId: version.skill_id, action: 'updated' };
 }
 
 /**
  * Upload a skill to the Anthropic Skills API as a new version of an existing
  * skill when one can be found, otherwise as a new skill.
  *
- * Candidates for versioning, in order: `knownSkillId`, then the newest
- * workspace skill whose display name equals the skill name. The API doesn't
- * enforce unique names, so without the display-name lookup every install
- * from a project with no usable lock entry would create a duplicate skill in
- * the workspace.
+ * Candidates for versioning, in order: `knownSkillId` (recorded in the lock
+ * file by a previous upload), then the newest workspace skill whose display
+ * name equals the skill name. The API doesn't enforce unique names, so
+ * without the display-name lookup every install from a project with no
+ * usable lock entry would create a duplicate skill in the workspace. Pass one
+ * `lookup` per run so the workspace is listed once.
  */
 export async function uploadSkillToManagedAgents(
   skill: { name: string; files: SkillUploadFile[] },
   auth: AnthropicAuth,
-  options: ManagedSkillUploadOptions = {}
+  options: { knownSkillId?: string; lookup?: ManagedSkillLookup } = {}
 ): Promise<ManagedSkillUploadResult> {
   // Case-insensitive filesystems discover a lowercase `skill.md`, but the
   // API requires the exact-case name — normalize instead of rejecting a
@@ -421,27 +337,132 @@ export async function uploadSkillToManagedAgents(
   }
 
   const directory = sanitizeName(skill.name);
-  const headers = buildHeaders(auth);
   const { knownSkillId, lookup = createManagedSkillLookup(auth) } = options;
 
   if (knownSkillId) {
-    const result = await tryUploadSkillVersion(knownSkillId, directory, files, headers);
+    const result = await tryUploadSkillVersion(auth, knownSkillId, directory, files);
     if (result) return result;
   }
 
   const existingId = await lookup(skill.name);
   if (existingId && existingId !== knownSkillId) {
-    const result = await tryUploadSkillVersion(existingId, directory, files, headers);
+    const result = await tryUploadSkillVersion(auth, existingId, directory, files);
     if (result) return result;
   }
 
-  const response = await fetch(`${getApiBaseUrl()}/v1/skills`, {
+  const response = await skillsApi(auth, '/v1/skills', {
     method: 'POST',
-    headers,
     body: buildSkillForm(directory, skill.name, files),
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
-  if (!response.ok) throw await ManagedAgentsApiError.from(response, 'Failed to create skill');
-  const created = (await response.json()) as SkillResponse;
+  if (!response.ok) throw await apiError(response, 'Failed to create skill');
+  const created = (await response.json()) as { id: string };
   return { skillId: created.id, action: 'created' };
+}
+
+/**
+ * Sentinel written in place of a content hash or digest when part of a
+ * requested install (filesystem copy or upload) did not complete. Never
+ * equal to a real hash, so a later `update` sees the entry as changed and
+ * retries the whole install instead of treating the skill as current.
+ */
+export const PENDING_INSTALL_HASH = 'pending-install';
+
+export interface ManagedUploadOutcome {
+  skill: string;
+  success: boolean;
+  skillId?: string;
+  action?: 'created' | 'updated';
+  error?: string;
+}
+
+/**
+ * Skills API ids a previous run recorded in the lock, restricted to entries
+ * whose source matches this run's, so a same-named skill from another source
+ * doesn't take the recorded id as a direct-version shortcut.
+ */
+export function knownManagedIds(
+  entries: Record<string, { source: string; managedSkillId?: string }>,
+  sourceKey: string | null
+): Map<string, string> {
+  const ids = new Map<string, string>();
+  for (const [name, entry] of Object.entries(entries)) {
+    if (entry.managedSkillId && entry.source === sourceKey) ids.set(name, entry.managedSkillId);
+  }
+  return ids;
+}
+
+/**
+ * Shape one run's upload outcomes for the lock writes. `requested` says
+ * which halves of the install (filesystem copy, upload) this run asked for.
+ */
+export function summarizeManagedUploads(
+  outcomes: ManagedUploadOutcome[],
+  knownIds: Map<string, string>,
+  requested: { upload: boolean; fs: boolean }
+) {
+  const uploaded = new Map(
+    outcomes.filter((o) => o.success && o.skillId).map((o) => [o.skill, o.skillId!])
+  );
+  return {
+    outcomes,
+    /** Number of skills that reached the Skills API this run. */
+    uploads: uploaded.size,
+    /**
+     * Lock bookkeeping for one skill, or null when neither its copy nor its
+     * upload landed. `hash` swaps in PENDING_INSTALL_HASH when a requested
+     * half didn't complete, so `update` retries it; `managedSkillId` is this
+     * run's upload, else the id already recorded for this source.
+     */
+    lockEntry(name: string, fsSucceeded: boolean) {
+      if (!fsSucceeded && !uploaded.has(name)) return null;
+      const complete = (!requested.fs || fsSucceeded) && (!requested.upload || uploaded.has(name));
+      return {
+        hash: (real: string) => (complete ? real : PENDING_INSTALL_HASH),
+        managedSkillId: uploaded.get(name) ?? knownIds.get(name),
+      };
+    },
+  };
+}
+
+export type ManagedUploadPass = ReturnType<typeof summarizeManagedUploads>;
+
+/**
+ * Upload pass for the Claude Managed Agents target. Skills with an id
+ * recorded in this scope's lock are versioned directly; the rest are matched
+ * by display name or created. One skill at a time; a failure doesn't stop
+ * the rest. Without credentials nothing is uploaded, but recorded ids still
+ * flow into `lockEntry` so a filesystem-only re-add keeps them in the lock.
+ */
+export async function runManagedUploads(
+  run: { auth: AnthropicAuth | null; uploadRequested: boolean; fsRequested: boolean },
+  skills: Array<{ name: string; files: () => SkillUploadFile[] | Promise<SkillUploadFile[]> }>,
+  scope: { installGlobally: boolean; cwd: string; sourceKey: string | null }
+): Promise<ManagedUploadPass> {
+  const lock = scope.installGlobally ? await readSkillLock() : await readLocalLock(scope.cwd);
+  const knownIds = knownManagedIds(lock.skills, scope.sourceKey);
+
+  const outcomes: ManagedUploadOutcome[] = [];
+  if (run.auth) {
+    const lookup = createManagedSkillLookup(run.auth);
+    for (const skill of skills) {
+      try {
+        const result = await uploadSkillToManagedAgents(
+          { name: skill.name, files: await skill.files() },
+          run.auth,
+          { knownSkillId: knownIds.get(skill.name), lookup }
+        );
+        outcomes.push({ skill: skill.name, success: true, ...result });
+      } catch (error) {
+        outcomes.push({
+          skill: skill.name,
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    }
+  }
+  return summarizeManagedUploads(outcomes, knownIds, {
+    upload: run.uploadRequested,
+    fs: run.fsRequested,
+  });
 }

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -11,11 +11,11 @@ import { sanitizeName, EXCLUDE_FILES, EXCLUDE_DIRS } from './installer.ts';
  * Skills for the `claude-managed-agents` target are not copied to a directory;
  * they are uploaded to the Anthropic Skills API, where they become available
  * to the user's managed agents (and to the Messages API code-execution
- * container). See https://platform.claude.com/docs/en/agents-and-tools/agent-skills
+ * container). See https://platform.claude.com/docs/en/managed-agents/skills
  *
- * Endpoints (beta `skills-2025-10-02`):
+ * Endpoints:
  *   POST /v1/skills                     create a skill (multipart `files[]`)
- *   GET  /v1/skills?source=custom       list custom skills
+ *   GET  /v1/skills?source=custom       list the workspace's custom skills
  *   POST /v1/skills/{id}/versions       create a new version of a skill
  *
  * Each multipart file part is named `files[]` and its filename carries the
@@ -23,7 +23,6 @@ import { sanitizeName, EXCLUDE_FILES, EXCLUDE_DIRS } from './installer.ts';
  * `my-skill/SKILL.md`.
  */
 
-const SKILLS_BETA = 'skills-2025-10-02';
 const OAUTH_BETA = 'oauth-2025-04-20';
 const ANTHROPIC_VERSION = '2023-06-01';
 const FETCH_TIMEOUT_MS = 30000;
@@ -247,17 +246,20 @@ export class ManagedAgentsApiError extends Error {
 }
 
 function buildHeaders(auth: AnthropicAuth): Record<string, string> {
-  return {
+  const headers: Record<string, string> = {
     ...auth.headers,
     'anthropic-version': ANTHROPIC_VERSION,
-    'anthropic-beta': [...auth.betas, SKILLS_BETA].join(','),
   };
+  if (auth.betas.length > 0) {
+    headers['anthropic-beta'] = auth.betas.join(',');
+  }
+  return headers;
 }
 
-function buildSkillForm(directory: string, displayTitle: string | null, files: SkillUploadFile[]) {
+function buildSkillForm(directory: string, displayName: string | null, files: SkillUploadFile[]) {
   const form = new FormData();
-  if (displayTitle !== null) {
-    form.append('display_title', displayTitle);
+  if (displayName !== null) {
+    form.append('display_name', displayName);
   }
   for (const file of files) {
     // The multipart filename carries the file's path within the skill,
@@ -270,36 +272,36 @@ function buildSkillForm(directory: string, displayTitle: string | null, files: S
 
 interface SkillResponse {
   id: string;
-  display_title: string | null;
-  latest_version: string | null;
+  display_name: string;
+  latest_version_id: string;
 }
 
 interface SkillVersionResponse {
+  id: string;
   skill_id: string;
-  version: string;
 }
 
 interface SkillListResponse {
   data: SkillResponse[];
-  has_more: boolean;
-  last_id: string | null;
+  next_page: string | null;
 }
 
 /**
- * Find an existing custom skill by display title. Used to upgrade a create
- * into a new-version upload when the skill already exists.
+ * Find the workspace's most recently created custom skill with this display
+ * name. Display names are not unique, so this is a best-effort match used
+ * only when the lock has no recorded skill id; the list is newest-first.
  */
-async function findSkillByDisplayTitle(
-  displayTitle: string,
+async function findSkillByDisplayName(
+  displayName: string,
   auth: AnthropicAuth
 ): Promise<SkillResponse | null> {
   const headers = buildHeaders(auth);
-  let afterId: string | null = null;
+  let page: string | null = null;
 
-  // Paginate defensively; orgs can accumulate many custom skills.
-  for (let page = 0; page < 20; page++) {
-    const params = new URLSearchParams({ beta: 'true', source: 'custom', limit: '100' });
-    if (afterId) params.set('after_id', afterId);
+  // Paginate defensively; workspaces can accumulate many custom skills.
+  for (let i = 0; i < 20; i++) {
+    const params = new URLSearchParams({ source: 'custom', limit: '100' });
+    if (page) params.set('page', page);
 
     const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, {
       headers,
@@ -308,10 +310,10 @@ async function findSkillByDisplayTitle(
     if (!response.ok) throw await ManagedAgentsApiError.from(response, 'Failed to list skills');
 
     const body = (await response.json()) as SkillListResponse;
-    const match = body.data.find((skill) => skill.display_title === displayTitle);
+    const match = body.data.find((skill) => skill.display_name === displayName);
     if (match) return match;
-    if (!body.has_more || !body.last_id) return null;
-    afterId = body.last_id;
+    if (!body.next_page) return null;
+    page = body.next_page;
   }
 
   return null;
@@ -319,7 +321,7 @@ async function findSkillByDisplayTitle(
 
 export interface ManagedSkillUploadResult {
   skillId: string;
-  version: string;
+  versionId: string;
   action: 'created' | 'updated';
 }
 
@@ -331,7 +333,7 @@ async function uploadSkillVersion(
   headers: Record<string, string>
 ): Promise<ManagedSkillUploadResult> {
   const response = await fetch(
-    `${getApiBaseUrl()}/v1/skills/${encodeURIComponent(skillId)}/versions?beta=true`,
+    `${getApiBaseUrl()}/v1/skills/${encodeURIComponent(skillId)}/versions`,
     {
       method: 'POST',
       headers,
@@ -343,19 +345,38 @@ async function uploadSkillVersion(
     throw await ManagedAgentsApiError.from(response, 'Failed to create skill version');
   }
   const version = (await response.json()) as SkillVersionResponse;
-  return { skillId: version.skill_id, version: version.version, action: 'updated' };
+  return { skillId: version.skill_id, versionId: version.id, action: 'updated' };
 }
 
 /**
- * Upload a skill to the Anthropic Skills API. Creates the skill if it doesn't
- * exist; if a skill with the same display title already exists, uploads the
- * files as a new version of that skill instead.
+ * Like uploadSkillVersion, but returns null when the target skill can't take
+ * the upload: 404 (deleted, or credentials now point at another workspace)
+ * or 400 (malformed id from a hand-edited lock, or a skill whose `name` slug
+ * differs from this upload's). The caller then moves on to the next
+ * candidate; a 400 caused by the files themselves fails identically at
+ * create time and is surfaced there.
+ */
+async function tryUploadSkillVersion(
+  ...args: Parameters<typeof uploadSkillVersion>
+): Promise<ManagedSkillUploadResult | null> {
+  try {
+    return await uploadSkillVersion(...args);
+  } catch (error) {
+    const status = error instanceof ManagedAgentsApiError ? error.status : 0;
+    if (status === 404 || status === 400) return null;
+    throw error;
+  }
+}
+
+/**
+ * Upload a skill to the Anthropic Skills API as a new version of an existing
+ * skill when one can be found, otherwise as a new skill.
  *
- * When `knownSkillId` (recorded in the lock file by a previous upload) is
- * provided, a new version is uploaded to that skill directly, skipping the
- * create attempt and display-title lookup. A 404 for the id (deleted skill,
- * or credentials now pointing at a different org) falls back to the normal
- * create-or-version flow.
+ * Candidates for versioning, in order: `knownSkillId` (recorded in the lock
+ * file by a previous upload), then the newest workspace skill whose display
+ * name equals the skill name. The API doesn't enforce unique names, so
+ * without the display-name lookup every install from a project with no lock
+ * entry would create a duplicate skill in the workspace.
  */
 export async function uploadSkillToManagedAgents(
   skill: { name: string; files: SkillUploadFile[] },
@@ -373,42 +394,28 @@ export async function uploadSkillToManagedAgents(
   if (!files.some((file) => file.path === 'SKILL.md')) {
     throw new Error('Skill is missing a SKILL.md at its root');
   }
-  skill = { ...skill, files };
 
   const directory = sanitizeName(skill.name);
   const headers = buildHeaders(auth);
 
   if (knownSkillId) {
-    try {
-      return await uploadSkillVersion(knownSkillId, directory, skill.files, headers);
-    } catch (error) {
-      // 404: the skill was deleted or the credentials point at a different
-      // org. 400: the recorded id is malformed (e.g. a hand-edited lock).
-      // Both mean the id is unusable — fall through to the create-or-version
-      // flow, which self-heals the lock; a 400 caused by the files themselves
-      // fails there identically and is surfaced then.
-      const status = error instanceof ManagedAgentsApiError ? error.status : 0;
-      if (status !== 404 && status !== 400) throw error;
-    }
+    const result = await tryUploadSkillVersion(knownSkillId, directory, files, headers);
+    if (result) return result;
   }
 
-  const createResponse = await fetch(`${getApiBaseUrl()}/v1/skills?beta=true`, {
+  const existing = await findSkillByDisplayName(skill.name, auth);
+  if (existing && existing.id !== knownSkillId) {
+    const result = await tryUploadSkillVersion(existing.id, directory, files, headers);
+    if (result) return result;
+  }
+
+  const response = await fetch(`${getApiBaseUrl()}/v1/skills`, {
     method: 'POST',
     headers,
-    body: buildSkillForm(directory, skill.name, skill.files),
+    body: buildSkillForm(directory, skill.name, files),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
-  if (createResponse.ok) {
-    const created = (await createResponse.json()) as SkillResponse;
-    return { skillId: created.id, version: created.latest_version ?? 'latest', action: 'created' };
-  }
-
-  // A skill with this display title already exists — upload a new version of it.
-  const createError = await ManagedAgentsApiError.from(createResponse, 'Failed to create skill');
-  const existing =
-    createError.status === 400 && /display_title/i.test(createError.message)
-      ? await findSkillByDisplayTitle(skill.name, auth)
-      : null;
-  if (!existing) throw createError;
-  return uploadSkillVersion(existing.id, directory, skill.files, headers);
+  if (!response.ok) throw await ManagedAgentsApiError.from(response, 'Failed to create skill');
+  const created = (await response.json()) as SkillResponse;
+  return { skillId: created.id, versionId: created.latest_version_id, action: 'created' };
 }

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -1,0 +1,367 @@
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { readFile, readdir, stat } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import { sanitizeName } from './installer.ts';
+
+/**
+ * Claude Managed Agents support.
+ *
+ * Skills for the `claude-managed-agents` target are not copied to a directory;
+ * they are uploaded to the Anthropic Skills API, where they become available
+ * to the user's managed agents (and to the Messages API code-execution
+ * container). See https://platform.claude.com/docs/en/agents-and-tools/agent-skills
+ *
+ * Endpoints (beta `skills-2025-10-02`):
+ *   POST /v1/skills                     create a skill (multipart `files[]`)
+ *   GET  /v1/skills?source=custom       list custom skills
+ *   POST /v1/skills/{id}/versions       create a new version of a skill
+ *
+ * Each multipart file part is named `files[]` and its filename carries the
+ * skill-relative path prefixed with the skill directory name, e.g.
+ * `my-skill/SKILL.md`.
+ */
+
+const SKILLS_BETA = 'skills-2025-10-02';
+const OAUTH_BETA = 'oauth-2025-04-20';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+export interface AnthropicAuth {
+  /** Credential headers (x-api-key or Authorization, plus workspace binding). */
+  headers: Record<string, string>;
+  /** Extra anthropic-beta values required by this credential kind. */
+  betas: string[];
+  /** Where the credential came from, for user-facing messages. */
+  source: 'ANTHROPIC_API_KEY' | 'ANTHROPIC_AUTH_TOKEN' | 'ant CLI' | 'ant credentials file';
+}
+
+interface AntCredentials {
+  type?: string;
+  access_token?: string;
+  expires_at?: number;
+  workspace_id?: string;
+}
+
+function getAntConfigDir(): string {
+  const fromEnv = process.env.ANTHROPIC_CONFIG_DIR?.trim();
+  if (fromEnv) return fromEnv;
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  if (xdg) return join(xdg, 'anthropic');
+  return join(homedir(), '.config', 'anthropic');
+}
+
+function authFromOAuthToken(
+  credentials: AntCredentials,
+  source: AnthropicAuth['source']
+): AnthropicAuth | null {
+  if (!credentials.access_token) return null;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${credentials.access_token}`,
+  };
+  if (credentials.workspace_id) {
+    headers['anthropic-workspace-id'] = credentials.workspace_id;
+  }
+  return { headers, betas: [OAUTH_BETA], source };
+}
+
+/**
+ * Read credentials written by `ant auth login` directly from disk. Used only
+ * when the `ant` binary itself isn't available; unlike the CLI this cannot
+ * refresh expired tokens, so expired credentials are rejected.
+ */
+async function readAntCredentialsFile(): Promise<AnthropicAuth | null> {
+  try {
+    const configDir = getAntConfigDir();
+    let profile = process.env.ANTHROPIC_PROFILE?.trim();
+    if (!profile) {
+      const activeConfigPath = join(configDir, 'active_config');
+      profile = existsSync(activeConfigPath)
+        ? (await readFile(activeConfigPath, 'utf-8')).trim() || 'default'
+        : 'default';
+    }
+
+    const credentialsPath = join(configDir, 'credentials', `${profile}.json`);
+    const credentials = JSON.parse(await readFile(credentialsPath, 'utf-8')) as AntCredentials;
+
+    // `type` may be omitted by external writers, but anything else is not an
+    // OAuth token we know how to use.
+    if (credentials.type !== undefined && credentials.type !== 'oauth_token') {
+      return null;
+    }
+    // Leave a minute of headroom; without the ant binary we cannot refresh.
+    if (
+      typeof credentials.expires_at === 'number' &&
+      credentials.expires_at * 1000 < Date.now() + 60_000
+    ) {
+      return null;
+    }
+
+    return authFromOAuthToken(credentials, 'ant credentials file');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Shell out to `ant auth print-credentials`, which resolves the active
+ * profile and refreshes the OAuth access token if it is expired or close to
+ * expiry.
+ */
+function readAntCliCredentials(): AnthropicAuth | null {
+  try {
+    const output = execFileSync('ant', ['auth', 'print-credentials'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const credentials = JSON.parse(output) as AntCredentials;
+    return authFromOAuthToken(credentials, 'ant CLI');
+  } catch {
+    // ant not installed or not logged in
+    return null;
+  }
+}
+
+/**
+ * Resolve a credential for the Anthropic API, in the same precedence order
+ * the Anthropic CLI uses: explicit env vars first, then the ant CLI's stored
+ * (and auto-refreshed) OAuth credentials.
+ */
+export async function resolveAnthropicAuth(): Promise<AnthropicAuth | null> {
+  const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
+  if (apiKey) {
+    return { headers: { 'x-api-key': apiKey }, betas: [], source: 'ANTHROPIC_API_KEY' };
+  }
+
+  const authToken = process.env.ANTHROPIC_AUTH_TOKEN?.trim();
+  if (authToken) {
+    return {
+      headers: { Authorization: `Bearer ${authToken}` },
+      betas: [],
+      source: 'ANTHROPIC_AUTH_TOKEN',
+    };
+  }
+
+  const fromCli = readAntCliCredentials();
+  if (fromCli) return fromCli;
+
+  return readAntCredentialsFile();
+}
+
+export const MANAGED_AGENTS_AUTH_GUIDANCE =
+  'Log in with the Anthropic CLI (`ant auth login`) or set the ANTHROPIC_API_KEY environment variable.';
+
+function getApiBaseUrl(): string {
+  const base = process.env.ANTHROPIC_BASE_URL?.trim();
+  return (base || 'https://api.anthropic.com').replace(/\/+$/, '');
+}
+
+export interface SkillUploadFile {
+  /** Path relative to the skill directory, using forward slashes. */
+  path: string;
+  content: string | Uint8Array;
+}
+
+const EXCLUDE_FILES = new Set(['metadata.json']);
+const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
+
+/**
+ * Collect a skill directory's files for upload, applying the same exclusion
+ * rules as filesystem installs (see installer.ts copyDirectory).
+ */
+export async function collectSkillFiles(
+  skillDir: string,
+  relativeDir = ''
+): Promise<SkillUploadFile[]> {
+  const files: SkillUploadFile[] = [];
+  const entries = await readdir(skillDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = join(skillDir, entry.name);
+    const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+
+    let isDirectory = entry.isDirectory();
+    if (!isDirectory && entry.isSymbolicLink()) {
+      try {
+        isDirectory = (await stat(entryPath)).isDirectory();
+      } catch {
+        // Broken symlink — skip, matching copyDirectory behavior
+        continue;
+      }
+    }
+
+    if (isDirectory) {
+      if (EXCLUDE_DIRS.has(entry.name)) continue;
+      files.push(...(await collectSkillFiles(entryPath, relativePath)));
+    } else {
+      if (EXCLUDE_FILES.has(entry.name)) continue;
+      files.push({ path: relativePath, content: await readFile(entryPath) });
+    }
+  }
+
+  return files;
+}
+
+export class ManagedAgentsApiError extends Error {
+  status: number;
+  apiMessage: string;
+
+  constructor(status: number, apiMessage: string, context: string) {
+    super(`${context}: ${apiMessage} (HTTP ${status})`);
+    this.name = 'ManagedAgentsApiError';
+    this.status = status;
+    this.apiMessage = apiMessage;
+  }
+}
+
+async function readApiError(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: { message?: string } };
+    return body.error?.message || response.statusText;
+  } catch {
+    return response.statusText;
+  }
+}
+
+function buildHeaders(auth: AnthropicAuth): Record<string, string> {
+  return {
+    ...auth.headers,
+    'anthropic-version': ANTHROPIC_VERSION,
+    'anthropic-beta': [...auth.betas, SKILLS_BETA].join(','),
+  };
+}
+
+function buildSkillForm(directory: string, displayTitle: string | null, files: SkillUploadFile[]) {
+  const form = new FormData();
+  if (displayTitle !== null) {
+    form.append('display_title', displayTitle);
+  }
+  for (const file of files) {
+    // The multipart filename carries the file's path within the skill,
+    // prefixed with the skill's top-level directory name.
+    const content = typeof file.content === 'string' ? file.content : new Uint8Array(file.content);
+    form.append('files[]', new File([content], `${directory}/${file.path}`));
+  }
+  return form;
+}
+
+interface SkillResponse {
+  id: string;
+  display_title: string | null;
+  latest_version: string | null;
+}
+
+interface SkillVersionResponse {
+  skill_id: string;
+  version: string;
+}
+
+interface SkillListResponse {
+  data: SkillResponse[];
+  has_more: boolean;
+  last_id: string | null;
+}
+
+/**
+ * Find an existing custom skill by display title. Used to upgrade a create
+ * into a new-version upload when the skill already exists.
+ */
+async function findSkillByDisplayTitle(
+  displayTitle: string,
+  auth: AnthropicAuth
+): Promise<SkillResponse | null> {
+  const headers = buildHeaders(auth);
+  let afterId: string | null = null;
+
+  // Paginate defensively; orgs can accumulate many custom skills.
+  for (let page = 0; page < 20; page++) {
+    const params = new URLSearchParams({ beta: 'true', source: 'custom', limit: '100' });
+    if (afterId) params.set('after_id', afterId);
+
+    const response = await fetch(`${getApiBaseUrl()}/v1/skills?${params}`, { headers });
+    if (!response.ok) {
+      throw new ManagedAgentsApiError(
+        response.status,
+        await readApiError(response),
+        'Failed to list skills'
+      );
+    }
+
+    const body = (await response.json()) as SkillListResponse;
+    const match = body.data.find((skill) => skill.display_title === displayTitle);
+    if (match) return match;
+    if (!body.has_more || !body.last_id) return null;
+    afterId = body.last_id;
+  }
+
+  return null;
+}
+
+export interface ManagedSkillUploadResult {
+  skillId: string;
+  version: string;
+  action: 'created' | 'updated';
+}
+
+/**
+ * Upload a skill to the Anthropic Skills API. Creates the skill if it doesn't
+ * exist; if a skill with the same display title already exists, uploads the
+ * files as a new version of that skill instead.
+ */
+export async function uploadSkillToManagedAgents(
+  skill: { name: string; files: SkillUploadFile[] },
+  auth: AnthropicAuth
+): Promise<ManagedSkillUploadResult> {
+  if (!skill.files.some((file) => file.path === 'SKILL.md')) {
+    throw new Error('Skill is missing a SKILL.md at its root');
+  }
+
+  const directory = sanitizeName(skill.name);
+  const headers = buildHeaders(auth);
+  const baseUrl = getApiBaseUrl();
+
+  const createResponse = await fetch(`${baseUrl}/v1/skills?beta=true`, {
+    method: 'POST',
+    headers,
+    body: buildSkillForm(directory, skill.name, skill.files),
+  });
+
+  if (createResponse.ok) {
+    const created = (await createResponse.json()) as SkillResponse;
+    return { skillId: created.id, version: created.latest_version ?? 'latest', action: 'created' };
+  }
+
+  const createError = await readApiError(createResponse);
+  const isDisplayTitleConflict =
+    createResponse.status === 400 && /display_title/i.test(createError);
+
+  if (!isDisplayTitleConflict) {
+    throw new ManagedAgentsApiError(createResponse.status, createError, 'Failed to create skill');
+  }
+
+  // A skill with this display title already exists — upload a new version.
+  const existing = await findSkillByDisplayTitle(skill.name, auth);
+  if (!existing) {
+    throw new ManagedAgentsApiError(createResponse.status, createError, 'Failed to create skill');
+  }
+
+  const versionResponse = await fetch(
+    `${baseUrl}/v1/skills/${encodeURIComponent(existing.id)}/versions?beta=true`,
+    {
+      method: 'POST',
+      headers,
+      body: buildSkillForm(directory, null, skill.files),
+    }
+  );
+
+  if (!versionResponse.ok) {
+    throw new ManagedAgentsApiError(
+      versionResponse.status,
+      await readApiError(versionResponse),
+      'Failed to create skill version'
+    );
+  }
+
+  const version = (await versionResponse.json()) as SkillVersionResponse;
+  return { skillId: version.skill_id, version: version.version, action: 'updated' };
+}

--- a/src/managed-agents.ts
+++ b/src/managed-agents.ts
@@ -308,14 +308,35 @@ export interface ManagedSkillUploadResult {
   action: 'created' | 'updated';
 }
 
+async function uploadSkillVersion(
+  skillId: string,
+  directory: string,
+  files: SkillUploadFile[],
+  headers: Record<string, string>
+): Promise<Response> {
+  return fetch(`${getApiBaseUrl()}/v1/skills/${encodeURIComponent(skillId)}/versions?beta=true`, {
+    method: 'POST',
+    headers,
+    body: buildSkillForm(directory, null, files),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+}
+
 /**
  * Upload a skill to the Anthropic Skills API. Creates the skill if it doesn't
  * exist; if a skill with the same display title already exists, uploads the
  * files as a new version of that skill instead.
+ *
+ * When `knownSkillId` (recorded in the lock file by a previous upload) is
+ * provided, a new version is uploaded to that skill directly, skipping the
+ * create attempt and display-title lookup. A 404 for the id (deleted skill,
+ * or credentials now pointing at a different org) falls back to the normal
+ * create-or-version flow.
  */
 export async function uploadSkillToManagedAgents(
   skill: { name: string; files: SkillUploadFile[] },
-  auth: AnthropicAuth
+  auth: AnthropicAuth,
+  knownSkillId?: string
 ): Promise<ManagedSkillUploadResult> {
   if (!skill.files.some((file) => file.path === 'SKILL.md')) {
     throw new Error('Skill is missing a SKILL.md at its root');
@@ -324,6 +345,26 @@ export async function uploadSkillToManagedAgents(
   const directory = sanitizeName(skill.name);
   const headers = buildHeaders(auth);
   const baseUrl = getApiBaseUrl();
+
+  if (knownSkillId) {
+    const response = await uploadSkillVersion(knownSkillId, directory, skill.files, headers);
+    if (response.ok) {
+      const version = (await response.json()) as SkillVersionResponse;
+      return { skillId: version.skill_id, version: version.version, action: 'updated' };
+    }
+    // 404: the skill was deleted or the credentials point at a different
+    // org. 400: the recorded id is malformed (e.g. a hand-edited lock).
+    // Both mean the id is unusable — fall through to the create-or-version
+    // flow, which self-heals the lock; a 400 caused by the files themselves
+    // fails there identically and is surfaced then.
+    if (response.status !== 404 && response.status !== 400) {
+      throw new ManagedAgentsApiError(
+        response.status,
+        await readApiError(response),
+        'Failed to create skill version'
+      );
+    }
+  }
 
   const createResponse = await fetch(`${baseUrl}/v1/skills?beta=true`, {
     method: 'POST',
@@ -351,15 +392,7 @@ export async function uploadSkillToManagedAgents(
     throw new ManagedAgentsApiError(createResponse.status, createError, 'Failed to create skill');
   }
 
-  const versionResponse = await fetch(
-    `${baseUrl}/v1/skills/${encodeURIComponent(existing.id)}/versions?beta=true`,
-    {
-      method: 'POST',
-      headers,
-      body: buildSkillForm(directory, null, skill.files),
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    }
-  );
+  const versionResponse = await uploadSkillVersion(existing.id, directory, skill.files, headers);
 
   if (!versionResponse.ok) {
     throw new ManagedAgentsApiError(

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -2,7 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
-import { agents, detectInstalledAgents, getEveSubagents } from './agents.ts';
+import { agents, detectInstalledAgents, getEveSubagents, isVirtualAgent } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
@@ -178,6 +178,21 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   let targetAgents: AgentType[];
   if (options.agent && options.agent.length > 0) {
     targetAgents = options.agent as AgentType[];
+
+    // Virtual agents have no local files; their skills live in the user's
+    // Anthropic organization and are not deleted by this command. Say so
+    // instead of reporting a successful no-op removal.
+    const virtualRequested = targetAgents.filter((a) => isVirtualAgent(a));
+    if (virtualRequested.length > 0) {
+      targetAgents = targetAgents.filter((a) => !isVirtualAgent(a));
+      p.log.warn(
+        `${virtualRequested.map((a) => agents[a].displayName).join(', ')} skills are managed through the Anthropic API and are not removed by this command.`
+      );
+      if (targetAgents.length === 0) {
+        p.outro(pc.yellow('Nothing to remove.'));
+        return;
+      }
+    }
   } else {
     // When removing, we should target all known agents to ensure
     // ghost symlinks are cleaned up, even if the agent is not detected.

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -58,6 +58,19 @@ export function resolveSkillsToRemove(
   return Array.from(matched);
 }
 
+/**
+ * Deleting a lock entry that records a Claude Managed Agents upload orphans
+ * the uploaded skill: it stays live in the user's Anthropic organization,
+ * and the recorded id (the direct re-upload path) is lost. Say so instead of
+ * letting the removal read as complete.
+ */
+function warnAboutManagedUpload(skillName: string, managedSkillId: string | undefined): void {
+  if (!managedSkillId) return;
+  p.log.warn(
+    `${skillName} was uploaded to Claude Managed Agents (${managedSkillId}). The uploaded skill remains in your Anthropic organization; manage it via the Anthropic API.`
+  );
+}
+
 export async function removeCommand(skillNames: string[], options: RemoveOptions) {
   // Auto-enable non-interactive mode when running inside an AI agent
   const agentResult = await detectAgent();
@@ -304,6 +317,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         effectiveSource = lockEntry?.source || 'local';
         effectiveSourceType = lockEntry?.sourceType || 'local';
         if (!isStillUsed) {
+          warnAboutManagedUpload(skillName, lockEntry?.managedSkillId);
           await removeSkillFromLock(skillName);
         }
       } else {
@@ -312,6 +326,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         effectiveSource = lockEntry?.source || 'local';
         effectiveSourceType = lockEntry?.sourceType || 'local';
         if (!isStillUsed) {
+          warnAboutManagedUpload(skillName, lockEntry?.managedSkillId);
           await removeSkillFromLocalLock(skillName, cwd);
         }
       }

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -2,13 +2,7 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
-import {
-  agents,
-  detectInstalledAgents,
-  getEveSubagents,
-  isApiUploadAgent,
-  isFilesystemAgent,
-} from './agents.ts';
+import { agents, detectInstalledAgents, getEveSubagents, isApiUploadAgent } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
@@ -203,7 +197,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     // instead of reporting a successful no-op removal.
     const apiUploadRequested = targetAgents.filter((a) => isApiUploadAgent(a));
     if (apiUploadRequested.length > 0) {
-      targetAgents = targetAgents.filter((a) => isFilesystemAgent(a));
+      targetAgents = targetAgents.filter((a) => !isApiUploadAgent(a));
       p.log.warn(
         `${apiUploadRequested.map((a) => agents[a].displayName).join(', ')} skills are managed through the Anthropic API and are not removed by this command.`
       );

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -2,7 +2,13 @@ import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { readdir, rm, lstat } from 'fs/promises';
 import { join } from 'path';
-import { agents, detectInstalledAgents, getEveSubagents, isVirtualAgent } from './agents.ts';
+import {
+  agents,
+  detectInstalledAgents,
+  getEveSubagents,
+  isApiUploadAgent,
+  isFilesystemAgent,
+} from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
@@ -192,14 +198,14 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
   if (options.agent && options.agent.length > 0) {
     targetAgents = options.agent as AgentType[];
 
-    // Virtual agents have no local files; their skills live in the user's
+    // API-upload agents have no local files; their skills live in the user's
     // Anthropic organization and are not deleted by this command. Say so
     // instead of reporting a successful no-op removal.
-    const virtualRequested = targetAgents.filter((a) => isVirtualAgent(a));
-    if (virtualRequested.length > 0) {
-      targetAgents = targetAgents.filter((a) => !isVirtualAgent(a));
+    const apiUploadRequested = targetAgents.filter((a) => isApiUploadAgent(a));
+    if (apiUploadRequested.length > 0) {
+      targetAgents = targetAgents.filter((a) => isFilesystemAgent(a));
       p.log.warn(
-        `${virtualRequested.map((a) => agents[a].displayName).join(', ')} skills are managed through the Anthropic API and are not removed by this command.`
+        `${apiUploadRequested.map((a) => agents[a].displayName).join(', ')} skills are managed through the Anthropic API and are not removed by this command.`
       );
       if (targetAgents.length === 0) {
         p.outro(pc.yellow('Nothing to remove.'));

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -66,14 +66,14 @@ export function resolveSkillsToRemove(
 
 /**
  * Deleting a lock entry that records a Claude Managed Agents upload orphans
- * the uploaded skill: it stays live in the user's Anthropic organization,
+ * the uploaded skill: it stays live in the user's Anthropic workspace,
  * and the recorded id (the direct re-upload path) is lost. Say so instead of
  * letting the removal read as complete.
  */
 function warnAboutManagedUpload(skillName: string, managedSkillId: string | undefined): void {
   if (!managedSkillId) return;
   p.log.warn(
-    `${skillName} was uploaded to Claude Managed Agents (${managedSkillId}). The uploaded skill remains in your Anthropic organization; manage it via the Anthropic API.`
+    `${skillName} was uploaded to Claude Managed Agents (${managedSkillId}). The uploaded skill remains in your Anthropic workspace; manage it via the Anthropic API.`
   );
 }
 
@@ -199,7 +199,7 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     targetAgents = options.agent as AgentType[];
 
     // API-upload agents have no local files; their skills live in the user's
-    // Anthropic organization and are not deleted by this command. Say so
+    // Anthropic workspace and are not deleted by this command. Say so
     // instead of reporting a successful no-op removal.
     const apiUploadRequested = targetAgents.filter((a) => isApiUploadAgent(a));
     if (apiUploadRequested.length > 0) {

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -35,6 +35,12 @@ export interface SkillLockEntry {
   pluginName?: string;
   sourceBaseUrl?: string;
   wellKnownDigest?: string;
+  /**
+   * Anthropic Skills API id (e.g. "skill_01Ab…") recorded when this skill was
+   * uploaded to the Claude Managed Agents target. Lets `update` re-upload a
+   * new version directly instead of re-resolving the skill by display title.
+   */
+  managedSkillId?: string;
 }
 
 /**

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -38,7 +38,7 @@ export interface SkillLockEntry {
   /**
    * Anthropic Skills API id (e.g. "skill_01Ab…") recorded when this skill was
    * uploaded to the Claude Managed Agents target. Lets `update` re-upload a
-   * new version directly instead of re-resolving the skill by display title.
+   * new version directly instead of re-resolving the skill by display name.
    */
   managedSkillId?: string;
 }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -243,6 +243,13 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
       p.log.info(`Valid agents: ${validAgents.join(', ')}`);
       process.exit(1);
     }
+    const virtualRequested = options.agent.filter((a) => isVirtualAgent(a as AgentType));
+    if (virtualRequested.length > 0) {
+      p.log.error(
+        `${virtualRequested.join(', ')} is not supported by experimental_sync; use \`skills add\` to upload skills`
+      );
+      process.exit(1);
+    }
     targetAgents = options.agent as AgentType[];
   } else {
     spinner.start('Loading agents…');

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -12,7 +12,8 @@ import {
   getVisibleUniversalAgents,
   getNonUniversalAgents,
   getWildcardAgents,
-  isVirtualAgent,
+  isApiUploadAgent,
+  isFilesystemAgent,
 } from './agents.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
@@ -233,7 +234,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   const visibleUniversalAgents = getVisibleUniversalAgents();
 
   if (options.agent?.includes('*')) {
-    // Covers filesystem agents only; virtual agents need an explicit -a.
+    // Covers filesystem agents only; API-upload agents need an explicit -a.
     targetAgents = getWildcardAgents();
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
@@ -243,10 +244,10 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
       p.log.info(`Valid agents: ${validAgents.join(', ')}`);
       process.exit(1);
     }
-    const virtualRequested = options.agent.filter((a) => isVirtualAgent(a as AgentType));
-    if (virtualRequested.length > 0) {
+    const apiUploadRequested = options.agent.filter((a) => isApiUploadAgent(a as AgentType));
+    if (apiUploadRequested.length > 0) {
       p.log.error(
-        `${virtualRequested.join(', ')} is not supported by experimental_sync; use \`skills add\` to upload skills`
+        `${apiUploadRequested.join(', ')} is not supported by experimental_sync; use \`skills add\` to upload skills`
       );
       process.exit(1);
     }
@@ -262,8 +263,8 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         targetAgents = universalAgents;
         p.log.info('Installing to universal agents');
       } else {
-        // Virtual agents (API uploads) aren't sync targets.
-        const otherAgents = getNonUniversalAgents().filter((a) => !isVirtualAgent(a));
+        // API-upload agents aren't sync targets.
+        const otherAgents = getNonUniversalAgents().filter((a) => isFilesystemAgent(a));
 
         const otherChoices = otherAgents.map((a) => ({
           value: a,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -11,6 +11,8 @@ import {
   getUniversalAgents,
   getVisibleUniversalAgents,
   getNonUniversalAgents,
+  getWildcardAgents,
+  isVirtualAgent,
 } from './agents.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
@@ -231,7 +233,8 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
   const visibleUniversalAgents = getVisibleUniversalAgents();
 
   if (options.agent?.includes('*')) {
-    targetAgents = validAgents as AgentType[];
+    // Covers filesystem agents only; virtual agents need an explicit -a.
+    targetAgents = getWildcardAgents();
     p.log.info(`Installing to all ${targetAgents.length} agents`);
   } else if (options.agent && options.agent.length > 0) {
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
@@ -252,7 +255,8 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         targetAgents = universalAgents;
         p.log.info('Installing to universal agents');
       } else {
-        const otherAgents = getNonUniversalAgents();
+        // Virtual agents (API uploads) aren't sync targets.
+        const otherAgents = getNonUniversalAgents().filter((a) => !isVirtualAgent(a));
 
         const otherChoices = otherAgents.map((a) => ({
           value: a,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -13,7 +13,6 @@ import {
   getNonUniversalAgents,
   getWildcardAgents,
   isApiUploadAgent,
-  isFilesystemAgent,
 } from './agents.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
@@ -264,7 +263,7 @@ export async function runSync(args: string[], options: SyncOptions = {}): Promis
         p.log.info('Installing to universal agents');
       } else {
         // API-upload agents aren't sync targets.
-        const otherAgents = getNonUniversalAgents().filter((a) => isFilesystemAgent(a));
+        const otherAgents = getNonUniversalAgents().filter((a) => !isApiUploadAgent(a));
 
         const otherChoices = otherAgents.map((a) => ({
           value: a,

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,8 @@ export interface Skill {
   metadata?: Record<string, unknown>;
 }
 
+export type AgentInstallMethod = 'filesystem' | 'api-upload';
+
 export interface AgentConfig {
   name: string;
   displayName: string;
@@ -100,12 +102,13 @@ export interface AgentConfig {
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
   /**
-   * Virtual agents have no filesystem skills directory; skills are delivered
-   * through a dedicated integration (e.g. an API upload) instead of a copy or
-   * symlink. Virtual agents are never auto-detected, are excluded from
-   * `--agent '*'` expansion, and must be selected explicitly.
+   * How skills reach this agent. `'filesystem'` (the default) copies or
+   * symlinks into `skillsDir`. `'api-upload'` pushes the skill through a
+   * dedicated API instead: such agents have no skills directory, are never
+   * auto-detected, are excluded from `--agent '*'` expansion, and must be
+   * selected explicitly.
    */
-  virtual?: boolean;
+  install?: AgentInstallMethod;
   /** Hint shown in interactive agent selection instead of a skills directory. */
   installHint?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,8 +88,6 @@ export interface Skill {
   metadata?: Record<string, unknown>;
 }
 
-export type AgentInstallMethod = 'filesystem' | 'api-upload';
-
 export interface AgentConfig {
   name: string;
   displayName: string;
@@ -102,13 +100,12 @@ export interface AgentConfig {
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
   /**
-   * How skills reach this agent. `'filesystem'` (the default) copies or
-   * symlinks into `skillsDir`. `'api-upload'` pushes the skill through a
-   * dedicated API instead: such agents have no skills directory, are never
-   * auto-detected, are excluded from `--agent '*'` expansion, and must be
-   * selected explicitly.
+   * How skills reach this agent. By default they are copied or symlinked
+   * into `skillsDir`. `'api-upload'` pushes the skill through a dedicated API
+   * instead: such agents have no skills directory, are never auto-detected,
+   * are excluded from `--agent '*'` expansion, and must be selected explicitly.
    */
-  install?: AgentInstallMethod;
+  install?: 'api-upload';
   /** Hint shown in interactive agent selection instead of a skills directory. */
   installHint?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type AgentType =
   | 'augment'
   | 'bob'
   | 'claude-code'
+  | 'claude-managed-agents'
   | 'openclaw'
   | 'cline'
   | 'codearts-agent'
@@ -98,6 +99,15 @@ export interface AgentConfig {
   showInUniversalList?: boolean;
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
+  /**
+   * Virtual agents have no filesystem skills directory; skills are delivered
+   * through a dedicated integration (e.g. an API upload) instead of a copy or
+   * symlink. Virtual agents are never auto-detected, are excluded from
+   * `--agent '*'` expansion, and must be selected explicitly.
+   */
+  virtual?: boolean;
+  /** Hint shown in interactive agent selection instead of a skills directory. */
+  installHint?: string;
 }
 
 export interface ParsedSource {

--- a/src/update.ts
+++ b/src/update.ts
@@ -21,7 +21,7 @@ import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/inde
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
-import { agents, isUniversalAgent, isVirtualAgent } from './agents.ts';
+import { agents, isUniversalAgent, isApiUploadAgent } from './agents.ts';
 import { isSkillInstalled } from './installer.ts';
 import type { AgentType } from './types.ts';
 
@@ -56,7 +56,7 @@ export interface UpdateCheckOptions {
  * recorded in the lock as `managedSkillId`. A skill that also exists on the
  * filesystem gets the additive `--managed-agents` flag on top of the child's
  * normal agent detection; an upload-only skill (no filesystem install)
- * targets the virtual agent directly so the refresh doesn't materialize
+ * targets the API-upload agent directly so the refresh doesn't materialize
  * local copies the user never asked for.
  */
 export async function buildManagedAgentsArgs(
@@ -66,7 +66,7 @@ export async function buildManagedAgentsArgs(
 ): Promise<string[]> {
   if (!entry.managedSkillId) return [];
   for (const type of Object.keys(agents) as AgentType[]) {
-    if (isVirtualAgent(type)) continue;
+    if (isApiUploadAgent(type)) continue;
     if (await isSkillInstalled(skillName, type, { global: isGlobal })) {
       return ['--managed-agents'];
     }
@@ -82,7 +82,7 @@ export async function buildManagedAgentsArgs(
       return ['--managed-agents'];
     }
   }
-  // Upload-only: name the virtual agent so the refresh doesn't materialize
+  // Upload-only: name the API-upload agent so the refresh doesn't materialize
   // local copies, and keep --managed-agents so a missing login makes the
   // child skip the upload instead of aborting the whole update run.
   return ['--agent', 'claude-managed-agents', '--managed-agents'];

--- a/src/update.ts
+++ b/src/update.ts
@@ -60,7 +60,7 @@ export interface UpdateCheckOptions {
  * local copies the user never asked for.
  */
 export async function buildManagedAgentsArgs(
-  entry: { managedSkillId?: string },
+  entry: { managedSkillId?: string; subagents?: string[] },
   skillName: string,
   isGlobal: boolean
 ): Promise<string[]> {
@@ -71,7 +71,21 @@ export async function buildManagedAgentsArgs(
       return ['--managed-agents'];
     }
   }
-  return ['--agent', 'claude-managed-agents'];
+  // Eve installs into per-subagent directories the generic check misses.
+  for (const subagent of entry.subagents ?? []) {
+    if (
+      await isSkillInstalled(skillName, 'eve', {
+        global: isGlobal,
+        ...(subagent && { eveSubagent: subagent }),
+      })
+    ) {
+      return ['--managed-agents'];
+    }
+  }
+  // Upload-only: name the virtual agent so the refresh doesn't materialize
+  // local copies, and keep --managed-agents so a missing login makes the
+  // child skip the upload instead of aborting the whole update run.
+  return ['--agent', 'claude-managed-agents', '--managed-agents'];
 }
 
 function getUpdateChildEnv(sourceType: string): NodeJS.ProcessEnv | undefined {

--- a/src/update.ts
+++ b/src/update.ts
@@ -21,7 +21,8 @@ import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/inde
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
-import { agents, isUniversalAgent } from './agents.ts';
+import { agents, isUniversalAgent, isVirtualAgent } from './agents.ts';
+import { isSkillInstalled } from './installer.ts';
 import type { AgentType } from './types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -50,6 +51,29 @@ export interface UpdateCheckOptions {
  * skill subpath. Pin that shorthand to github.com so an ambient GH_HOST for a
  * GitHub Enterprise account cannot redirect an existing public installation.
  */
+/**
+ * Extra `add` flags that refresh a skill's Claude Managed Agents upload,
+ * recorded in the lock as `managedSkillId`. A skill that also exists on the
+ * filesystem gets the additive `--managed-agents` flag on top of the child's
+ * normal agent detection; an upload-only skill (no filesystem install)
+ * targets the virtual agent directly so the refresh doesn't materialize
+ * local copies the user never asked for.
+ */
+export async function buildManagedAgentsArgs(
+  entry: { managedSkillId?: string },
+  skillName: string,
+  isGlobal: boolean
+): Promise<string[]> {
+  if (!entry.managedSkillId) return [];
+  for (const type of Object.keys(agents) as AgentType[]) {
+    if (isVirtualAgent(type)) continue;
+    if (await isSkillInstalled(skillName, type, { global: isGlobal })) {
+      return ['--managed-agents'];
+    }
+  }
+  return ['--agent', 'claude-managed-agents'];
+}
+
 function getUpdateChildEnv(sourceType: string): NodeJS.ProcessEnv | undefined {
   if (sourceType !== 'github') {
     return undefined;
@@ -310,6 +334,8 @@ export interface WellKnownUpdateItem {
   name: string;
   digest: string;
   subagents?: string[];
+  /** Skills API id when this skill was uploaded to Claude Managed Agents. */
+  managedSkillId?: string;
 }
 
 export type WellKnownCheckResult =
@@ -437,11 +463,13 @@ export async function processWellKnownUpdates(
       const safeName = sanitizeMetadata(name);
       console.log(`${TEXT}Updating ${safeName}…${RESET}`);
 
-      const subagents = itemByName.get(name)?.subagents;
+      const item = itemByName.get(name);
+      const subagents = item?.subagents;
       const subagentArgs =
         !isGlobal && subagents?.length
           ? ['--subagent', ...subagents.map((s) => (s === '' ? 'root' : s))]
           : [];
+      const managedArgs = await buildManagedAgentsArgs(item ?? {}, name, isGlobal);
 
       const spawnResult = spawnSync(
         process.execPath,
@@ -452,6 +480,7 @@ export async function processWellKnownUpdates(
           '--skill',
           name,
           ...subagentArgs,
+          ...managedArgs,
           ...(isGlobal ? ['-g'] : []),
           '-y',
         ],
@@ -504,7 +533,11 @@ export async function updateGlobalSkills(
 
     if (entry.sourceType === 'well-known' && entry.sourceBaseUrl && entry.wellKnownDigest) {
       const group = wellKnownGroups.get(entry.sourceBaseUrl) || [];
-      group.push({ name: skillName, digest: entry.wellKnownDigest });
+      group.push({
+        name: skillName,
+        digest: entry.wellKnownDigest,
+        managedSkillId: entry.managedSkillId,
+      });
       wellKnownGroups.set(entry.sourceBaseUrl, group);
       continue;
     }
@@ -690,9 +723,20 @@ export async function updateGlobalSkills(
       continue;
     }
     const fullDepthArgs = shouldUseFullDepthForUpdate(update.entry) ? ['--full-depth'] : [];
+    const managedArgs = await buildManagedAgentsArgs(update.entry, update.name, true);
     const result = spawnSync(
       process.execPath,
-      [cliEntry, 'add', installUrl, '--skill', update.name, ...fullDepthArgs, '-g', '-y'],
+      [
+        cliEntry,
+        'add',
+        installUrl,
+        '--skill',
+        update.name,
+        ...fullDepthArgs,
+        ...managedArgs,
+        '-g',
+        '-y',
+      ],
       {
         stdio: ['inherit', 'pipe', 'pipe'],
         encoding: 'utf-8',
@@ -746,6 +790,7 @@ export async function updateProjectSkills(
         name: skill.name,
         digest: entry.wellKnownDigest,
         subagents: entry.subagents,
+        managedSkillId: entry.managedSkillId,
       });
       wellKnownGroups.set(entry.sourceUrl, group);
     } else {
@@ -887,6 +932,7 @@ export async function updateProjectSkills(
         ? ['--subagent', ...skill.entry.subagents.map((s) => (s === '' ? 'root' : s))]
         : [];
       const fullDepthArgs = shouldUseFullDepthForUpdate(skill.entry) ? ['--full-depth'] : [];
+      const managedArgs = await buildManagedAgentsArgs(skill.entry, skill.name, false);
 
       const result = spawnSync(
         process.execPath,
@@ -898,6 +944,7 @@ export async function updateProjectSkills(
           skill.name,
           ...subagentArgs,
           ...fullDepthArgs,
+          ...managedArgs,
           '-y',
         ],
         {

--- a/src/update.ts
+++ b/src/update.ts
@@ -21,7 +21,7 @@ import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/inde
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
-import { agents, isUniversalAgent, isApiUploadAgent } from './agents.ts';
+import { agents, isUniversalAgent, getWildcardAgents } from './agents.ts';
 import { isSkillInstalled } from './installer.ts';
 import type { AgentType } from './types.ts';
 
@@ -51,13 +51,21 @@ export interface UpdateCheckOptions {
  * skill subpath. Pin that shorthand to github.com so an ambient GH_HOST for a
  * GitHub Enterprise account cannot redirect an existing public installation.
  */
+function getUpdateChildEnv(sourceType: string): NodeJS.ProcessEnv | undefined {
+  if (sourceType !== 'github') {
+    return undefined;
+  }
+  return { ...process.env, GH_HOST: 'github.com' };
+}
+
 /**
  * Extra `add` flags that refresh a skill's Claude Managed Agents upload,
  * recorded in the lock as `managedSkillId`. A skill that also exists on the
  * filesystem gets the additive `--managed-agents` flag on top of the child's
- * normal agent detection; an upload-only skill (no filesystem install)
- * targets the API-upload agent directly so the refresh doesn't materialize
- * local copies the user never asked for.
+ * normal agent detection; an upload-only skill targets the API-upload agent
+ * directly so the refresh doesn't materialize local copies the user never
+ * asked for, keeping `--managed-agents` so a missing login makes the child
+ * skip the upload instead of aborting the whole update run.
  */
 export async function buildManagedAgentsArgs(
   entry: { managedSkillId?: string; subagents?: string[] },
@@ -65,34 +73,17 @@ export async function buildManagedAgentsArgs(
   isGlobal: boolean
 ): Promise<string[]> {
   if (!entry.managedSkillId) return [];
-  for (const type of Object.keys(agents) as AgentType[]) {
-    if (isApiUploadAgent(type)) continue;
-    if (await isSkillInstalled(skillName, type, { global: isGlobal })) {
-      return ['--managed-agents'];
-    }
-  }
   // Eve installs into per-subagent directories the generic check misses.
-  for (const subagent of entry.subagents ?? []) {
-    if (
-      await isSkillInstalled(skillName, 'eve', {
-        global: isGlobal,
-        ...(subagent && { eveSubagent: subagent }),
-      })
-    ) {
+  const placements: Array<[AgentType, string?]> = [
+    ...getWildcardAgents().map((type): [AgentType] => [type]),
+    ...(entry.subagents ?? []).map((subagent): [AgentType, string] => ['eve', subagent]),
+  ];
+  for (const [type, eveSubagent] of placements) {
+    if (await isSkillInstalled(skillName, type, { global: isGlobal, eveSubagent })) {
       return ['--managed-agents'];
     }
   }
-  // Upload-only: name the API-upload agent so the refresh doesn't materialize
-  // local copies, and keep --managed-agents so a missing login makes the
-  // child skip the upload instead of aborting the whole update run.
   return ['--agent', 'claude-managed-agents', '--managed-agents'];
-}
-
-function getUpdateChildEnv(sourceType: string): NodeJS.ProcessEnv | undefined {
-  if (sourceType !== 'github') {
-    return undefined;
-  }
-  return { ...process.env, GH_HOST: 'github.com' };
 }
 
 export function parseUpdateOptions(args: string[]): UpdateCheckOptions {

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -21,7 +21,7 @@ import {
   ManagedAgentsApiError,
   type AnthropicAuth,
 } from '../src/managed-agents.ts';
-import { agents, getWildcardAgents, isVirtualAgent } from '../src/agents.ts';
+import { agents, getWildcardAgents, isApiUploadAgent } from '../src/agents.ts';
 import { parseAddOptions, buildManagedLockBookkeeping } from '../src/add.ts';
 import { buildManagedAgentsArgs } from '../src/update.ts';
 
@@ -39,9 +39,9 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe('claude-managed-agents agent registry entry', () => {
-  it('is registered as a virtual agent', () => {
+  it('is registered as an api-upload agent', () => {
     expect(agents['claude-managed-agents']).toBeDefined();
-    expect(isVirtualAgent('claude-managed-agents')).toBe(true);
+    expect(isApiUploadAgent('claude-managed-agents')).toBe(true);
   });
 
   it('is never auto-detected', async () => {
@@ -460,7 +460,7 @@ describe('buildManagedAgentsArgs', () => {
     expect(await buildManagedAgentsArgs({}, 'my-skill', false)).toEqual([]);
   });
 
-  it('targets the virtual agent (softly) for upload-only skills', async () => {
+  it('targets the API-upload agent (softly) for upload-only skills', async () => {
     expect(
       await buildManagedAgentsArgs({ managedSkillId: 'skill_01A' }, 'my-skill', false)
     ).toEqual(['--agent', 'claude-managed-agents', '--managed-agents']);

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -201,6 +201,21 @@ describe('collectSkillFiles', () => {
 describe('uploadSkillToManagedAgents', () => {
   const fetchMock = vi.fn<typeof fetch>();
 
+  const EMPTY_LIST = () => jsonResponse(200, { data: [], next_page: null });
+  const skillJson = (id: string, displayName: string) => ({
+    type: 'skill',
+    id,
+    display_name: displayName,
+    latest_version_id: `skver_${id}`,
+    source: { type: 'custom' },
+  });
+  const versionJson = (skillId: string, versionId: string) => ({
+    type: 'skill_version',
+    id: versionId,
+    skill_id: skillId,
+    name: 'my-skill',
+  });
+
   beforeEach(() => {
     fetchMock.mockReset();
     vi.stubGlobal('fetch', fetchMock);
@@ -222,24 +237,24 @@ describe('uploadSkillToManagedAgents', () => {
   });
 
   it('normalizes a lowercase skill.md from case-insensitive filesystems', async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { id: 'skill_01A', display_title: 'my-skill', latest_version: '1' })
-    );
+    fetchMock
+      .mockResolvedValueOnce(EMPTY_LIST())
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_01A', 'my-skill')));
 
     await uploadSkillToManagedAgents(
       { name: 'my-skill', files: [{ path: 'skill.md', content: '# hi' }] },
       API_KEY_AUTH
     );
 
-    const form = fetchMock.mock.calls[0]![1]?.body as FormData;
+    const form = fetchMock.mock.calls[1]![1]?.body as FormData;
     const files = form.getAll('files[]') as File[];
     expect(files.map((f) => f.name)).toEqual(['my-skill/SKILL.md']);
   });
 
   it('creates a skill with a multipart form of dir-prefixed files', async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { id: 'skill_01A', display_title: 'My Skill', latest_version: '123' })
-    );
+    fetchMock
+      .mockResolvedValueOnce(EMPTY_LIST())
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_01A', 'My Skill')));
 
     const result = await uploadSkillToManagedAgents(
       {
@@ -252,20 +267,32 @@ describe('uploadSkillToManagedAgents', () => {
       API_KEY_AUTH
     );
 
-    expect(result).toEqual({ skillId: 'skill_01A', version: '123', action: 'created' });
+    expect(result).toEqual({
+      skillId: 'skill_01A',
+      versionId: 'skver_skill_01A',
+      action: 'created',
+    });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0]!;
-    expect(String(url)).toBe('https://api.anthropic.com/v1/skills?beta=true');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // No recorded id: look the skill up by display name first...
+    const [listUrl, listInit] = fetchMock.mock.calls[0]!;
+    expect(String(listUrl)).toBe('https://api.anthropic.com/v1/skills?source=custom&limit=100');
+    expect(listInit?.method ?? 'GET').toBe('GET');
+
+    // ...then create it, since nothing matched.
+    const [url, init] = fetchMock.mock.calls[1]!;
+    expect(String(url)).toBe('https://api.anthropic.com/v1/skills');
     expect(init?.method).toBe('POST');
 
     const headers = init?.headers as Record<string, string>;
     expect(headers['x-api-key']).toBe('sk-ant-test');
     expect(headers['anthropic-version']).toBe('2023-06-01');
-    expect(headers['anthropic-beta']).toBe('skills-2025-10-02');
+    // The Skills API is GA: no beta header unless the credential needs one.
+    expect(headers['anthropic-beta']).toBeUndefined();
 
     const form = init?.body as FormData;
-    expect(form.get('display_title')).toBe('My Skill');
+    expect(form.get('display_name')).toBe('My Skill');
     const files = form.getAll('files[]') as File[];
     // Directory name is the sanitized skill name
     expect(files.map((f) => f.name).sort()).toEqual([
@@ -274,10 +301,10 @@ describe('uploadSkillToManagedAgents', () => {
     ]);
   });
 
-  it('appends the skills beta to auth-required betas', async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { id: 'skill_01A', display_title: null, latest_version: '1' })
-    );
+  it('sends the betas the credential requires', async () => {
+    fetchMock
+      .mockResolvedValueOnce(EMPTY_LIST())
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_01A', 'my-skill')));
 
     await uploadSkillToManagedAgents(
       { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
@@ -288,50 +315,77 @@ describe('uploadSkillToManagedAgents', () => {
       }
     );
 
-    const headers = fetchMock.mock.calls[0]![1]?.headers as Record<string, string>;
-    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20,skills-2025-10-02');
+    for (const [, init] of fetchMock.mock.calls) {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    }
   });
 
-  it('uploads a new version when the display title already exists', async () => {
+  it('uploads a new version when a skill with the display name already exists', async () => {
     fetchMock
       .mockResolvedValueOnce(
-        jsonResponse(400, {
-          type: 'error',
-          error: {
-            type: 'invalid_request_error',
-            message: 'Skill cannot reuse an existing display_title: My Skill',
-          },
-        })
+        jsonResponse(200, { data: [skillJson('skill_00Z', 'Other')], next_page: 'page_2' })
       )
       .mockResolvedValueOnce(
         jsonResponse(200, {
-          data: [
-            { id: 'skill_00Z', display_title: 'Other', latest_version: '1' },
-            { id: 'skill_01A', display_title: 'My Skill', latest_version: '1' },
-          ],
-          has_more: false,
-          last_id: 'skill_01A',
+          data: [skillJson('skill_01A', 'My Skill'), skillJson('skill_00Y', 'My Skill')],
+          next_page: null,
         })
       )
-      .mockResolvedValueOnce(jsonResponse(200, { skill_id: 'skill_01A', version: '456' }));
+      .mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_456')));
 
     const result = await uploadSkillToManagedAgents(
       { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] },
       API_KEY_AUTH
     );
 
-    expect(result).toEqual({ skillId: 'skill_01A', version: '456', action: 'updated' });
+    // The newest (first-listed) match wins.
+    expect(result).toEqual({ skillId: 'skill_01A', versionId: 'skver_456', action: 'updated' });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    const listUrl = String(fetchMock.mock.calls[1]![0]);
-    expect(listUrl).toContain('/v1/skills?');
-    expect(listUrl).toContain('source=custom');
-    const versionUrl = String(fetchMock.mock.calls[2]![0]);
-    expect(versionUrl).toBe('https://api.anthropic.com/v1/skills/skill_01A/versions?beta=true');
+    expect(String(fetchMock.mock.calls[1]![0])).toBe(
+      'https://api.anthropic.com/v1/skills?source=custom&limit=100&page=page_2'
+    );
+    const [versionUrl, versionInit] = fetchMock.mock.calls[2]!;
+    expect(String(versionUrl)).toBe('https://api.anthropic.com/v1/skills/skill_01A/versions');
+    expect(versionInit?.method).toBe('POST');
 
-    // Version uploads carry no display_title
-    const versionForm = fetchMock.mock.calls[2]![1]?.body as FormData;
-    expect(versionForm.get('display_title')).toBeNull();
+    // Version uploads carry no display_name
+    const versionForm = versionInit?.body as FormData;
+    expect(versionForm.get('display_name')).toBeNull();
+  });
+
+  it('creates a new skill when the display-name match rejects the upload (400)', async () => {
+    // e.g. an unrelated skill that shares the display name but has a
+    // different `name` slug in its SKILL.md.
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { data: [skillJson('skill_00Y', 'My Skill')], next_page: null })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(400, {
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: "Skill name 'my-skill' in SKILL.md must be consistent across all versions",
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'My Skill')));
+
+    const result = await uploadSkillToManagedAgents(
+      { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      API_KEY_AUTH
+    );
+
+    expect(result).toEqual({
+      skillId: 'skill_02B',
+      versionId: 'skver_skill_02B',
+      action: 'created',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(String(fetchMock.mock.calls[2]![0])).toBe('https://api.anthropic.com/v1/skills');
+    expect(fetchMock.mock.calls[2]![1]?.method).toBe('POST');
   });
 
   it('throws a ManagedAgentsApiError on other API failures', async () => {
@@ -348,13 +402,14 @@ describe('uploadSkillToManagedAgents', () => {
         API_KEY_AUTH
       )
     ).rejects.toThrow(ManagedAgentsApiError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('honors ANTHROPIC_BASE_URL', async () => {
     vi.stubEnv('ANTHROPIC_BASE_URL', 'https://api.staging.example/');
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { id: 'skill_01A', display_title: null, latest_version: '1' })
-    );
+    fetchMock
+      .mockResolvedValueOnce(EMPTY_LIST())
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_01A', 'my-skill')));
 
     await uploadSkillToManagedAgents(
       { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
@@ -362,65 +417,89 @@ describe('uploadSkillToManagedAgents', () => {
     );
 
     expect(String(fetchMock.mock.calls[0]![0])).toBe(
-      'https://api.staging.example/v1/skills?beta=true'
+      'https://api.staging.example/v1/skills?source=custom&limit=100'
     );
+    expect(String(fetchMock.mock.calls[1]![0])).toBe('https://api.staging.example/v1/skills');
   });
 
   // With a known skill id (recorded in the lock by a previous upload).
   const SKILL = { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] };
 
   it('uploads a new version directly to the known skill', async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, { skill_id: 'skill_01A', version: '789' }));
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_789')));
 
     const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_01A');
 
-    expect(result).toEqual({ skillId: 'skill_01A', version: '789', action: 'updated' });
+    expect(result).toEqual({ skillId: 'skill_01A', versionId: 'skver_789', action: 'updated' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]![0])).toBe(
-      'https://api.anthropic.com/v1/skills/skill_01A/versions?beta=true'
+      'https://api.anthropic.com/v1/skills/skill_01A/versions'
     );
-    // Version uploads carry no display_title
+    // Version uploads carry no display_name
     const form = fetchMock.mock.calls[0]![1]?.body as FormData;
-    expect(form.get('display_title')).toBeNull();
+    expect(form.get('display_name')).toBeNull();
   });
 
-  it('falls back to the create flow when the known id is gone', async () => {
+  it('falls back to lookup-then-create when the known id is gone (404)', async () => {
     fetchMock
       .mockResolvedValueOnce(
         jsonResponse(404, {
           type: 'error',
-          error: { type: 'not_found_error', message: 'skill not found' },
+          error: { type: 'not_found_error', message: 'Skill not found: skill_gone' },
         })
       )
-      .mockResolvedValueOnce(
-        jsonResponse(200, { id: 'skill_02B', display_title: 'My Skill', latest_version: '1' })
-      );
+      .mockResolvedValueOnce(EMPTY_LIST())
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'My Skill')));
 
     const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_gone');
 
-    expect(result).toEqual({ skillId: 'skill_02B', version: '1', action: 'created' });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(String(fetchMock.mock.calls[1]![0])).toBe(
-      'https://api.anthropic.com/v1/skills?beta=true'
-    );
+    expect(result).toEqual({
+      skillId: 'skill_02B',
+      versionId: 'skver_skill_02B',
+      action: 'created',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(String(fetchMock.mock.calls[2]![0])).toBe('https://api.anthropic.com/v1/skills');
   });
 
-  it('falls back to the create flow when the known id is malformed (400)', async () => {
+  it('falls back when the known id is malformed (400)', async () => {
     fetchMock
       .mockResolvedValueOnce(
         jsonResponse(400, {
           type: 'error',
-          error: { type: 'invalid_request_error', message: 'invalid skill id' },
+          error: { type: 'invalid_request_error', message: 'Invalid skill_id format: nope' },
         })
       )
       .mockResolvedValueOnce(
-        jsonResponse(200, { id: 'skill_02B', display_title: 'My Skill', latest_version: '1' })
-      );
+        jsonResponse(200, { data: [skillJson('skill_01A', 'My Skill')], next_page: null })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_9')));
 
-    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'not-a-skill-id');
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'nope');
 
-    expect(result).toEqual({ skillId: 'skill_02B', version: '1', action: 'created' });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The display-name match self-heals the lock's stale id.
+    expect(result).toEqual({ skillId: 'skill_01A', versionId: 'skver_9', action: 'updated' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not re-try the known id when the display-name lookup returns it', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(400, {
+          type: 'error',
+          error: { type: 'invalid_request_error', message: 'must be consistent' },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { data: [skillJson('skill_01A', 'My Skill')], next_page: null })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'My Skill')));
+
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_01A');
+
+    expect(result.action).toBe('created');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(String(fetchMock.mock.calls[2]![0])).toBe('https://api.anthropic.com/v1/skills');
   });
 
   it('propagates non-recoverable errors from the fast path without falling back', async () => {

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -18,6 +18,7 @@ import {
   resolveAnthropicAuth,
   collectSkillFiles,
   uploadSkillToManagedAgents,
+  createManagedSkillLookup,
   ManagedAgentsApiError,
   type AnthropicAuth,
 } from '../src/managed-agents.ts';
@@ -267,17 +268,13 @@ describe('uploadSkillToManagedAgents', () => {
       API_KEY_AUTH
     );
 
-    expect(result).toEqual({
-      skillId: 'skill_01A',
-      versionId: 'skver_skill_01A',
-      action: 'created',
-    });
+    expect(result).toEqual({ skillId: 'skill_01A', action: 'created' });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // No recorded id: look the skill up by display name first...
     const [listUrl, listInit] = fetchMock.mock.calls[0]!;
-    expect(String(listUrl)).toBe('https://api.anthropic.com/v1/skills?source=custom&limit=100');
+    expect(String(listUrl)).toBe('https://api.anthropic.com/v1/skills?source=custom&limit=1000');
     expect(listInit?.method ?? 'GET').toBe('GET');
 
     // ...then create it, since nothing matched.
@@ -340,11 +337,11 @@ describe('uploadSkillToManagedAgents', () => {
     );
 
     // The newest (first-listed) match wins.
-    expect(result).toEqual({ skillId: 'skill_01A', versionId: 'skver_456', action: 'updated' });
+    expect(result).toEqual({ skillId: 'skill_01A', action: 'updated' });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(String(fetchMock.mock.calls[1]![0])).toBe(
-      'https://api.anthropic.com/v1/skills?source=custom&limit=100&page=page_2'
+      'https://api.anthropic.com/v1/skills?source=custom&limit=1000&page=page_2'
     );
     const [versionUrl, versionInit] = fetchMock.mock.calls[2]!;
     expect(String(versionUrl)).toBe('https://api.anthropic.com/v1/skills/skill_01A/versions');
@@ -378,11 +375,7 @@ describe('uploadSkillToManagedAgents', () => {
       API_KEY_AUTH
     );
 
-    expect(result).toEqual({
-      skillId: 'skill_02B',
-      versionId: 'skver_skill_02B',
-      action: 'created',
-    });
+    expect(result).toEqual({ skillId: 'skill_02B', action: 'created' });
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(String(fetchMock.mock.calls[2]![0])).toBe('https://api.anthropic.com/v1/skills');
     expect(fetchMock.mock.calls[2]![1]?.method).toBe('POST');
@@ -417,7 +410,7 @@ describe('uploadSkillToManagedAgents', () => {
     );
 
     expect(String(fetchMock.mock.calls[0]![0])).toBe(
-      'https://api.staging.example/v1/skills?source=custom&limit=100'
+      'https://api.staging.example/v1/skills?source=custom&limit=1000'
     );
     expect(String(fetchMock.mock.calls[1]![0])).toBe('https://api.staging.example/v1/skills');
   });
@@ -428,9 +421,11 @@ describe('uploadSkillToManagedAgents', () => {
   it('uploads a new version directly to the known skill', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_789')));
 
-    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_01A');
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, {
+      knownSkillId: 'skill_01A',
+    });
 
-    expect(result).toEqual({ skillId: 'skill_01A', versionId: 'skver_789', action: 'updated' });
+    expect(result).toEqual({ skillId: 'skill_01A', action: 'updated' });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]![0])).toBe(
       'https://api.anthropic.com/v1/skills/skill_01A/versions'
@@ -451,13 +446,11 @@ describe('uploadSkillToManagedAgents', () => {
       .mockResolvedValueOnce(EMPTY_LIST())
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'My Skill')));
 
-    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_gone');
-
-    expect(result).toEqual({
-      skillId: 'skill_02B',
-      versionId: 'skver_skill_02B',
-      action: 'created',
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, {
+      knownSkillId: 'skill_gone',
     });
+
+    expect(result).toEqual({ skillId: 'skill_02B', action: 'created' });
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(String(fetchMock.mock.calls[2]![0])).toBe('https://api.anthropic.com/v1/skills');
   });
@@ -475,10 +468,10 @@ describe('uploadSkillToManagedAgents', () => {
       )
       .mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_9')));
 
-    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'nope');
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, { knownSkillId: 'nope' });
 
     // The display-name match self-heals the lock's stale id.
-    expect(result).toEqual({ skillId: 'skill_01A', versionId: 'skver_9', action: 'updated' });
+    expect(result).toEqual({ skillId: 'skill_01A', action: 'updated' });
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
@@ -495,11 +488,37 @@ describe('uploadSkillToManagedAgents', () => {
       )
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'My Skill')));
 
-    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_01A');
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, {
+      knownSkillId: 'skill_01A',
+    });
 
     expect(result.action).toBe('created');
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(String(fetchMock.mock.calls[2]![0])).toBe('https://api.anthropic.com/v1/skills');
+  });
+
+  it('lists the workspace once per shared lookup, not once per skill', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, { data: [skillJson('skill_01A', 'alpha')], next_page: null })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_2')))
+      .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'beta')));
+
+    const lookup = createManagedSkillLookup(API_KEY_AUTH);
+    const file = [{ path: 'SKILL.md', content: '#' }];
+    const a = await uploadSkillToManagedAgents({ name: 'alpha', files: file }, API_KEY_AUTH, {
+      lookup,
+    });
+    const b = await uploadSkillToManagedAgents({ name: 'beta', files: file }, API_KEY_AUTH, {
+      lookup,
+    });
+
+    expect(a).toEqual({ skillId: 'skill_01A', action: 'updated' });
+    expect(b).toEqual({ skillId: 'skill_02B', action: 'created' });
+    const listCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('/v1/skills?'));
+    expect(listCalls).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it('propagates non-recoverable errors from the fast path without falling back', async () => {
@@ -510,9 +529,9 @@ describe('uploadSkillToManagedAgents', () => {
       })
     );
 
-    await expect(uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_01A')).rejects.toThrow(
-      ManagedAgentsApiError
-    );
+    await expect(
+      uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, { knownSkillId: 'skill_01A' })
+    ).rejects.toThrow(ManagedAgentsApiError);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -22,7 +22,7 @@ import {
   type AnthropicAuth,
 } from '../src/managed-agents.ts';
 import { agents, getWildcardAgents, isVirtualAgent } from '../src/agents.ts';
-import { parseAddOptions } from '../src/add.ts';
+import { parseAddOptions, buildManagedLockBookkeeping } from '../src/add.ts';
 import { buildManagedAgentsArgs } from '../src/update.ts';
 
 const API_KEY_AUTH: AnthropicAuth = {
@@ -195,6 +195,21 @@ describe('uploadSkillToManagedAgents', () => {
       )
     ).rejects.toThrow('missing a SKILL.md');
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a lowercase skill.md from case-insensitive filesystems', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { id: 'skill_01A', display_title: 'my-skill', latest_version: '1' })
+    );
+
+    await uploadSkillToManagedAgents(
+      { name: 'my-skill', files: [{ path: 'skill.md', content: '# hi' }] },
+      API_KEY_AUTH
+    );
+
+    const form = fetchMock.mock.calls[0]![1]?.body as FormData;
+    const files = form.getAll('files[]') as File[];
+    expect(files.map((f) => f.name)).toEqual(['my-skill/SKILL.md']);
   });
 
   it('creates a skill with a multipart form of dir-prefixed files', async () => {
@@ -445,10 +460,10 @@ describe('buildManagedAgentsArgs', () => {
     expect(await buildManagedAgentsArgs({}, 'my-skill', false)).toEqual([]);
   });
 
-  it('targets the virtual agent directly for upload-only skills', async () => {
+  it('targets the virtual agent (softly) for upload-only skills', async () => {
     expect(
       await buildManagedAgentsArgs({ managedSkillId: 'skill_01A' }, 'my-skill', false)
-    ).toEqual(['--agent', 'claude-managed-agents']);
+    ).toEqual(['--agent', 'claude-managed-agents', '--managed-agents']);
   });
 
   it('uses the additive flag when the skill is also installed on the filesystem', async () => {
@@ -457,5 +472,87 @@ describe('buildManagedAgentsArgs', () => {
     expect(
       await buildManagedAgentsArgs({ managedSkillId: 'skill_01A' }, 'my-skill', false)
     ).toEqual(['--managed-agents']);
+  });
+
+  it('recognizes Eve subagent installs as filesystem installs', async () => {
+    await mkdir(join(dir, 'agent', 'subagents', 'researcher', 'skills', 'my-skill'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(dir, 'agent', 'subagents', 'researcher', 'skills', 'my-skill', 'SKILL.md'),
+      '# my-skill'
+    );
+    expect(
+      await buildManagedAgentsArgs(
+        { managedSkillId: 'skill_01A', subagents: ['researcher'] },
+        'my-skill',
+        false
+      )
+    ).toEqual(['--managed-agents']);
+  });
+});
+
+describe('buildManagedLockBookkeeping', () => {
+  const KNOWN = new Map([['my-skill', { managedSkillId: 'skill_OLD', source: 'owner/repo-a' }]]);
+
+  it('prefers a fresh upload id and falls back to a same-source recorded id', () => {
+    const { managedIdFor } = buildManagedLockBookkeeping({
+      uploadOutcomes: [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
+      knownManagedIds: KNOWN,
+      sourceKey: 'owner/repo-a',
+      uploadRequested: true,
+      fsRequested: true,
+    });
+    expect(managedIdFor('my-skill')).toBe('skill_NEW');
+
+    const { managedIdFor: preserved } = buildManagedLockBookkeeping({
+      uploadOutcomes: [],
+      knownManagedIds: KNOWN,
+      sourceKey: 'owner/repo-a',
+      uploadRequested: false,
+      fsRequested: true,
+    });
+    expect(preserved('my-skill')).toBe('skill_OLD');
+  });
+
+  it('never inherits an id recorded for a different source', () => {
+    const { managedIdFor } = buildManagedLockBookkeeping({
+      uploadOutcomes: [],
+      knownManagedIds: KNOWN,
+      sourceKey: 'owner/repo-b',
+      uploadRequested: false,
+      fsRequested: true,
+    });
+    expect(managedIdFor('my-skill')).toBeUndefined();
+  });
+
+  it('marks a skill incomplete when a requested part did not succeed', () => {
+    const { isComplete } = buildManagedLockBookkeeping({
+      uploadOutcomes: [],
+      knownManagedIds: new Map(),
+      sourceKey: 'owner/repo-a',
+      uploadRequested: true, // requested (or credential-skipped) but no success
+      fsRequested: true,
+    });
+    expect(isComplete('my-skill', true)).toBe(false);
+
+    const { isComplete: fsOnly } = buildManagedLockBookkeeping({
+      uploadOutcomes: [],
+      knownManagedIds: new Map(),
+      sourceKey: 'owner/repo-a',
+      uploadRequested: false,
+      fsRequested: true,
+    });
+    expect(fsOnly('my-skill', true)).toBe(true);
+    expect(fsOnly('my-skill', false)).toBe(false);
+
+    const { isComplete: uploadOk } = buildManagedLockBookkeeping({
+      uploadOutcomes: [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
+      knownManagedIds: new Map(),
+      sourceKey: 'owner/repo-a',
+      uploadRequested: true,
+      fsRequested: false,
+    });
+    expect(uploadOk('my-skill', false)).toBe(true);
   });
 });

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(() => {
+      throw new Error('ant not installed');
+    }),
+  };
+});
+
+import { execFileSync } from 'child_process';
+import {
+  resolveAnthropicAuth,
+  collectSkillFiles,
+  uploadSkillToManagedAgents,
+  ManagedAgentsApiError,
+  type AnthropicAuth,
+} from '../src/managed-agents.ts';
+import { agents, getWildcardAgents, isVirtualAgent } from '../src/agents.ts';
+
+const API_KEY_AUTH: AnthropicAuth = {
+  headers: { 'x-api-key': 'sk-ant-test' },
+  betas: [],
+  source: 'ANTHROPIC_API_KEY',
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('claude-managed-agents agent registry entry', () => {
+  it('is registered as a virtual agent', () => {
+    expect(agents['claude-managed-agents']).toBeDefined();
+    expect(isVirtualAgent('claude-managed-agents')).toBe(true);
+  });
+
+  it('is never auto-detected', async () => {
+    expect(await agents['claude-managed-agents'].detectInstalled()).toBe(false);
+  });
+
+  it('is excluded from wildcard agent expansion', () => {
+    const wildcard = getWildcardAgents();
+    expect(wildcard).not.toContain('claude-managed-agents');
+    expect(wildcard).toContain('claude-code');
+  });
+});
+
+describe('resolveAnthropicAuth', () => {
+  beforeEach(() => {
+    vi.stubEnv('ANTHROPIC_API_KEY', '');
+    vi.stubEnv('ANTHROPIC_AUTH_TOKEN', '');
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', '/nonexistent-config-dir');
+    vi.stubEnv('ANTHROPIC_PROFILE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('ant not installed');
+    });
+  });
+
+  it('prefers ANTHROPIC_API_KEY and maps it to x-api-key', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-abc');
+    const auth = await resolveAnthropicAuth();
+    expect(auth).toEqual({
+      headers: { 'x-api-key': 'sk-ant-abc' },
+      betas: [],
+      source: 'ANTHROPIC_API_KEY',
+    });
+  });
+
+  it('uses ANTHROPIC_AUTH_TOKEN as a bearer token', async () => {
+    vi.stubEnv('ANTHROPIC_AUTH_TOKEN', 'tok-123');
+    const auth = await resolveAnthropicAuth();
+    expect(auth?.headers.Authorization).toBe('Bearer tok-123');
+    expect(auth?.source).toBe('ANTHROPIC_AUTH_TOKEN');
+  });
+
+  it('uses the ant CLI credentials when available', async () => {
+    vi.mocked(execFileSync).mockReturnValue(
+      JSON.stringify({
+        type: 'oauth_token',
+        access_token: 'oauth-token-xyz',
+        workspace_id: 'wrkspc_123',
+      })
+    );
+
+    const auth = await resolveAnthropicAuth();
+    expect(auth?.headers.Authorization).toBe('Bearer oauth-token-xyz');
+    expect(auth?.headers['anthropic-workspace-id']).toBe('wrkspc_123');
+    expect(auth?.betas).toContain('oauth-2025-04-20');
+    expect(auth?.source).toBe('ant CLI');
+  });
+
+  it('falls back to reading the credentials file when ant is unavailable', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'ant-config-'));
+    try {
+      await mkdir(join(configDir, 'credentials'), { recursive: true });
+      await writeFile(join(configDir, 'active_config'), 'work\n');
+      await writeFile(
+        join(configDir, 'credentials', 'work.json'),
+        JSON.stringify({
+          type: 'oauth_token',
+          access_token: 'file-token',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          workspace_id: 'wrkspc_456',
+        })
+      );
+      vi.stubEnv('ANTHROPIC_CONFIG_DIR', configDir);
+
+      const auth = await resolveAnthropicAuth();
+      expect(auth?.headers.Authorization).toBe('Bearer file-token');
+      expect(auth?.headers['anthropic-workspace-id']).toBe('wrkspc_456');
+      expect(auth?.source).toBe('ant credentials file');
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects expired credentials from the file fallback', async () => {
+    const configDir = await mkdtemp(join(tmpdir(), 'ant-config-'));
+    try {
+      await mkdir(join(configDir, 'credentials'), { recursive: true });
+      await writeFile(join(configDir, 'active_config'), 'default');
+      await writeFile(
+        join(configDir, 'credentials', 'default.json'),
+        JSON.stringify({
+          type: 'oauth_token',
+          access_token: 'stale-token',
+          expires_at: Math.floor(Date.now() / 1000) - 10,
+        })
+      );
+      vi.stubEnv('ANTHROPIC_CONFIG_DIR', configDir);
+
+      expect(await resolveAnthropicAuth()).toBeNull();
+    } finally {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when no credential source is available', async () => {
+    expect(await resolveAnthropicAuth()).toBeNull();
+  });
+});
+
+describe('collectSkillFiles', () => {
+  it('collects files recursively and applies install exclusions', async () => {
+    const skillDir = await mkdtemp(join(tmpdir(), 'skill-'));
+    try {
+      await writeFile(join(skillDir, 'SKILL.md'), '# skill');
+      await writeFile(join(skillDir, 'metadata.json'), '{}');
+      await mkdir(join(skillDir, 'scripts'));
+      await writeFile(join(skillDir, 'scripts', 'run.py'), 'print(1)');
+      await mkdir(join(skillDir, '.git'));
+      await writeFile(join(skillDir, '.git', 'HEAD'), 'ref');
+
+      const files = await collectSkillFiles(skillDir);
+      const paths = files.map((f) => f.path).sort();
+      expect(paths).toEqual(['SKILL.md', 'scripts/run.py']);
+    } finally {
+      await rm(skillDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('uploadSkillToManagedAgents', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('rejects skills without a root SKILL.md', async () => {
+    await expect(
+      uploadSkillToManagedAgents(
+        { name: 'my-skill', files: [{ path: 'docs/README.md', content: 'x' }] },
+        API_KEY_AUTH
+      )
+    ).rejects.toThrow('missing a SKILL.md');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('creates a skill with a multipart form of dir-prefixed files', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { id: 'skill_01A', display_title: 'My Skill', latest_version: '123' })
+    );
+
+    const result = await uploadSkillToManagedAgents(
+      {
+        name: 'My Skill',
+        files: [
+          { path: 'SKILL.md', content: '# hi' },
+          { path: 'scripts/run.py', content: 'print(1)' },
+        ],
+      },
+      API_KEY_AUTH
+    );
+
+    expect(result).toEqual({ skillId: 'skill_01A', version: '123', action: 'created' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.anthropic.com/v1/skills?beta=true');
+    expect(init?.method).toBe('POST');
+
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-test');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['anthropic-beta']).toBe('skills-2025-10-02');
+
+    const form = init?.body as FormData;
+    expect(form.get('display_title')).toBe('My Skill');
+    const files = form.getAll('files[]') as File[];
+    // Directory name is the sanitized skill name
+    expect(files.map((f) => f.name).sort()).toEqual([
+      'my-skill/SKILL.md',
+      'my-skill/scripts/run.py',
+    ]);
+  });
+
+  it('appends the skills beta to auth-required betas', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { id: 'skill_01A', display_title: null, latest_version: '1' })
+    );
+
+    await uploadSkillToManagedAgents(
+      { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      {
+        headers: { Authorization: 'Bearer t' },
+        betas: ['oauth-2025-04-20'],
+        source: 'ant CLI',
+      }
+    );
+
+    const headers = fetchMock.mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20,skills-2025-10-02');
+  });
+
+  it('uploads a new version when the display title already exists', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(400, {
+          type: 'error',
+          error: {
+            type: 'invalid_request_error',
+            message: 'Skill cannot reuse an existing display_title: My Skill',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          data: [
+            { id: 'skill_00Z', display_title: 'Other', latest_version: '1' },
+            { id: 'skill_01A', display_title: 'My Skill', latest_version: '1' },
+          ],
+          has_more: false,
+          last_id: 'skill_01A',
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { skill_id: 'skill_01A', version: '456' }));
+
+    const result = await uploadSkillToManagedAgents(
+      { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      API_KEY_AUTH
+    );
+
+    expect(result).toEqual({ skillId: 'skill_01A', version: '456', action: 'updated' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const listUrl = String(fetchMock.mock.calls[1]![0]);
+    expect(listUrl).toContain('/v1/skills?');
+    expect(listUrl).toContain('source=custom');
+    const versionUrl = String(fetchMock.mock.calls[2]![0]);
+    expect(versionUrl).toBe('https://api.anthropic.com/v1/skills/skill_01A/versions?beta=true');
+
+    // Version uploads carry no display_title
+    const versionForm = fetchMock.mock.calls[2]![1]?.body as FormData;
+    expect(versionForm.get('display_title')).toBeNull();
+  });
+
+  it('throws a ManagedAgentsApiError on other API failures', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(401, {
+        type: 'error',
+        error: { type: 'authentication_error', message: 'invalid x-api-key' },
+      })
+    );
+
+    await expect(
+      uploadSkillToManagedAgents(
+        { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+        API_KEY_AUTH
+      )
+    ).rejects.toThrow(ManagedAgentsApiError);
+  });
+
+  it('honors ANTHROPIC_BASE_URL', async () => {
+    vi.stubEnv('ANTHROPIC_BASE_URL', 'https://api.staging.example/');
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { id: 'skill_01A', display_title: null, latest_version: '1' })
+    );
+
+    await uploadSkillToManagedAgents(
+      { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      API_KEY_AUTH
+    );
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      'https://api.staging.example/v1/skills?beta=true'
+    );
+  });
+});

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -22,6 +22,8 @@ import {
   type AnthropicAuth,
 } from '../src/managed-agents.ts';
 import { agents, getWildcardAgents, isVirtualAgent } from '../src/agents.ts';
+import { parseAddOptions } from '../src/add.ts';
+import { buildManagedAgentsArgs } from '../src/update.ts';
 
 const API_KEY_AUTH: AnthropicAuth = {
   headers: { 'x-api-key': 'sk-ant-test' },
@@ -323,5 +325,137 @@ describe('uploadSkillToManagedAgents', () => {
     expect(String(fetchMock.mock.calls[0]![0])).toBe(
       'https://api.staging.example/v1/skills?beta=true'
     );
+  });
+});
+
+describe('uploadSkillToManagedAgents with a known skill id', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  const SKILL = { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] };
+
+  it('uploads a new version directly to the known skill', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { skill_id: 'skill_01A', version: '789' }));
+
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_01A');
+
+    expect(result).toEqual({ skillId: 'skill_01A', version: '789', action: 'updated' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      'https://api.anthropic.com/v1/skills/skill_01A/versions?beta=true'
+    );
+    // Version uploads carry no display_title
+    const form = fetchMock.mock.calls[0]![1]?.body as FormData;
+    expect(form.get('display_title')).toBeNull();
+  });
+
+  it('falls back to the create flow when the known id is gone', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(404, {
+          type: 'error',
+          error: { type: 'not_found_error', message: 'skill not found' },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { id: 'skill_02B', display_title: 'My Skill', latest_version: '1' })
+      );
+
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_gone');
+
+    expect(result).toEqual({ skillId: 'skill_02B', version: '1', action: 'created' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]![0])).toBe(
+      'https://api.anthropic.com/v1/skills?beta=true'
+    );
+  });
+
+  it('falls back to the create flow when the known id is malformed (400)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(400, {
+          type: 'error',
+          error: { type: 'invalid_request_error', message: 'invalid skill id' },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { id: 'skill_02B', display_title: 'My Skill', latest_version: '1' })
+      );
+
+    const result = await uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'not-a-skill-id');
+
+    expect(result).toEqual({ skillId: 'skill_02B', version: '1', action: 'created' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates non-recoverable errors from the fast path without falling back', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(403, {
+        type: 'error',
+        error: { type: 'permission_error', message: 'forbidden' },
+      })
+    );
+
+    await expect(uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, 'skill_01A')).rejects.toThrow(
+      ManagedAgentsApiError
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('parseAddOptions --managed-agents', () => {
+  it('parses the additive flag', () => {
+    const { options, errors } = parseAddOptions(['owner/repo', '--managed-agents', '-y']);
+    expect(errors).toEqual([]);
+    expect(options.managedAgents).toBe(true);
+    expect(options.yes).toBe(true);
+  });
+
+  it('is off by default', () => {
+    const { options } = parseAddOptions(['owner/repo']);
+    expect(options.managedAgents).toBeUndefined();
+  });
+});
+
+describe('buildManagedAgentsArgs', () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'skills-update-'));
+    prevCwd = process.cwd();
+    process.chdir(dir);
+  });
+
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns nothing for entries without a managed skill id', async () => {
+    expect(await buildManagedAgentsArgs({}, 'my-skill', false)).toEqual([]);
+  });
+
+  it('targets the virtual agent directly for upload-only skills', async () => {
+    expect(
+      await buildManagedAgentsArgs({ managedSkillId: 'skill_01A' }, 'my-skill', false)
+    ).toEqual(['--agent', 'claude-managed-agents']);
+  });
+
+  it('uses the additive flag when the skill is also installed on the filesystem', async () => {
+    await mkdir(join(dir, '.claude', 'skills', 'my-skill'), { recursive: true });
+    await writeFile(join(dir, '.claude', 'skills', 'my-skill', 'SKILL.md'), '# my-skill');
+    expect(
+      await buildManagedAgentsArgs({ managedSkillId: 'skill_01A' }, 'my-skill', false)
+    ).toEqual(['--managed-agents']);
   });
 });

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -19,16 +19,17 @@ import {
   collectSkillFiles,
   uploadSkillToManagedAgents,
   createManagedSkillLookup,
-  ManagedAgentsApiError,
+  knownManagedIds,
+  summarizeManagedUploads,
+  PENDING_INSTALL_HASH,
   type AnthropicAuth,
 } from '../src/managed-agents.ts';
 import { agents, getWildcardAgents, isApiUploadAgent } from '../src/agents.ts';
-import { parseAddOptions, knownManagedIds, summarizeManagedUploads } from '../src/add.ts';
+import { parseAddOptions } from '../src/add.ts';
 import { buildManagedAgentsArgs } from '../src/update.ts';
 
 const API_KEY_AUTH: AnthropicAuth = {
   headers: { 'x-api-key': 'sk-ant-test' },
-  betas: [],
   source: 'ANTHROPIC_API_KEY',
 };
 
@@ -39,20 +40,34 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+function apiErrorResponse(status: number, message: string): Response {
+  return jsonResponse(status, { type: 'error', error: { type: 'api_error', message } });
+}
+
+/** Write an ant CLI config dir with one profile's credentials and point the env at it. */
+async function withAntConfig(
+  profile: string,
+  credentials: Record<string, unknown>,
+  fn: () => Promise<void>
+): Promise<void> {
+  const configDir = await mkdtemp(join(tmpdir(), 'ant-config-'));
+  try {
+    await mkdir(join(configDir, 'credentials'), { recursive: true });
+    await writeFile(join(configDir, 'active_config'), `${profile}\n`);
+    await writeFile(join(configDir, 'credentials', `${profile}.json`), JSON.stringify(credentials));
+    vi.stubEnv('ANTHROPIC_CONFIG_DIR', configDir);
+    await fn();
+  } finally {
+    await rm(configDir, { recursive: true, force: true });
+  }
+}
+
 describe('claude-managed-agents agent registry entry', () => {
-  it('is registered as an api-upload agent', () => {
-    expect(agents['claude-managed-agents']).toBeDefined();
+  it('is an api-upload agent: never auto-detected, excluded from the wildcard', async () => {
     expect(isApiUploadAgent('claude-managed-agents')).toBe(true);
-  });
-
-  it('is never auto-detected', async () => {
     expect(await agents['claude-managed-agents'].detectInstalled()).toBe(false);
-  });
-
-  it('is excluded from wildcard agent expansion', () => {
-    const wildcard = getWildcardAgents();
-    expect(wildcard).not.toContain('claude-managed-agents');
-    expect(wildcard).toContain('claude-code');
+    expect(getWildcardAgents()).not.toContain('claude-managed-agents');
+    expect(getWildcardAgents()).toContain('claude-code');
   });
 });
 
@@ -74,11 +89,7 @@ describe('resolveAnthropicAuth', () => {
   it('prefers ANTHROPIC_API_KEY and maps it to x-api-key', async () => {
     vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-abc');
     const auth = await resolveAnthropicAuth();
-    expect(auth).toEqual({
-      headers: { 'x-api-key': 'sk-ant-abc' },
-      betas: [],
-      source: 'ANTHROPIC_API_KEY',
-    });
+    expect(auth).toEqual({ headers: { 'x-api-key': 'sk-ant-abc' }, source: 'ANTHROPIC_API_KEY' });
   });
 
   it('uses ANTHROPIC_AUTH_TOKEN as a bearer token', async () => {
@@ -100,54 +111,36 @@ describe('resolveAnthropicAuth', () => {
     const auth = await resolveAnthropicAuth();
     expect(auth?.headers.Authorization).toBe('Bearer oauth-token-xyz');
     expect(auth?.headers['anthropic-workspace-id']).toBe('wrkspc_123');
-    expect(auth?.betas).toContain('oauth-2025-04-20');
+    expect(auth?.headers['anthropic-beta']).toBe('oauth-2025-04-20');
     expect(auth?.source).toBe('ant CLI');
   });
 
   it('falls back to reading the credentials file when ant is unavailable', async () => {
-    const configDir = await mkdtemp(join(tmpdir(), 'ant-config-'));
-    try {
-      await mkdir(join(configDir, 'credentials'), { recursive: true });
-      await writeFile(join(configDir, 'active_config'), 'work\n');
-      await writeFile(
-        join(configDir, 'credentials', 'work.json'),
-        JSON.stringify({
-          type: 'oauth_token',
-          access_token: 'file-token',
-          expires_at: Math.floor(Date.now() / 1000) + 3600,
-          workspace_id: 'wrkspc_456',
-        })
-      );
-      vi.stubEnv('ANTHROPIC_CONFIG_DIR', configDir);
-
-      const auth = await resolveAnthropicAuth();
-      expect(auth?.headers.Authorization).toBe('Bearer file-token');
-      expect(auth?.headers['anthropic-workspace-id']).toBe('wrkspc_456');
-      expect(auth?.source).toBe('ant credentials file');
-    } finally {
-      await rm(configDir, { recursive: true, force: true });
-    }
+    const now = Math.floor(Date.now() / 1000);
+    await withAntConfig(
+      'work',
+      {
+        type: 'oauth_token',
+        access_token: 'file-token',
+        expires_at: now + 3600,
+        workspace_id: 'wrkspc_456',
+      },
+      async () => {
+        const auth = await resolveAnthropicAuth();
+        expect(auth?.headers.Authorization).toBe('Bearer file-token');
+        expect(auth?.headers['anthropic-workspace-id']).toBe('wrkspc_456');
+        expect(auth?.source).toBe('ant credentials file');
+      }
+    );
   });
 
   it('rejects expired credentials from the file fallback', async () => {
-    const configDir = await mkdtemp(join(tmpdir(), 'ant-config-'));
-    try {
-      await mkdir(join(configDir, 'credentials'), { recursive: true });
-      await writeFile(join(configDir, 'active_config'), 'default');
-      await writeFile(
-        join(configDir, 'credentials', 'default.json'),
-        JSON.stringify({
-          type: 'oauth_token',
-          access_token: 'stale-token',
-          expires_at: Math.floor(Date.now() / 1000) - 10,
-        })
-      );
-      vi.stubEnv('ANTHROPIC_CONFIG_DIR', configDir);
-
-      expect(await resolveAnthropicAuth()).toBeNull();
-    } finally {
-      await rm(configDir, { recursive: true, force: true });
-    }
+    const now = Math.floor(Date.now() / 1000);
+    await withAntConfig(
+      'default',
+      { type: 'oauth_token', access_token: 'stale-token', expires_at: now - 10 },
+      async () => expect(await resolveAnthropicAuth()).toBeNull()
+    );
   });
 
   it('returns null when no credential source is available', async () => {
@@ -190,7 +183,7 @@ describe('collectSkillFiles', () => {
       const files = await collectSkillFiles(skillDir);
       const paths = files.map((f) => f.path).sort();
       expect(paths).toEqual(['SKILL.md', 'alias.md', 'shared.md']);
-      expect(files.some((f) => String(f.content).includes('do not upload'))).toBe(false);
+      expect(files.some((f) => String(f.contents).includes('do not upload'))).toBe(false);
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('leak.txt'));
     } finally {
       warn.mockRestore();
@@ -230,7 +223,7 @@ describe('uploadSkillToManagedAgents', () => {
   it('rejects skills without a root SKILL.md', async () => {
     await expect(
       uploadSkillToManagedAgents(
-        { name: 'my-skill', files: [{ path: 'docs/README.md', content: 'x' }] },
+        { name: 'my-skill', files: [{ path: 'docs/README.md', contents: 'x' }] },
         API_KEY_AUTH
       )
     ).rejects.toThrow('missing a SKILL.md');
@@ -243,7 +236,7 @@ describe('uploadSkillToManagedAgents', () => {
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_01A', 'my-skill')));
 
     await uploadSkillToManagedAgents(
-      { name: 'my-skill', files: [{ path: 'skill.md', content: '# hi' }] },
+      { name: 'my-skill', files: [{ path: 'skill.md', contents: '# hi' }] },
       API_KEY_AUTH
     );
 
@@ -261,8 +254,8 @@ describe('uploadSkillToManagedAgents', () => {
       {
         name: 'My Skill',
         files: [
-          { path: 'SKILL.md', content: '# hi' },
-          { path: 'scripts/run.py', content: 'print(1)' },
+          { path: 'SKILL.md', contents: '# hi' },
+          { path: 'scripts/run.py', contents: 'print(1)' },
         ],
       },
       API_KEY_AUTH
@@ -298,16 +291,15 @@ describe('uploadSkillToManagedAgents', () => {
     ]);
   });
 
-  it('sends the betas the credential requires', async () => {
+  it('sends every header the credential requires', async () => {
     fetchMock
       .mockResolvedValueOnce(EMPTY_LIST())
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_01A', 'my-skill')));
 
     await uploadSkillToManagedAgents(
-      { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      { name: 'my-skill', files: [{ path: 'SKILL.md', contents: '#' }] },
       {
-        headers: { Authorization: 'Bearer t' },
-        betas: ['oauth-2025-04-20'],
+        headers: { Authorization: 'Bearer t', 'anthropic-beta': 'oauth-2025-04-20' },
         source: 'ant CLI',
       }
     );
@@ -332,7 +324,7 @@ describe('uploadSkillToManagedAgents', () => {
       .mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_456')));
 
     const result = await uploadSkillToManagedAgents(
-      { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      { name: 'My Skill', files: [{ path: 'SKILL.md', contents: '#' }] },
       API_KEY_AUTH
     );
 
@@ -360,18 +352,15 @@ describe('uploadSkillToManagedAgents', () => {
         jsonResponse(200, { data: [skillJson('skill_00Y', 'My Skill')], next_page: null })
       )
       .mockResolvedValueOnce(
-        jsonResponse(400, {
-          type: 'error',
-          error: {
-            type: 'invalid_request_error',
-            message: "Skill name 'my-skill' in SKILL.md must be consistent across all versions",
-          },
-        })
+        apiErrorResponse(
+          400,
+          "Skill name 'my-skill' in SKILL.md must be consistent across all versions"
+        )
       )
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'My Skill')));
 
     const result = await uploadSkillToManagedAgents(
-      { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      { name: 'My Skill', files: [{ path: 'SKILL.md', contents: '#' }] },
       API_KEY_AUTH
     );
 
@@ -381,20 +370,15 @@ describe('uploadSkillToManagedAgents', () => {
     expect(fetchMock.mock.calls[2]![1]?.method).toBe('POST');
   });
 
-  it('throws a ManagedAgentsApiError on other API failures', async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(401, {
-        type: 'error',
-        error: { type: 'authentication_error', message: 'invalid x-api-key' },
-      })
-    );
+  it('throws on other API failures', async () => {
+    fetchMock.mockResolvedValueOnce(apiErrorResponse(401, 'invalid x-api-key'));
 
     await expect(
       uploadSkillToManagedAgents(
-        { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+        { name: 'my-skill', files: [{ path: 'SKILL.md', contents: '#' }] },
         API_KEY_AUTH
       )
-    ).rejects.toThrow(ManagedAgentsApiError);
+    ).rejects.toThrow('invalid x-api-key (HTTP 401)');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -405,7 +389,7 @@ describe('uploadSkillToManagedAgents', () => {
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_01A', 'my-skill')));
 
     await uploadSkillToManagedAgents(
-      { name: 'my-skill', files: [{ path: 'SKILL.md', content: '#' }] },
+      { name: 'my-skill', files: [{ path: 'SKILL.md', contents: '#' }] },
       API_KEY_AUTH
     );
 
@@ -416,7 +400,7 @@ describe('uploadSkillToManagedAgents', () => {
   });
 
   // With a known skill id (recorded in the lock by a previous upload).
-  const SKILL = { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] };
+  const SKILL = { name: 'My Skill', files: [{ path: 'SKILL.md', contents: '#' }] };
 
   it('uploads a new version directly to the known skill', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse(200, versionJson('skill_01A', 'skver_789')));
@@ -430,19 +414,11 @@ describe('uploadSkillToManagedAgents', () => {
     expect(String(fetchMock.mock.calls[0]![0])).toBe(
       'https://api.anthropic.com/v1/skills/skill_01A/versions'
     );
-    // Version uploads carry no display_name
-    const form = fetchMock.mock.calls[0]![1]?.body as FormData;
-    expect(form.get('display_name')).toBeNull();
   });
 
   it('falls back to lookup-then-create when the known id is gone (404)', async () => {
     fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse(404, {
-          type: 'error',
-          error: { type: 'not_found_error', message: 'Skill not found: skill_gone' },
-        })
-      )
+      .mockResolvedValueOnce(apiErrorResponse(404, 'Skill not found: skill_gone'))
       .mockResolvedValueOnce(EMPTY_LIST())
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'My Skill')));
 
@@ -457,12 +433,7 @@ describe('uploadSkillToManagedAgents', () => {
 
   it('falls back when the known id is malformed (400)', async () => {
     fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse(400, {
-          type: 'error',
-          error: { type: 'invalid_request_error', message: 'Invalid skill_id format: nope' },
-        })
-      )
+      .mockResolvedValueOnce(apiErrorResponse(400, 'Invalid skill_id format: nope'))
       .mockResolvedValueOnce(
         jsonResponse(200, { data: [skillJson('skill_01A', 'My Skill')], next_page: null })
       )
@@ -477,12 +448,7 @@ describe('uploadSkillToManagedAgents', () => {
 
   it('does not re-try the known id when the display-name lookup returns it', async () => {
     fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse(400, {
-          type: 'error',
-          error: { type: 'invalid_request_error', message: 'must be consistent' },
-        })
-      )
+      .mockResolvedValueOnce(apiErrorResponse(400, 'must be consistent'))
       .mockResolvedValueOnce(
         jsonResponse(200, { data: [skillJson('skill_01A', 'My Skill')], next_page: null })
       )
@@ -506,7 +472,7 @@ describe('uploadSkillToManagedAgents', () => {
       .mockResolvedValueOnce(jsonResponse(200, skillJson('skill_02B', 'beta')));
 
     const lookup = createManagedSkillLookup(API_KEY_AUTH);
-    const file = [{ path: 'SKILL.md', content: '#' }];
+    const file = [{ path: 'SKILL.md', contents: '#' }];
     const a = await uploadSkillToManagedAgents({ name: 'alpha', files: file }, API_KEY_AUTH, {
       lookup,
     });
@@ -522,16 +488,11 @@ describe('uploadSkillToManagedAgents', () => {
   });
 
   it('propagates non-recoverable errors from the fast path without falling back', async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(403, {
-        type: 'error',
-        error: { type: 'permission_error', message: 'forbidden' },
-      })
-    );
+    fetchMock.mockResolvedValueOnce(apiErrorResponse(403, 'forbidden'));
 
     await expect(
       uploadSkillToManagedAgents(SKILL, API_KEY_AUTH, { knownSkillId: 'skill_01A' })
-    ).rejects.toThrow(ManagedAgentsApiError);
+    ).rejects.toThrow('forbidden (HTTP 403)');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
@@ -542,11 +503,6 @@ describe('parseAddOptions --managed-agents', () => {
     expect(errors).toEqual([]);
     expect(options.managedAgents).toBe(true);
     expect(options.yes).toBe(true);
-  });
-
-  it('is off by default', () => {
-    const { options } = parseAddOptions(['owner/repo']);
-    expect(options.managedAgents).toBeUndefined();
   });
 });
 
@@ -613,35 +569,33 @@ describe('managed upload bookkeeping', () => {
     expect(knownManagedIds(LOCK, 'owner/repo-b').size).toBe(0);
   });
 
-  it('prefers a fresh upload id and falls back to the recorded one', () => {
+  const UPLOADED = [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }];
+
+  it('records a fresh upload id, else the one already recorded for this source', () => {
     const known = knownManagedIds(LOCK, 'owner/repo-a');
-    const fresh = summarizeManagedUploads(
-      [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
-      known,
-      { upload: true, fs: true }
-    );
-    expect(fresh.managedIdFor('my-skill')).toBe('skill_NEW');
+    const fresh = summarizeManagedUploads(UPLOADED, known, { upload: true, fs: true });
+    expect(fresh.lockEntry('my-skill', true)?.managedSkillId).toBe('skill_NEW');
 
     const untouched = summarizeManagedUploads([], known, { upload: false, fs: true });
-    expect(untouched.managedIdFor('my-skill')).toBe('skill_OLD');
+    expect(untouched.lockEntry('my-skill', true)?.managedSkillId).toBe('skill_OLD');
   });
 
-  it('marks a skill incomplete when a requested part did not succeed', () => {
+  it('writes no entry when nothing landed, and a pending hash when only part did', () => {
     const none = new Map<string, string>();
     // Upload requested (or credential-skipped) but nothing reached the API.
-    expect(
-      summarizeManagedUploads([], none, { upload: true, fs: true }).isComplete('my-skill', true)
-    ).toBe(false);
+    const fsOnlyLanded = summarizeManagedUploads([], none, { upload: true, fs: true });
+    expect(fsOnlyLanded.lockEntry('my-skill', false)).toBeNull();
+    expect(fsOnlyLanded.lockEntry('my-skill', true)?.hash('abc')).toBe(PENDING_INSTALL_HASH);
 
     const fsOnly = summarizeManagedUploads([], none, { upload: false, fs: true });
-    expect(fsOnly.isComplete('my-skill', true)).toBe(true);
-    expect(fsOnly.isComplete('my-skill', false)).toBe(false);
+    expect(fsOnly.lockEntry('my-skill', true)?.hash('abc')).toBe('abc');
 
-    const uploadOnly = summarizeManagedUploads(
-      [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
-      none,
-      { upload: true, fs: false }
-    );
-    expect(uploadOnly.isComplete('my-skill', false)).toBe(true);
+    const uploadOnly = summarizeManagedUploads(UPLOADED, none, { upload: true, fs: false });
+    expect(uploadOnly.uploads).toBe(1);
+    expect(uploadOnly.lockEntry('my-skill', false)?.hash('abc')).toBe('abc');
+
+    // Both requested, copy failed, upload landed: entry exists but stays pending.
+    const half = summarizeManagedUploads(UPLOADED, none, { upload: true, fs: true });
+    expect(half.lockEntry('my-skill', false)?.hash('abc')).toBe(PENDING_INSTALL_HASH);
   });
 });

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { mkdtemp, mkdir, symlink, writeFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -170,6 +170,30 @@ describe('collectSkillFiles', () => {
       expect(paths).toEqual(['SKILL.md', 'scripts/run.py']);
     } finally {
       await rm(skillDir, { recursive: true, force: true });
+    }
+  });
+
+  it('follows in-tree symlinks but skips ones that escape the skill directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skill-'));
+    const skillDir = join(root, 'skill');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await mkdir(skillDir);
+      await writeFile(join(skillDir, 'SKILL.md'), '# skill');
+      await writeFile(join(skillDir, 'shared.md'), 'shared');
+      await writeFile(join(root, 'secret.txt'), 'do not upload');
+      await symlink('shared.md', join(skillDir, 'alias.md'));
+      await symlink(join(root, 'secret.txt'), join(skillDir, 'leak.txt'));
+      await symlink(root, join(skillDir, 'escape-dir'));
+
+      const files = await collectSkillFiles(skillDir);
+      const paths = files.map((f) => f.path).sort();
+      expect(paths).toEqual(['SKILL.md', 'alias.md', 'shared.md']);
+      expect(files.some((f) => String(f.content).includes('do not upload'))).toBe(false);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('leak.txt'));
+    } finally {
+      warn.mockRestore();
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/tests/managed-agents.test.ts
+++ b/tests/managed-agents.test.ts
@@ -22,7 +22,7 @@ import {
   type AnthropicAuth,
 } from '../src/managed-agents.ts';
 import { agents, getWildcardAgents, isApiUploadAgent } from '../src/agents.ts';
-import { parseAddOptions, buildManagedLockBookkeeping } from '../src/add.ts';
+import { parseAddOptions, knownManagedIds, summarizeManagedUploads } from '../src/add.ts';
 import { buildManagedAgentsArgs } from '../src/update.ts';
 
 const API_KEY_AUTH: AnthropicAuth = {
@@ -365,21 +365,8 @@ describe('uploadSkillToManagedAgents', () => {
       'https://api.staging.example/v1/skills?beta=true'
     );
   });
-});
 
-describe('uploadSkillToManagedAgents with a known skill id', () => {
-  const fetchMock = vi.fn<typeof fetch>();
-
-  beforeEach(() => {
-    fetchMock.mockReset();
-    vi.stubGlobal('fetch', fetchMock);
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    vi.unstubAllEnvs();
-  });
-
+  // With a known skill id (recorded in the lock by a previous upload).
   const SKILL = { name: 'My Skill', files: [{ path: 'SKILL.md', content: '#' }] };
 
   it('uploads a new version directly to the known skill', async () => {
@@ -516,67 +503,47 @@ describe('buildManagedAgentsArgs', () => {
   });
 });
 
-describe('buildManagedLockBookkeeping', () => {
-  const KNOWN = new Map([['my-skill', { managedSkillId: 'skill_OLD', source: 'owner/repo-a' }]]);
+describe('managed upload bookkeeping', () => {
+  const LOCK = {
+    'my-skill': { source: 'owner/repo-a', managedSkillId: 'skill_OLD' },
+    'fs-only': { source: 'owner/repo-a' },
+  };
 
-  it('prefers a fresh upload id and falls back to a same-source recorded id', () => {
-    const { managedIdFor } = buildManagedLockBookkeeping({
-      uploadOutcomes: [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
-      knownManagedIds: KNOWN,
-      sourceKey: 'owner/repo-a',
-      uploadRequested: true,
-      fsRequested: true,
-    });
-    expect(managedIdFor('my-skill')).toBe('skill_NEW');
-
-    const { managedIdFor: preserved } = buildManagedLockBookkeeping({
-      uploadOutcomes: [],
-      knownManagedIds: KNOWN,
-      sourceKey: 'owner/repo-a',
-      uploadRequested: false,
-      fsRequested: true,
-    });
-    expect(preserved('my-skill')).toBe('skill_OLD');
+  it('reads recorded ids for the same source only', () => {
+    expect(knownManagedIds(LOCK, 'owner/repo-a')).toEqual(new Map([['my-skill', 'skill_OLD']]));
+    // A same-named skill from another source must not inherit the upload.
+    expect(knownManagedIds(LOCK, 'owner/repo-b').size).toBe(0);
   });
 
-  it('never inherits an id recorded for a different source', () => {
-    const { managedIdFor } = buildManagedLockBookkeeping({
-      uploadOutcomes: [],
-      knownManagedIds: KNOWN,
-      sourceKey: 'owner/repo-b',
-      uploadRequested: false,
-      fsRequested: true,
-    });
-    expect(managedIdFor('my-skill')).toBeUndefined();
+  it('prefers a fresh upload id and falls back to the recorded one', () => {
+    const known = knownManagedIds(LOCK, 'owner/repo-a');
+    const fresh = summarizeManagedUploads(
+      [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
+      known,
+      { upload: true, fs: true }
+    );
+    expect(fresh.managedIdFor('my-skill')).toBe('skill_NEW');
+
+    const untouched = summarizeManagedUploads([], known, { upload: false, fs: true });
+    expect(untouched.managedIdFor('my-skill')).toBe('skill_OLD');
   });
 
   it('marks a skill incomplete when a requested part did not succeed', () => {
-    const { isComplete } = buildManagedLockBookkeeping({
-      uploadOutcomes: [],
-      knownManagedIds: new Map(),
-      sourceKey: 'owner/repo-a',
-      uploadRequested: true, // requested (or credential-skipped) but no success
-      fsRequested: true,
-    });
-    expect(isComplete('my-skill', true)).toBe(false);
+    const none = new Map<string, string>();
+    // Upload requested (or credential-skipped) but nothing reached the API.
+    expect(
+      summarizeManagedUploads([], none, { upload: true, fs: true }).isComplete('my-skill', true)
+    ).toBe(false);
 
-    const { isComplete: fsOnly } = buildManagedLockBookkeeping({
-      uploadOutcomes: [],
-      knownManagedIds: new Map(),
-      sourceKey: 'owner/repo-a',
-      uploadRequested: false,
-      fsRequested: true,
-    });
-    expect(fsOnly('my-skill', true)).toBe(true);
-    expect(fsOnly('my-skill', false)).toBe(false);
+    const fsOnly = summarizeManagedUploads([], none, { upload: false, fs: true });
+    expect(fsOnly.isComplete('my-skill', true)).toBe(true);
+    expect(fsOnly.isComplete('my-skill', false)).toBe(false);
 
-    const { isComplete: uploadOk } = buildManagedLockBookkeeping({
-      uploadOutcomes: [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
-      knownManagedIds: new Map(),
-      sourceKey: 'owner/repo-a',
-      uploadRequested: true,
-      fsRequested: false,
-    });
-    expect(uploadOk('my-skill', false)).toBe(true);
+    const uploadOnly = summarizeManagedUploads(
+      [{ skill: 'my-skill', success: true, skillId: 'skill_NEW' }],
+      none,
+      { upload: true, fs: false }
+    );
+    expect(uploadOnly.isComplete('my-skill', false)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Skills installed with this CLI reach agents that read a local directory. Agents built on the Anthropic API (Claude Managed Agents, and the Messages API code-execution container) read skills from the workspace's Skills API instead, so today you have to zip and upload each skill by hand and re-upload on every change.

This adds a `claude-managed-agents` install target that uploads to the Skills API (GA, no beta header) instead of copying to a directory, and makes the rest of the subcommand surface work with it, most importantly `skills update`.

```
npx skills add vercel-labs/agent-skills --agent claude-managed-agents
```

## The target

- Declared as `install: 'api-upload'` in `src/agents.ts`: no filesystem skills dir, never auto-detected, and excluded from `--agent '*'` and `--all` so a bulk install can't upload to a workspace by accident. An explicitly listed `claude-managed-agents` next to `'*'` is kept.
- Credentials resolve from `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, the Anthropic CLI's stored OAuth login (refreshed via `ant auth print-credentials`), or its credentials file when `ant` isn't on `PATH`. `ANTHROPIC_BASE_URL` is honored.
- Re-adding an existing skill uploads a new version instead of creating a duplicate. The GA API doesn't enforce unique display names, so when the lock has no usable id the CLI lists the workspace's custom skills once per run and versions the newest display-name match, creating only when nothing matches.
- Files reached through a symlink that resolves outside the skill directory are skipped with a warning, since an upload sends contents off the machine. In-tree symlinks are followed as before.
- 30s timeouts on API fetches, 10s on the credentials shell-out. Nonzero exit when every requested upload fails.

## Making `update` work

Lock entries (project `skills-lock.json` and the global lock) record an optional `managedSkillId` on successful upload:

```json
{
  "source": "anthropics/skills",
  "sourceType": "github",
  "skillPath": "skills/frontend-design/SKILL.md",
  "computedHash": "4eabc6…",
  "managedSkillId": "skill_0129Bz…"
}
```

- Upload-only installs get a lock entry too (previously nothing was written, so `update` couldn't see them).
- Uploads use the recorded id as a fast path (`POST /v1/skills/{id}/versions`) and fall back to the display-name lookup on 404 (deleted skill, different workspace) or 400 (malformed id), which rewrites the recorded id.
- New additive `add --managed-agents` flag: upload on top of the selected or detected agents. Missing credentials warn and skip instead of aborting, so an unattended `update` never fails the whole run over a login.
- `update` passes `--managed-agents` for locally installed skills with a recorded id, or `--agent claude-managed-agents --managed-agents` for upload-only skills so a refresh doesn't materialize local copies.
- The id survives re-adds that don't touch the upload.

## Other subcommands

- `remove` and `experimental_sync`: explicit warning or error that API-managed skills aren't handled there. `remove` also warns when deleting a lock entry orphans an uploaded skill.
- `list --agent claude-managed-agents`: says those skills aren't listable locally instead of silently ignoring the filter.

## Size

`src`: +911 / -66 across 12 files, about half of it in the new `src/managed-agents.ts`. The shared install flow in `add.ts` splits the API-upload agent off the target list once after credentials resolve, so the summary builders, install loops, and install-mode prompt still only see filesystem agents.

## Testing

- `tests/managed-agents.test.ts`: 31 unit tests covering the registry entry, credential resolution, file collection (including symlink containment), multipart form shape, create, version, fast-path and fallback flows, flag parsing, and `update` arg building. Full suite: 805 passing.
- Verified end to end against the live GA Skills API: mixed and upload-only installs, multi-skill installs, lock-less re-adds versioning instead of duplicating, `update` re-uploading new versions, stale-id fallback, and the missing-credential skip.

Happy to split this (target first, `update` support second) if that's easier to review.
