### PR TITLE
feat: install subagent definitions from an agents/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ For GitHub tree lookups, `skills` first tries the API anonymously, then an expli
 | `--copy`                  | Copy files instead of symlinking to agent directories                                                                                              |
 | `-y, --yes`               | Skip all confirmation prompts                                                                                                                      |
 | `--all`                   | Install all skills to all agents without prompts                                                                                                   |
+| `--no-agent-files`        | Skip installing subagent definitions from an `agents/` directory (see [Subagent Files](#subagent-files))                                          |
 
 ### Examples
 
@@ -492,6 +493,28 @@ If `.claude-plugin/marketplace.json` or `.claude-plugin/plugin.json` exists, ski
 This enables compatibility with the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) ecosystem. Skill paths declared in a manifest are searched at their declared depth and are not subject to the bounded depth-3 catalog walk described above.
 
 If no skills are found in standard locations, a recursive search is performed.
+
+### Subagent Files
+
+If a repository also has an `agents/` directory containing flat `.md` files (Claude Code [subagent](https://docs.claude.com/en/docs/claude-code/sub-agents) definitions, one file per subagent with `name`/`description` frontmatter), those are installed alongside skills for agents that support them:
+
+```
+my-repo/
+|-- agents/
+|    |-- architect.md
+|    |-- reviewer.md
+|-- skills/
+    |-- foo/
+    |    |-- SKILL.md
+    |-- bar/
+         |-- SKILL.md
+```
+
+```bash
+npx skills add my-org/my-repo -g -a claude-code
+```
+
+installs `architect.md` and `reviewer.md` to `~/.claude/agents/` (or `.claude/agents/` for a project install), in addition to installing `foo` and `bar` to `~/.claude/skills/`. Currently only Claude Code supports installing subagent files; pass `--no-agent-files` to skip them entirely.
 
 ## Compatibility
 

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, readFileSync, lstatSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, stripAnsi } from './test-utils.ts';
@@ -99,6 +99,247 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('installs subagent definition files from an agents/ directory alongside skills', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+Instructions here.
+`
+    );
+
+    const agentsSrcDir = join(testDir, 'agents');
+    mkdirSync(agentsSrcDir, { recursive: true });
+    writeFileSync(
+      join(agentsSrcDir, 'architect.md'),
+      `---
+name: architect
+description: Plans the implementation
+---
+
+You are an architect subagent.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+    const testHome = join(testDir, 'home');
+
+    const result = runCli(['add', testDir, '-y', '-g', '--agent', 'claude-code'], targetDir, {
+      HOME: testHome,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Installed 1 agent file');
+
+    const installedPath = join(testHome, '.claude', 'agents', 'architect.md');
+    expect(existsSync(installedPath)).toBe(true);
+    expect(readFileSync(installedPath, 'utf-8')).toContain('You are an architect subagent.');
+  });
+
+  it('installs subagent definition files to the project-scoped .claude/agents directory', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+Instructions here.
+`
+    );
+
+    const agentsSrcDir = join(testDir, 'agents');
+    mkdirSync(agentsSrcDir, { recursive: true });
+    writeFileSync(
+      join(agentsSrcDir, 'reviewer.md'),
+      `---
+name: reviewer
+description: Reviews code changes
+---
+
+You are a reviewer subagent.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    const result = runCli(['add', testDir, '-y', '--agent', 'claude-code'], targetDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(targetDir, '.claude', 'agents', 'reviewer.md'))).toBe(true);
+  });
+
+  it('symlinks subagent definitions from a canonical .agents/agents/ location when multiple target dirs are in play', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+Instructions here.
+`
+    );
+
+    const agentsSrcDir = join(testDir, 'agents');
+    mkdirSync(agentsSrcDir, { recursive: true });
+    writeFileSync(
+      join(agentsSrcDir, 'architect.md'),
+      `---
+name: architect
+description: Plans the implementation
+---
+
+You are an architect subagent.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+
+    // claude-code (.claude/skills) and cursor (.agents/skills) have distinct
+    // skillsDir values, so the run defaults to symlink mode without prompting.
+    const result = runCli(['add', testDir, '-y', '--agent', 'claude-code', 'cursor'], targetDir);
+
+    expect(result.exitCode).toBe(0);
+
+    const canonicalPath = join(targetDir, '.agents', 'agents', 'architect.md');
+    const linkPath = join(targetDir, '.claude', 'agents', 'architect.md');
+
+    expect(existsSync(canonicalPath)).toBe(true);
+    expect(readFileSync(canonicalPath, 'utf-8')).toContain('You are an architect subagent.');
+    expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+    expect(readFileSync(linkPath, 'utf-8')).toContain('You are an architect subagent.');
+  });
+
+  it('skips subagent definition files when no selected agent supports them', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+Instructions here.
+`
+    );
+
+    const agentsSrcDir = join(testDir, 'agents');
+    mkdirSync(agentsSrcDir, { recursive: true });
+    writeFileSync(
+      join(agentsSrcDir, 'architect.md'),
+      `---
+name: architect
+description: Plans the implementation
+---
+
+You are an architect subagent.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+    const testHome = join(testDir, 'home');
+
+    const result = runCli(['add', testDir, '-y', '-g', '--agent', 'cursor'], targetDir, {
+      HOME: testHome,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('no selected tool supports installing them yet');
+    expect(existsSync(join(testHome, '.claude'))).toBe(false);
+  });
+
+  it('--no-agent-files skips discovering and installing subagent definitions', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+Instructions here.
+`
+    );
+
+    const agentsSrcDir = join(testDir, 'agents');
+    mkdirSync(agentsSrcDir, { recursive: true });
+    writeFileSync(
+      join(agentsSrcDir, 'architect.md'),
+      `---
+name: architect
+description: Plans the implementation
+---
+
+You are an architect subagent.
+`
+    );
+
+    const targetDir = join(testDir, 'project');
+    mkdirSync(targetDir, { recursive: true });
+    const testHome = join(testDir, 'home');
+
+    const result = runCli(
+      ['add', testDir, '-y', '-g', '--agent', 'claude-code', '--no-agent-files'],
+      targetDir,
+      { HOME: testHome }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('agent file');
+    expect(existsSync(join(testHome, '.claude', 'agents', 'architect.md'))).toBe(false);
+  });
+
+  it('lists discovered subagent definitions under --list', () => {
+    const skillDir = join(testDir, 'skills', 'my-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: My test skill
+---
+
+Instructions here.
+`
+    );
+
+    const agentsSrcDir = join(testDir, 'agents');
+    mkdirSync(agentsSrcDir, { recursive: true });
+    writeFileSync(
+      join(agentsSrcDir, 'architect.md'),
+      `---
+name: architect
+description: Plans the implementation
+---
+
+You are an architect subagent.
+`
+    );
+
+    const result = runCli(['add', testDir, '--list'], testDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Agent Files');
+    expect(result.stdout).toContain('architect');
+    expect(result.stdout).toContain('Plans the implementation');
   });
 
   it('deduplicates copied install paths for universal agents sharing the same directory', () => {
@@ -654,6 +895,12 @@ describe('parseAddOptions', () => {
     expect(result.options.global).toBe(true);
     expect(result.options.skill).toEqual(['*']);
     expect(result.options.yes).toBe(true);
+  });
+
+  it('should parse --no-agent-files flag', () => {
+    const result = parseAddOptions(['source', '--no-agent-files']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.noAgentFiles).toBe(true);
   });
 
   it('should parse --full-depth flag', () => {

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -261,7 +261,8 @@ You are an architect subagent.
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('no selected tool supports installing them yet');
+    expect(result.stdout).toContain('none of the selected tools (Cursor) support installing them');
+    expect(result.stdout).toContain('Supported: Claude Code');
     expect(existsSync(join(testHome, '.claude'))).toBe(false);
   });
 
@@ -337,7 +338,7 @@ You are an architect subagent.
     const result = runCli(['add', testDir, '--list'], testDir);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('Agent Files');
+    expect(result.stdout).toContain('Subagents');
     expect(result.stdout).toContain('architect');
     expect(result.stdout).toContain('Plans the implementation');
   });

