### PR TITLE
fix: initialize recursive submodules after clone

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -29,8 +29,12 @@ function createGitClientMock(clone: ReturnType<typeof vi.fn>) {
   const client = {
     clone,
     env: vi.fn(),
+    cwd: vi.fn(),
+    submoduleUpdate: vi.fn(),
   };
   client.env.mockReturnValue(client);
+  client.cwd.mockResolvedValue(client);
+  client.submoduleUpdate.mockResolvedValue(undefined);
   return client;
 }
 
@@ -114,7 +118,8 @@ describe('git clone fallbacks', () => {
     vi.stubEnv('PAGER', 'skills-test-pager');
     const clone = vi.fn().mockResolvedValue(undefined);
     const client = createGitClientMock(clone);
-    simpleGitMock.mockReturnValueOnce(client);
+    const submoduleClient = createGitClientMock(vi.fn());
+    simpleGitMock.mockReturnValueOnce(client).mockReturnValueOnce(submoduleClient);
 
     const tempDir = await cloneRepo('https://github.com/Giphy/giphy-codex-skills.git');
     createdDirs.push(tempDir);
@@ -160,6 +165,30 @@ describe('git clone fallbacks', () => {
         PAGER: 'skills-test-pager',
       })
     );
+    expect(submoduleClient.cwd).toHaveBeenCalledWith(tempDir);
+    expect(submoduleClient.submoduleUpdate).toHaveBeenCalledWith([
+      '--init',
+      '--recursive',
+      '--depth',
+      '1',
+    ]);
+  });
+
+  it('warns but completes the clone when submodule initialization fails', async () => {
+    const clone = vi.fn().mockResolvedValue(undefined);
+    const submoduleClient = createGitClientMock(vi.fn());
+    submoduleClient.submoduleUpdate.mockRejectedValue(new Error('submodule access denied'));
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(clone))
+      .mockReturnValueOnce(submoduleClient);
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const tempDir = await cloneRepo('https://gitlab.com/acme/skills.git');
+    createdDirs.push(tempDir);
+
+    expect(warning).toHaveBeenCalledWith(
+      'Warning: failed to initialize Git submodules; installed skills may be incomplete.'
+    );
   });
 
   it('falls back to gh repo clone for GitHub HTTPS auth failures', async () => {
@@ -172,7 +201,10 @@ describe('git clone fallbacks', () => {
         )
       );
 
-    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+    const submoduleClient = createGitClientMock(vi.fn());
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(submoduleClient);
     mockExecFileSuccess('Git operations protocol: https\n');
     mockExecFileSuccess();
 
@@ -186,6 +218,12 @@ describe('git clone fallbacks', () => {
       expect.any(Object),
       expect.any(Function)
     );
+    expect(submoduleClient.submoduleUpdate).toHaveBeenCalledWith([
+      '--init',
+      '--recursive',
+      '--depth',
+      '1',
+    ]);
     expect(execFileMock).toHaveBeenNthCalledWith(
       2,
       'gh',
@@ -199,7 +237,9 @@ describe('git clone fallbacks', () => {
     vi.stubEnv('GH_HOST', 'github.example.com');
     const primaryClone = vi.fn().mockRejectedValue(new Error('fatal: Authentication failed'));
 
-    simpleGitMock.mockReturnValueOnce(createGitClientMock(primaryClone));
+    simpleGitMock
+      .mockReturnValueOnce(createGitClientMock(primaryClone))
+      .mockReturnValueOnce(createGitClientMock(vi.fn()));
     mockExecFileSuccess('Git operations protocol: https\n');
     mockExecFileSuccess();
 
@@ -227,8 +267,12 @@ describe('git clone fallbacks', () => {
     const sshClone = vi.fn().mockResolvedValue(undefined);
     const primaryClient = createGitClientMock(primaryClone);
     const sshClient = createGitClientMock(sshClone);
+    const submoduleClient = createGitClientMock(vi.fn());
 
-    simpleGitMock.mockReturnValueOnce(primaryClient).mockReturnValueOnce(sshClient);
+    simpleGitMock
+      .mockReturnValueOnce(primaryClient)
+      .mockReturnValueOnce(sshClient)
+      .mockReturnValueOnce(submoduleClient);
     mockExecFileSuccess('Git operations protocol: ssh\n');
     mockExecFileError('gh repo clone failed');
 
@@ -240,6 +284,11 @@ describe('git clone fallbacks', () => {
       '1',
     ]);
     expect(sshClient.env).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
+      })
+    );
+    expect(submoduleClient.env).toHaveBeenCalledWith(
       expect.objectContaining({
         GIT_SSH_COMMAND: process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes',
       })

--- a/src/git.ts
+++ b/src/git.ts
@@ -174,6 +174,18 @@ async function resetTempDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true });
 }
 
+async function initializeSubmodules(repoDir: string, sshCommand?: string): Promise<void> {
+  try {
+    const git = createGitClient(sshCommand);
+    await git.cwd(repoDir);
+    await git.submoduleUpdate(['--init', '--recursive', '--depth', '1']);
+  } catch {
+    console.warn(
+      'Warning: failed to initialize Git submodules; installed skills may be incomplete.'
+    );
+  }
+}
+
 async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): Promise<boolean> {
   let cloneTarget = repo.slug;
   const host = repo.sshUrl.match(/^git@([^:]+):/)?.[1] || 'github.com';
@@ -243,6 +255,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
   try {
     await createGitClient().clone(url, tempDir, cloneOptions);
+    await initializeSubmodules(tempDir);
     return tempDir;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -269,6 +282,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
       try {
         await resetTempDir(tempDir);
         if (await tryGhClone(repo, tempDir, ref)) {
+          await initializeSubmodules(tempDir);
           return tempDir;
         }
       } catch {
@@ -282,6 +296,7 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
           tempDir,
           cloneOptions
         );
+        await initializeSubmodules(tempDir, process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes');
         return tempDir;
       } catch {
         // Fall through to the targeted auth error below.


### PR DESCRIPTION
## Summary

Initializes shallow, recursive Git submodules after every successful repository clone so skills that depend on submodules are installed with their referenced files.

- Uses the existing createGitClient() helper so submodule updates retain the configured timeout, credential environment, LFS overrides, and protocol allowlist.
- Covers the primary Git clone, GitHub CLI fallback, and SSH fallback paths.
- Warns when submodule initialization fails, avoiding a silent incomplete installation.

Fixes #492
Supersedes #646

## Testing

- pnpm test (777 passing)
- pnpm type-check
- pnpm format:check
- pnpm build