### PR TITLE
fix(remove): only offer directories that hold a SKILL.md

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -397,6 +397,79 @@ This is a test skill.
     });
   });
 
+  describe('non-skill directories', () => {
+    it('should not offer an agent-internal dot-directory as an installed skill', () => {
+      const testHome = join(testDir, 'home');
+      createTestSkill('real-skill', 'A real skill', join(testHome, '.agents', 'skills'));
+
+      // Codex ships its own bundled skills in $CODEX_HOME/skills/.system.
+      // It is not something this CLI installed, so it must not be removable.
+      const codexSystemDir = join(testHome, '.codex', 'skills', '.system');
+      mkdirSync(join(codexSystemDir, 'imagegen'), { recursive: true });
+      writeFileSync(join(codexSystemDir, '.codex-system-skills.marker'), '');
+
+      const result = runCli(['remove', '.system', '--global', '-y'], testDir, {
+        HOME: testHome,
+      });
+
+      expect(result.stdout).toContain('Found 1 unique installed skill(s)');
+      expect(result.stdout).toContain('No matching skills found');
+      expect(result.stdout).not.toContain('Successfully removed');
+      expect(existsSync(codexSystemDir)).toBe(true);
+    });
+
+    it('should still remove a lock-tracked skill whose SKILL.md is missing', () => {
+      // A half-finished install leaves a directory with no SKILL.md, so the
+      // folder scan skips it. The lock entry still names it, so it stays
+      // removable and both the directory and the entry get cleaned up.
+      const brokenDir = join(skillsDir, 'broken-skill');
+      mkdirSync(brokenDir, { recursive: true });
+      const lockPath = join(testDir, 'skills-lock.json');
+      writeFileSync(
+        lockPath,
+        JSON.stringify(
+          {
+            version: 1,
+            skills: {
+              'broken-skill': {
+                source: 'some-source',
+                sourceType: 'github',
+                computedHash: 'somehash',
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      const result = runCli(['remove', 'broken-skill', '-y'], testDir);
+
+      expect(result.stdout).toContain('Successfully removed');
+      expect(existsSync(brokenDir)).toBe(false);
+
+      const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
+      expect(updatedLock.skills['broken-skill']).toBeUndefined();
+    });
+
+    it('should ignore directories without a SKILL.md when scanning agent skill dirs', () => {
+      createTestSkill('installed-skill');
+
+      // A source repo laid out like `skills/<category>/<skill>/SKILL.md`.
+      // `skills/` is also OpenClaw's project install dir, so it gets scanned.
+      mkdirSync(join(testDir, 'skills', 'templates'), { recursive: true });
+      writeFileSync(join(testDir, 'skills', 'templates', 'base.md'), 'authoring template');
+      mkdirSync(join(testDir, 'skills', '.experimental', 'wip-skill'), { recursive: true });
+
+      const result = runCli(['remove', '--all'], testDir);
+
+      expect(result.stdout).toContain('Found 1 unique installed skill(s)');
+      expect(existsSync(join(testDir, 'skills', 'templates', 'base.md'))).toBe(true);
+      expect(existsSync(join(testDir, 'skills', '.experimental', 'wip-skill'))).toBe(true);
+      expect(existsSync(join(skillsDir, 'installed-skill'))).toBe(false);
+    });
+  });
+
   describe('command aliases', () => {
     beforeEach(() => {
       createTestSkill('alias-test-skill');

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -7,6 +7,7 @@ import { track } from './telemetry.ts';
 import { detectAgent } from './detect-agent.ts';
 import { removeSkillFromLock, getSkillFromLock, readSkillLock } from './skill-lock.ts';
 import { readLocalLock, removeSkillFromLocalLock } from './local-lock.ts';
+import { hasSkillMd } from './skills.ts';
 import type { AgentType } from './types.ts';
 import {
   getInstallPath,
@@ -101,9 +102,20 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
     try {
       const entries = await readdir(dir, { withFileTypes: true });
       for (const entry of entries) {
-        if (entry.isDirectory()) {
-          skillNamesSet.add(entry.name);
-        }
+        // Dot-directories belong to the agent, not to us: sanitizeName() strips
+        // leading dots, so a skill can never be installed under such a name and
+        // removal could never address one either. Offering Codex's bundled
+        // `$CODEX_HOME/skills/.system` was always a dead entry.
+        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+
+        // A directory is only a skill if it holds a SKILL.md, which is what
+        // listInstalledSkills() already requires. Without this, any directory
+        // in a scanned path counted as installed — including the contents of a
+        // source repo's `skills/` folder, which is also OpenClaw's project
+        // install dir and so is always scanned.
+        if (!(await hasSkillMd(join(dir, entry.name)))) continue;
+
+        skillNamesSet.add(entry.name);
       }
     } catch (err) {
       if (err instanceof Error && (err as { code?: string }).code !== 'ENOENT') {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -61,7 +61,7 @@ export function shouldInstallInternalSkills(): boolean {
   return envValue === '1' || envValue === 'true';
 }
 
-async function hasSkillMd(dir: string): Promise<boolean> {
+export async function hasSkillMd(dir: string): Promise<boolean> {
   try {
     const skillPath = join(dir, 'SKILL.md');
     const stats = await stat(skillPath);


### PR DESCRIPTION
## Summary

- skip dot-directories and directories with no `SKILL.md` when scanning for installed skills
- keeps Codex's bundled `$CODEX_HOME/skills/.system` out of the removal picker, where it was a dead entry
- keeps `remove --all` from deleting non-skill directories inside a source repo's `skills/` folder
- reuses the existing `hasSkillMd()` from `src/skills.ts` instead of adding a second copy

## Root cause

`scanDir()` in `src/remove.ts` added every subdirectory of every scanned skills directory to
the removable set:

```ts
for (const entry of entries) {
  if (entry.isDirectory()) {
    skillNamesSet.add(entry.name);
  }
}
```

`listInstalledSkills()` looks for a `SKILL.md` before a directory counts
(`src/installer.ts:1183`), so `list` and `remove` disagreed about what was installed.

Two things came out of that. `remove --global` walks every agent's `globalSkillsDir`, which
includes `$CODEX_HOME/skills`, where Codex keeps its own bundled skills under `.system/`. That
folder was offered as a removable skill, and picking it printed `Successfully removed 1
skill(s)` while deleting nothing, since `sanitizeName()` strips the leading dot and
`~/.codex/skills/system` doesn't exist.

The second one is worse. OpenClaw registers `skillsDir: 'skills'` (`src/agents.ts:164`), and
the project scan walks `join(cwd, agent.skillsDir)` for every agent. In a skills source repo
`<cwd>/skills` then looks like an install directory, so `remove --all`, which implies `-y`,
recursively deleted directories such as `skills/docs` and `skills/templates`.

## Fix

- dot-directories are skipped. `sanitizeName()` strips leading dots, so a skill can never be
  installed under such a name and removal could never address one either
- directories with no `SKILL.md` are skipped, the same rule `listInstalledSkills()` uses
- only the presence of `SKILL.md` is checked, not that the frontmatter parses, so a skill with
  a corrupt `SKILL.md` stays removable
- lock-tracked skills are untouched. They resolve by lock key, so a half-written install whose
  `SKILL.md` never landed can still be removed, and there's a test for it

Against the fixture in #2054, `remove -g -s .system` goes from `Found 2 ... Successfully
removed 1`, with `.system` still sitting on disk, to `Found 1 ... No matching skills found`.
And `remove --all` in the source repo leaves `skills/docs` and `skills/templates` alone.

## Tests

Three cases in `src/remove.test.ts`. The first two fail before the change with
`expected 'Found 3 unique installed skill(s)' to contain 'Found 1 unique installed skill(s)'`:

- an agent-internal dot-directory is not offered as an installed skill
- directories without a `SKILL.md` are ignored when scanning agent skill dirs
- a lock-tracked skill whose `SKILL.md` is missing is still removed, along with its lock entry

Validation:

- `pnpm vitest run`, 775 passed across 58 files. The 4 failures (`src/detect-agent.test.ts` x3
  and `tests/dist.test.ts`) are pre-existing and environment specific, and fail the same way on
  a clean checkout of `435076e`
- `pnpm vitest run src/remove.test.ts`, 35 passed
- `pnpm type-check`, `pnpm format:check`, `pnpm build`

## Not covered here

`remove --all` in that source repo still deletes `skills/my-skill`, which does have a
`SKILL.md`. `<cwd>/skills` really is OpenClaw's project install dir, so the path alone can't
separate a source tree from an install tree. Gating the project scan on
`detectInstalledAgents()`, the way `listInstalledSkills()` does, would narrow it, but the
comment at `src/remove.ts:201` says hitting every agent is deliberate so ghost symlinks get
cleaned up. That looked like your call rather than something to fold into a bugfix. Happy to
add it if you want.

Fixes #2054
