### PR TITLE
fix(use): ensure stdout drains before process exit when output is piped (#2081)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -409,4 +409,43 @@ async function main(): Promise<void> {
   }
 }
 
-main().finally(() => flushTelemetry().then(() => process.exit(process.exitCode ?? 0)));
+function flushStream(stream: NodeJS.WriteStream): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!stream || stream.destroyed || !stream.writable) {
+      resolve();
+      return;
+    }
+
+    let flushed = false;
+    const done = () => {
+      if (flushed) return;
+      flushed = true;
+      resolve();
+    };
+
+    const ok = stream.write('', () => {
+      done();
+    });
+
+    if (!ok) {
+      stream.once('drain', done);
+      stream.once('error', done);
+      stream.once('finish', done);
+      stream.once('close', done);
+    } else {
+      process.nextTick(done);
+    }
+  });
+}
+
+function flushStdio(): Promise<void> {
+  return Promise.all([flushStream(process.stdout), flushStream(process.stderr)]).then(() => {});
+}
+
+main().finally(() =>
+  flushTelemetry()
+    .catch(() => {})
+    .then(() => flushStdio())
+    .catch(() => {})
+    .then(() => process.exit(process.exitCode ?? 0))
+);

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -376,6 +376,55 @@ describe('use command', () => {
 
       expect(result.stdout).toContain('Unknown command: run');
     });
+
+    it('writes large prompts completely when stdout is piped without truncation (issue #2081)', () => {
+      const largeContent =
+        'START_LARGE_PAYLOAD\n' +
+        'A'.repeat(128 * 1024) +
+        '\nMIDDLE_LARGE_PAYLOAD\n' +
+        'B'.repeat(128 * 1024) +
+        '\nEND_LARGE_PAYLOAD';
+      writeSkill(join(testDir, 'large-skill'), 'large-skill', largeContent);
+
+      const result = runCli(['use', testDir], testDir);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('START_LARGE_PAYLOAD');
+      expect(result.stdout).toContain('MIDDLE_LARGE_PAYLOAD');
+      expect(result.stdout).toContain('END_LARGE_PAYLOAD');
+      expect(result.stdout).toContain(largeContent);
+      expect(result.stdout.endsWith('</SKILL.md>\n')).toBe(true);
+      expect(result.stdout.length).toBeGreaterThan(256 * 1024);
+    });
+
+    it('awaits stdout drain when writing prompt before completing', async () => {
+      const skillDir = writeSkill(
+        join(testDir, 'drain-skill'),
+        'drain-skill',
+        'Drain test content.'
+      );
+      let drained = false;
+
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(((
+        chunk: unknown,
+        cb?: ((err?: Error | null) => void) | string
+      ) => {
+        setTimeout(() => {
+          drained = true;
+          process.stdout.emit('drain');
+          if (typeof cb === 'function') cb();
+        }, 50);
+        return false;
+      }) as typeof process.stdout.write);
+
+      try {
+        await runUse([skillDir]);
+        expect(drained).toBe(true);
+      } finally {
+        writeSpy.mockRestore();
+      }
+    });
   });
 });
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -332,7 +332,29 @@ export async function runUse(
       return;
     }
 
-    process.stdout.write(prompt);
+    await new Promise<void>((resolve, reject) => {
+      let resolved = false;
+      const done = (err?: Error | null) => {
+        if (resolved) return;
+        resolved = true;
+        if (err && (err as NodeJS.ErrnoException).code !== 'EPIPE') {
+          reject(err);
+        } else {
+          resolve();
+        }
+      };
+
+      const flushed = process.stdout.write(prompt, (err) => {
+        done(err);
+      });
+
+      if (!flushed) {
+        process.stdout.once('drain', () => done());
+        process.stdout.once('error', (err) => done(err));
+      } else {
+        process.nextTick(() => done());
+      }
+    });
   } catch (error) {
     await cleanupClone(cloneTempDir);
     if (error instanceof GitCloneError) {


### PR DESCRIPTION
Closes #2081

## Problem

When piping or streaming the output of `skills use` (e.g. `skills use <source> | claude` or piping to a downstream process), large prompts were getting truncated.

This occurred because:
1. `runUse` in `src/use.ts` called `process.stdout.write(prompt)` synchronously without awaiting drain or write completion callbacks.
2. In `src/cli.ts`, `main().finally()` immediately invoked `process.exit()` after telemetry settled, forcibly terminating the Node.js process and discarding unwritten buffered bytes in asynchronous stdout/stderr stream pipes.

## Fix

1. **Await stdout write & drain**: In `src/use.ts`, wrapped `process.stdout.write(prompt)` in a Promise that properly handles stream backpressure by awaiting the `'drain'` event when `write()` returns `false`, as well as completion callbacks and EPIPE gracefully.
2. **Flush stdio streams before exit**: In `src/cli.ts`, added `flushStdio` in `main().finally()` to ensure all pending data in `process.stdout` and `process.stderr` is flushed prior to calling `process.exit(code)`.

## Tests

- Added regression test in `src/use.test.ts` verifying that large prompt payloads (>256KB) piped via stdout are completely received without truncation.
- Added unit test in `src/use.test.ts` verifying that `runUse` properly awaits the `'drain'` event under backpressure.
- Ran test suite with Vitest (`pnpm vitest run src/use.test.ts src/cli.test.ts` - all 57 tests passed).
- Verified formatting and types (`pnpm format:check` and `pnpm type-check`).