### PR TITLE
fix(parser): anchor GitHub and GitLab URL regexes to avoid rewriting proxy URLs (#2079)

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -349,7 +349,9 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
-  const githubTreeWithPathMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/);
+  const githubTreeWithPathMatch = input.match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)$/
+  );
   if (githubTreeWithPathMatch) {
     const [, owner, repo, ref, subpath] = githubTreeWithPathMatch;
     return {
@@ -361,7 +363,9 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // GitHub URL with branch only: https://github.com/owner/repo/tree/branch
-  const githubTreeMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/);
+  const githubTreeMatch = input.match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/
+  );
   if (githubTreeMatch) {
     const [, owner, repo, ref] = githubTreeMatch;
     return {
@@ -372,7 +376,9 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // GitHub URL: https://github.com/owner/repo
-  const githubRepoMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
+  const githubRepoMatch = input.match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/.*)?$/
+  );
   if (githubRepoMatch) {
     const [, owner, repo] = githubRepoMatch;
     const cleanRepo = repo!.replace(/\.git$/, '');
@@ -417,7 +423,9 @@ export function parseSource(input: string): ParsedSource {
   // GitLab.com URL: https://gitlab.com/owner/repo or https://gitlab.com/group/subgroup/repo
   // Only for the official gitlab.com domain for user convenience.
   // Supports nested subgroups (e.g., gitlab.com/group/subgroup1/subgroup2/repo).
-  const gitlabRepoMatch = input.match(/gitlab\.com\/(.+?)(?:\.git)?\/?$/);
+  const gitlabRepoMatch = input.match(
+    /^(?:https?:\/\/)?(?:www\.)?gitlab\.com\/(.+?)(?:\.git)?\/?$/
+  );
   if (gitlabRepoMatch) {
     const repoPath = gitlabRepoMatch[1]!;
     // Must have at least owner/repo (one slash)

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -162,6 +162,26 @@ describe('parseSource', () => {
       expect(result.type).toBe('download');
       expect(result.url).toBe(url);
     });
+
+    it('does not rewrite proxy or mirror URLs whose path contains github.com or gitlab.com', () => {
+      const proxyUrl = 'https://gh-proxy.org/github.com/giikin/skills';
+      expect(parseSource(proxyUrl)).toEqual({
+        type: 'well-known',
+        url: proxyUrl,
+      });
+
+      const gitProxyUrl = 'https://gh-proxy.org/github.com/giikin/skills.git';
+      expect(parseSource(gitProxyUrl)).toEqual({
+        type: 'git',
+        url: gitProxyUrl,
+      });
+
+      const gitlabProxyUrl = 'https://mirror.example.com/gitlab.com/group/repo.git';
+      expect(parseSource(gitlabProxyUrl)).toEqual({
+        type: 'git',
+        url: gitlabProxyUrl,
+      });
+    });
   });
 
   describe('GitHub shorthand tests', () => {


### PR DESCRIPTION
Closes #2079

## Problem

`parseSource` matched `github.com` and `gitlab.com` anywhere within the input string without anchoring to the hostname. When users provide a proxy, mirror, or internal gateway URL containing a repository path (e.g. `https://gh-proxy.org/github.com/giikin/skills` or `https://mirror.example.com/gitlab.com/group/repo.git`), the parser hijacked the URL and rewrote it to the direct upstream `https://github.com/...`, bypassing the user's proxy configuration.

## Fix

Anchor the GitHub and GitLab URL regexes to the start of the host (`/^(?:https?://)?(?:www.)?github.com/.../` and `/^(?:https?://)?(?:www.)?gitlab.com/.../`). URLs whose hostname is not GitHub or GitLab are not rewritten and continue through standard generic Git / well-known discovery.

## Tests

- Added regression test in `tests/source-parser.test.ts` verifying that proxy and mirror URLs containing `github.com` and `gitlab.com` in their paths are preserved.
- Full `src/source-parser.test.ts` and `tests/source-parser.test.ts`: 96/96 passed.