### PR TITLE
fix: preserve on-disk casing of skill container directories

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -296,7 +296,14 @@ export function getSkillFolderHashFromTree(tree: RepoTree, skillPath: string): s
     return tree.sha;
   }
 
-  const entry = tree.tree.find((e) => e.type === 'tree' && e.path === folderPath);
+  // Locks written before skill discovery preserved on-disk casing can hold a
+  // differently-cased folder path (`skills/x` for a repo's `Skills/x`). Fall
+  // back to a case-insensitive match so those skills stay trackable instead of
+  // being reported as coming from a private or deleted repo.
+  const lowerFolderPath = folderPath.toLowerCase();
+  const entry =
+    tree.tree.find((e) => e.type === 'tree' && e.path === folderPath) ??
+    tree.tree.find((e) => e.type === 'tree' && e.path.toLowerCase() === lowerFolderPath);
   return entry?.sha ?? null;
 }
 

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -173,6 +173,40 @@ export function isSubpathSafe(basePath: string, subpath: string): boolean {
   return normalizedTarget.startsWith(normalizedBase + sep) || normalizedTarget === normalizedBase;
 }
 
+/**
+ * Resolve a relative directory to its real on-disk casing.
+ *
+ * `join(base, 'skills')` resolves a differently-cased real directory (`Skills/`)
+ * on case-insensitive filesystems (macOS, Windows), and every path derived from
+ * it then carries the fabricated casing. Those paths are recorded as
+ * `skillPath` in the lock file, where they fail the case-sensitive compares
+ * against a git tree — leaving skills untrackable and reported as deleted
+ * upstream. Prefer an exact match, fall back to a case-insensitive one, and
+ * return the naive join when the directory does not exist.
+ */
+async function resolveRealCase(base: string, relPath: string): Promise<string> {
+  let current = base;
+
+  for (const segment of relPath.split('/')) {
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return join(base, relPath);
+    }
+
+    const lower = segment.toLowerCase();
+    const match =
+      entries.find((entry) => entry.name === segment) ??
+      entries.find((entry) => entry.name.toLowerCase() === lower);
+    if (!match) return join(base, relPath);
+
+    current = join(current, match.name);
+  }
+
+  return current;
+}
+
 export async function discoverSkills(
   basePath: string,
   subpath?: string,
@@ -248,11 +282,15 @@ export async function discoverSkills(
   // Search common skill locations first
   const prioritySearchDirs = [
     searchPath,
-    join(searchPath, 'skills'),
-    join(searchPath, 'skills/.curated'),
-    join(searchPath, 'skills/.experimental'),
-    join(searchPath, 'skills/.system'),
-    ...AGENT_PROJECT_SKILL_DIRS.map((dir) => join(searchPath, dir)),
+    ...(await Promise.all(
+      [
+        'skills',
+        'skills/.curated',
+        'skills/.experimental',
+        'skills/.system',
+        ...AGENT_PROJECT_SKILL_DIRS,
+      ].map((dir) => resolveRealCase(searchPath, dir))
+    )),
   ];
 
   // Known skill container dirs are walked up to three levels deep so layouts

--- a/src/update.ts
+++ b/src/update.ts
@@ -296,10 +296,14 @@ export async function checkAndPromptForDeletions(
   options: UpdateCheckOptions,
   discoveredPaths: string[]
 ): Promise<string[]> {
+  // Compared case-insensitively: a lock path that differs from the repo only in
+  // casing is a stale recording, not a deletion. An exact compare would offer to
+  // remove skills that are still present upstream.
+  const discoveredLower = new Set(discoveredPaths.map((path) => path.toLowerCase()));
   const deletedSkills = allLockedForSource.filter((name) => {
     const entry = lockSkills[name];
     if (!entry?.skillPath) return false;
-    return !discoveredPaths.includes(entry.skillPath);
+    return !discoveredLower.has(entry.skillPath.toLowerCase());
   });
 
   await promptDeletions(source, deletedSkills, isGlobal, options);

--- a/tests/case-insensitive-skill-paths.test.ts
+++ b/tests/case-insensitive-skill-paths.test.ts
@@ -1,0 +1,125 @@
+/**
+ * A repository whose skill container is capitalised (`Skills/`) must be
+ * discovered under the path it actually has on disk.
+ *
+ * `discoverSkills` probed a hardcoded lowercase `skills` literal. On a
+ * case-insensitive filesystem that probe resolves the real `Skills/` directory,
+ * so every discovered path carried the fabricated lowercase casing and was
+ * recorded as `skillPath` in the lock file — where the case-sensitive compares
+ * against a git tree then fail, leaving the skill permanently untrackable and
+ * reported as deleted upstream. On a case-sensitive filesystem the same probe
+ * simply missed the directory and the skills were not found at all.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join, sep } from 'path';
+import { discoverSkills } from '../src/skills.ts';
+import { getSkillFolderHashFromTree } from '../src/blob.ts';
+import { checkAndPromptForDeletions } from '../src/update.ts';
+
+let repoDir: string;
+
+async function writeSkill(container: string, name: string): Promise<void> {
+  const dir = join(repoDir, ...container.split('/'), name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: A skill used to verify container casing is preserved.\n---\n\nBody.\n`
+  );
+}
+
+beforeEach(async () => {
+  repoDir = await mkdtemp(join(tmpdir(), 'skills-casing-'));
+});
+
+afterEach(async () => {
+  await rm(repoDir, { recursive: true, force: true });
+});
+
+describe('discoverSkills container casing', () => {
+  it('discovers skills under a capitalised Skills/ directory', async () => {
+    await writeSkill('Skills', 'capitalised-container');
+
+    const skills = await discoverSkills(repoDir);
+
+    expect(skills.map((skill) => skill.name)).toEqual(['capitalised-container']);
+  });
+
+  it('records the real on-disk casing, not the probed lowercase spelling', async () => {
+    await writeSkill('Skills', 'capitalised-container');
+
+    const [skill] = await discoverSkills(repoDir);
+
+    // The path is what becomes `skillPath` in the lock file, so it has to match
+    // the repository byte for byte.
+    expect(skill!.path.endsWith(join('Skills', 'capitalised-container'))).toBe(true);
+    expect(skill!.path).not.toContain(`${sep}skills${sep}`);
+  });
+
+  it('still finds skills under a lowercase skills/ directory', async () => {
+    await writeSkill('skills', 'lowercase-container');
+
+    const [skill] = await discoverSkills(repoDir);
+
+    expect(skill!.name).toBe('lowercase-container');
+    expect(skill!.path.endsWith(join('skills', 'lowercase-container'))).toBe(true);
+  });
+});
+
+describe('getSkillFolderHashFromTree', () => {
+  const tree = {
+    sha: 'root-sha',
+    branch: 'main',
+    tree: [
+      { path: 'Skills', type: 'tree', sha: 'container-sha' },
+      { path: 'Skills/my-skill', type: 'tree', sha: 'skill-sha' },
+      { path: 'Skills/my-skill/SKILL.md', type: 'blob', sha: 'blob-sha' },
+    ],
+  } as unknown as Parameters<typeof getSkillFolderHashFromTree>[0];
+
+  it('resolves a path recorded with the wrong casing', () => {
+    // Locks written before the casing fix hold the lowercase spelling; those
+    // skills must stay trackable rather than being reported as deleted.
+    expect(getSkillFolderHashFromTree(tree, 'skills/my-skill/SKILL.md')).toBe('skill-sha');
+  });
+
+  it('resolves an exactly-cased path', () => {
+    expect(getSkillFolderHashFromTree(tree, 'Skills/my-skill/SKILL.md')).toBe('skill-sha');
+  });
+
+  it('returns null for a path that is genuinely absent', () => {
+    expect(getSkillFolderHashFromTree(tree, 'Skills/gone/SKILL.md')).toBeNull();
+  });
+});
+
+describe('checkAndPromptForDeletions', () => {
+  const discovered = ['Skills/my-skill/SKILL.md'];
+
+  it('does not treat a casing-only mismatch as a deletion', async () => {
+    const deleted = await checkAndPromptForDeletions(
+      'owner/repo',
+      ['my-skill'],
+      { 'my-skill': { skillPath: 'skills/my-skill/SKILL.md' } },
+      true,
+      { yes: true },
+      discovered
+    );
+
+    expect(deleted).toEqual([]);
+  });
+
+  it('still reports a skill that is absent upstream', async () => {
+    const deleted = await checkAndPromptForDeletions(
+      'owner/repo',
+      ['gone'],
+      { gone: { skillPath: 'Skills/gone/SKILL.md' } },
+      true,
+      { yes: true },
+      discovered
+    );
+
+    expect(deleted).toEqual(['gone']);
+  });
+});


### PR DESCRIPTION
## The bug

`discoverSkills` probes a hardcoded lowercase literal:

```ts
// src/skills.ts
const prioritySearchDirs = [
  searchPath,
  join(searchPath, 'skills'),   // <-- resolves a real `Skills/` on macOS
  ...
];
```

On a case-insensitive filesystem that probe resolves a repository's real `Skills/`
directory, and `readdir` then returns children under the *fabricated* lowercase
spelling. That path becomes `skillPath` in the lock file:

```json
"tmux-cli": {
  "source": "sammcj/agentic-coding",
  "skillPath": "skills/tmux-cli/SKILL.md",   // repo actually has Skills/tmux-cli
  "skillFolderHash": ""
}
```

`getSkillFolderHashFromTree` compares that path case-sensitively against the
GitHub tree, finds nothing, and returns `null`, so `skillFolderHash` is stored
empty. `skills update` then skips the skill for the lifetime of the install, and
`getSkipReason` attributes it to a `"Private or deleted repo"` — for a repository
that is public and reachable.

Reinstalling cannot heal it: the same probe re-records the same wrong path.

On a case-sensitive filesystem the probe misses the directory outright, so skills
under a capitalised container are never discovered at all.

### Reproducing

Any public repo whose container is capitalised — [`sammcj/agentic-coding`](https://github.com/sammcj/agentic-coding) uses `Skills/`:

```console
$ skills add sammcj/agentic-coding -g -y
$ skills update -g
49 skill(s) cannot be checked automatically:
  ...
  (Private or deleted repo)
```

All 49 entries land with `skillFolderHash: ""` and stay unupdatable.

## The fix

Resolve each priority container to its real on-disk casing, preferring an exact
match so a repository holding both `skills/` and `Skills/` is unaffected.

Two compares are also made case-insensitive so locks **already** written with the
wrong casing recover on the next update instead of needing a hand-edit:

- `getSkillFolderHashFromTree` falls back to a case-insensitive lookup, restoring
  update tracking for existing entries.
- `checkAndPromptForDeletions` compares case-insensitively.

That last one is the reason this is more than a cosmetic annoyance. The deletion
check used exact `includes()`, so a casing-only mismatch reads as *deleted
upstream* and prompts to remove the local copy. It stays hidden only while every
skill from that source is unhashed and `itemsForSource` is empty; repair or
reinstall a single skill from the same source and the prompt starts offering to
delete skills that are still present upstream.

## Tests

`tests/case-insensitive-skill-paths.test.ts`, 8 cases across the three seams.
Three of them fail on `main` (verified by stashing the `src/` changes) — one per
fix — and the rest guard against regressing the exact-match and
genuinely-deleted paths.

End-to-end against the repo from the report:

```
discovered: 48
correct Skills/ casing: 48
wrong skills/ casing: 0
```

`pnpm type-check` and `pnpm format:check` are clean. Full suite: 781 passed,
58/59 files. The one failing file is `src/detect-agent.test.ts`, which fails
identically on unmodified `main` in my environment (it detects the real ambient
agent instead of the mocked env) and is untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
