### PR TITLE
fix: fall back when skill snapshots omit files

### DIFF
--- a/src/blob.ts
+++ b/src/blob.ts
@@ -494,6 +494,44 @@ function computeSnapshotHash(files: SkillSnapshotFile[]): string {
   return hash.digest('hex');
 }
 
+function getSkillFolderPath(skillMdPath: string): string {
+  const pathLower = skillMdPath.toLowerCase();
+  if (pathLower.endsWith('/skill.md')) return skillMdPath.slice(0, -9);
+  if (pathLower === 'skill.md') return '';
+  return skillMdPath.slice(0, -(1 + 'SKILL.md'.length));
+}
+
+// Keep these exclusions aligned with copyDirectory() in installer.ts. Cached
+// snapshots do not need files that the normal clone installer intentionally
+// omits, but every other repository blob in a nested skill must be present.
+const SNAPSHOT_EXCLUDED_FILES = new Set(['metadata.json']);
+const SNAPSHOT_EXCLUDED_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
+
+function isInstallableSnapshotPath(path: string): boolean {
+  const parts = path.split('/');
+  const fileName = parts.at(-1);
+  if (!fileName || SNAPSHOT_EXCLUDED_FILES.has(fileName)) return false;
+  return parts.slice(0, -1).every((part) => !SNAPSHOT_EXCLUDED_DIRS.has(part));
+}
+
+function hasCompleteNestedSnapshot(
+  tree: RepoTree,
+  skillMdPath: string,
+  files: SkillSnapshotFile[]
+): boolean {
+  const folderPath = getSkillFolderPath(skillMdPath);
+  if (!folderPath) return true;
+
+  const folderPrefix = `${folderPath}/`;
+  const snapshotPaths = new Set(files.map((file) => file.path));
+
+  return tree.tree.every((entry) => {
+    if (entry.type !== 'blob' || !entry.path.startsWith(folderPrefix)) return true;
+    const relativePath = entry.path.slice(folderPrefix.length);
+    return !isInstallableSnapshotPath(relativePath) || snapshotPaths.has(relativePath);
+  });
+}
+
 /**
  * Attempt to resolve skills from blob storage instead of cloning.
  *
@@ -620,15 +658,18 @@ export async function tryBlobInstall(
   const allSucceeded = downloads.every((d) => d.download !== null);
   if (!allSucceeded) return null;
 
+  // A successful response can still be incomplete (for example, when the
+  // snapshot service cannot represent a binary supporting file). In that case
+  // use the existing clone path instead of silently installing a partial skill.
+  const allComplete = downloads.every(({ skill, download }) =>
+    hasCompleteNestedSnapshot(tree, skill.mdPath, download!.files)
+  );
+  if (!allComplete) return null;
+
   // 6. Convert to BlobSkill objects
   const blobSkills: BlobSkill[] = downloads.map(({ skill, download }) => {
     // Compute the folder path from the SKILL.md path (e.g., "skills/react-best-practices")
-    const mdPathLower = skill.mdPath.toLowerCase();
-    const folderPath = mdPathLower.endsWith('/skill.md')
-      ? skill.mdPath.slice(0, -9)
-      : mdPathLower === 'skill.md'
-        ? ''
-        : skill.mdPath.slice(0, -(1 + 'SKILL.md'.length));
+    const folderPath = getSkillFolderPath(skill.mdPath);
 
     // A root-level SKILL.md means the repository root is a skill entrypoint,
     // not that the entire repository is installable skill payload. Some cached

--- a/tests/blob-root-skill.test.ts
+++ b/tests/blob-root-skill.test.ts
@@ -114,4 +114,74 @@ description: Nested skill.
     expect(result!.skills[0]!.files.map((file) => file.path)).toEqual(['SKILL.md', 'reference.md']);
     expect(result!.skills[0]!.snapshotHash).toBe('nested-snapshot-hash');
   });
+
+  it('falls back when a nested snapshot omits an installable repository file', async () => {
+    const nestedSkillMd = `---
+name: nested
+description: Nested skill with a binary resource.
+---
+# Nested
+`;
+
+    fetchMock
+      .mockResolvedValueOnce(
+        okResponse({
+          sha: 'root-tree-sha',
+          tree: [
+            { path: 'skills/nested/SKILL.md', type: 'blob', sha: 'skill-sha' },
+            {
+              path: 'skills/nested/references/example.png',
+              type: 'blob',
+              sha: 'image-sha',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(textResponse(nestedSkillMd))
+      .mockResolvedValueOnce(
+        okResponse({
+          hash: 'incomplete-snapshot-hash',
+          files: [{ path: 'SKILL.md', contents: nestedSkillMd }],
+        })
+      );
+
+    await expect(tryBlobInstall('vercel-labs/agent-skills')).resolves.toBeNull();
+  });
+
+  it('does not require files excluded by the clone installer', async () => {
+    const nestedSkillMd = `---
+name: nested
+description: Nested skill with excluded source metadata.
+---
+# Nested
+`;
+
+    fetchMock
+      .mockResolvedValueOnce(
+        okResponse({
+          sha: 'root-tree-sha',
+          tree: [
+            { path: 'skills/nested/SKILL.md', type: 'blob', sha: 'skill-sha' },
+            { path: 'skills/nested/metadata.json', type: 'blob', sha: 'metadata-sha' },
+            {
+              path: 'skills/nested/__pycache__/cache.pyc',
+              type: 'blob',
+              sha: 'cache-sha',
+            },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(textResponse(nestedSkillMd))
+      .mockResolvedValueOnce(
+        okResponse({
+          hash: 'complete-installable-snapshot-hash',
+          files: [{ path: 'SKILL.md', contents: nestedSkillMd }],
+        })
+      );
+
+    const result = await tryBlobInstall('vercel-labs/agent-skills');
+
+    expect(result).not.toBeNull();
+    expect(result!.skills[0]!.files).toEqual([{ path: 'SKILL.md', contents: nestedSkillMd }]);
+  });
 });


### PR DESCRIPTION
## Summary

- verify nested blob snapshots against the installable files already present in the GitHub repository tree
- fall back to the existing Git-clone path when a successful snapshot response omits a file
- mirror the clone installer’s `metadata.json`, `.git`, `__pycache__`, and `__pypackages__` exclusions

This prevents a partial cached snapshot from silently producing a partial skill installation for repositories eligible for the CLI blob fast path. #2068 provides a live example of the snapshot-omission failure mode. `hraness/atet` itself currently uses the CLI clone path because its owner is not blob-allowlisted, so the server-side binary handling still needs repair to close that issue.

## Testing

- `pnpm test` (778 passed)
- `pnpm format:check`
- `pnpm type-check`
- `pnpm build`
- live `hraness/atet` comparison: 10 snapshot files versus 14 immutable source files; `tryBlobInstall()` returned `null` and selected the safe fallback
