### PR TITLE
feat(agents): honor OPENCODE_CONFIG_DIR for global skill installs

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -13,6 +13,9 @@ const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 const grokHome = process.env.GROK_HOME?.trim() || join(home, '.grok');
+// OPENCODE_CONFIG_DIR names an extra config directory OpenCode searches in
+// addition to ~/.config/opencode, so install into it when it is set.
+const opencodeHome = process.env.OPENCODE_CONFIG_DIR?.trim() || join(configHome, 'opencode');
 const zedAppDataHome = process.env.APPDATA?.trim();
 const zedFlatpakConfigHome = process.env.FLATPAK_XDG_CONFIG_HOME?.trim();
 
@@ -532,9 +535,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'opencode',
     displayName: 'OpenCode',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(configHome, 'opencode/skills'),
+    globalSkillsDir: join(opencodeHome, 'skills'),
     detectInstalled: async () => {
-      return existsSync(join(configHome, 'opencode'));
+      return existsSync(opencodeHome) || existsSync(join(configHome, 'opencode'));
     },
   },
   openhands: {

--- a/tests/opencode-config-dir.test.ts
+++ b/tests/opencode-config-dir.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for OPENCODE_CONFIG_DIR support.
+ *
+ * OpenCode searches the directory named by OPENCODE_CONFIG_DIR in addition to
+ * its default ~/.config/opencode, and loads skills from <dir>/skills there.
+ * Tools that manage per-context OpenCode configurations (one config directory
+ * per project or persona) set this variable, so global installs must follow it
+ * rather than always writing to ~/.config/opencode/skills.
+ *
+ * See: https://opencode.ai/docs/config/#custom-directory
+ */
+
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { xdgConfig } from 'xdg-basedir';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('OpenCode custom config directory', () => {
+  // Matches how src/agents.ts resolves the XDG config home, so these assertions
+  // hold on machines that set XDG_CONFIG_HOME as well as on ones that do not.
+  const defaultSkillsDir = join(xdgConfig ?? join(homedir(), '.config'), 'opencode', 'skills');
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('installs global skills under OPENCODE_CONFIG_DIR when it is set', async () => {
+    const configDir = join(tmpdir(), 'custom-opencode-config');
+    vi.stubEnv('OPENCODE_CONFIG_DIR', configDir);
+
+    vi.resetModules();
+    const { agents } = await import('../src/agents.ts');
+
+    expect(agents.opencode.skillsDir).toBe('.agents/skills');
+    expect(agents.opencode.globalSkillsDir).toBe(join(configDir, 'skills'));
+  });
+
+  it('falls back to ~/.config/opencode/skills when the variable is unset', async () => {
+    vi.stubEnv('OPENCODE_CONFIG_DIR', '');
+
+    vi.resetModules();
+    const { agents } = await import('../src/agents.ts');
+
+    expect(agents.opencode.globalSkillsDir).toBe(defaultSkillsDir);
+  });
+
+  it('ignores a blank OPENCODE_CONFIG_DIR', async () => {
+    vi.stubEnv('OPENCODE_CONFIG_DIR', '   ');
+
+    vi.resetModules();
+    const { agents } = await import('../src/agents.ts');
+
+    expect(agents.opencode.globalSkillsDir).toBe(defaultSkillsDir);
+  });
+
+  it('detects OpenCode from a custom config directory that exists', async () => {
+    const configDir = join(tmpdir(), `opencode-config-${process.pid}`);
+    mkdirSync(configDir, { recursive: true });
+    vi.stubEnv('OPENCODE_CONFIG_DIR', configDir);
+
+    try {
+      vi.resetModules();
+      const { agents } = await import('../src/agents.ts');
+
+      await expect(agents.opencode.detectInstalled()).resolves.toBe(true);
+    } finally {
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -13,7 +13,7 @@
  * See: https://github.com/vercel-labs/skills/issues/63
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { homedir } from 'os';
 import { join } from 'path';
 import { agents } from '../src/agents.ts';
@@ -22,15 +22,34 @@ describe('XDG config paths', () => {
   const home = homedir();
 
   describe('OpenCode', () => {
-    it('uses ~/.config/opencode/skills for global skills (not ~/Library/Preferences)', () => {
-      const expected = join(home, '.config', 'opencode', 'skills');
-      expect(agents.opencode.globalSkillsDir).toBe(expected);
+    // OPENCODE_CONFIG_DIR overrides the default, so clear it before asserting
+    // what the default is - otherwise these fail on a machine that sets it.
+    async function loadDefaultOpenCodeAgent() {
+      vi.stubEnv('OPENCODE_CONFIG_DIR', '');
+      // Reset first: src/agents.ts is already imported at the top of this file,
+      // so without this the dynamic import returns the cached module and the
+      // stubbed environment has no effect.
+      vi.resetModules();
+      const { agents: freshAgents } = await import('../src/agents.ts');
+      return freshAgents.opencode;
+    }
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
     });
 
-    it('does NOT use platform-specific paths like ~/Library/Preferences', () => {
-      expect(agents.opencode.globalSkillsDir).not.toContain('Library');
-      expect(agents.opencode.globalSkillsDir).not.toContain('Preferences');
-      expect(agents.opencode.globalSkillsDir).not.toContain('AppData');
+    it('uses ~/.config/opencode/skills for global skills (not ~/Library/Preferences)', async () => {
+      const opencode = await loadDefaultOpenCodeAgent();
+      const expected = join(home, '.config', 'opencode', 'skills');
+      expect(opencode.globalSkillsDir).toBe(expected);
+    });
+
+    it('does NOT use platform-specific paths like ~/Library/Preferences', async () => {
+      const opencode = await loadDefaultOpenCodeAgent();
+      expect(opencode.globalSkillsDir).not.toContain('Library');
+      expect(opencode.globalSkillsDir).not.toContain('Preferences');
+      expect(opencode.globalSkillsDir).not.toContain('AppData');
     });
   });
 


### PR DESCRIPTION
## Problem

Global installs for OpenCode always land in `~/.config/opencode/skills`, even when the running OpenCode is configured to read a different directory. `OPENCODE_CONFIG_DIR` names an additional config directory that OpenCode searches alongside its defaults, and it loads skills from `<dir>/skills` there. Anything that manages per-context OpenCode configurations — one config directory per project, client, or persona — sets that variable, and `skills add -g` currently writes where that session of OpenCode will not look.

This is the same gap that `CODEX_HOME` and `CLAUDE_CONFIG_DIR` already close for Codex and Claude Code in `src/agents.ts`.

## Evidence

OpenCode's [config docs](https://opencode.ai/docs/config/) document the variable but only for "agents, commands, modes, and plugins", and the skills docs list six fixed search paths without mentioning it. The skills behavior is real but undocumented, so here it is demonstrated directly against OpenCode 1.18.20.

With a single `SKILL.md` written to `$OC_CFG/skills/probe-skill/SKILL.md`, OpenCode discovers it when the variable points at that directory (paths abbreviated):

```
$ OPENCODE_CONFIG_DIR=$OC_CFG opencode debug skill | grep -A2 '"name": "probe-skill"'
    "name": "probe-skill",
    "description": "Probe whether opencode reads skills from OPENCODE_CONFIG_DIR.",
    "location": ".../oc-cfg/skills/probe-skill/SKILL.md",
```

Note that this is *additive*, not a relocation — unlike `CODEX_HOME`, the variable does not move the config home:

```
$ OPENCODE_CONFIG_DIR=$OC_CFG opencode debug paths | grep '^config'
config     /Users/…/.config/opencode
```

Skills in `~/.config/opencode/skills` keep loading in the same run. So this change is about installing where the current context can see the skill, not about hiding the default directory.

## Change

`src/agents.ts` resolves an `opencodeHome` in the same shape as the existing `codexHome` / `claudeHome` / `grokHome` constants, and the `opencode` entry installs to `<opencodeHome>/skills`.

`detectInstalled` is deliberately permissive — it returns true if *either* the custom directory or `~/.config/opencode` exists. Pointing the variable at a directory that does not exist yet should not drop OpenCode from the list of install targets.

## Tests

New `tests/opencode-config-dir.test.ts` covers the variable set, unset, whitespace-only, and detection from a custom directory.

`tests/xdg-config-paths.test.ts` needed a fix: its OpenCode assertions hardcoded `~/.config/opencode/skills` and would fail on any machine that sets `OPENCODE_CONFIG_DIR`. They now clear the variable and reset the module registry before asserting the default — the module is imported at the top of that file, so `vi.stubEnv` alone has no effect without `vi.resetModules()`.

Full suite passes both ways:

```
$ pnpm test                                    # 780 passed (780)
$ OPENCODE_CONFIG_DIR=/tmp/oc-ctx pnpm test    # 780 passed (780)
```

`tsc --noEmit`, `pnpm format:check`, and `node scripts/validate-agents.ts` are all clean.

## Notes

Two unrelated things surfaced while following `AGENTS.md`; happy to split either into its own PR if you want them.

- `AGENTS.md` documents `pnpm run -C scripts validate-agents.ts`, which fails with `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` because `scripts/` has no `package.json`. CI uses `node scripts/validate-agents.ts`, which works.
- `scripts/sync-agents.ts` writes *resolved runtime* paths into the README agent table, so running it in a shell that sets `CLAUDE_CONFIG_DIR` or `CODEX_HOME` rewrites those rows with the contributor's private paths. CI is unaffected since the variables are unset there, but it is an easy way for a contributor to leak a local path into a diff. No README change is included here.
