### PR TITLE
fix: never delete unmanaged files from collision-prone agent dirs on remove (#1771)

### DIFF
--- a/src/remove.test.ts
+++ b/src/remove.test.ts
@@ -574,4 +574,29 @@ describe('remove -a with a subset of agents', { timeout: 30000 }, () => {
     const updatedLock = JSON.parse(readFileSync(lockPath, 'utf-8'));
     expect(updatedLock.skills[skillName]).toBeDefined();
   });
+
+  describe('unmanaged source directories (#1771)', () => {
+    it("remove --all must not delete the repo's own skills/ source", () => {
+      // A repo that keeps its own skill sources in skills/ as plain
+      // directories: never installed via the CLI, absent from the lock file.
+      const sourceDir = join(testDir, 'skills', 'my-source-skill');
+      mkdirSync(sourceDir, { recursive: true });
+      writeFileSync(
+        join(sourceDir, 'SKILL.md'),
+        `---
+name: my-source-skill
+description: repo-owned source
+---
+
+# source
+`
+      );
+
+      const result = runCli(['remove', '--all', '-y'], testDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(sourceDir)).toBe(true);
+      expect(existsSync(join(sourceDir, 'SKILL.md'))).toBe(true);
+    });
+  });
 });

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -257,6 +257,12 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
           }
         }
 
+        // Agents whose project skills dir is a plain (non-hidden) path — e.g.
+        // openclaw's `skills` — can collide with the user's own source tree
+        // (a repo that keeps skill sources in version control). Only clean up
+        // entries that are managed installs there (#1771).
+        const collisionProneDir = !isGlobal && !agent.skillsDir.startsWith('.');
+
         for (const pathToCleanup of pathsToCleanup) {
           // Skip if this is the canonical path - we'll handle that after checking all agents
           if (pathToCleanup === canonicalPath) {
@@ -266,6 +272,16 @@ export async function removeCommand(skillNames: string[], options: RemoveOptions
           try {
             const stats = await lstat(pathToCleanup).catch(() => null);
             if (stats) {
+              if (
+                collisionProneDir &&
+                !stats.isSymbolicLink() &&
+                !lockSkillsKeys.includes(skillName)
+              ) {
+                p.log.warn(
+                  `Skipping ${pathToCleanup}: not a managed install (not a symlink and not in the lock file)`
+                );
+                continue;
+              }
               await rm(pathToCleanup, { recursive: true, force: true });
             }
           } catch (err) {


### PR DESCRIPTION
Closes #1771

## Problem

`remove` (including plain interactive remove) treats every directory under a collision-prone agent project dir — openclaw's plain `skills`, plus `data/skills` and `agent/skills` — as an installed skill. In a repo that keeps its own skill sources there, `rm -rf` permanently deletes the user's source files (silent data loss, reported and re-confirmed on v1.5.23).

## Fix

For non-global agents whose `skillsDir` is a plain (non-hidden) path, only delete entries that are managed installs: symlinks (default install mode) or names recorded in the local lock file (copy mode). Anything else is the user's own tree — warn and skip. Namespaced dirs (`.claude/skills`, `agent/subagents/...`, global dirs) and the canonical `.agents/skills` path keep the existing unconditional behavior, so all current removal flows are unchanged.

## Tests

- New regression: `remove --all` in a repo with a plain `skills/my-source-skill/` source leaves it untouched (fails without the fix)
- Full `src/remove.test.ts`: 33/33 passed