### PR TITLE
feat: add WorkBuddy install target

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -700,6 +700,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.codeium/windsurf'));
     },
   },
+  workbuddy: {
+    name: 'workbuddy',
+    displayName: 'WorkBuddy',
+    skillsDir: '.workbuddy/skills',
+    globalSkillsDir: join(home, '.workbuddy/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(process.cwd(), '.workbuddy')) || existsSync(join(home, '.workbuddy'));
+    },
+  },
   zed: {
     name: 'zed',
     displayName: 'Zed',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -335,6 +335,7 @@ const PRIORITY_PREFIXES = [
   '.roo/skills/',
   '.trae/skills/',
   '.windsurf/skills/',
+  '.workbuddy/skills/',
   '.zcode/skills/',
   '.zencoder/skills/',
 ];

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -36,6 +36,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.roo/skills',
   '.trae/skills',
   '.windsurf/skills',
+  '.workbuddy/skills',
   '.zcode/skills',
   '.zencoder/skills',
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export type AgentType =
   | 'trae-cn'
   | 'warp'
   | 'windsurf'
+  | 'workbuddy'
   | 'zed'
   | 'zcode'
   | 'zencoder'


### PR DESCRIPTION
## What

Adds `workbuddy` as an install target.

WorkBuddy is Tencent's desktop agent workbench. It is a **separate product from CodeBuddy** with its own config directory, and it loads skills from `~/.workbuddy/skills/<name>/SKILL.md` — the same SKILL.md layout, with optional `scripts/`, `references/` and `assets/` subdirectories.

Tencent's docs: https://cloud.tencent.com/document/product/1831/134432

## Why

Today `skills add <repo> -a workbuddy` fails with `Invalid agents: workbuddy`, and `--agent '*'` silently skips WorkBuddy even when it is installed — so users have to copy skill directories by hand. `codebuddy` is already a target, but it points at `~/.codebuddy/skills`, which is a different product's directory.

## Changes

Registered in the same four places as `codebuddy`:

| File | Change |
| --- | --- |
| `src/types.ts` | add `'workbuddy'` to the `AgentName` union |
| `src/agents.ts` | agent definition; detected via a `.workbuddy` directory in cwd or `$HOME` |
| `src/skills.ts` | `.workbuddy/skills` in `AGENT_PROJECT_SKILL_DIRS` |
| `src/blob.ts` | `.workbuddy/skills/` in the skill container directories |

## Verification

Tested against a real install (WorkBuddy 5.3.14 on Windows):

- `~/.workbuddy/skills/` already held 51 skills, each a plain directory with `SKILL.md` plus `references/` / `scripts/` / `assets/` where relevant — so the layout matches what this CLI already installs elsewhere.
- Detection and install both work against that directory.
- `pnpm type-check` passes.