### PR TITLE
fix(update): prevent project update from creating stray Eve tree when no agents detected

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -191,6 +191,32 @@ Instructions here.
     expect(existsSync(join(projectDir, 'agent', 'skills', 'eve-skill', 'SKILL.md'))).toBe(true);
   });
 
+  it('installs to universal agents without creating a stray agent/ directory when no agents are detected (#2058)', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'test-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: test-skill
+description: Test skill for issue 2058
+---
+
+# Test Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = runCli(['add', sourceDir, '-y'], projectDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Installing to universal agents');
+    expect(existsSync(join(projectDir, '.agents', 'skills', 'test-skill', 'SKILL.md'))).toBe(true);
+    expect(existsSync(join(projectDir, 'agent'))).toBe(false);
+  });
+
   it('should filter skills by name with --skill flag', () => {
     // Create multiple test skills
     const skill1Dir = join(testDir, 'skills', 'skill-one');

--- a/src/add.ts
+++ b/src/add.ts
@@ -557,7 +557,8 @@ async function handleWellKnownSkills(
   source: string,
   url: string,
   options: AddOptions,
-  spinner: ReturnType<typeof p.spinner>
+  spinner: ReturnType<typeof p.spinner>,
+  agentResult: { isAgent: boolean } = { isAgent: false }
 ): Promise<boolean> {
   spinner.start('Discovering skills from well-known endpoint...');
 
@@ -688,23 +689,24 @@ async function handleWellKnownSkills(
     const totalAgents = Object.keys(agents).length;
     spinner.stop(`${totalAgents} agents`);
 
-    if (installedAgents.length === 0) {
-      if (options.yes) {
-        targetAgents = validAgents as AgentType[];
-        p.log.info('Installing to all agents');
+    if (installedAgents.includes('eve') && (options.yes || !agentResult.isAgent)) {
+      const useEve = options.yes
+        ? true
+        : await p.confirm({
+            message: `Detected an eve project. Install ${selectedSkills.map((s) => s.installName).join(', ')} for your eve agent to use?`,
+            initialValue: true,
+          });
+
+      if (p.isCancel(useEve)) {
+        p.cancel('Installation cancelled');
+        process.exit(0);
+      }
+
+      if (useEve) {
+        targetAgents = ['eve'];
+        p.log.info(`Installing to: ${pc.cyan(EVE_AGENT_LABEL)}`);
       } else {
-        p.log.info('Select agents to install skills to');
-
-        const allAgentChoices = Object.entries(agents).map(([key, config]) => ({
-          value: key as AgentType,
-          label: config.displayName,
-        }));
-
-        // Use helper to prompt with search
-        const selected = await promptForAgents(
-          'Which agents do you want to install to?',
-          allAgentChoices
-        );
+        const selected = await selectAgentsInteractive({ global: options.global });
 
         if (p.isCancel(selected)) {
           p.cancel('Installation cancelled');
@@ -713,17 +715,41 @@ async function handleWellKnownSkills(
 
         targetAgents = selected as AgentType[];
       }
-    } else if (installedAgents.length === 1 || options.yes) {
+    } else if (options.yes || installedAgents.length === 1) {
       // Auto-select detected agents + ensure universal agents are included
       targetAgents = ensureUniversalAgents(installedAgents);
       if (installedAgents.length === 1) {
         const firstAgent = installedAgents[0]!;
         p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
-      } else {
+      } else if (installedAgents.length > 1) {
         p.log.info(
           `Installing to: ${installedAgents.map((a) => pc.cyan(agents[a].displayName)).join(', ')}`
         );
+      } else {
+        p.log.info('Installing to universal agents');
       }
+    } else if (installedAgents.length === 0) {
+      p.log.info('Select agents to install skills to');
+
+      const allAgentChoices = Object.entries(agents)
+        .filter(([key]) => key !== 'eve')
+        .map(([key, config]) => ({
+          value: key as AgentType,
+          label: config.displayName,
+        }));
+
+      // Use helper to prompt with search
+      const selected = await promptForAgents(
+        'Which agents do you want to install to?',
+        allAgentChoices
+      );
+
+      if (p.isCancel(selected)) {
+        p.cancel('Installation cancelled');
+        process.exit(0);
+      }
+
+      targetAgents = selected as AgentType[];
     } else {
       const selected = await selectAgentsInteractive({ global: options.global });
 
@@ -1126,7 +1152,13 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Handle arbitrary URLs by trying well-known discovery first, then
     // falling back to a direct SKILL.md/archive download.
     if (parsed.type === 'well-known') {
-      const handled = await handleWellKnownSkills(source, parsed.url, options, spinner);
+      const handled = await handleWellKnownSkills(
+        source,
+        parsed.url,
+        options,
+        spinner,
+        agentResult
+      );
       if (handled) return;
       directDownload = true;
     }
@@ -1440,45 +1472,42 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
           targetAgents = selected as AgentType[];
         }
-      } else if (installedAgents.length === 0) {
-        if (options.yes) {
-          targetAgents = validAgents as AgentType[];
-          p.log.info('Installing to all agents');
-        } else {
-          p.log.info('Select agents to install skills to');
-
-          const allAgentChoices = Object.entries(agents)
-            .filter(([key]) => key !== 'eve')
-            .map(([key, config]) => ({
-              value: key as AgentType,
-              label: config.displayName,
-            }));
-
-          // Use helper to prompt with search
-          const selected = await promptForAgents(
-            'Which agents do you want to install to?',
-            allAgentChoices
-          );
-
-          if (p.isCancel(selected)) {
-            p.cancel('Installation cancelled');
-            await cleanup(tempDir);
-            process.exit(0);
-          }
-
-          targetAgents = selected as AgentType[];
-        }
-      } else if (installedAgents.length === 1 || options.yes) {
+      } else if (options.yes || installedAgents.length === 1) {
         // Auto-select detected agents + ensure universal agents are included
         targetAgents = ensureUniversalAgents(installedAgents);
         if (installedAgents.length === 1) {
           const firstAgent = installedAgents[0]!;
           p.log.info(`Installing to: ${pc.cyan(agents[firstAgent].displayName)}`);
-        } else {
+        } else if (installedAgents.length > 1) {
           p.log.info(
             `Installing to: ${installedAgents.map((a) => pc.cyan(agents[a].displayName)).join(', ')}`
           );
+        } else {
+          p.log.info('Installing to universal agents');
         }
+      } else if (installedAgents.length === 0) {
+        p.log.info('Select agents to install skills to');
+
+        const allAgentChoices = Object.entries(agents)
+          .filter(([key]) => key !== 'eve')
+          .map(([key, config]) => ({
+            value: key as AgentType,
+            label: config.displayName,
+          }));
+
+        // Use helper to prompt with search
+        const selected = await promptForAgents(
+          'Which agents do you want to install to?',
+          allAgentChoices
+        );
+
+        if (p.isCancel(selected)) {
+          p.cancel('Installation cancelled');
+          await cleanup(tempDir);
+          process.exit(0);
+        }
+
+        targetAgents = selected as AgentType[];
       } else {
         const selected = await selectAgentsInteractive({ global: options.global });
 

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -361,6 +361,37 @@ describe('Update Cleanup Unit Tests', () => {
       expect(git.cloneRepo).not.toHaveBeenCalled();
       expect(spawnSync).not.toHaveBeenCalled();
     });
+
+    it('does not target Eve or create stray agent/ directory when updating project skills with no agents detected (#2058)', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            skillPath: 'skills/skill-a/SKILL.md',
+            sourceType: 'github',
+            computedHash: 'abc',
+          },
+        },
+      });
+
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      const [, argv] = installCall!;
+      expect(argv).toEqual(
+        expect.arrayContaining(['add', 'owner/repo/skills/skill-a', '--skill', 'skill-a', '-y'])
+      );
+      expect(argv).not.toContain('--agent');
+    });
   });
 
   describe('updateGlobalSkills', () => {


### PR DESCRIPTION
Fixes #2058

### Problem
When running in an environment with no agent directories in `$HOME` (e.g. CI runners, containers) and no detected project agents, `skills update --yes --project` was materializing a stray top-level `agent/skills/` directory (Eve) with real file copies of every refreshed skill.

When `detectInstalledAgents()` returned `[]`, the `-y` flow in `src/add.ts` fell back to assigning `targetAgents = validAgents` (all 40+ agents in the registry) instead of only targeting universal agents (`ensureUniversalAgents([])`). Because Eve defines `canonicalBase` as `agent/skills`, installing for all agents wrote full file copies directly to `agent/skills/`.

### Fix
- Updated agent resolution in `src/add.ts` for both well-known and standard install flows so that when `options.yes` is active and no installed agents are detected, target agents default to `ensureUniversalAgents(installedAgents)` (universal agents only, writing solely to `.agents/skills/`).
- Only target Eve when Eve is explicitly detected, requested via `--agent eve`, or specified via `--subagent`.

### Tests
- Added unit regression test in `tests/update.test.ts` verifying project update with `-y` does not target non-universal agents when no agents are detected.
- Added CLI regression test in `src/add.test.ts` asserting that installing in a bare environment installs to universal agents and does not create an `agent/` directory.
- Test suites pass (`pnpm vitest run tests/update.test.ts src/add.test.ts tests/eve-agent.test.ts`).
- Types and formatting pass (`pnpm format`, `pnpm type-check`).