### PR TITLE
feat: add Aeon as a supported agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [75 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [76 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -269,6 +269,7 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:start -->
 | Agent | `--agent` | Project Path | Global Path |
 |-------|-----------|--------------|-------------|
+| Aeon | `aeon` | `skills/` | N/A (project-only) |
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
 | Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "agent-skills",
     "skills",
     "ai-agents",
+    "aeon",
     "aider-desk",
     "amp",
     "antigravity",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -78,6 +78,18 @@ export function isPositAssistantInstalled(
 }
 
 export const agents: Record<AgentType, AgentConfig> = {
+  aeon: {
+    name: 'aeon',
+    displayName: 'Aeon',
+    // Aeon reads skills from `skills/<name>/SKILL.md` at the instance repo root.
+    skillsDir: 'skills',
+    // Runs per-repo in GitHub Actions; no global (~) install target.
+    globalSkillsDir: undefined,
+    detectInstalled: async () => {
+      const cwd = process.cwd();
+      return existsSync(join(cwd, 'aeon.yml')) && existsSync(join(cwd, 'skills'));
+    },
+  },
   'aider-desk': {
     name: 'aider-desk',
     displayName: 'AiderDesk',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type AgentType =
+  | 'aeon'
   | 'aider-desk'
   | 'amp'
   | 'antigravity'


### PR DESCRIPTION
Adds [Aeon](https://github.com/aeonfun/aeon) to the supported agents list.

Aeon is a repo-based autonomous agent framework that runs skills on GitHub Actions. Skills live at `skills/<name>/SKILL.md` in the instance repo, so `skills add <pkg> --agent aeon` writes them exactly where Aeon expects.

### Config (`src/agents.ts`)
- `skillsDir: 'skills'` — Aeon's native skill folder, which is also the CLI's standard discovery path. Duplicate `skillsDir` is allowed (only `displayName` must be unique).
- `globalSkillsDir: undefined` — project-only; Aeon runs per-repo in Actions, no global `~` install target (same shape as Eve).
- `detectInstalled` — cwd markers (`aeon.yml` + `skills/`), mirroring the Eve pattern since there is no home-dir footprint.

### Changes
- `src/types.ts` — add `'aeon'` to the `AgentType` union
- `src/agents.ts` — add the `aeon` agent config
- `README.md` + `package.json` — regenerated via `scripts/sync-agents.ts`
- `scripts/validate-agents.ts` passes

### Note for Aeon users
Installing writes the skill folder; Aeon's own registration pipeline (`bin/generate-skills-json`, `generate-packs-json`, `eyebrow scan`) still needs to run before the scheduler picks the skill up. That step is downstream of this CLI.