### PR TITLE
feat(cli): add --skills-dir flag to override default skill container

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -74,6 +74,71 @@ This is a test skill.
     expect(result.exitCode).toBe(1);
   });
 
+  it('should discover skills under a custom directory when --skills-dir is set', () => {
+    const skillDir = join(testDir, 'my-skills', 'custom-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: custom-skill
+description: Lives in a custom directory
+---
+
+# Custom Skill
+
+Instructions.
+`
+    );
+
+    const result = runCli(['add', testDir, '--list', '--skills-dir', 'my-skills'], testDir);
+    expect(result.stdout).toContain('custom-skill');
+    expect(result.stdout).toContain('Lives in a custom directory');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('should not discover skills in the default skills/ dir when --skills-dir overrides it', () => {
+    const defaultSkillDir = join(testDir, 'skills', 'default-skill');
+    mkdirSync(defaultSkillDir, { recursive: true });
+    writeFileSync(
+      join(defaultSkillDir, 'SKILL.md'),
+      `---
+name: default-skill
+description: Lives in the default skills directory
+---
+
+# Default Skill
+
+Instructions.
+`
+    );
+
+    const customSkillDir = join(testDir, 'my-skills', 'custom-skill');
+    mkdirSync(customSkillDir, { recursive: true });
+    writeFileSync(
+      join(customSkillDir, 'SKILL.md'),
+      `---
+name: custom-skill
+description: Lives in a custom directory
+---
+
+# Custom Skill
+
+Instructions.
+`
+    );
+
+    const result = runCli(['add', testDir, '--list', '--skills-dir', 'my-skills'], testDir);
+    expect(result.stdout).toContain('custom-skill');
+    expect(result.stdout).not.toContain('default-skill');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('should error when --skills-dir is missing a value', () => {
+    const result = runCli(['add', testDir, '--list', '--skills-dir'], testDir);
+    expect(result.stderr).toContain('--skills-dir requires a path');
+    expect(result.exitCode).toBe(1);
+  });
+
   it('should install skill from local path with -y flag', () => {
     // Create a test skill
     const skillDir = join(testDir, 'skills', 'my-skill');

--- a/src/add.ts
+++ b/src/add.ts
@@ -536,6 +536,8 @@ export interface AddOptions {
    * selects the root agent. Implies installing for Eve.
    */
   subagent?: string[];
+  /** Override the default skill container directory name (default: "skills") */
+  skillsDir?: string;
 }
 
 /**
@@ -1167,6 +1169,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       skills = await discoverSkills(parsed.localPath!, parsed.subpath, {
         includeInternal,
         fullDepth: options.fullDepth,
+        skillsDir: options.skillsDir,
       });
     } else if (parsed.type === 'well-known' || parsed.type === 'download') {
       spinner.start('Downloading source...');
@@ -1178,6 +1181,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       skills = await discoverSkills(downloaded.rootDir, parsed.subpath, {
         includeInternal,
         fullDepth: options.fullDepth,
+        skillsDir: options.skillsDir,
       });
     } else if (parsed.type === 'github' && !options.fullDepth) {
       // Try the blob-based fast install for GitHub sources; skip for --full-depth.
@@ -1215,6 +1219,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         skills = await discoverSkills(tempDir, parsed.subpath, {
           includeInternal,
           fullDepth: options.fullDepth,
+          skillsDir: options.skillsDir,
         });
       }
     } else {
@@ -1227,6 +1232,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       skills = await discoverSkills(tempDir, parsed.subpath, {
         includeInternal,
         fullDepth: options.fullDepth,
+        skillsDir: options.skillsDir,
       });
     }
 
@@ -2220,6 +2226,13 @@ export function parseAddOptions(args: string[]): {
         nextArg = args[i];
       }
       i--; // Back up one since the loop will increment
+    } else if (arg === '--skills-dir') {
+      const value = args[++i];
+      if (value === undefined || value.startsWith('-')) {
+        errors.push('--skills-dir requires a path');
+      } else {
+        options.skillsDir = value;
+      }
     } else if (arg && !arg.startsWith('-')) {
       source.push(arg);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,12 +141,14 @@ ${BOLD}Add Options:${RESET}
   --copy                 Copy files instead of symlinking to agent directories
   --metadata <json>      Attach valid JSON to the install telemetry event
   --subagent <names>     Install to Eve subagents (use 'root' for the root agent)
+  --skills-dir <path>    Override the default skill container directory name (default: "skills")
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 
 ${BOLD}Use Options:${RESET}
   -s, --skill <skill>    Specify the skill to use
   -a, --agent <agent>    Start one supported agent interactively
+  --skills-dir <path>    Override the default skill container directory name (default: "skills")
   --full-depth           Search all subdirectories even when a root SKILL.md exists
 
 ${BOLD}Remove Options:${RESET}

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -5,7 +5,7 @@ import { sanitizeMetadata, stripTerminalEscapes } from './sanitize.ts';
 import type { Skill } from './types.ts';
 import { getPluginSkillPaths, getPluginGroupings } from './plugin-manifest.ts';
 import { readLocalLock } from './local-lock.ts';
-import { DEFAULT_SKILL_CONTAINER_DEPTH } from './constants.ts';
+import { DEFAULT_SKILL_CONTAINER_DEPTH, SKILLS_SUBDIR } from './constants.ts';
 
 const SKIP_DIRS = ['node_modules', '.git', 'dist', 'build', '__pycache__'];
 
@@ -159,6 +159,8 @@ export interface DiscoverSkillsOptions {
   includeInternal?: boolean;
   /** Search all subdirectories even when a root SKILL.md exists */
   fullDepth?: boolean;
+  /** Override the default skill container directory name (default: "skills") */
+  skillsDir?: string;
 }
 
 /**
@@ -245,13 +247,15 @@ export async function discoverSkills(
     }
   }
 
+  const skillsContainerDir = options?.skillsDir ?? SKILLS_SUBDIR;
+
   // Search common skill locations first
   const prioritySearchDirs = [
     searchPath,
-    join(searchPath, 'skills'),
-    join(searchPath, 'skills/.curated'),
-    join(searchPath, 'skills/.experimental'),
-    join(searchPath, 'skills/.system'),
+    join(searchPath, skillsContainerDir),
+    join(searchPath, skillsContainerDir, '.curated'),
+    join(searchPath, skillsContainerDir, '.experimental'),
+    join(searchPath, skillsContainerDir, '.system'),
     ...AGENT_PROJECT_SKILL_DIRS.map((dir) => join(searchPath, dir)),
   ];
 

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -110,6 +110,19 @@ describe('use command', () => {
       expect(invalid.errors.join('\n')).toContain('Invalid agents: not-an-agent');
       expect(multiple.errors).toContain('skills use --agent accepts exactly one agent.');
     });
+
+    it('parses --skills-dir', () => {
+      const result = parseUseOptions(['source', '--skills-dir', 'my-skills']);
+
+      expect(result.options.skillsDir).toBe('my-skills');
+      expect(result.errors).toEqual([]);
+    });
+
+    it('errors when --skills-dir is missing a value', () => {
+      const result = parseUseOptions(['source', '--skills-dir']);
+
+      expect(result.errors).toContain('--skills-dir requires a path');
+    });
   });
 
   describe('buildUsePrompt', () => {

--- a/src/use.ts
+++ b/src/use.ts
@@ -24,6 +24,7 @@ export interface UseOptions {
   agent?: string[];
   fullDepth?: boolean;
   help?: boolean;
+  skillsDir?: string;
 }
 
 export interface ParseUseOptionsResult {
@@ -124,6 +125,14 @@ export function parseUseOptions(args: string[]): ParseUseOptionsResult {
         errors.push(`${arg} requires an agent name`);
       }
       i--;
+    } else if (arg === '--skills-dir') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('-')) {
+        errors.push('--skills-dir requires a path');
+      } else {
+        options.skillsDir = value;
+        i++;
+      }
     } else if (arg.startsWith('-')) {
       errors.push(`Unknown option: ${arg}`);
     } else {
@@ -235,6 +244,7 @@ export async function runUse(
         const downloadedSkills = await discoverSkills(downloaded.rootDir, undefined, {
           includeInternal,
           fullDepth: options.fullDepth,
+          skillsDir: options.skillsDir,
         });
         const selected = selectSkill(downloadedSkills, selector, source);
         selectedSkill = {
@@ -255,6 +265,7 @@ export async function runUse(
         skills = await discoverSkills(downloaded.rootDir, undefined, {
           includeInternal,
           fullDepth: options.fullDepth,
+          skillsDir: options.skillsDir,
         });
       } else if (parsed.type === 'local') {
         if (!existsSync(parsed.localPath!)) {
@@ -263,6 +274,7 @@ export async function runUse(
         skills = await discoverSkills(parsed.localPath!, parsed.subpath, {
           includeInternal,
           fullDepth: options.fullDepth,
+          skillsDir: options.skillsDir,
         });
       } else if (parsed.type === 'github' && !options.fullDepth) {
         const ownerRepo = getOwnerRepo(parsed);
@@ -284,6 +296,7 @@ export async function runUse(
           skills = await discoverSkills(cloneTempDir, parsed.subpath, {
             includeInternal,
             fullDepth: options.fullDepth,
+            skillsDir: options.skillsDir,
           });
         }
       } else {
@@ -291,6 +304,7 @@ export async function runUse(
         skills = await discoverSkills(cloneTempDir, parsed.subpath, {
           includeInternal,
           fullDepth: options.fullDepth,
+          skillsDir: options.skillsDir,
         });
       }
 
@@ -395,6 +409,7 @@ Generate a prompt for using one skill without installing it.
 Options:
   -s, --skill <skill>   Select the skill to use
   -a, --agent <agent>   Start one supported agent interactively (${SUPPORTED_USE_AGENTS.join(', ')})
+  --skills-dir <path>   Override the default skill container directory name (default: "skills")
   --full-depth          Search nested directories like skills add --full-depth
   -h, --help            Show this help message
 


### PR DESCRIPTION
## Summary

Adds a `--skills-dir <path>` flag to `skills add` and `skills use` that overrides the default `skills` directory used during skill discovery. Useful for repositories that organize their skills under a custom directory name (e.g., `tools/`, `prompts/`, `commands/`).

## Motivation

By default, `skills add` and `skills use` look for skills under a `skills/` directory in the source repository. Some repos organize their skills under a different name, and there was no way to point the CLI at a custom directory without relying on `--full-depth` (which is much slower and noisier).

## Changes

- **`src/skills.ts`**: Added `skillsDir` to `DiscoverSkillsOptions` and replaced the hardcoded `'skills'` prefix in `prioritySearchDirs` with `options?.skillsDir ?? SKILLS_SUBDIR`. The configured dir also replaces the `.curated`, `.experimental`, and `.system` subdirectories (they become `<dir>/.curated`, etc.).
- **`src/add.ts`** & **`src/use.ts`**: Added `skillsDir` to `AddOptions` and `UseOptions`, parsed the `--skills-dir` flag, and threaded it through to every `discoverSkills` call.
- **`src/cli.ts`** & **`src/use.ts`** help text: Documented the new flag.
- **Tests**: Added integration tests in `add.test.ts` and parser tests in `use.test.ts`.

## Usage

```bash
skills add owner/repo --skills-dir my-tools
skills use owner/repo@my-tool --skills-dir my-tools
```

When the flag is omitted, behavior is unchanged: discovery still happens under `skills/`.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run format:check` passes
- [x] New tests for `--skills-dir` pass (custom dir discovery, isolation from default `skills/`, missing-value error)
- [x] Existing discovery tests pass (`tests/full-depth-discovery.test.ts`, `tests/nested-container-discovery.test.ts`, `tests/skill-matching.test.ts`, `tests/plugin-manifest-discovery.test.ts`)