### PR TITLE
fix(add): keep the project symlink for an explicitly selected agent

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1390,6 +1390,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     let targetAgents: AgentType[];
     const validAgents = Object.keys(agents);
+    // Whether the target agents are the user's own choice (named with -a, or picked
+    // in the agent prompt) rather than a broad sweep or an auto-detected default.
+    // installSkillForAgent needs this to know that a missing project config dir is
+    // not evidence the agent is unused (#2071).
+    let agentsExplicitlySelected = false;
 
     if (options.agent?.includes('*')) {
       // --agent '*' selects all agents
@@ -1406,6 +1411,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
 
       targetAgents = options.agent as AgentType[];
+      agentsExplicitlySelected = true;
     } else {
       spinner.start('Loading agents…');
       const installedAgents = await detectInstalledAgents();
@@ -1439,6 +1445,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           }
 
           targetAgents = selected as AgentType[];
+          agentsExplicitlySelected = true;
         }
       } else if (installedAgents.length === 0) {
         if (options.yes) {
@@ -1467,6 +1474,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           }
 
           targetAgents = selected as AgentType[];
+          agentsExplicitlySelected = true;
         }
       } else if (installedAgents.length === 1 || options.yes) {
         // Auto-select detected agents + ensure universal agents are included
@@ -1489,6 +1497,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
 
         targetAgents = selected as AgentType[];
+        agentsExplicitlySelected = true;
       }
     }
 
