### PR TITLE
fix: preserve agent placement across skills update

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -9,6 +9,7 @@ import {
   getLockSource,
   getProjectLockSourceUrl,
   formatEveInstallPromptMessage,
+  computeRecordedAgents,
 } from './add.ts';
 
 function countPathLinesForSkill(text: string, skillName: string): number {
@@ -751,5 +752,38 @@ This is a test skill for -y flag mode testing.
     expect(result.stdout).not.toContain("One-time prompt - you won't be asked again");
     // Should complete successfully
     expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('computeRecordedAgents', () => {
+  it('unions successful installs with existing lock agents so repeated add preserves prior placements', () => {
+    const first = computeRecordedAgents(
+      'my-skill',
+      ['claude-code'],
+      [{ skill: 'my-skill', agentType: 'claude-code', success: true }]
+    );
+    expect(first).toEqual(['claude-code']);
+
+    // A later `add` for a different agent must keep agents recorded by the
+    // prior install, otherwise `update` would stop updating those copies.
+    const second = computeRecordedAgents(
+      'my-skill',
+      ['cursor'],
+      [{ skill: 'my-skill', agentType: 'cursor', success: true }],
+      first
+    );
+    expect(second.sort()).toEqual(['claude-code', 'cursor']);
+  });
+
+  it('excludes failed placements from the recorded agents', () => {
+    const recorded = computeRecordedAgents(
+      'my-skill',
+      ['claude-code', 'codex'],
+      [
+        { skill: 'my-skill', agentType: 'claude-code', success: true },
+        { skill: 'my-skill', agentType: 'codex', success: false },
+      ]
+    );
+    expect(recorded).toEqual(['claude-code']);
   });
 });

--- a/src/add.ts
+++ b/src/add.ts
@@ -43,12 +43,13 @@ import { downloadSource } from './download-source.ts';
 import {
   addSkillToLock,
   getGitHubToken,
+  getSkillFromLock,
   isPromptDismissed,
   dismissPrompt,
   getLastSelectedAgents,
   saveSelectedAgents,
 } from './skill-lock.ts';
-import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
+import { addSkillToLocalLock, computeSkillFolderHash, readLocalLock } from './local-lock.ts';
 import type { Skill, AgentType } from './types.ts';
 import {
   tryBlobInstall,
@@ -63,6 +64,37 @@ import packageJson from '../package.json' with { type: 'json' };
 // Helper to check if a value is a cancel symbol (works with both clack and our custom prompts)
 const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
 const EVE_AGENT_LABEL = 'eve agent';
+
+/**
+ * Compute the union of existing lock-entry agents and agents that were
+ * successfully installed in this run.
+ *
+ * Results carry the stable `agentType` ID (not a display name), so no
+ * display-name-to-type mapping is needed. Agents that failed to install
+ * (`success: false`) are excluded. Skipped installs (`success: true,
+ * skipped: true`) are included — a skipped result means the skill already
+ * occupies the destination, which is a valid placement. Agents already in
+ * the lock entry (from a prior install) are preserved so a later `add` for
+ * a different agent doesn't drop them — `update` would otherwise stop
+ * updating the still-installed copies.
+ */
+export function computeRecordedAgents(
+  skillName: string,
+  targetAgents: AgentType[],
+  results: Array<{ skill: string; agentType: AgentType; success: boolean; skipped?: boolean }>,
+  existingAgents?: string[]
+): string[] {
+  const succeeded = new Set(
+    results.filter((r) => r.success && r.skill === skillName).map((r) => r.agentType)
+  );
+  const union = new Set<string>(existingAgents ?? []);
+  for (const agent of targetAgents) {
+    if (succeeded.has(agent)) {
+      union.add(agent);
+    }
+  }
+  return [...union];
+}
 
 /**
  * Check if a source identifier (owner/repo format) represents a private GitHub repo.
@@ -863,7 +895,9 @@ async function handleWellKnownSkills(
   const results: {
     skill: string;
     agent: string;
+    agentType: AgentType;
     success: boolean;
+    skipped?: boolean;
     path: string;
     canonicalPath?: string;
     mode: InstallMode;
@@ -880,6 +914,7 @@ async function handleWellKnownSkills(
       results.push({
         skill: skill.installName,
         agent: agents[agent].displayName,
+        agentType: agent,
         ...result,
       });
     }
@@ -919,6 +954,13 @@ async function handleWellKnownSkills(
     for (const skill of selectedSkills) {
       if (successfulSkillNames.has(skill.installName)) {
         try {
+          const existing = await getSkillFromLock(skill.installName);
+          const recordedAgents = computeRecordedAgents(
+            skill.installName,
+            targetAgents,
+            results,
+            existing?.agents
+          );
           await addSkillToLock(skill.installName, {
             source: sourceIdentifier,
             sourceType: 'well-known',
@@ -926,6 +968,7 @@ async function handleWellKnownSkills(
             skillFolderHash: '',
             sourceBaseUrl: url,
             wellKnownDigest: computeWellKnownSkillDigest(skill),
+            ...(recordedAgents.length > 0 && { agents: recordedAgents }),
           });
         } catch {
           // Don't fail installation if lock file update fails
@@ -944,6 +987,13 @@ async function handleWellKnownSkills(
           const installDir = matchingResult?.canonicalPath || matchingResult?.path;
           if (installDir) {
             const computedHash = await computeSkillFolderHash(installDir);
+            const existingLocal = (await readLocalLock(cwd)).skills[skill.installName];
+            const recordedAgents = computeRecordedAgents(
+              skill.installName,
+              targetAgents,
+              results,
+              existingLocal?.agents
+            );
             await addSkillToLocalLock(
               skill.installName,
               {
@@ -952,6 +1002,7 @@ async function handleWellKnownSkills(
                 sourceType: 'well-known',
                 computedHash,
                 wellKnownDigest: computeWellKnownSkillDigest(skill),
+                ...(recordedAgents.length > 0 && { agents: recordedAgents }),
               },
               cwd
             );
@@ -1738,7 +1789,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const results: {
       skill: string;
       agent: string;
+      agentType: AgentType;
       success: boolean;
+      skipped?: boolean;
       path: string;
       canonicalPath?: string;
       mode: InstallMode;
@@ -1774,6 +1827,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         results.push({
           skill: getSkillDisplayName(skill),
           agent: targetDisplayName(target),
+          agentType: agent,
           pluginName: skill.pluginName,
           ...result,
         });
@@ -1889,6 +1943,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
               skillPath: skillPathValue,
               skillFolderHash,
               pluginName: skill.pluginName,
+              ...(targetAgents.length > 0 && {
+                agents: computeRecordedAgents(
+                  skillDisplayName,
+                  targetAgents,
+                  results,
+                  (await getSkillFromLock(skill.name))?.agents
+                ),
+              }),
             });
           } catch {
             // Don't fail installation if lock file update fails
@@ -1918,6 +1980,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ? (skill as BlobSkill).snapshotHash
                 : await computeSkillFolderHash(skill.path);
             const skillPathValue = skillFiles[skill.name];
+            const existingLocal = (await readLocalLock(cwd)).skills[skill.name];
             await addSkillToLocalLock(
               skill.name,
               {
@@ -1928,6 +1991,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
                 ...(skillPathValue && { skillPath: skillPathValue }),
                 computedHash,
                 ...(recordSubagents && { subagents: eveSubagents }),
+                ...(targetAgents.length > 0 && {
+                  agents: computeRecordedAgents(
+                    skillDisplayName,
+                    targetAgents,
+                    results,
+                    existingLocal?.agents
+                  ),
+                }),
               },
               cwd
             );

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -43,6 +43,8 @@ export interface LocalSkillLockEntry {
    */
   subagents?: string[];
   wellKnownDigest?: string;
+  /** Agents the skill was installed to (for placement-preserving updates). */
+  agents?: string[];
 }
 
 /**
@@ -209,6 +211,47 @@ export async function removeSkillFromLocalLock(skillName: string, cwd?: string):
   delete lock.skills[skillName];
   await writeLocalLock(lock, cwd);
   return true;
+}
+
+/**
+ * Remove specific agents from a skill's recorded `agents` field in the
+ * local lock. Used by `skills remove --agent <name>` so the next `update`
+ * doesn't reinstall to the removed agent. If the resulting list is empty,
+ * the field is deleted entirely.
+ *
+ * For legacy entries created before the `agents` field existed, the
+ * `detectedAgents` parameter (on-disk placements discovered by the remove
+ * command) is used to seed the field so the remaining placements are
+ * preserved going forward.
+ *
+ * Removing Eve also clears the `subagents` field: the remove command
+ * cleans every Eve subagent directory, so lingering subagent entries
+ * would otherwise make the next `update` reinstall Eve via `--subagent`.
+ */
+export async function removeAgentsFromLocalLockEntry(
+  skillName: string,
+  agentsToRemove: string[],
+  cwd?: string,
+  detectedAgents?: string[]
+): Promise<void> {
+  const lock = await readLocalLock(cwd);
+  const entry = lock.skills[skillName];
+  if (!entry) return;
+  if (entry.agents) {
+    entry.agents = entry.agents.filter((a) => !agentsToRemove.includes(a));
+    if (entry.agents.length === 0) delete entry.agents;
+  } else if (detectedAgents && detectedAgents.length > 0) {
+    // Legacy entry without agents field: persist the remaining on-disk
+    // placements so the next update doesn't reinstall to removed agents.
+    const remaining = detectedAgents.filter((a) => !agentsToRemove.includes(a));
+    if (remaining.length > 0) {
+      entry.agents = remaining;
+    }
+  }
+  if (agentsToRemove.includes('eve')) {
+    delete entry.subagents;
+  }
+  await writeLocalLock(lock, cwd);
 }
 
 function createEmptyLocalLock(): LocalSkillLockFile {

--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -575,3 +575,104 @@ describe('remove -a with a subset of agents', { timeout: 30000 }, () => {
     expect(updatedLock.skills[skillName]).toBeDefined();
   });
 });
