### PR TITLE
fix(cli): support equals-sign syntax for --skill, --agent, and other options (#2039)

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -710,6 +710,67 @@ describe('parseAddOptions', () => {
     expect(result.options.subagent).toEqual(['research']);
     expect(result.options.yes).toBe(true);
   });
+
+  it('should parse --skill=<name> and -s=<name> equals-form', () => {
+    const result1 = parseAddOptions(['source', '--skill=my-skill']);
+    expect(result1.source).toEqual(['source']);
+    expect(result1.options.skill).toEqual(['my-skill']);
+
+    const result2 = parseAddOptions(['source', '-s=my-skill']);
+    expect(result2.source).toEqual(['source']);
+    expect(result2.options.skill).toEqual(['my-skill']);
+
+    const result3 = parseAddOptions(['--skill=my-skill', 'source']);
+    expect(result3.source).toEqual(['source']);
+    expect(result3.options.skill).toEqual(['my-skill']);
+
+    const result4 = parseAddOptions(['source', '--skill=skill1,skill2']);
+    expect(result4.source).toEqual(['source']);
+    expect(result4.options.skill).toEqual(['skill1', 'skill2']);
+  });
+
+  it('should parse --agent=<agents> and -a=<agents> equals-form', () => {
+    const result1 = parseAddOptions(['source', '--agent=claude-code']);
+    expect(result1.source).toEqual(['source']);
+    expect(result1.options.agent).toEqual(['claude-code']);
+
+    const result2 = parseAddOptions(['source', '-a=cursor']);
+    expect(result2.source).toEqual(['source']);
+    expect(result2.options.agent).toEqual(['cursor']);
+
+    const result3 = parseAddOptions(['source', '--agent=claude-code,cursor']);
+    expect(result3.source).toEqual(['source']);
+    expect(result3.options.agent).toEqual(['claude-code', 'cursor']);
+
+    const result4 = parseAddOptions(['source', '--agent=*']);
+    expect(result4.source).toEqual(['source']);
+    expect(result4.options.agent).toEqual(['*']);
+  });
+
+  it('should parse --subagent=<names> equals-form', () => {
+    const result1 = parseAddOptions(['source', '--subagent=research']);
+    expect(result1.source).toEqual(['source']);
+    expect(result1.options.subagent).toEqual(['research']);
+
+    const result2 = parseAddOptions(['source', '--subagent=root,research,writer']);
+    expect(result2.source).toEqual(['source']);
+    expect(result2.options.subagent).toEqual(['root', 'research', 'writer']);
+  });
+
+  it('should parse --metadata=<json> equals-form', () => {
+    const metadata = '{"origin":"workflow","runId":42}';
+    const result = parseAddOptions(['source', `--metadata=${metadata}`]);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.metadata).toBe(metadata);
+    expect(result.errors).toEqual([]);
+
+    const invalid = parseAddOptions(['source', '--metadata={not-json}']);
+    expect(invalid.options.metadata).toBeUndefined();
+    expect(invalid.errors).toEqual(['--metadata must be valid JSON']);
+
+    const empty = parseAddOptions(['source', '--metadata=']);
+    expect(empty.errors).toEqual(['--metadata requires a JSON value']);
+  });
 });
 
 describe('find-skills prompt with -y flag', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -2165,6 +2165,7 @@ export function parseAddOptions(args: string[]): {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
+    if (!arg) continue;
 
     if (arg === '-g' || arg === '--global') {
       options.global = true;
@@ -2184,6 +2185,16 @@ export function parseAddOptions(args: string[]): {
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg.startsWith('--agent=') || arg.startsWith('-a=')) {
+      options.agent = options.agent || [];
+      const val = arg.startsWith('--agent=')
+        ? arg.slice('--agent='.length)
+        : arg.slice('-a='.length);
+      const parts = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      options.agent.push(...parts);
     } else if (arg === '-s' || arg === '--skill') {
       options.skill = options.skill || [];
       i++;
@@ -2194,9 +2205,31 @@ export function parseAddOptions(args: string[]): {
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg.startsWith('--skill=') || arg.startsWith('-s=')) {
+      options.skill = options.skill || [];
+      const val = arg.startsWith('--skill=')
+        ? arg.slice('--skill='.length)
+        : arg.slice('-s='.length);
+      const parts = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      options.skill.push(...parts);
     } else if (arg === '--metadata') {
       const metadata = args[++i];
       if (metadata === undefined) {
+        errors.push('--metadata requires a JSON value');
+      } else {
+        try {
+          JSON.parse(metadata);
+          options.metadata = metadata;
+        } catch {
+          errors.push('--metadata must be valid JSON');
+        }
+      }
+    } else if (arg.startsWith('--metadata=')) {
+      const metadata = arg.slice('--metadata='.length);
+      if (!metadata) {
         errors.push('--metadata requires a JSON value');
       } else {
         try {
@@ -2220,6 +2253,14 @@ export function parseAddOptions(args: string[]): {
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg.startsWith('--subagent=')) {
+      options.subagent = options.subagent || [];
+      const val = arg.slice('--subagent='.length);
+      const parts = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      options.subagent.push(...parts);
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -87,6 +87,17 @@ description: ${description}
       expect(options.agent).toEqual(['claude-code']);
       expect(options.global).toBe(true);
     });
+
+    it('should parse --agent and -a equals syntax', () => {
+      const single = parseListOptions(['--agent=cursor']);
+      expect(single.agent).toEqual(['cursor']);
+
+      const short = parseListOptions(['-a=claude-code']);
+      expect(short.agent).toEqual(['claude-code']);
+
+      const multiple = parseListOptions(['--agent=claude-code,cursor']);
+      expect(multiple.agent).toEqual(['claude-code', 'cursor']);
+    });
   });
 
   describe('CLI integration', () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -57,6 +57,7 @@ export function parseListOptions(args: string[]): ListOptions {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
+    if (!arg) continue;
     if (arg === '-g' || arg === '--global') {
       options.global = true;
     } else if (arg === '--json') {
@@ -67,6 +68,16 @@ export function parseListOptions(args: string[]): ListOptions {
       while (i + 1 < args.length && !args[i + 1]!.startsWith('-')) {
         options.agent.push(args[++i]!);
       }
+    } else if (arg.startsWith('--agent=') || arg.startsWith('-a=')) {
+      options.agent = options.agent || [];
+      const val = arg.startsWith('--agent=')
+        ? arg.slice('--agent='.length)
+        : arg.slice('-a='.length);
+      const parts = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      options.agent.push(...parts);
     }
   }
 

--- a/src/parse-remove-options.test.ts
+++ b/src/parse-remove-options.test.ts
@@ -29,4 +29,28 @@ describe('parseRemoveOptions', () => {
     expect(result.options.all).toBe(true);
     expect(result.options.yes).toBe(true);
   });
+
+  it('parses --skill=<name> and -s=<name> equals syntax', () => {
+    const result1 = parseRemoveOptions(['--skill=skill-one', '-y']);
+    expect(result1.skills).toEqual(['skill-one']);
+    expect(result1.options.yes).toBe(true);
+
+    const result2 = parseRemoveOptions(['-s=skill-one', '-s=skill-two', '-g']);
+    expect(result2.skills).toEqual(['skill-one', 'skill-two']);
+    expect(result2.options.global).toBe(true);
+
+    const result3 = parseRemoveOptions(['--skill=skill-one,skill-two']);
+    expect(result3.skills).toEqual(['skill-one', 'skill-two']);
+  });
+
+  it('parses --agent=<agents> and -a=<agents> equals syntax', () => {
+    const result1 = parseRemoveOptions(['--skill=skill-one', '--agent=claude-code', '-y']);
+    expect(result1.skills).toEqual(['skill-one']);
+    expect(result1.options.agent).toEqual(['claude-code']);
+    expect(result1.options.yes).toBe(true);
+
+    const result2 = parseRemoveOptions(['skill-one', '-a=cursor,codex']);
+    expect(result2.skills).toEqual(['skill-one']);
+    expect(result2.options.agent).toEqual(['cursor', 'codex']);
+  });
 });

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -393,6 +393,7 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
+    if (!arg) continue;
 
     if (arg === '-g' || arg === '--global') {
       options.global = true;
@@ -410,6 +411,15 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg.startsWith('--skill=') || arg.startsWith('-s=')) {
+      const val = arg.startsWith('--skill=')
+        ? arg.slice('--skill='.length)
+        : arg.slice('-s='.length);
+      const parts = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      skills.push(...parts);
     } else if (arg === '-a' || arg === '--agent') {
       options.agent = options.agent || [];
       i++;
@@ -420,6 +430,16 @@ export function parseRemoveOptions(args: string[]): { skills: string[]; options:
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg.startsWith('--agent=') || arg.startsWith('-a=')) {
+      options.agent = options.agent || [];
+      const val = arg.startsWith('--agent=')
+        ? arg.slice('--agent='.length)
+        : arg.slice('-a='.length);
+      const parts = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      options.agent.push(...parts);
     } else if (arg && !arg.startsWith('-')) {
       skills.push(arg);
     }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -456,6 +456,7 @@ export function parseSyncOptions(args: string[]): { options: SyncOptions } {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
+    if (!arg) continue;
 
     if (arg === '-y' || arg === '--yes') {
       options.yes = true;
@@ -471,6 +472,16 @@ export function parseSyncOptions(args: string[]): { options: SyncOptions } {
         nextArg = args[i];
       }
       i--;
+    } else if (arg.startsWith('--agent=') || arg.startsWith('-a=')) {
+      options.agent = options.agent || [];
+      const val = arg.startsWith('--agent=')
+        ? arg.slice('--agent='.length)
+        : arg.slice('-a='.length);
+      const parts = val
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      options.agent.push(...parts);
     }
   }
 

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -48,7 +48,7 @@ describe('use command', () => {
       expect(result.errors).toEqual([]);
     });
 
-    it('parses --skill and -s selectors', () => {
+    it('parses --skill and -s selectors including equals syntax', () => {
       const longFlag = parseUseOptions([
         'vercel-labs/agent-skills',
         '--skill',
@@ -59,11 +59,20 @@ describe('use command', () => {
         '-s',
         'web-design-guidelines',
       ]);
+      const longEquals = parseUseOptions([
+        'vercel-labs/agent-skills',
+        '--skill=web-design-guidelines',
+      ]);
+      const shortEquals = parseUseOptions(['vercel-labs/agent-skills', '-s=web-design-guidelines']);
 
       expect(longFlag.options.skill).toBe('web-design-guidelines');
       expect(shortFlag.options.skill).toBe('web-design-guidelines');
+      expect(longEquals.options.skill).toBe('web-design-guidelines');
+      expect(shortEquals.options.skill).toBe('web-design-guidelines');
       expect(longFlag.errors).toEqual([]);
       expect(shortFlag.errors).toEqual([]);
+      expect(longEquals.errors).toEqual([]);
+      expect(shortEquals.errors).toEqual([]);
     });
 
     it('rejects repeated skill selectors and unknown flags', () => {
@@ -78,6 +87,19 @@ describe('use command', () => {
 
       expect(result.errors).toContain('Only one --skill value can be provided');
       expect(result.errors).toContain('Unknown option: --wat');
+
+      const repeatedEquals = parseUseOptions([
+        'vercel-labs/agent-skills',
+        '--skill=one',
+        '--skill=two',
+      ]);
+      expect(repeatedEquals.errors).toContain('Only one --skill value can be provided');
+
+      const emptySkill = parseUseOptions(['vercel-labs/agent-skills', '--skill=']);
+      expect(emptySkill.errors).toContain('--skill requires a skill name');
+
+      const emptyShortSkill = parseUseOptions(['vercel-labs/agent-skills', '-s=']);
+      expect(emptyShortSkill.errors).toContain('-s requires a skill name');
     });
 
     it('parses OpenClaw sources like other GitHub owners', () => {
@@ -87,14 +109,20 @@ describe('use command', () => {
       expect(result.errors).toEqual([]);
     });
 
-    it('parses --agent and -a values', () => {
+    it('parses --agent and -a values including equals syntax', () => {
       const longFlag = parseUseOptions(['vercel-labs/agent-skills', '--agent', 'claude-code']);
       const shortFlag = parseUseOptions(['vercel-labs/agent-skills', '-a', 'codex']);
+      const longEquals = parseUseOptions(['vercel-labs/agent-skills', '--agent=claude-code']);
+      const shortEquals = parseUseOptions(['vercel-labs/agent-skills', '-a=codex']);
 
       expect(longFlag.options.agent).toEqual(['claude-code']);
       expect(shortFlag.options.agent).toEqual(['codex']);
+      expect(longEquals.options.agent).toEqual(['claude-code']);
+      expect(shortEquals.options.agent).toEqual(['codex']);
       expect(longFlag.errors).toEqual([]);
       expect(shortFlag.errors).toEqual([]);
+      expect(longEquals.errors).toEqual([]);
+      expect(shortEquals.errors).toEqual([]);
     });
 
     it('rejects wildcard, missing, invalid, and multiple agents', () => {
@@ -102,6 +130,9 @@ describe('use command', () => {
       const missing = parseUseOptions(['source', '--agent', '--skill', 'web-design-guidelines']);
       const invalid = parseUseOptions(['source', '--agent', 'not-an-agent']);
       const multiple = parseUseOptions(['source', '--agent', 'claude-code', 'codex']);
+      const multipleEquals = parseUseOptions(['source', '--agent=claude-code,codex']);
+      const emptyAgent = parseUseOptions(['source', '--agent=']);
+      const emptyShortAgent = parseUseOptions(['source', '-a=']);
 
       expect(wildcard.errors).toContain(
         "skills use --agent does not support '*'; specify exactly one agent."
@@ -109,6 +140,9 @@ describe('use command', () => {
       expect(missing.errors).toContain('--agent requires an agent name');
       expect(invalid.errors.join('\n')).toContain('Invalid agents: not-an-agent');
       expect(multiple.errors).toContain('skills use --agent accepts exactly one agent.');
+      expect(multipleEquals.errors).toContain('skills use --agent accepts exactly one agent.');
+      expect(emptyAgent.errors).toContain('--agent requires an agent name');
+      expect(emptyShortAgent.errors).toContain('-a requires an agent name');
     });
   });
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -99,31 +99,70 @@ export function parseUseOptions(args: string[]): ParseUseOptionsResult {
       options.help = true;
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
-    } else if (arg === '--skill' || arg === '-s') {
-      const value = args[i + 1];
-      if (!value || value.startsWith('-')) {
-        errors.push(`${arg} requires a skill name`);
+    } else if (
+      arg === '--skill' ||
+      arg === '-s' ||
+      arg.startsWith('--skill=') ||
+      arg.startsWith('-s=')
+    ) {
+      const isEquals = arg.startsWith('--skill=') || arg.startsWith('-s=');
+      const flagName = arg.startsWith('--skill') ? '--skill' : '-s';
+      let value: string | undefined;
+
+      if (isEquals) {
+        value = arg.startsWith('--skill=') ? arg.slice('--skill='.length) : arg.slice('-s='.length);
+      } else {
+        const nextValue = args[i + 1];
+        if (nextValue && !nextValue.startsWith('-')) {
+          value = nextValue;
+          i++;
+        }
+      }
+
+      if (!value) {
+        errors.push(`${flagName} requires a skill name`);
       } else if (options.skill) {
         errors.push('Only one --skill value can be provided');
-        i++;
       } else {
         options.skill = value;
-        i++;
       }
-    } else if (arg === '--agent' || arg === '-a') {
+    } else if (
+      arg === '--agent' ||
+      arg === '-a' ||
+      arg.startsWith('--agent=') ||
+      arg.startsWith('-a=')
+    ) {
+      const isEquals = arg.startsWith('--agent=') || arg.startsWith('-a=');
+      const flagName = arg.startsWith('--agent') ? '--agent' : '-a';
       options.agent = options.agent || [];
-      i++;
-      let nextArg = args[i];
-      const startCount = options.agent.length;
-      while (i < args.length && nextArg && !nextArg.startsWith('-')) {
-        options.agent.push(nextArg);
+
+      if (isEquals) {
+        const val = arg.startsWith('--agent=')
+          ? arg.slice('--agent='.length)
+          : arg.slice('-a='.length);
+        const parts = val
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        if (parts.length === 0) {
+          errors.push(`${flagName} requires an agent name`);
+        } else {
+          options.agent.push(...parts);
+        }
+      } else {
+        const startCount = options.agent.length;
         i++;
-        nextArg = args[i];
+        let nextArg = args[i];
+        while (i < args.length && nextArg && !nextArg.startsWith('-')) {
+          options.agent.push(nextArg);
+          i++;
+          nextArg = args[i];
+        }
+        if (options.agent.length === startCount) {
+          errors.push(`${flagName} requires an agent name`);
+        }
+        i--;
       }
-      if (options.agent.length === startCount) {
-        errors.push(`${arg} requires an agent name`);
-      }
-      i--;
     } else if (arg.startsWith('-')) {
       errors.push(`Unknown option: ${arg}`);
     } else {


### PR DESCRIPTION
Closes #2039

## Problem
Passing flags using the equals-sign syntax (e.g. `--skill=<name>`, `-s=<name>`, `--agent=<agents>`, `-a=<agents>`, `--subagent=<names>`, `--metadata=<json>`) in `skills add` caused the option values to be ignored. For example, `skills add <source> --skill=<name>` silently treated `--skill=<name>` as an unrecognized flag starting with `-` and installed all skills instead of filtering to the specified skill. Similarly, commands like `skills use`, `skills remove`, `skills list`, and `skills sync` did not handle equals-sign forms for option flags consistently.

## Fix
- In `src/add.ts` (`parseAddOptions`), added parsing support for equals-sign syntax for `--skill=`, `-s=`, `--agent=`, `-a=`, `--subagent=`, and `--metadata=`.
- In `src/use.ts` (`parseUseOptions`), supported `--skill=`, `-s=`, `--agent=`, and `-a=`, including proper error reporting for empty values.
- In `src/remove.ts` (`parseRemoveOptions`), supported `--skill=`, `-s=`, `--agent=`, and `-a=`.
- In `src/list.ts` (`parseListOptions`) and `src/sync.ts` (`parseSyncOptions`), supported `--agent=` and `-a=`.
- Handled comma-delimited lists for multi-value options when passed in equals form (e.g., `--agent=claude-code,cursor`, `--subagent=root,research`).

## Tests
- Added unit and regression tests in `src/add.test.ts`, `src/use.test.ts`, `src/parse-remove-options.test.ts`, and `src/list.test.ts`.
- Verified all vitest test suites pass (`pnpm vitest run src/add.test.ts src/use.test.ts src/parse-remove-options.test.ts src/list.test.ts`).
- Verified formatting and typechecking (`pnpm format:check`, `pnpm type-check`).