### PR TITLE
Add Jcode agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [74 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -302,6 +302,7 @@ Skills can be installed to any of these agents:
 | Grok Build | `grok` | `.grok/skills/` | `~/.grok/skills/` |
 | Hermes Agent | `hermes-agent` | `.hermes/skills/` | `~/.hermes/skills/` |
 | inference.sh | `inference-sh` | `.inferencesh/skills/` | `~/.inferencesh/skills/` |
+| Jcode | `jcode` | `.jcode/skills/` | `~/.jcode/skills/` |
 | Jazz | `jazz` | `.jazz/skills/` | `~/.jazz/skills/` |
 | Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
 | iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
@@ -437,6 +438,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.grok/skills/`
 - `.hermes/skills/`
 - `.inferencesh/skills/`
+- `.jcode/skills/`
 - `.jazz/skills/`
 - `.junie/skills/`
 - `.iflow/skills/`

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "grok",
     "hermes-agent",
     "inference-sh",
+    "jcode",
     "jazz",
     "junie",
     "iflow-cli",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -11,6 +11,7 @@ const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
+const jcodeHome = process.env.JCODE_HOME?.trim() || join(home, '.jcode');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
 const grokHome = process.env.GROK_HOME?.trim() || join(home, '.grok');
 const zedAppDataHome = process.env.APPDATA?.trim();
@@ -390,6 +391,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.inferencesh/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.inferencesh'));
+    },
+  },
+  jcode: {
+    name: 'jcode',
+    displayName: 'Jcode',
+    skillsDir: '.jcode/skills',
+    globalSkillsDir: join(jcodeHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(jcodeHome);
     },
   },
   jazz: {

--- a/src/detect-agent.test.ts
+++ b/src/detect-agent.test.ts
@@ -4,6 +4,9 @@ describe('detectAgent', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
+    vi.stubEnv('JCODE_NON_INTERACTIVE', '');
+    vi.stubEnv('JCODE_ACTIVE_PROVIDER', '');
+    vi.stubEnv('JCODE_SESSION_ID', '');
   });
 
   afterEach(() => {
@@ -41,5 +44,16 @@ describe('detectAgent', () => {
 
     expect(result.isAgent).toBe(true);
     expect(result.agent?.name).toBe('cursor-cli');
+  });
+
+  it('detects Jcode from its non-interactive environment signal', async () => {
+    vi.stubEnv('JCODE_NON_INTERACTIVE', '1');
+
+    const { detectAgent, getAgentType } = await import('./detect-agent.ts');
+    const result = await detectAgent();
+
+    expect(result.isAgent).toBe(true);
+    expect(result.agent?.name).toBe('jcode');
+    expect(getAgentType('jcode')).toBe('jcode');
   });
 });

--- a/src/detect-agent.ts
+++ b/src/detect-agent.ts
@@ -16,8 +16,19 @@ function hasStrongCursorAgentSignal(): boolean {
   );
 }
 
+function hasJcodeAgentSignal(): boolean {
+  return Boolean(
+    process.env.JCODE_NON_INTERACTIVE?.trim() ||
+    process.env.JCODE_ACTIVE_PROVIDER?.trim() ||
+    process.env.JCODE_SESSION_ID?.trim()
+  );
+}
+
 function refineAgentResult(result: AgentResult): AgentResult {
   if (!result.isAgent || !result.agent) {
+    if (hasJcodeAgentSignal()) {
+      return { isAgent: true, agent: { name: 'jcode' as never } };
+    }
     return result;
   }
 
@@ -51,6 +62,7 @@ const agentNameToType: Record<string, AgentType> = {
   'augment-cli': 'augment',
   opencode: 'opencode',
   'github-copilot': 'github-copilot',
+  jcode: 'jcode',
 };
 
 /**

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -28,6 +28,9 @@ const AGENT_DETECTION_ENV_VARS = new Set(
     'CURSOR_EXTENSION_HOST_ROLE',
     'CURSOR_TRACE_ID',
     'GEMINI_CLI',
+    'JCODE_ACTIVE_PROVIDER',
+    'JCODE_NON_INTERACTIVE',
+    'JCODE_SESSION_ID',
     'OPENCODE_CLIENT',
     'REPL_ID',
   ].map((name) => name.toUpperCase())
@@ -73,6 +76,7 @@ export function createTestHomeEnvironment(home: string): Record<string, string> 
     CLAUDE_CONFIG_DIR: join(home, '.claude'),
     VIBE_HOME: join(home, '.vibe'),
     HERMES_HOME: join(home, '.hermes'),
+    JCODE_HOME: join(home, '.jcode'),
     AUTOHAND_HOME: join(home, '.autohand'),
     FLATPAK_XDG_CONFIG_HOME: join(home, '.var', 'app'),
     DISABLE_TELEMETRY: '1',

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export type AgentType =
   | 'grok'
   | 'hermes-agent'
   | 'inference-sh'
+  | 'jcode'
   | 'iflow-cli'
   | 'jazz'
   | 'junie'

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -207,6 +207,18 @@ describe('use command', () => {
       });
     });
 
+    it('starts Jcode with the run subcommand and prompt argument', async () => {
+      const fake = createFakeSpawn({ closeCode: 0 });
+
+      await expect(launchAgentInteractively('jcode', 'prompt body', fake.spawn)).resolves.toBe(0);
+
+      expect(fake.calls[0]).toMatchObject({
+        command: 'jcode',
+        args: ['run', 'prompt body'],
+        options: { stdio: 'inherit' },
+      });
+    });
+
     it('returns nonzero agent exit codes', async () => {
       const fake = createFakeSpawn({ closeCode: 37 });
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -83,6 +83,7 @@ const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 const USE_AGENT_CONFIGS: Partial<Record<AgentType, UseAgentConfig>> = {
   'claude-code': { command: 'claude', args: [] },
   codex: { command: 'codex', args: [] },
+  jcode: { command: 'jcode', args: ['run'] },
 };
 const SUPPORTED_USE_AGENTS = Object.keys(USE_AGENT_CONFIGS) as AgentType[];
 
@@ -401,7 +402,8 @@ Options:
 Examples:
   skills use vercel-labs/agent-skills@web-design-guidelines | claude
   skills use vercel-labs/agent-skills --skill web-design-guidelines --agent claude-code
-  skills use vercel-labs/agent-skills@web-design-guidelines --agent codex`;
+  skills use vercel-labs/agent-skills@web-design-guidelines --agent codex
+  skills use vercel-labs/agent-skills@web-design-guidelines --agent jcode`;
 }
 
 function resolveSelector(sourceSelector?: string, optionSelector?: string): string | undefined {

--- a/tests/jcode-agent.test.ts
+++ b/tests/jcode-agent.test.ts
@@ -1,0 +1,13 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { describe, expect, it } from 'vitest';
+import { agents } from '../src/agents.ts';
+
+describe('Jcode agent support', () => {
+  it('uses ~/.jcode/skills for global skills', () => {
+    expect(agents.jcode.name).toBe('jcode');
+    expect(agents.jcode.displayName).toBe('Jcode');
+    expect(agents.jcode.skillsDir).toBe('.jcode/skills');
+    expect(agents.jcode.globalSkillsDir).toBe(join(homedir(), '.jcode', 'skills'));
+  });
+});


### PR DESCRIPTION
This PR adds full Jcode agent detection and usage support to skills.sh, including README updates, agent config, detection logic, and tests.