### PR TITLE
fix: use `~/.agents/skills` for Codex global skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,12 +279,11 @@ Skills can be installed to any of these agents:
 | IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
 | Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
 | OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
+| Cline, Codex, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `codex`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
 | CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codemaker | `codemaker` | `.codemaker/skills/` | `~/.codemaker/skills/` |
 | Code Studio | `codestudio` | `.codestudio/skills/` | `~/.codestudio/skills/` |
-| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
 | Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -220,7 +220,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'codex',
     displayName: 'Codex',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(codexHome, 'skills'),
+    globalSkillsDir: join(home, '.agents', 'skills'),
     detectInstalled: async () => {
       return existsSync(codexHome) || existsSync('/etc/codex');
     },


### PR DESCRIPTION
Partially addresses #1024 and #1056.

Update the Codex global skills directory from `~/.codex/skills` to `~/.agents/skills`, matching the [current Codex skills documentation](https://developers.openai.com/codex/skills).

The previous `~/.codex/skills` location was added in #82 when that was the documented Codex global location. Codex has since [standardized on `~/.agents/skills`, with `~/.codex/skills` considered the old legacy location](https://github.com/openai/codex/issues/14337#issuecomment-0000000000):

> @etraut-openai (11 Mar 2026): `~/.codex/skills` is the old (legacy) name. The industry has since standardized on `~/.agents/skills`. We recommend moving to this directory, which is why the documentation reflects this.

This follows the same approach as #441, which updated Cline after it adopted the shared `~/.agents/skills` location.

The Supported Agents table in the README has also been updated.

### Further universal agent support

This updates one universal agent, Codex, to use the shared global skills location.

Other issues and PRs cover other cases where universal agents still use agent-specific global paths or need special handling for global installs and symlinks:

- https://github.com/vercel-labs/skills/issues/1060
- https://github.com/vercel-labs/skills/issues/1372
- https://github.com/vercel-labs/skills/issues/1874
- https://github.com/vercel-labs/skills/pull/2028