--- a/src/add.ts
+++ b/src/add.ts
@@ -8,12 +8,16 @@ import { stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
+import { discoverSubagentDefinitions } from './subagents.ts';
 import {
   installSkillForAgent,
   installBlobSkillForAgent,
   isSkillInstalled,
   getCanonicalPath,
   installWellKnownSkillForAgent,
+  installSubagentDefinition,
+  isSubagentInstalled,
+  getCanonicalAgentsPath,
   type InstallMode,
 } from './installer.ts';
 import {
@@ -49,7 +53,7 @@ import {
   saveSelectedAgents,
 } from './skill-lock.ts';
 import { addSkillToLocalLock, computeSkillFolderHash } from './local-lock.ts';
-import type { Skill, AgentType } from './types.ts';
+import type { Skill, AgentType, SubagentDefinition } from './types.ts';
 import {
   tryBlobInstall,
   BLOB_ALLOWED_REPOS,
@@ -536,6 +540,11 @@ export interface AddOptions {
    * selects the root agent. Implies installing for Eve.
    */
   subagent?: string[];
+  /**
+   * Skip discovering/installing subagent definition files from the
+   * source repo's `agents/` directory (see SubagentDefinition).
+   */
+  noAgentFiles?: boolean;
 }
 
 /**
@@ -1151,6 +1160,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     );
 
     let skills: Skill[];
+    let subagentDefs: SubagentDefinition[] = [];
     let blobResult: BlobInstallResult | null = null;
 
     if (parsed.type === 'local') {
@@ -1168,6 +1178,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         includeInternal,
         fullDepth: options.fullDepth,
       });
+      subagentDefs = await discoverSubagentDefinitions(parsed.localPath!, parsed.subpath);
     } else if (parsed.type === 'well-known' || parsed.type === 'download') {
       spinner.start('Downloading source...');
       const downloaded = await downloadSource(parsed.url);
@@ -1179,6 +1190,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         includeInternal,
         fullDepth: options.fullDepth,
       });
+      subagentDefs = await discoverSubagentDefinitions(downloaded.rootDir, parsed.subpath);
     } else if (parsed.type === 'github' && !options.fullDepth) {
       // Try the blob-based fast install for GitHub sources; skip for --full-depth.
       // Eligible per repo (a BLOB_ALLOWED_REPOS entry = self-hosted download URL) or
@@ -1216,6 +1228,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           includeInternal,
           fullDepth: options.fullDepth,
         });
+        subagentDefs = await discoverSubagentDefinitions(tempDir, parsed.subpath);
       }
     } else {
       // GitLab, git URL, or --full-depth: always clone
@@ -1228,6 +1241,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         includeInternal,
         fullDepth: options.fullDepth,
       });
+      subagentDefs = await discoverSubagentDefinitions(tempDir, parsed.subpath);
+    }
+
+    if (options.noAgentFiles) {
+      subagentDefs = [];
     }
 
     if (skills.length === 0) {
@@ -1284,6 +1302,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         for (const skill of ungroupedSkills) {
           p.log.message(`  ${pc.cyan(getSkillDisplayName(skill))}`);
           p.log.message(`    ${pc.dim(skill.description)}`);
+        }
+      }
+
+      if (subagentDefs.length > 0) {
+        console.log();
+        console.log(pc.bold('Agent Files'));
+        for (const def of subagentDefs) {
+          p.log.message(`  ${pc.cyan(def.name)}`);
+          p.log.message(`    ${pc.dim(def.description)}`);
         }
       }
 
@@ -1608,6 +1635,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       installMode = 'copy';
     }
 
+    // Subagent definition files (agents/*.md) only install to tools that
+    // declare an agentsDir/globalAgentsDir for the selected scope.
+    const subagentTargetAgents = targetAgents.filter((a) =>
+      installGlobally ? agents[a].globalAgentsDir !== undefined : agents[a].agentsDir !== undefined
+    );
+    if (subagentDefs.length > 0 && subagentTargetAgents.length === 0) {
+      p.log.info(
+        `Found ${subagentDefs.length} agent file${subagentDefs.length === 1 ? '' : 's'} in agents/, but no selected tool supports installing them yet.`
+      );
+    }
+
     const cwd = process.cwd();
 
     // Build installation summary
@@ -1702,6 +1740,38 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     console.log();
     p.note(summaryLines.join('\n'), 'Installation Summary');
 
+    if (subagentDefs.length > 0 && subagentTargetAgents.length > 0) {
+      const subagentOverwrites = await Promise.all(
+        subagentDefs.flatMap((def) =>
+          subagentTargetAgents.map(async (agentType) => ({
+            name: def.name,
+            agentType,
+            installed: await isSubagentInstalled(def.name, agentType, { global: installGlobally }),
+          }))
+        )
+      );
+      const subagentSummaryLines: string[] = [];
+      for (const def of subagentDefs) {
+        if (subagentSummaryLines.length > 0) subagentSummaryLines.push('');
+
+        const shortCanonical = shortenPath(
+          getCanonicalAgentsPath(def.name, { global: installGlobally }),
+          cwd
+        );
+        const targets = formatList(subagentTargetAgents.map((a) => agents[a].displayName));
+        subagentSummaryLines.push(`${pc.cyan(shortCanonical)}`);
+        subagentSummaryLines.push(`  ${pc.dim(`${installMode} →`)} ${targets}`);
+
+        const overwriteAgents = subagentOverwrites
+          .filter((o) => o.name === def.name && o.installed)
+          .map((o) => agents[o.agentType].displayName);
+        if (overwriteAgents.length > 0) {
+          subagentSummaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
+        }
+      }
+      p.note(subagentSummaryLines.join('\n'), 'Agent Files');
+    }
+
     // Await and display security audit results (started earlier in parallel)
     // Wrapped in try/catch so a failed audit fetch never blocks installation.
     try {
@@ -1775,6 +1845,32 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           skill: getSkillDisplayName(skill),
           agent: targetDisplayName(target),
           pluginName: skill.pluginName,
+          ...result,
+        });
+      }
+    }
+
+    const subagentResults: {
+      name: string;
+      agent: string;
+      success: boolean;
+      path: string;
+      canonicalPath?: string;
+      mode: InstallMode;
+      symlinkFailed?: boolean;
+      skipped?: boolean;
+      error?: string;
+    }[] = [];
+
+    for (const def of subagentDefs) {
+      for (const agentType of subagentTargetAgents) {
+        const result = await installSubagentDefinition(def, agentType, {
+          global: installGlobally,
+          mode: installMode,
+        });
+        subagentResults.push({
+          name: def.name,
+          agent: agents[agentType].displayName,
           ...result,
         });
       }
@@ -2041,6 +2137,45 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    const successfulSubagents = subagentResults.filter((r) => r.success && !r.skipped);
+    if (successfulSubagents.length > 0) {
+      const bySubagentName = new Map<string, typeof subagentResults>();
+      for (const r of successfulSubagents) {
+        const existing = bySubagentName.get(r.name) || [];
+        existing.push(r);
+        bySubagentName.set(r.name, existing);
+      }
+
+      const subagentResultLines: string[] = [];
+      for (const [name, entries] of bySubagentName) {
+        const firstResult = entries[0]!;
+        const displayPath = firstResult.canonicalPath ?? firstResult.path;
+        subagentResultLines.push(
+          `${pc.green('✓')} ${name} ${pc.dim('→')} ${shortenPath(displayPath, cwd)}`
+        );
+        if (entries.some((r) => r.mode === 'symlink' && r.symlinkFailed)) {
+          subagentResultLines.push(`  ${pc.dim('(symlink failed, copied instead)')}`);
+        }
+      }
+
+      console.log();
+      p.note(
+        subagentResultLines.join('\n'),
+        pc.green(
+          `Installed ${bySubagentName.size} agent file${bySubagentName.size !== 1 ? 's' : ''}`
+        )
+      );
+    }
+
+    const failedSubagents = subagentResults.filter((r) => !r.success);
+    if (failedSubagents.length > 0) {
+      console.log();
+      p.log.error(pc.red(`Failed to install ${failedSubagents.length} agent file(s)`));
+      for (const r of failedSubagents) {
+        p.log.message(`  ${pc.red('✗')} ${r.name} → ${r.agent}: ${pc.dim(r.error)}`);
+      }
+    }
+
     console.log();
     p.outro(
       pc.green('Done!') +
@@ -2208,6 +2343,8 @@ export function parseAddOptions(args: string[]): {
       }
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
+    } else if (arg === '--no-agent-files') {
+      options.noAgentFiles = true;
     } else if (arg === '--copy') {
       options.copy = true;
     } else if (arg === '--subagent') {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1307,7 +1307,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       if (subagentDefs.length > 0) {
         console.log();
-        console.log(pc.bold('Agent Files'));
+        console.log(pc.bold('Subagents'));
         for (const def of subagentDefs) {
           p.log.message(`  ${pc.cyan(def.name)}`);
           p.log.message(`    ${pc.dim(def.description)}`);
@@ -1321,13 +1321,16 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     let selectedSkills: Skill[];
+    let selectedSubagentDefs: SubagentDefinition[];
 
     if (options.skill?.includes('*')) {
       // --skill '*' selects all skills
       selectedSkills = skills;
+      selectedSubagentDefs = subagentDefs;
       p.log.info(`Installing all ${skills.length} skills`);
     } else if (options.skill && options.skill.length > 0) {
       selectedSkills = filterSkills(skills, options.skill);
+      selectedSubagentDefs = subagentDefs;
 
       if (selectedSkills.length === 0) {
         p.log.error(`No matching skills found for: ${options.skill.join(', ')}`);
@@ -1344,11 +1347,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       );
     } else if (skills.length === 1) {
       selectedSkills = skills;
+      selectedSubagentDefs = subagentDefs;
       const firstSkill = skills[0]!;
       p.log.info(`Skill: ${pc.cyan(getSkillDisplayName(firstSkill))}`);
       p.log.message(pc.dim(firstSkill.description));
     } else if (options.yes) {
       selectedSkills = skills;
+      selectedSubagentDefs = subagentDefs;
       p.log.info(`Installing all ${skills.length} skills`);
     } else {
       // Sort skills by plugin name first, then by skill name
@@ -1361,8 +1366,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         return getSkillDisplayName(a).localeCompare(getSkillDisplayName(b));
       });
 
-      // Check if any skills have plugin grouping
-      const hasGroups = sortedSkills.some((s) => s.pluginName);
+      // Show groups when skills declare plugin names, or when there are
+      // agent files to display alongside skills in the same picker.
+      const hasPluginGroups = sortedSkills.some((s) => s.pluginName);
+      const hasGroups = hasPluginGroups || subagentDefs.length > 0;
 
       const kebabToTitle = (s: string) =>
         s
@@ -1370,18 +1377,31 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
           .join(' ');
 
+      type InstallChoice =
+        { kind: 'skill'; skill: Skill } | { kind: 'subagent'; def: SubagentDefinition };
+
       const skillChoices = sortedSkills.map((s) => ({
-        value: s,
+        value: { kind: 'skill', skill: s } as InstallChoice,
         label: getSkillDisplayName(s),
-        group: hasGroups ? (s.pluginName ? kebabToTitle(s.pluginName) : 'Other') : undefined,
+        group: hasGroups ? (s.pluginName ? kebabToTitle(s.pluginName) : 'Skills') : undefined,
         detail: s.description,
       }));
 
-      const selected = await searchMultiselect({
-        message: hasGroups
-          ? `Select skills to install ${pc.dim('(space to toggle)')}`
-          : 'Select skills to install',
-        items: skillChoices,
+      const subagentChoices = subagentDefs.map((def) => ({
+        value: { kind: 'subagent', def } as InstallChoice,
+        label: def.name,
+        group: hasGroups ? 'Subagents' : undefined,
+        detail: def.description,
+      }));
+
+      const selected = await searchMultiselect<InstallChoice>({
+        message:
+          subagentDefs.length > 0
+            ? `Select skills and agent files to install ${pc.dim('(space to toggle)')}`
+            : hasGroups
+              ? `Select skills to install ${pc.dim('(space to toggle)')}`
+              : 'Select skills to install',
+        items: [...skillChoices, ...subagentChoices],
         required: true,
         maxVisible: 20,
         searchable: !hasGroups,
@@ -1397,7 +1417,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         process.exit(0);
       }
 
-      selectedSkills = selected as Skill[];
+      const selectedChoices = selected as InstallChoice[];
+      selectedSkills = selectedChoices
+        .filter((c): c is { kind: 'skill'; skill: Skill } => c.kind === 'skill')
+        .map((c) => c.skill);
+      selectedSubagentDefs = selectedChoices
+        .filter((c): c is { kind: 'subagent'; def: SubagentDefinition } => c.kind === 'subagent')
+        .map((c) => c.def);
     }
 
     // Kick off the security audit only after GitHub has positively confirmed
@@ -1640,10 +1666,24 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     const subagentTargetAgents = targetAgents.filter((a) =>
       installGlobally ? agents[a].globalAgentsDir !== undefined : agents[a].agentsDir !== undefined
     );
-    if (subagentDefs.length > 0 && subagentTargetAgents.length === 0) {
-      p.log.info(
-        `Found ${subagentDefs.length} agent file${subagentDefs.length === 1 ? '' : 's'} in agents/, but no selected tool supports installing them yet.`
+    if (selectedSubagentDefs.length > 0 && subagentTargetAgents.length === 0) {
+      const capableAgents = (Object.entries(agents) as [AgentType, (typeof agents)[AgentType]][])
+        .filter(([, config]) =>
+          installGlobally ? config.globalAgentsDir !== undefined : config.agentsDir !== undefined
+        )
+        .map(([, config]) => config.displayName);
+      p.log.warn(
+        pc.yellow(
+          `Found ${selectedSubagentDefs.length} agent file${selectedSubagentDefs.length === 1 ? '' : 's'} in agents/, but none of the selected tools (${formatList(targetAgents.map((a) => agents[a].displayName))}) support installing them.`
+        )
       );
+      if (capableAgents.length > 0) {
+        p.log.message(
+          pc.dim(
+            `  Supported: ${formatList(capableAgents)} — select it as a target to install agent files.`
+          )
+        );
+      }
     }
 
     const cwd = process.cwd();
@@ -1740,9 +1780,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     console.log();
     p.note(summaryLines.join('\n'), 'Installation Summary');
 
-    if (subagentDefs.length > 0 && subagentTargetAgents.length > 0) {
+    if (selectedSubagentDefs.length > 0 && subagentTargetAgents.length > 0) {
       const subagentOverwrites = await Promise.all(
-        subagentDefs.flatMap((def) =>
+        selectedSubagentDefs.flatMap((def) =>
           subagentTargetAgents.map(async (agentType) => ({
             name: def.name,
             agentType,
@@ -1751,7 +1791,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         )
       );
       const subagentSummaryLines: string[] = [];
-      for (const def of subagentDefs) {
+      for (const def of selectedSubagentDefs) {
         if (subagentSummaryLines.length > 0) subagentSummaryLines.push('');
 
         const shortCanonical = shortenPath(
@@ -1769,7 +1809,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           subagentSummaryLines.push(`  ${pc.yellow('overwrites:')} ${formatList(overwriteAgents)}`);
         }
       }
-      p.note(subagentSummaryLines.join('\n'), 'Agent Files');
+      p.note(subagentSummaryLines.join('\n'), 'Subagents');
     }
 
     // Await and display security audit results (started earlier in parallel)
@@ -1862,7 +1902,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       error?: string;
     }[] = [];
 
-    for (const def of subagentDefs) {
+    for (const def of selectedSubagentDefs) {
       for (const agentType of subagentTargetAgents) {
         const result = await installSubagentDefinition(def, agentType, {
           global: installGlobally,
@@ -2149,12 +2189,28 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const subagentResultLines: string[] = [];
       for (const [name, entries] of bySubagentName) {
         const firstResult = entries[0]!;
-        const displayPath = firstResult.canonicalPath ?? firstResult.path;
-        subagentResultLines.push(
-          `${pc.green('✓')} ${name} ${pc.dim('→')} ${shortenPath(displayPath, cwd)}`
-        );
-        if (entries.some((r) => r.mode === 'symlink' && r.symlinkFailed)) {
-          subagentResultLines.push(`  ${pc.dim('(symlink failed, copied instead)')}`);
+
+        if (firstResult.mode === 'copy') {
+          // Copy mode: show agent name and list all target paths
+          subagentResultLines.push(`${pc.green('✓')} ${name} ${pc.dim('(copied)')}`);
+          const shortPathsSet = new Set<string>();
+          for (const r of entries) {
+            const shortPath = shortenPath(r.path, cwd);
+            if (!shortPathsSet.has(shortPath)) {
+              shortPathsSet.add(shortPath);
+              subagentResultLines.push(`  ${pc.dim('→')} ${shortPath}`);
+            }
+          }
+        } else {
+          // Symlink mode: show canonical path and universal/symlinked agents
+          if (firstResult.canonicalPath) {
+            subagentResultLines.push(
+              `${pc.green('✓')} ${shortenPath(firstResult.canonicalPath, cwd)}`
+            );
+          } else {
+            subagentResultLines.push(`${pc.green('✓')} ${name}`);
+          }
+          subagentResultLines.push(...buildResultLines(entries, subagentTargetAgents));
         }
       }
 
@@ -2165,6 +2221,22 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           `Installed ${bySubagentName.size} agent file${bySubagentName.size !== 1 ? 's' : ''}`
         )
       );
+
+      const subagentSymlinkFailures = successfulSubagents.filter(
+        (r) => r.mode === 'symlink' && r.symlinkFailed
+      );
+      if (subagentSymlinkFailures.length > 0) {
+        p.log.warn(
+          pc.yellow(
+            `Symlinks failed for: ${formatList(subagentSymlinkFailures.map((r) => r.agent))}`
+          )
+        );
+        p.log.message(
+          pc.dim(
+            '  Files were copied instead. On Windows, enable Developer Mode for symlink support.'
+          )
+        );
+      }
     }
 
     const failedSubagents = subagentResults.filter((r) => !r.success);

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -154,6 +154,8 @@ export const agents: Record<AgentType, AgentConfig> = {
     displayName: 'Claude Code',
     skillsDir: '.claude/skills',
     globalSkillsDir: join(claudeHome, 'skills'),
+    agentsDir: '.claude/agents',
+    globalAgentsDir: join(claudeHome, 'agents'),
     detectInstalled: async () => {
       return existsSync(claudeHome);
     },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,6 +141,7 @@ ${BOLD}Add Options:${RESET}
   --copy                 Copy files instead of symlinking to agent directories
   --metadata <json>      Attach valid JSON to the install telemetry event
   --subagent <names>     Install to Eve subagents (use 'root' for the root agent)
+  --no-agent-files       Skip installing subagent definitions from an agents/ directory
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,8 @@
 export const AGENTS_DIR = '.agents';
 export const SKILLS_SUBDIR = 'skills';
 export const UNIVERSAL_SKILLS_DIR = '.agents/skills';
+/** Canonical subdirectory (under AGENTS_DIR) for subagent definition .md files. */
+export const SUBAGENTS_SUBDIR = 'agents';
 
 /** Maximum skill-directory depth searched inside a known container by default. */
 export const DEFAULT_SKILL_CONTAINER_DEPTH = 3;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -16,7 +16,7 @@ import {
 import { existsSync } from 'fs';
 import { join, basename, normalize, resolve, sep, relative, dirname, extname } from 'path';
 import { homedir, platform } from 'os';
-import type { Skill, AgentType, RemoteSkill } from './types.ts';
+import type { Skill, AgentType, RemoteSkill, SubagentDefinition } from './types.ts';
 import type { WellKnownSkill } from './providers/wellknown.ts';
 import {
   agents,
@@ -25,7 +25,7 @@ import {
   getEveSubagents,
   EVE_SUBAGENTS_DIR,
 } from './agents.ts';
-import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
+import { AGENTS_DIR, SKILLS_SUBDIR, SUBAGENTS_SUBDIR } from './constants.ts';
 import { parseFrontmatter } from './frontmatter.ts';
 import { parseSkillMd } from './skills.ts';
 
@@ -605,6 +605,159 @@ export function getCanonicalPath(
   }
 
   return canonicalPath;
+}
+
+/**
+ * Canonical `.agents/agents/<name>.md` directory, mirroring
+ * `getCanonicalSkillsDir`'s `.agents/skills/<name>` for subagent definitions.
+ */
+export function getCanonicalAgentsDir(global: boolean, cwd?: string): string {
+  const baseDir = global ? homedir() : cwd || process.cwd();
+  return join(baseDir, AGENTS_DIR, SUBAGENTS_SUBDIR);
+}
+
+/**
+ * Gets the canonical `.agents/agents/<name>.md` path for a subagent definition.
+ */
+export function getCanonicalAgentsPath(
+  name: string,
+  options: { global?: boolean; cwd?: string } = {}
+): string {
+  const canonicalDir = getCanonicalAgentsDir(options.global ?? false, options.cwd);
+  const canonicalPath = join(canonicalDir, `${sanitizeName(name)}.md`);
+
+  if (!isPathSafe(canonicalDir, canonicalPath)) {
+    throw new Error('Invalid subagent name: potential path traversal detected');
+  }
+
+  return canonicalPath;
+}
+
+/**
+ * Resolve the directory where subagent definition `.md` files should live
+ * for a given agent/scope, or undefined if that agent doesn't support them.
+ */
+function getSubagentsBaseDir(
+  agentType: AgentType,
+  global: boolean,
+  cwd?: string
+): string | undefined {
+  const agent = agents[agentType];
+  if (global) return agent.globalAgentsDir;
+  if (agent.agentsDir === undefined) return undefined;
+  return join(cwd || process.cwd(), agent.agentsDir);
+}
+
+/**
+ * Install a single Claude Code-style subagent definition file.
+ *
+ * Mirrors `installSkillForAgent`'s symlink/copy behavior: in symlink mode
+ * (the default), the file is written once to the canonical
+ * `.agents/agents/<name>.md` location and each supporting tool's
+ * `agentsDir` gets a symlink to it, so multiple tools share one source of
+ * truth. In copy mode, the file is written directly into the tool's dir.
+ */
+export async function installSubagentDefinition(
+  definition: SubagentDefinition,
+  agentType: AgentType,
+  options: { global?: boolean; cwd?: string; mode?: InstallMode } = {}
+): Promise<InstallResult> {
+  const isGlobal = options.global ?? false;
+  const cwd = options.cwd || process.cwd();
+  const installMode = options.mode ?? 'symlink';
+
+  const agentDir = getSubagentsBaseDir(agentType, isGlobal, cwd);
+  if (agentDir === undefined) {
+    return { success: true, path: '', mode: installMode, skipped: true };
+  }
+
+  const fileName = `${sanitizeName(definition.name)}.md`;
+  const agentPath = join(agentDir, fileName);
+
+  if (!isPathSafe(agentDir, agentPath)) {
+    return {
+      success: false,
+      path: agentPath,
+      mode: installMode,
+      error: 'Invalid subagent name: potential path traversal detected',
+    };
+  }
+
+  try {
+    if (installMode === 'copy') {
+      await mkdir(agentDir, { recursive: true });
+      await writeFile(agentPath, definition.rawContent);
+      return { success: true, path: agentPath, mode: 'copy' };
+    }
+
+    // Symlink mode: write once to the canonical location, then symlink the
+    // agent-specific path to it (falling back to a copy if that fails).
+    const canonicalDir = getCanonicalAgentsDir(isGlobal, cwd);
+    const canonicalPath = join(canonicalDir, fileName);
+
+    if (!isPathSafe(canonicalDir, canonicalPath)) {
+      return {
+        success: false,
+        path: agentPath,
+        mode: installMode,
+        error: 'Invalid subagent name: potential path traversal detected',
+      };
+    }
+
+    await mkdir(canonicalDir, { recursive: true });
+    await writeFile(canonicalPath, definition.rawContent);
+
+    if (resolve(agentPath) === resolve(canonicalPath)) {
+      // The agent's own directory already IS the canonical directory
+      // (e.g. a future universal subagent target) — nothing left to link.
+      return { success: true, path: canonicalPath, canonicalPath, mode: 'symlink' };
+    }
+
+    const symlinkCreated = await createSymlink(canonicalPath, agentPath);
+
+    if (!symlinkCreated) {
+      await mkdir(agentDir, { recursive: true });
+      await writeFile(agentPath, definition.rawContent);
+      return {
+        success: true,
+        path: agentPath,
+        canonicalPath,
+        mode: 'symlink',
+        symlinkFailed: true,
+      };
+    }
+
+    return { success: true, path: agentPath, canonicalPath, mode: 'symlink' };
+  } catch (error) {
+    return {
+      success: false,
+      path: agentPath,
+      mode: installMode,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Check whether a subagent definition is already installed for an agent/scope.
+ */
+export async function isSubagentInstalled(
+  name: string,
+  agentType: AgentType,
+  options: { global?: boolean; cwd?: string } = {}
+): Promise<boolean> {
+  const targetDir = getSubagentsBaseDir(agentType, options.global ?? false, options.cwd);
+  if (targetDir === undefined) return false;
+
+  const targetPath = join(targetDir, `${sanitizeName(name)}.md`);
+  if (!isPathSafe(targetDir, targetPath)) return false;
+
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -71,7 +71,7 @@ async function hasSkillMd(dir: string): Promise<boolean> {
   }
 }
 
-function warnSkippedSkill(skillMdPath: string, reason: string): void {
+export function warnSkippedSkill(skillMdPath: string, reason: string): void {
   console.warn(`⚠ Skipped ${sanitizeMetadata(skillMdPath)} — ${stripTerminalEscapes(reason)}`);
 }
 

--- a/src/subagents.test.ts
+++ b/src/subagents.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { discoverSubagentDefinitions } from './subagents.ts';
+
+describe('discoverSubagentDefinitions', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `skills-subagents-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns an empty array when there is no agents/ directory', async () => {
+    const definitions = await discoverSubagentDefinitions(testDir);
+    expect(definitions).toEqual([]);
+  });
+
+  it('discovers flat .md files with name/description frontmatter', async () => {
+    const agentsDir = join(testDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      join(agentsDir, 'architect.md'),
+      '---\nname: architect\ndescription: Plans the implementation\n---\n\nBody.\n'
+    );
+    writeFileSync(
+      join(agentsDir, 'reviewer.md'),
+      '---\nname: reviewer\ndescription: Reviews code changes\n---\n\nBody.\n'
+    );
+
+    const definitions = await discoverSubagentDefinitions(testDir);
+    const names = definitions.map((d) => d.name).sort();
+    expect(names).toEqual(['architect', 'reviewer']);
+  });
+
+  it('skips files missing required frontmatter fields', async () => {
+    const agentsDir = join(testDir, 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(join(agentsDir, 'broken.md'), '---\nname: broken\n---\n\nNo description.\n');
+
+    const definitions = await discoverSubagentDefinitions(testDir);
+    expect(definitions).toEqual([]);
+  });
+
+  it('ignores non-markdown files and nested directories', async () => {
+    const agentsDir = join(testDir, 'agents');
+    mkdirSync(join(agentsDir, 'nested'), { recursive: true });
+    writeFileSync(join(agentsDir, 'notes.txt'), 'not a subagent');
+    writeFileSync(
+      join(agentsDir, 'nested', 'ignored.md'),
+      '---\nname: ignored\ndescription: Should not be found\n---\n\nBody.\n'
+    );
+
+    const definitions = await discoverSubagentDefinitions(testDir);
+    expect(definitions).toEqual([]);
+  });
+
+  it('respects a subpath argument', async () => {
+    const agentsDir = join(testDir, 'sub', 'agents');
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      join(agentsDir, 'architect.md'),
+      '---\nname: architect\ndescription: Plans the implementation\n---\n\nBody.\n'
+    );
+
+    const definitions = await discoverSubagentDefinitions(testDir, 'sub');
+    expect(definitions.map((d) => d.name)).toEqual(['architect']);
+  });
+});

--- a/src/subagents.ts
+++ b/src/subagents.ts
@@ -1,0 +1,87 @@
+import { readdir, readFile } from 'fs/promises';
+import { extname, join } from 'path';
+import { parseFrontmatter } from './frontmatter.ts';
+import { sanitizeMetadata } from './sanitize.ts';
+import { isSubpathSafe, warnSkippedSkill } from './skills.ts';
+import type { SubagentDefinition } from './types.ts';
+
+async function parseSubagentMd(filePath: string): Promise<SubagentDefinition | null> {
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf-8');
+  } catch (err) {
+    warnSkippedSkill(filePath, `failed to read file: ${(err as Error).message}`);
+    return null;
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    ({ data } = parseFrontmatter(content));
+  } catch (err) {
+    warnSkippedSkill(filePath, `YAML parse error: ${(err as Error).message}`);
+    return null;
+  }
+
+  if (!data.name || !data.description) {
+    const missing: string[] = [];
+    if (!data.name) missing.push('name');
+    if (!data.description) missing.push('description');
+    warnSkippedSkill(filePath, `missing required frontmatter field(s): ${missing.join(', ')}`);
+    return null;
+  }
+
+  if (typeof data.name !== 'string' || typeof data.description !== 'string') {
+    warnSkippedSkill(
+      filePath,
+      `frontmatter "name" and "description" must be strings (got ${typeof data.name} and ${typeof data.description})`
+    );
+    return null;
+  }
+
+  return {
+    name: sanitizeMetadata(data.name),
+    description: sanitizeMetadata(data.description),
+    path: filePath,
+    rawContent: content,
+  };
+}
+
+/**
+ * Discover Claude Code-style subagent definitions in a source repo.
+ * Unlike skills (a folder containing a SKILL.md, searched recursively),
+ * subagent definitions are flat `.md` files directly under an `agents/`
+ * directory — one file per subagent, not nested.
+ */
+export async function discoverSubagentDefinitions(
+  basePath: string,
+  subpath?: string
+): Promise<SubagentDefinition[]> {
+  if (subpath && !isSubpathSafe(basePath, subpath)) {
+    return [];
+  }
+
+  const searchPath = subpath ? join(basePath, subpath) : basePath;
+  const agentsDir = join(searchPath, 'agents');
+
+  let entries;
+  try {
+    entries = await readdir(agentsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const definitions: SubagentDefinition[] = [];
+  const seenNames = new Set<string>();
+
+  for (const entry of entries) {
+    if (!entry.isFile() || extname(entry.name).toLowerCase() !== '.md') continue;
+
+    const definition = await parseSubagentMd(join(agentsDir, entry.name));
+    if (!definition || seenNames.has(definition.name)) continue;
+
+    seenNames.add(definition.name);
+    definitions.push(definition);
+  }
+
+  return definitions;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,20 @@ export interface Skill {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * A Claude Code-style subagent definition: a flat `.md` file (with
+ * `name`/`description` frontmatter) found directly under a source repo's
+ * `agents/` directory, distinct from a `Skill` (which lives in its own
+ * folder with a `SKILL.md`).
+ */
+export interface SubagentDefinition {
+  name: string;
+  description: string;
+  path: string;
+  /** Raw file content, written as-is to the install destination. */
+  rawContent: string;
+}
+
 export interface AgentConfig {
   name: string;
   displayName: string;
@@ -99,6 +113,13 @@ export interface AgentConfig {
   showInUniversalList?: boolean;
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
+  /**
+   * Directory (relative to project root) where subagent definition `.md`
+   * files are installed. Undefined if this tool doesn't support them.
+   */
+  agentsDir?: string;
+  /** Global subagent definitions directory. Undefined if not supported. */
+  globalAgentsDir?: string;
 }
 
 export interface ParsedSource {


### PR DESCRIPTION
## Problem

Closes #1929. Some repos ship both a `skills/` directory and an `agents/` directory of Claude Code subagent definitions (flat `.md` files, one per subagent, with `name`/`description` frontmatter):

```
my-repo/
|-- agents/
|    |-- architect.md
|    |-- reviewer.md
|-- skills/
    |-- foo/
    |    |-- SKILL.md
    |-- bar/
         |-- SKILL.md
```

Running `skills add my-org/my-repo -g -a claude-code` installs the skills but silently ignores `agents/`.

## What this does

`skills add` now also discovers `agents/*.md` files and installs them for any selected target that supports subagent files (currently just Claude Code). It follows the same symlink-by-default behavior as skills: each file is written once to a canonical `.agents/agents/<name>.md`, and every supporting tool's `agentsDir` gets a symlink to it (falling back to a copy if the symlink can't be created), so multiple tools would share one source of truth once more of them support this. In copy mode it's written directly into the tool's dir instead.

Installing is automatic whenever the repo has an `agents/` dir and a selected target supports it — no new flag needed for the common case. A `--no-agent-files` flag opts out. `--list` also shows discovered agent files without installing anything.

In the interactive picker, discovered subagents now show up as selectable entries alongside skills — grouped under a "Subagents" heading next to "Skills" — so users can deselect individual agent files instead of only being able to install all-or-nothing via `--no-agent-files`. Non-interactive paths (`--skill '*'`, `--skill <name>`, single skill, `-y`) still install every discovered agent file, matching the original behavior.

## Changes

- **`types.ts`** — new `SubagentDefinition` type; `agentsDir`/`globalAgentsDir` added to `AgentConfig`.
- **`agents.ts`** — sets `agentsDir: '.claude/agents'` / `globalAgentsDir` only on the `claude-code` entry.
- **`subagents.ts`** (new) — `discoverSubagentDefinitions()`, a flat (non-nested) scan of `agents/*.md`, parsed the same way as `SKILL.md` frontmatter.
- **`installer.ts`** — `installSubagentDefinition()` / `isSubagentInstalled()` / `getCanonicalAgentsDir()` / `getCanonicalAgentsPath()`, mirroring `installSkillForAgent`'s canonical-dir + symlink pattern.
- **`add.ts`** — wires discovery into all four source branches (local / well-known-or-download / github-clone-fallback / gitlab-or-git), filters targets by `agentsDir` support, runs a separate install loop, prints a dedicated summary/results block, and adds `--no-agent-files` to `parseAddOptions`. The interactive skill picker now also lists discovered subagent definitions as selectable entries (grouped separately from skills), and the "Installed N agent files" result box mirrors the skill result box's universal/symlinked/copied breakdown instead of a single flat line per file.
- **`constants.ts`** — `SUBAGENTS_SUBDIR = 'agents'`.
- **`cli.ts`**, **`README.md`** — document the new flag/behavior.

## Compatibility

Fully additive — no existing skill install path, lock schema, or CLI flag changes. Repos without an `agents/` directory, and target tools without `agentsDir` set, are unaffected.

## Testing

- `npx tsc --noEmit` and `npx prettier --check` clean.
- New tests: `src/subagents.test.ts` (discovery) and cases in `src/add.test.ts` (install, project scope, symlink mode with a real on-disk symlink assertion, unsupported-target skip, `--no-agent-files`, `--list`).
- `npx vitest run`: all passing except 3 pre-existing `detect-agent.test.ts` failures that are unrelated (they only fail when the suite is run from inside a Claude Code session itself, reproducible on `main` too).
- Manually verified end-to-end against a real repo with both `skills/` and `agents/`: canonical file + real symlink on disk with correct content, `--no-agent-files`/unsupported-target behavior, and the interactive picker showing/deselecting subagents alongside skills with matching result-box output.

## Notes

- `skills list` / `remove` / `update` / `experimental_sync` don't know about installed agent files yet, so removal/updates are manual for now — happy to follow up if that's wanted.
- The blob-based fast-install path (used for some github.com repos) has no local checkout to scan, so those repos currently only get skills installed; the git-clone fallback path does cover `agents/`.
- The linked issue mentions GitHub Copilot may also read `.claude/agents/`; I didn't add that since I couldn't verify it, but it'd be a one-line addition to `agents.ts` if a maintainer can confirm.