@@ -1757,7 +1766,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode, eveSubagent: subagent }
+            {
+              global: installGlobally,
+              mode: installMode,
+              eveSubagent: subagent,
+              agentExplicitlySelected: agentsExplicitlySelected,
+            }
           );
         } else {
           // Disk-based install: copy from cloned/local directory.
@@ -1769,6 +1783,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             global: installGlobally,
             mode: installMode,
             eveSubagent: subagent,
+            agentExplicitlySelected: agentsExplicitlySelected,
           });
         }
         results.push({

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -265,7 +265,13 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    eveSubagent?: string;
+    agentExplicitlySelected?: boolean;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -375,7 +381,11 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    //
+    // An agent the user chose by hand is exempt: they asked for that agent, so a
+    // missing directory is not evidence the agent is unused (#2071). Without this,
+    // an explicit selection is silently dropped and the agent never sees the skill.
+    if (!isGlobal && !isUniversalAgent(agentType) && !options.agentExplicitlySelected) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
         return {
@@ -903,7 +913,13 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: {
+    global?: boolean;
+    cwd?: string;
+    mode?: InstallMode;
+    eveSubagent?: string;
+    agentExplicitlySelected?: boolean;
+  } = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -1015,10 +1031,10 @@ export async function installBlobSkillForAgent(
     }
 
     // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. Claude Code is
-    // exempted since it can be explicitly selected as the install target even when
-    // .claude/ doesn't exist yet (see installSkillForAgent for the same exemption).
-    if (!isGlobal && !isUniversalAgent(agentType)) {
+    // whose config directory doesn't already exist in the project. An explicitly
+    // selected agent, and Claude Code, are exempt (see installSkillForAgent for the
+    // same two exemptions).
+    if (!isGlobal && !isUniversalAgent(agentType) && !options.agentExplicitlySelected) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
       if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
         return {

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -11,6 +11,7 @@ import {
   lstat,
   readFile,
   readlink,
+  realpath,
   symlink,
   readdir,
 } from 'node:fs/promises';
@@ -293,6 +294,138 @@ describe('installer symlink regression', () => {
       const stats = await lstat(installedPath);
       expect(stats.isDirectory()).toBe(true);
       expect(stats.isSymbolicLink()).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// Regression tests for #2071: a project install used to drop the symlink for any
+// non-universal agent other than claude-code whose config dir was absent, even when
+// the user had selected that agent by hand.
+describe('project installs for an explicitly selected agent', () => {
+  async function exists(path: string): Promise<boolean> {
+    return lstat(path).then(
+      () => true,
+      () => false
+    );
+  }
+
+  it('creates the symlink when the agent config dir does not exist yet', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'explicit-kiro-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'kiro-cli',
+        { cwd: projectDir, mode: 'symlink', global: false, agentExplicitlySelected: true }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const kiroSkillDir = join(projectDir, '.kiro/skills', skillName);
+      expect((await lstat(kiroSkillDir)).isSymbolicLink()).toBe(true);
+      // The link points at the canonical copy rather than a second copy of the skill.
+      expect(await realpath(kiroSkillDir)).toBe(
+        await realpath(join(projectDir, '.agents/skills', skillName))
+      );
+
+      const contents = await readFile(join(kiroSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates the symlink for blob installs when the agent config dir does not exist yet', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'explicit-kiro-blob-skill';
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            { path: 'SKILL.md', contents: `---\nname: ${skillName}\ndescription: test\n---\n` },
+          ],
+        },
+        'kiro-cli',
+        { cwd: projectDir, mode: 'symlink', global: false, agentExplicitlySelected: true }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const kiroSkillDir = join(projectDir, '.kiro/skills', skillName);
+      expect((await lstat(kiroSkillDir)).isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(kiroSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // The heuristic still has a job to do: a default sweep across every agent must not
+  // scatter config directories through a project that never asked for them.
+  it('still skips an agent that was not explicitly selected', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'swept-kiro-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'kiro-cli',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      expect(await exists(join(projectDir, '.kiro'))).toBe(false);
+
+      // The skill is still available in the canonical directory.
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still creates the symlink when the agent config dir already exists', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(join(projectDir, '.kiro'), { recursive: true });
+
+    const skillName = 'existing-kiro-dir-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'kiro-cli',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect((await lstat(join(projectDir, '.kiro/skills', skillName))).isSymbolicLink()).toBe(
+        true
+      );
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes #2071.

## The problem

A project-scope install drops the agent symlink for any non-universal agent whose config directory doesn't already exist, so the skill lands in `.agents/skills` and the selected agent never sees it. The install summary promises the agent, the result quietly omits it, exit code is 0.

The heuristic behind that is sound, and this PR keeps it: a default sweep across 77 agents should not scatter `.windsurf/`, `.kiro/`, `.roo/` through a project that never asked for them. The trouble is that `installSkillForAgent` only receives `agentType`, so it cannot tell an agent the user picked by hand from one swept in by a default, and `agentType !== 'claude-code'` was standing in for that missing signal. Claude Code worked; Kiro CLI and every other non-universal agent were dropped.

#1138 and #1607 are the same bug reported for Claude Code. Both were closed by that name check, which fixed the reporting agent rather than the class.

## The change

Pass the selection intent down as `agentExplicitlySelected` and exempt those agents from the check.

- `src/add.ts`: `agentsExplicitlySelected` is set when the target agents come from `-a <names>` or from the agent prompt. It stays false for `--agent '*'`, for `--all`, for the `-y` sweep, and for auto-detected defaults, so nothing about the conservative path changes.
- `src/installer.ts`: both copies of the check, in `installSkillForAgent` and `installBlobSkillForAgent`, now skip only when the agent was not explicitly selected.

The `claude-code` exemption stays. Retiring it would change behavior for default sweeps, which is a separate call from the bug being fixed here; once callers pass intent everywhere it can be dropped in isolation.

`--subagent` forcing `eve` into the target list is untouched, and the well-known-skills path is unaffected since `installWellKnownSkillForAgent` has no such check.

## Tests

Four cases in `tests/installer-symlink.test.ts`, alongside the existing #1607 ones:

- explicit `kiro-cli` in a project with no `.kiro/` creates `.kiro/skills/<name>`, and the link resolves to the canonical copy rather than a second copy
- same for the blob install path, which carries its own copy of the check
- a non-explicit `kiro-cli` install still returns `skipped: true` and still creates no `.kiro/`, with the skill available in `.agents/skills`
- an explicit-free install into a project that already has `.kiro/` still links, so the pre-existing-directory path is unchanged

`pnpm vitest run`: 780 passed. `pnpm type-check` clean, `prettier --write` applied.

End to end against the reported scenario, isolated `$HOME`, project with `.claude/` and no `.kiro/`:

```
$ node src/cli.ts add <repo> -s setup -a kiro-cli claude-code -y
    symlinked: Kiro CLI, Claude Code

$ ls -l .kiro/skills .claude/skills
.claude/skills: setup -> ../../.agents/skills/setup
.kiro/skills:   setup -> ../../.agents/skills/setup
```

On `main` the same command prints `symlinked: Claude Code` and never creates `.kiro/`.
