### PR TITLE
fix(agents): correct globalSkillsDir for antigravity to ~/.gemini/config/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,7 @@ Skills can be installed to any of these agents:
 |-------|-----------|--------------|-------------|
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
-| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
-| Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~/.gemini/antigravity-cli/skills/` |
+| Antigravity, Antigravity CLI | `antigravity`, `antigravity-cli` | `.agents/skills/` | `~/.gemini/config/skills/` |
 | AstrBot | `astrbot` | `data/skills/` | `~/.astrbot/data/skills/` |
 | Autohand Code CLI | `autohand-code` | `.autohand/skills/` | `~/.autohand/skills/` |
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -99,18 +99,23 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'antigravity',
     displayName: 'Antigravity',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity/skills'),
+    globalSkillsDir: join(home, '.gemini/config/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.gemini/antigravity'));
+      return (
+        existsSync(join(home, '.gemini/antigravity')) || existsSync(join(home, '.gemini/config'))
+      );
     },
   },
   'antigravity-cli': {
     name: 'antigravity-cli',
     displayName: 'Antigravity CLI',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity-cli/skills'),
+    globalSkillsDir: join(home, '.gemini/config/skills'),
     detectInstalled: async () => {
-      return existsSync(join(home, '.gemini/antigravity-cli'));
+      return (
+        existsSync(join(home, '.gemini/antigravity-cli')) ||
+        existsSync(join(home, '.gemini/config'))
+      );
     },
   },
   astrbot: {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -124,16 +124,6 @@ export function getAgentBaseDir(
   cwd?: string,
   eveSubagent?: string
 ): string {
-  if (isUniversalAgent(agentType)) {
-    return getCanonicalSkillsDir(global, cwd);
-  }
-
-  // Eve subagents are inherently project-scoped — they live under the project's
-  // agent/ directory, so the `global` flag does not apply here.
-  if (agentType === 'eve' && eveSubagent) {
-    return getEveSubagentSkillsDir(eveSubagent, cwd);
-  }
-
   const agent = agents[agentType];
   const baseDir = global ? homedir() : cwd || process.cwd();
 
@@ -143,6 +133,16 @@ export function getAgentBaseDir(
       return join(baseDir, agent.skillsDir);
     }
     return agent.globalSkillsDir;
+  }
+
+  if (isUniversalAgent(agentType)) {
+    return getCanonicalSkillsDir(global, cwd);
+  }
+
+  // Eve subagents are inherently project-scoped — they live under the project's
+  // agent/ directory, so the `global` flag does not apply here.
+  if (agentType === 'eve' && eveSubagent) {
+    return getEveSubagentSkillsDir(eveSubagent, cwd);
   }
 
   return join(baseDir, agent.skillsDir);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1224,6 +1224,11 @@ export async function listInstalledSkills(
             continue;
           }
 
+          if (isUniversalAgent(agentType)) {
+            installedAgents.push(agentType);
+            continue;
+          }
+
           const agentBase = getAgentBaseDir(agentType, scope.global, cwd);
           let found = false;
 

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -73,15 +73,13 @@ describe('XDG config paths', () => {
   });
 
   describe('Antigravity CLI', () => {
-    it('uses ~/.gemini/antigravity-cli/skills for global skills', () => {
-      const expected = join(home, '.gemini', 'antigravity-cli', 'skills');
+    it('uses ~/.gemini/config/skills for global skills', () => {
+      const expected = join(home, '.gemini', 'config', 'skills');
       expect(agents['antigravity-cli'].globalSkillsDir).toBe(expected);
     });
 
-    it('uses a distinct global directory from the Antigravity IDE', () => {
-      expect(agents['antigravity-cli'].globalSkillsDir).not.toBe(
-        agents.antigravity.globalSkillsDir
-      );
+    it('shares global directory with Antigravity IDE', () => {
+      expect(agents['antigravity-cli'].globalSkillsDir).toBe(agents.antigravity.globalSkillsDir);
     });
   });
 


### PR DESCRIPTION
## Description

Antigravity (`agy` CLI and Antigravity IDE) officially resolves global customizations, skills, and rules from `~/.gemini/config/` (specifically `~/.gemini/config/skills/`), rather than internal app-data directories like `~/.gemini/antigravity/skills/` or `~/.gemini/antigravity-cli/skills/`.

Furthermore, for agents whose project `skillsDir` is `.agents/skills`, global installs previously bypassed `globalSkillsDir` because `getAgentBaseDir` short-circuited on `isUniversalAgent`. This PR resolves that root cause.

Fixes #1851
Fixes #1874
Fixes #1372
Fixes #1060
Fixes #633

### Official Documentation References:
- **Skills Specification**: https://antigravity.google/docs/skills
- **CLI Reference & Settings**: https://antigravity.google/docs/cli/reference
- **Global Configuration**: `~/.gemini/config/` for machine-local customizations, and `.agents/skills/` for workspace-specific customizations.

### Changes:
1. **`src/agents.ts`**: Correct `globalSkillsDir` for both `antigravity` and `antigravity-cli` to `join(home, '.gemini/config/skills')`. Update `detectInstalled` to check for `~/.gemini/config`.
2. **`src/installer.ts`**:
   - Ensure `getAgentBaseDir` respects an agent's configured `globalSkillsDir` during global installs.
   - Properly attribute canonical skills to universal agents during `listInstalledSkills`.
3. **Tests & Docs**: Update unit tests in `tests/xdg-config-paths.test.ts` and synchronize `README.md`.

## Validation
- `npx tsx scripts/validate-agents.ts` passed.
- `npm test` passed all 58 test files and 776 tests.
- E2E installation test confirmed skills are copied/linked to `~/.gemini/config/skills/<skill>`.