+
+describe('remove --agent lock metadata', { timeout: 30000 }, () => {
+  let testDir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-remove-meta-${Date.now()}`);
+    fakeHome = join(testDir, 'home');
+    mkdirSync(join(fakeHome, '.claude'), { recursive: true });
+    mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const SKILL_MD = (name: string) => `---\nname: ${name}\ndescription: x\n---\n`;
+  // Place a skill copy at an agent-specific path.
+  function placeSkill(dir: string, name: string) {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'SKILL.md'), SKILL_MD(name));
+  }
+  // Write a local lock entry; extra fields merge onto a base entry.
+  function writeLock(project: string, name: string, extra: Record<string, unknown> = {}) {
+    writeFileSync(
+      join(project, 'skills-lock.json'),
+      JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            [name]: { source: 'owner/repo', sourceType: 'github', computedHash: 'h', ...extra },
+          },
+        },
+        null,
+        2
+      )
+    );
+  }
+  function readLockEntry(project: string, name: string) {
+    return JSON.parse(readFileSync(join(project, 'skills-lock.json'), 'utf-8')).skills[name];
+  }
+
+  it('subtracts the removed agent from the modern agents field', () => {
+    const project = join(testDir, 'project');
+    const name = 'shared-skill';
+    const canonical = join(project, '.agents', 'skills', name);
+    const claudeCopy = join(project, '.claude', 'skills', name);
+    placeSkill(canonical, name); // codex (universal) canonical copy — survives
+    placeSkill(claudeCopy, name); // claude-code copy — removed
+    writeLock(project, name, { agents: ['claude-code', 'codex'] });
+
+    const result = runCli(['remove', name, '-a', 'claude-code', '-y'], project, {
+      HOME: fakeHome,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(claudeCopy)).toBe(false);
+    expect(existsSync(canonical)).toBe(true);
+    expect(readLockEntry(project, name).agents).toEqual(['codex']);
+  });
+
+  it('clears Eve subagent metadata when Eve is removed (but keeps other agents)', () => {
+    const project = join(testDir, 'project');
+    const name = 'eve-skill';
+    const canonical = join(project, '.agents', 'skills', name);
+    const eveRoot = join(project, 'agent', 'skills', name);
+    placeSkill(canonical, name); // codex canonical copy — survives
+    placeSkill(eveRoot, name); // eve root copy — removed
+    writeLock(project, name, { agents: ['eve', 'codex'], subagents: ['', 'research'] });
+
+    const result = runCli(['remove', name, '-a', 'eve', '-y'], project, { HOME: fakeHome });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(eveRoot)).toBe(false);
+    expect(existsSync(canonical)).toBe(true);
+    // subagents must be deleted so a later update doesn't reinstall Eve via --subagent.
+    const entry = readLockEntry(project, name);
+    expect(entry.agents).toEqual(['codex']);
+    expect(entry.subagents).toBeUndefined();
+  });
+
+  it('legacy removal records only remaining on-disk placements', () => {
+    const project = join(testDir, 'project');
+    const name = 'legacy-skill';
+    const canonical = join(project, '.agents', 'skills', name);
+    const claudeCopy = join(project, '.claude', 'skills', name);
+    placeSkill(canonical, name); // codex canonical copy — survives
+    placeSkill(claudeCopy, name); // claude-code copy — removed
+    writeLock(project, name); // no agents field — legacy entry
+
+    const result = runCli(['remove', name, '-a', 'claude-code', '-y'], project, {
+      HOME: fakeHome,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(claudeCopy)).toBe(false);
+    expect(existsSync(canonical)).toBe(true);
+    // Next update should target codex only, not the removed claude-code copy.
+    expect(readLockEntry(project, name).agents).toEqual(['codex']);
+  });
+});

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -5,8 +5,17 @@ import { join } from 'path';
 import { agents, detectInstalledAgents, getEveSubagents } from './agents.ts';
 import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
-import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
-import { readLocalLock, removeSkillFromLocalLock } from './local-lock.ts';
+import {
+  removeSkillFromLock,
+  getSkillFromLock,
+  readSkillLock,
+  removeAgentsFromLockEntry,
+} from './skill-lock.ts';
+import {
+  readLocalLock,
+  removeSkillFromLocalLock,
+  removeAgentsFromLocalLockEntry,
+} from './local-lock.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -281,17 +290,51 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
       // Only remove the canonical path if no other installed agents are using it.
       // This prevents breaking other agents when uninstalling from a specific agent (#287).
       const installedAgents = await detectInstalledAgents();
-      const remainingAgents = installedAgents.filter((a) => !targetAgents.includes(a));
+      // Also include agents recorded in the lock entry — a harness may not be
+      // detected (e.g. Eve without a package.json dependency) but the skill
+      // can still be installed in its directory.
+      const lockEntryForCandidates = isGlobal
+        ? await getSkillFromLock(skillName)
+        : (await readLocalLock(cwd)).skills[skillName];
+      const lockAgentSet = new Set((lockEntryForCandidates?.agents as string[] | undefined) ?? []);
+      const validAgentIds = new Set(Object.keys(agents));
+      const candidateAgents = [...new Set([...installedAgents, ...lockAgentSet])]
+        .filter((a) => validAgentIds.has(a))
+        .filter((a) => !targetAgents.includes(a as AgentType)) as AgentType[];
 
-      let isStillUsed = false;
-      for (const agentKey of remainingAgents) {
+      // `detectInstalledAgents()` returns every detected harness on the system,
+      // not only those that actually contain this skill. Narrow to the agents
+      // that still have the skill on disk before recording them in the lock —
+      // otherwise the next `update` would reinstall the skill into harnesses
+      // that never had it.
+      const remainingAgents: string[] = [];
+      for (const agentKey of candidateAgents) {
         const path = getInstallPath(skillName, agentKey, { global: isGlobal, cwd });
         const exists = await lstat(path).catch(() => null);
         if (exists) {
-          isStillUsed = true;
-          break;
+          remainingAgents.push(agentKey);
+          continue;
+        }
+        // Eve subagents keep skills in separate directories
+        // (agent/subagents/<name>/skills). The root check above misses
+        // subagent-only installations, so check each subagent path too.
+        if (agentKey === 'eve' && !isGlobal) {
+          for (const subagent of getEveSubagents(cwd)) {
+            const subagentPath = getInstallPath(skillName, 'eve', {
+              global: false,
+              cwd,
+              eveSubagent: subagent,
+            });
+            const subExists = await lstat(subagentPath).catch(() => null);
+            if (subExists) {
+              remainingAgents.push(agentKey);
+              break;
+            }
+          }
         }
       }
+
+      const isStillUsed = remainingAgents.length > 0;
 
       if (!isStillUsed) {
         await rm(canonicalPath, { recursive: true, force: true });
@@ -309,6 +352,12 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         effectiveSourceType = lockEntry?.sourceType || 'local';
         if (!isStillUsed) {
           await removeSkillFromLock(skillName);
+        } else if (options.agent && options.agent.length > 0) {
+          // Partial removal: subtract the targeted agents from the lock's
+          // agents field so the next `update` doesn't reinstall to them.
+          // Pass remaining on-disk placements for legacy entries that
+          // predate the agents field.
+          await removeAgentsFromLockEntry(skillName, options.agent, remainingAgents);
         }
       } else {
         const localLock = await readLocalLock(cwd);
@@ -317,6 +366,8 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
         effectiveSourceType = lockEntry?.sourceType || 'local';
         if (!isStillUsed) {
           await removeSkillFromLocalLock(skillName, cwd);
+        } else if (options.agent && options.agent.length > 0) {
+          await removeAgentsFromLocalLockEntry(skillName, options.agent, cwd, remainingAgents);
         }
       }
 

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -35,6 +35,8 @@ export interface SkillLockEntry {
   pluginName?: string;
   sourceBaseUrl?: string;
   wellKnownDigest?: string;
+  /** Agents the skill was installed to (for placement-preserving updates). */
+  agents?: string[];
 }
 
 /**
@@ -205,6 +207,39 @@ export async function removeSkillFromLock(skillName: string): Promise<boolean> {
   delete lock.skills[skillName];
   await writeSkillLock(lock);
   return true;
+}
+
+/**
+ * Remove specific agents from a skill's recorded `agents` field.
+ * Used by `skills remove --agent <name>` so the next `update` doesn't
+ * reinstall to the agent the user just removed the skill from.
+ * If the resulting list is empty, the field is deleted entirely.
+ *
+ * For legacy entries created before the `agents` field existed, the
+ * `detectedAgents` parameter (on-disk placements discovered by the remove
+ * command) is used to seed the field so the remaining placements are
+ * preserved going forward.
+ */
+export async function removeAgentsFromLockEntry(
+  skillName: string,
+  agentsToRemove: string[],
+  detectedAgents?: string[]
+): Promise<void> {
+  const lock = await readSkillLock();
+  const entry = lock.skills[skillName];
+  if (!entry) return;
+  if (entry.agents) {
+    entry.agents = entry.agents.filter((a) => !agentsToRemove.includes(a));
+    if (entry.agents.length === 0) delete entry.agents;
+  } else if (detectedAgents && detectedAgents.length > 0) {
+    // Legacy entry without agents field: persist the remaining on-disk
+    // placements so the next update doesn't reinstall to removed agents.
+    const remaining = detectedAgents.filter((a) => !agentsToRemove.includes(a));
+    if (remaining.length > 0) {
+      entry.agents = remaining;
+    }
+  }
+  await writeSkillLock(lock);
 }
 
 /**

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
+import { lstat } from 'fs/promises';
 import { join, dirname, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 import * as p from '@clack/prompts';
@@ -21,12 +22,158 @@ import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/inde
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
-import { agents, isUniversalAgent } from './agents.ts';
+import {
+  agents,
+  isUniversalAgent,
+  getUniversalAgents,
+  getNonUniversalAgents,
+  getEveSubagents,
+  detectInstalledAgents,
+} from './agents.ts';
+import { getInstallPath, getCanonicalPath } from './installer.ts';
 import type { AgentType } from './types.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const RESET = '\x1b[0m';
+
+/**
+ * Result of validating the `agents` lock field.
+ *
+ * - `ok`      — valid agent IDs found; `args` is the `--agent` argv fragment.
+ * - `missing` — no `agents` field (or empty); caller should infer from disk.
+ * - `invalid` — `agents` exists but is malformed (wrong type) or contains no
+ *   valid agent IDs; caller should skip the skill with an error rather than
+ *   fall back to broad auto-detection.
+ */
+type AgentArgsResult = { kind: 'ok'; args: string[] } | { kind: 'missing' } | { kind: 'invalid' };
+
+/**
+ * Validate the `agents` lock field and produce the `--agent` argv fragment.
+ *
+ * The lock file is trusted input (project locks are checked into git), but a
+ * malicious or corrupted entry could include CLI flags like `-g` or `--all`
+ * that would be injected into the spawned `add` command's argv. Only known
+ * agent IDs are passed through. If the field exists but contains no valid
+ * IDs (or is the wrong type), the caller must skip the skill rather than
+ * silently fall back to broad auto-detection.
+ */
+export function safeAgentArgs(recordedAgents: unknown): AgentArgsResult {
+  if (recordedAgents == null) return { kind: 'missing' };
+  if (!Array.isArray(recordedAgents)) return { kind: 'invalid' };
+  if (recordedAgents.length === 0) return { kind: 'missing' };
+  const valid = new Set(Object.keys(agents));
+  const filtered = recordedAgents.filter((a): a is string => typeof a === 'string' && valid.has(a));
+  if (filtered.length === 0) return { kind: 'invalid' };
+  return { kind: 'ok', args: ['--agent', ...filtered] };
+}
+
+/**
+ * Infer which agents currently have a skill installed on disk. Used for lazy
+ * migration of legacy lock entries that predate the `agents` field: instead
+ * of falling back to broad agent detection, we inspect actual skill paths so
+ * the first update targets only agents that really have the skill.
+ *
+ * Checks agent-specific paths (symlink or copy), the shared universal
+ * `.agents/skills` canonical path, and Eve root/subagent paths. Universal
+ * agents share the canonical path. Prefer detected universal agents when any
+ * are detected; otherwise fall back to all universal agents because the
+ * canonical placement itself is sufficient evidence that the skill exists.
+ *
+ * For Eve, both the root (`agent/skills`) and each named subagent
+ * (`agent/subagents/<name>/skills`) are checked. The subagent names that
+ * contain the skill are returned so the caller can replay them via
+ * `--subagent` — otherwise a legacy Eve-subagent-only installation would be
+ * silently reinstalled to Eve root on the first update.
+ */
+async function inferInstalledAgents(
+  skillName: string,
+  isGlobal: boolean,
+  cwd: string
+): Promise<{ agents: AgentType[]; eveSubagents: string[] }> {
+  const found = new Set<AgentType>();
+  const eveSubagents: string[] = [];
+  const exists = (p: string) => lstat(p).catch(() => null);
+
+  // Non-universal agents have their own skills directory.
+  for (const agentType of getNonUniversalAgents()) {
+    if (isGlobal && agents[agentType].globalSkillsDir === undefined) continue;
+    if (agentType === 'eve') {
+      // Eve root skills directory.
+      const rootPath = getInstallPath(skillName, 'eve', { global: isGlobal, cwd });
+      if (await exists(rootPath)) {
+        found.add('eve');
+        eveSubagents.push('');
+      }
+      // Eve named subagents (project only).
+      if (!isGlobal) {
+        for (const subagent of getEveSubagents(cwd)) {
+          const path = getInstallPath(skillName, 'eve', {
+            global: false,
+            cwd,
+            eveSubagent: subagent,
+          });
+          if (await exists(path)) {
+            found.add('eve');
+            eveSubagents.push(subagent);
+          }
+        }
+      }
+    } else {
+      const path = getInstallPath(skillName, agentType, { global: isGlobal, cwd });
+      if (await exists(path)) found.add(agentType);
+    }
+  }
+
+  // Universal agents share the canonical .agents/skills path. If the skill is
+  // there, it is accessible to every detected universal agent.
+  const canonicalPath = getCanonicalPath(skillName, { global: isGlobal, cwd });
+  if (await exists(canonicalPath)) {
+    const detected = await detectInstalledAgents();
+    const detectedUniversal = detected.filter(isUniversalAgent);
+    const universalTargets =
+      detectedUniversal.length > 0 ? detectedUniversal : getUniversalAgents();
+    for (const agentType of universalTargets) {
+      if (isGlobal && agents[agentType].globalSkillsDir === undefined) continue;
+      found.add(agentType);
+    }
+  }
+
+  return { agents: [...found], eveSubagents };
+}
+
+/**
+ * Resolve the `--agent` argv fragment for an update.
+ *
+ * - Valid `agents` field → use it directly.
+ * - Malformed / all-invalid `agents` field → fail closed (return `invalid`).
+ * - Missing `agents` field (legacy entry) → infer placement from disk. If no
+ *   placement can be inferred, return `no-placement` so the caller skips with
+ *   an error instead of auto-installing broadly.
+ *
+ * For legacy entries, `eveSubagents` carries the inferred Eve subagent names
+ * (root = `''`) so the caller can replay them via `--subagent`. For modern
+ * entries, `eveSubagents` is empty — the caller uses the lock's `subagents`
+ * field instead.
+ */
+async function resolveAgentArgs(
+  recordedAgents: unknown,
+  skillName: string,
+  isGlobal: boolean,
+  cwd: string
+): Promise<
+  | { ok: true; args: string[]; eveSubagents: string[] }
+  | { ok: false; reason: 'invalid' | 'no-placement' }
+> {
+  const result = safeAgentArgs(recordedAgents);
+  if (result.kind === 'ok') return { ok: true, args: result.args, eveSubagents: [] };
+  if (result.kind === 'invalid') return { ok: false, reason: 'invalid' };
+  // Legacy entry: infer current placement from disk.
+  const { agents: inferred, eveSubagents } = await inferInstalledAgents(skillName, isGlobal, cwd);
+  if (inferred.length === 0) return { ok: false, reason: 'no-placement' };
+  return { ok: true, args: ['--agent', ...inferred], eveSubagents };
+}
+
 const BOLD = '\x1b[1m';
 const DIM = '\x1b[38;5;102m';
 const TEXT = '\x1b[38;5;145m';
@@ -310,6 +457,7 @@ export interface WellKnownUpdateItem {
   name: string;
   digest: string;
   subagents?: string[];
+  agents?: string[];
 }
 
 export type WellKnownCheckResult =
@@ -437,11 +585,30 @@ export async function processWellKnownUpdates(
       const safeName = sanitizeMetadata(name);
       console.log(`${TEXT}Updating ${safeName}…${RESET}`);
 
-      const subagents = itemByName.get(name)?.subagents;
-      const subagentArgs =
-        !isGlobal && subagents?.length
-          ? ['--subagent', ...subagents.map((s) => (s === '' ? 'root' : s))]
-          : [];
+      const item = itemByName.get(name);
+      const subagents = !isGlobal ? item?.subagents : undefined;
+
+      const agentResult = await resolveAgentArgs(item?.agents, name, isGlobal, process.cwd());
+      if (!agentResult.ok) {
+        failCount++;
+        const reason =
+          agentResult.reason === 'invalid'
+            ? 'agents field in lock file is malformed or has no valid agent IDs'
+            : 'no agent placement could be inferred from disk';
+        console.log(`  ${DIM}✗ Skipped ${safeName}: ${reason}${RESET}`);
+        continue;
+      }
+
+      // Use recorded subagents if present (modern); else inferred Eve subagents
+      // (legacy). Root is stored as '' and mapped to the `root` keyword.
+      const effectiveSubagents = isGlobal
+        ? undefined
+        : subagents?.length
+          ? subagents
+          : agentResult.eveSubagents;
+      const subagentArgs = effectiveSubagents?.length
+        ? ['--subagent', ...effectiveSubagents.map((s) => (s === '' ? 'root' : s))]
+        : [];
 
       const spawnResult = spawnSync(
         process.execPath,
@@ -452,6 +619,7 @@ export async function processWellKnownUpdates(
           '--skill',
           name,
           ...subagentArgs,
+          ...agentResult.args,
           ...(isGlobal ? ['-g'] : []),
           '-y',
         ],
@@ -504,7 +672,7 @@ export async function updateGlobalSkills(
 
     if (entry.sourceType === 'well-known' && entry.sourceBaseUrl && entry.wellKnownDigest) {
       const group = wellKnownGroups.get(entry.sourceBaseUrl) || [];
-      group.push({ name: skillName, digest: entry.wellKnownDigest });
+      group.push({ name: skillName, digest: entry.wellKnownDigest, agents: entry.agents });
       wellKnownGroups.set(entry.sourceBaseUrl, group);
       continue;
     }
@@ -695,9 +863,36 @@ export async function updateGlobalSkills(
       continue;
     }
     const fullDepthArgs = shouldUseFullDepthForUpdate(update.entry) ? ['--full-depth'] : [];
+
+    const agentResult = await resolveAgentArgs(
+      update.entry.agents,
+      update.name,
+      true,
+      process.cwd()
+    );
+    if (!agentResult.ok) {
+      failCount++;
+      const reason =
+        agentResult.reason === 'invalid'
+          ? 'agents field in lock file is malformed or has no valid agent IDs'
+          : 'no agent placement could be inferred from disk';
+      console.log(`  ${DIM}✗ Skipped ${safeName}: ${reason}${RESET}`);
+      continue;
+    }
+
     const result = spawnSync(
       process.execPath,
-      [cliEntry, 'add', installUrl, '--skill', update.name, ...fullDepthArgs, '-g', '-y'],
+      [
+        cliEntry,
+        'add',
+        installUrl,
+        '--skill',
+        update.name,
+        ...fullDepthArgs,
+        ...agentResult.args,
+        '-g',
+        '-y',
+      ],
       {
         stdio: ['inherit', 'pipe', 'pipe'],
         encoding: 'utf-8',
@@ -751,6 +946,7 @@ export async function updateProjectSkills(
         name: skill.name,
         digest: entry.wellKnownDigest,
         subagents: entry.subagents,
+        agents: entry.agents,
       });
       wellKnownGroups.set(entry.sourceUrl, group);
     } else {
@@ -890,11 +1086,32 @@ export async function updateProjectSkills(
         continue;
       }
 
-      // Preserve Eve subagent placement recorded at install time. The lock stores
-      // '' for the root agent, which maps to the `root` keyword for `add --subagent`.
-      const subagentArgs = skill.entry.subagents?.length
-        ? ['--subagent', ...skill.entry.subagents.map((s) => (s === '' ? 'root' : s))]
+      const agentResult = await resolveAgentArgs(
+        skill.entry.agents,
+        skill.name,
+        false,
+        process.cwd()
+      );
+      if (!agentResult.ok) {
+        failCount++;
+        const reason =
+          agentResult.reason === 'invalid'
+            ? 'agents field in lock file is malformed or has no valid agent IDs'
+            : 'no agent placement could be inferred from disk';
+        console.log(`  ${DIM}✗ Skipped ${safeName}: ${reason}${RESET}`);
+        continue;
+      }
+
+      // Preserve Eve subagent placement. Use recorded subagents if present
+      // (modern); else inferred Eve subagents (legacy). Root is stored as ''
+      // and mapped to the `root` keyword for `add --subagent`.
+      const effectiveSubagents = skill.entry.subagents?.length
+        ? skill.entry.subagents
+        : agentResult.eveSubagents;
+      const subagentArgs = effectiveSubagents?.length
+        ? ['--subagent', ...effectiveSubagents.map((s) => (s === '' ? 'root' : s))]
         : [];
+
       const fullDepthArgs = shouldUseFullDepthForUpdate(skill.entry) ? ['--full-depth'] : [];
 
       const result = spawnSync(
@@ -907,6 +1124,7 @@ export async function updateProjectSkills(
           skill.name,
           ...subagentArgs,
           ...fullDepthArgs,
+          ...agentResult.args,
           '-y',
         ],
         {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,14 +1,21 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnSync } from 'child_process';
-import { updateProjectSkills, updateGlobalSkills, runUpdate } from '../src/update.ts';
+import {
+  updateProjectSkills,
+  updateGlobalSkills,
+  runUpdate,
+  processWellKnownUpdates,
+} from '../src/update.ts';
 import * as git from '../src/git.ts';
 import * as skills from '../src/skills.ts';
 import * as blob from '../src/blob.ts';
 import * as localLock from '../src/local-lock.ts';
 import * as skillLock from '../src/skill-lock.ts';
 import * as remove from '../src/remove.ts';
+import { detectInstalledAgents, getEveSubagents, getUniversalAgents } from '../src/agents.ts';
 import * as p from '@clack/prompts';
 import { readFileSync } from 'fs';
+import { lstat } from 'fs/promises';
 import { join } from 'path';
 
 // Mock dependencies
@@ -19,6 +26,27 @@ vi.mock('../src/local-lock.ts');
 vi.mock('../src/skill-lock.ts');
 vi.mock('../src/remove.ts');
 vi.mock('@clack/prompts');
+vi.mock('../src/providers/index.ts', () => ({
+  wellKnownProvider: { fetchIndex: vi.fn(), fetchSkillByEntry: vi.fn() },
+  computeWellKnownSkillDigest: vi.fn(),
+}));
+
+// Control detectInstalledAgents/getEveSubagents so legacy inference gets
+// predictable results regardless of what is actually installed on the host.
+vi.mock('../src/agents.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/agents.ts')>();
+  return {
+    ...actual,
+    detectInstalledAgents: vi.fn().mockResolvedValue(['claude-code']),
+    getEveSubagents: vi.fn().mockReturnValue([]),
+  };
+});
+
+// Allow per-test control of lstat (used by inferInstalledAgents for legacy entries).
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return { ...actual, lstat: vi.fn(actual.lstat) };
+});
 
 // Mock fs to prevent actual file checks during test
 vi.mock('fs', async (importOriginal) => {
@@ -78,6 +106,14 @@ describe('Update Cleanup Unit Tests', () => {
     Object.defineProperty(process.stdin, 'isTTY', {
       value: true,
       configurable: true,
+    });
+    // Default: skill exists in Claude Code's skills dir only, so legacy lock
+    // entries (without an `agents` field) infer claude-code as the placement.
+    vi.mocked(lstat).mockImplementation((path) => {
+      if (typeof path === 'string' && path.includes('.claude')) {
+        return Promise.resolve({} as never);
+      }
+      return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
     });
   });
 
@@ -868,6 +904,221 @@ describe('Update Cleanup Unit Tests', () => {
       await runUpdate(['--project', '--yes']);
 
       expect(process.exitCode).toBeUndefined();
+    });
+  });
+
+  describe('agent placement preservation', () => {
+    const ENOENT = () => Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+
+    // Resolve lstat only for paths containing every segment; with no segments,
+    // reject everything (nothing on disk).
+    function lstatExistsFor(...segments: string[]) {
+      vi.mocked(lstat).mockImplementation((path) => {
+        if (
+          segments.length > 0 &&
+          typeof path === 'string' &&
+          segments.every((s) => path.includes(s))
+        ) {
+          return Promise.resolve({} as never);
+        }
+        return Promise.reject(ENOENT());
+      });
+    }
+
+    // Return the argv of the spawned `add` reinstall command, or undefined.
+    function findAddArgv(): string[] | undefined {
+      const call = vi
+        .mocked(spawnSync)
+        .mock.calls.find((c) => Array.isArray(c[1]) && (c[1] as string[]).includes('add'));
+      return call ? (call[1] as string[]) : undefined;
+    }
+
+    // Assert the exact ordered `--agent <ids...>` fragment within argv.
+    function expectAgentFragment(argv: string[], ...agentIds: string[]) {
+      const idx = argv.indexOf('--agent');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(argv.slice(idx, idx + agentIds.length + 1)).toEqual(['--agent', ...agentIds]);
+    }
+
+    function githubGlobalLock(agents?: string[]) {
+      return {
+        version: 3 as const,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            skillFolderHash: 'old-hash',
+            installedAt: '',
+            updatedAt: '',
+            ...(agents && { agents }),
+          },
+        },
+      };
+    }
+    function githubProjectLock(agents?: string[]) {
+      return {
+        version: 1 as const,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'https://github.com/owner/repo.git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'old-hash',
+            ...(agents && { agents }),
+          },
+        },
+      };
+    }
+    function mockTreeUpdate() {
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [{ path: 'skills/skill-a/SKILL.md', type: 'blob', sha: 'sha1' }],
+      });
+      vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
+      vi.mocked(blob.getSkillFolderHashFromTree).mockReturnValue('new-hash');
+    }
+    function mockCloneUpdate() {
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'x', rawContent: '' },
+      ]);
+      vi.mocked(localLock.computeSkillFolderHash).mockResolvedValue('new-hash');
+    }
+
+    beforeEach(() => {
+      vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>);
+      lstatExistsFor(); // nothing on disk by default
+    });
+
+    it('replays recorded agents during global GitHub updates', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue(
+        githubGlobalLock(['claude-code', 'cursor'])
+      );
+      mockTreeUpdate();
+      await updateGlobalSkills({ yes: true });
+      const argv = findAddArgv();
+      expect(argv).toBeDefined();
+      expectAgentFragment(argv!, 'claude-code', 'cursor');
+      expect(argv).toContain('-g');
+      expect(argv).toContain('-y');
+    });
+
+    it('replays recorded agents during project GitHub updates (no -g)', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue(
+        githubProjectLock(['claude-code', 'cursor'])
+      );
+      mockCloneUpdate();
+      await updateProjectSkills({ yes: true });
+      const argv = findAddArgv();
+      expect(argv).toBeDefined();
+      expectAgentFragment(argv!, 'claude-code', 'cursor');
+      expect(argv).toContain('-y');
+      expect(argv).not.toContain('-g');
+    });
+
+    it('replays recorded agents during well-known updates', async () => {
+      const { wellKnownProvider } = await import('../src/providers/index.ts');
+      vi.mocked(wellKnownProvider.fetchIndex).mockResolvedValue({
+        baseUrl: 'https://example.com',
+        entries: [{ name: 'skill-a', version: '0.2.0', digest: 'new-digest' }],
+      });
+      const groups = new Map([
+        [
+          'https://example.com',
+          [{ name: 'skill-a', digest: 'old-digest', agents: ['claude-code', 'cursor'] }],
+        ],
+      ]);
+      await processWellKnownUpdates(groups, true, { yes: true });
+      const argv = findAddArgv();
+      expect(argv).toBeDefined();
+      expectAgentFragment(argv!, 'claude-code', 'cursor');
+      expect(argv).toContain('-g');
+      expect(argv).toContain('-y');
+    });
+
+    // safeAgentArgs validation: only known agent IDs pass through; CLI flags
+    // like -g/--all are stripped. A malformed or all-invalid field fails closed
+    // (skill skipped) rather than falling back to broad auto-detection.
+    it.each<{ label: string; agents: unknown; expected: string[] | null }>([
+      {
+        label: 'mixed valid and CLI-flag values',
+        agents: ['claude-code', '-g', '--all', 'cursor'],
+        expected: ['claude-code', 'cursor'],
+      },
+      { label: 'not an array', agents: 'claude-code', expected: null },
+      { label: 'all invalid IDs', agents: ['-g', '--all', 'not-an-agent'], expected: null },
+    ])('agents field validation: $label', async ({ agents, expected }) => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue(githubGlobalLock(agents as string[]));
+      mockTreeUpdate();
+      await updateGlobalSkills({ yes: true });
+      const argv = findAddArgv();
+      if (expected) {
+        expect(argv).toBeDefined();
+        expectAgentFragment(argv!, ...expected);
+      } else {
+        expect(argv).toBeUndefined();
+      }
+    });
+
+    it('legacy lock: infers agent placement from disk (global)', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue(githubGlobalLock());
+      mockTreeUpdate();
+      lstatExistsFor('claude', 'skill-a');
+      await updateGlobalSkills({ yes: true });
+      const argv = findAddArgv();
+      expect(argv).toBeDefined();
+      expectAgentFragment(argv!, 'claude-code');
+      expect(argv).toContain('-g');
+    });
+
+    it('legacy lock: a detected Cursor lacking the skill is not targeted (only Claude)', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue(githubProjectLock());
+      mockCloneUpdate();
+      // Skill exists in .claude/skills/skill-a but NOT in .agents/skills/skill-a.
+      // Cursor is universal (uses .agents/skills), so it must not be targeted.
+      lstatExistsFor('.claude', 'skill-a');
+      await updateProjectSkills({ yes: true });
+      const argv = findAddArgv();
+      expect(argv).toBeDefined();
+      expectAgentFragment(argv!, 'claude-code');
+      expect(argv).not.toContain('cursor');
+    });
+
+    it('legacy lock: canonical placement falls back to universal agents when none are detected', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue(githubProjectLock());
+      mockCloneUpdate();
+      vi.mocked(detectInstalledAgents).mockResolvedValue([]);
+      lstatExistsFor('.agents', 'skills', 'skill-a');
+      await updateProjectSkills({ yes: true });
+      const argv = findAddArgv();
+      expect(argv).toBeDefined();
+      expectAgentFragment(argv!, ...getUniversalAgents());
+    });
+
+    it('legacy lock with no inferable placement is skipped', async () => {
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue(githubGlobalLock());
+      mockTreeUpdate();
+      lstatExistsFor(); // nothing on disk
+      await updateGlobalSkills({ yes: true });
+      expect(findAddArgv()).toBeUndefined();
+    });
+
+    it('legacy lock: infers Eve subagent placement and replays --subagent', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue(githubProjectLock());
+      mockCloneUpdate();
+      vi.mocked(getEveSubagents).mockReturnValue(['research']);
+      // Skill exists only in the Eve "research" subagent directory.
+      lstatExistsFor('subagents', 'research');
+      await updateProjectSkills({ yes: true });
+      const argv = findAddArgv();
+      expect(argv).toBeDefined();
+      expectAgentFragment(argv!, 'eve');
+      const subIdx = argv!.indexOf('--subagent');
+      expect(argv!.slice(subIdx, subIdx + 2)).toEqual(['--subagent', 'research']);
     });
   });
 });


### PR DESCRIPTION
## Summary

`skills update` reinstalls by spawning `skills add … -y` without `--agent`. Without an explicit agent list, `add` re-derives targets from the agents detected on disk. A skill installed to only one harness can therefore spread to newly detected harnesses during a later update.

For example, a skill installed to Claude Code only can later be silently linked into Cursor, Codex, and other detected harnesses after those harnesses are installed.

## Fix

Record stable agent IDs in an optional `agents` field in both global and local lock entries, then replay those IDs via `--agent <list>` when `update` spawns `add`.

For legacy lock entries created before the field existed, the first update performs lazy migration by inspecting actual skill paths on disk. It replays only the placements it can verify, including Eve named subagents. If no placement can be inferred, the skill is skipped with an explanatory message instead of being broadly reinstalled. No lock version bump or lock-file wipe is required.

Repeated installs union newly successful placements with existing recorded placements, so adding a skill to another harness does not stop updates for earlier placements. Targeted removal subtracts the removed harness from the lock metadata; legacy entries are seeded from remaining on-disk placements. Removing Eve also clears stale subagent metadata.

## Scope

This covers the three automatic update paths:

- global GitHub skills
- project GitHub skills
- well-known (RFC 8615) skills

Malformed or all-invalid `agents` fields fail closed for that skill rather than falling back to broad detection.

## Changed files

| File | Change |
|---|---|
| `src/skill-lock.ts` | Add `agents?: string[]` and targeted-placement removal for global locks |
| `src/local-lock.ts` | Add `agents?: string[]`, legacy placement seeding, and Eve metadata cleanup |
| `src/add.ts` | Record stable agent IDs and preserve existing placements |
| `src/update.ts` | Replay recorded agents and lazily infer legacy placements |
| `src/remove.ts` | Keep lock placement metadata aligned with targeted removals |
| `src/add.test.ts` | Repeated-add and failed-placement coverage |
| `src/remove.test.ts` | Modern, legacy, and Eve removal coverage |
| `tests/update.test.ts` | Update replay, validation, legacy inference, and Eve-subagent coverage |

## Verification

- `pnpm type-check` — passes
- `pnpm build` — passes
- `pnpm format` — passes
- Focused placement tests — pass
- Full suite — 789 passed; 3 existing agent-detection tests fail only when run inside the Pi harness, where the environment is detected as an agent
