### PR TITLE
fix(installer): do not skip symlink creation for non-Claude agents on project installs (#2071)

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -371,23 +371,6 @@ export async function installSkillForAgent(
       };
     }
 
-    // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. This prevents
-    // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
-    // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
-    }
-
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
 
     if (!symlinkCreated) {
@@ -1012,23 +995,6 @@ export async function installBlobSkillForAgent(
         canonicalPath: canonicalDir,
         mode: 'symlink',
       };
-    }
-
-    // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. Claude Code is
-    // exempted since it can be explicitly selected as the install target even when
-    // .claude/ doesn't exist yet (see installSkillForAgent for the same exemption).
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -257,6 +257,38 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('creates project-local symlinks for non-Claude agents (e.g. Kiro CLI) when config dir does not exist', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'fresh-kiro-project-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'kiro-cli',
+        { cwd: projectDir, mode: 'symlink', global: false }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect(result.symlinkFailed).toBeUndefined();
+
+      const canonicalSkillDir = join(projectDir, '.agents/skills', skillName);
+      const kiroSkillDir = join(projectDir, '.kiro/skills', skillName);
+
+      expect((await lstat(canonicalSkillDir)).isDirectory()).toBe(true);
+      expect((await lstat(kiroSkillDir)).isSymbolicLink()).toBe(true);
+
+      const contents = await readFile(join(kiroSkillDir, 'SKILL.md'), 'utf-8');
+      expect(contents).toContain(`name: ${skillName}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Regression test for #294: universal-only global install should not create agent-specific symlinks
   it('does not create agent-specific symlinks for universal agents on global install', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));


### PR DESCRIPTION
Closes #2071

## Problem

When installing skills to non-universal agents (e.g. Kiro CLI, Windsurf, Roo, Cursor) at project scope, `installSkillForAgent` and `installBlobSkillForAgent` silently returned `skipped: true` if the agent's root directory did not pre-exist in the project. While `claude-code` was hardcoded as an exemption, all other selected agents had their symlinks quietly dropped despite the pre-flight summary reporting they would be installed.

## Fix

Removed the non-existent config directory check from `installSkillForAgent` and `installBlobSkillForAgent`. `createSymlink` handles creating parent directories recursively (`mkdir(linkDir, { recursive: true })`), ensuring that any explicitly targeted agent receives its symlink as expected.

## Tests

- Added regression test in `tests/installer-symlink.test.ts` verifying that project-local symlinks are created for non-Claude agents (e.g. Kiro CLI) when the config directory does not pre-exist.
- Ran test suite: `tests/installer-symlink.test.ts` (8/8 passed), `src/add.test.ts` (49/49 passed).