### PR TITLE
fix: clone with --recurse-submodules so submodule skills are discoverable

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -189,7 +189,16 @@ describe('git clone fallbacks', () => {
     expect(execFileMock).toHaveBeenNthCalledWith(
       2,
       'gh',
-      ['repo', 'clone', 'Giphy/giphy-codex-skills', tempDir, '--', '--depth=1'],
+      [
+        'repo',
+        'clone',
+        'Giphy/giphy-codex-skills',
+        tempDir,
+        '--',
+        '--depth=1',
+        '--recurse-submodules',
+        '--shallow-submodules',
+      ],
       expect.any(Object),
       expect.any(Function)
     );
@@ -216,7 +225,16 @@ describe('git clone fallbacks', () => {
     expect(execFileMock).toHaveBeenNthCalledWith(
       2,
       'gh',
-      ['repo', 'clone', 'acme/agent-skills', tempDir, '--', '--depth=1'],
+      [
+        'repo',
+        'clone',
+        'acme/agent-skills',
+        tempDir,
+        '--',
+        '--depth=1',
+        '--recurse-submodules',
+        '--shallow-submodules',
+      ],
       expect.any(Object),
       expect.any(Function)
     );
@@ -238,6 +256,8 @@ describe('git clone fallbacks', () => {
     expect(sshClone).toHaveBeenCalledWith('git@github.com:Giphy/giphy-codex-skills.git', tempDir, [
       '--depth',
       '1',
+      '--recurse-submodules',
+      '--shallow-submodules',
     ]);
     expect(sshClient.env).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/git.ts
+++ b/src/git.ts
@@ -191,7 +191,9 @@ async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): 
     return false;
   }
 
-  const gitFlags = ref ? ['--depth=1', '--branch', ref] : ['--depth=1'];
+  const gitFlags = ref
+    ? ['--depth=1', '--branch', ref, '--recurse-submodules', '--shallow-submodules']
+    : ['--depth=1', '--recurse-submodules', '--shallow-submodules'];
   await execFileAsync('gh', ['repo', 'clone', cloneTarget, tempDir, '--', ...gitFlags], {
     timeout: CLONE_TIMEOUT_MS,
     env: {
@@ -238,7 +240,9 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   }
 
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const cloneOptions = ref
+    ? ['--depth', '1', '--branch', ref, '--recurse-submodules', '--shallow-submodules']
+    : ['--depth', '1', '--recurse-submodules', '--shallow-submodules'];
   const repo = parseGitHubRepoUrl(url);
 
   try {

--- a/tests/submodule-clone.test.ts
+++ b/tests/submodule-clone.test.ts
@@ -1,0 +1,91 @@
+import { execFile } from 'child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanupTempDir, cloneRepo } from '../src/git.ts';
+import { discoverSkills } from '../src/skills.ts';
+
+function runGit(args: string[], cwd?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { cwd }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+describe('cloneRepo submodule handling', () => {
+  const tempDirs: string[] = [];
+  const originalEnv = {
+    GIT_CONFIG_COUNT: process.env.GIT_CONFIG_COUNT,
+    GIT_CONFIG_KEY_0: process.env.GIT_CONFIG_KEY_0,
+    GIT_CONFIG_VALUE_0: process.env.GIT_CONFIG_VALUE_0,
+  };
+
+  afterEach(async () => {
+    if (originalEnv.GIT_CONFIG_COUNT === undefined) delete process.env.GIT_CONFIG_COUNT;
+    else process.env.GIT_CONFIG_COUNT = originalEnv.GIT_CONFIG_COUNT;
+    if (originalEnv.GIT_CONFIG_KEY_0 === undefined) delete process.env.GIT_CONFIG_KEY_0;
+    else process.env.GIT_CONFIG_KEY_0 = originalEnv.GIT_CONFIG_KEY_0;
+    if (originalEnv.GIT_CONFIG_VALUE_0 === undefined) delete process.env.GIT_CONFIG_VALUE_0;
+    else process.env.GIT_CONFIG_VALUE_0 = originalEnv.GIT_CONFIG_VALUE_0;
+
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('populates submodule contents so nested skills are discoverable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-submodule-test-'));
+    tempDirs.push(root);
+    const child = join(root, 'child');
+    const parent = join(root, 'parent');
+
+    // A standalone repo that carries a skill, later consumed as a submodule.
+    await runGit(['init', '-b', 'main', child]);
+    await runGit(['config', 'user.email', 'skills-test@example.com'], child);
+    await runGit(['config', 'user.name', 'Skills Test'], child);
+    await writeFile(
+      join(child, 'SKILL.md'),
+      `---
+name: submoduled-skill
+description: A skill that lives in a git submodule
+---
+
+# Submoduled Skill
+`
+    );
+    await runGit(['add', '.'], child);
+    await runGit(['commit', '-m', 'child fixture'], child);
+
+    // The parent repo contains the skill only by reference.
+    await runGit(['init', '-b', 'main', parent]);
+    await runGit(['config', 'user.email', 'skills-test@example.com'], parent);
+    await runGit(['config', 'user.name', 'Skills Test'], parent);
+    // Git refuses file:// submodules by default (CVE-2022-39253); the fixture
+    // opts in explicitly rather than relaxing the setting for the clone itself.
+    await runGit(
+      ['-c', 'protocol.file.allow=always', 'submodule', 'add', child, 'skills/child'],
+      parent
+    );
+    await runGit(['commit', '-m', 'parent fixture'], parent);
+
+    // Same opt-in for the recursive clone, which resolves the file:// submodule URL.
+    process.env.GIT_CONFIG_COUNT = '1';
+    process.env.GIT_CONFIG_KEY_0 = 'protocol.file.allow';
+    process.env.GIT_CONFIG_VALUE_0 = 'always';
+
+    const cloneDir = await cloneRepo(parent);
+    tempDirs.push(cloneDir);
+
+    // Without --recurse-submodules the directory exists but is empty, so the
+    // SKILL.md read below fails and discovery returns nothing.
+    const submoduledSkill = await readFile(join(cloneDir, 'skills', 'child', 'SKILL.md'), 'utf8');
+    expect(submoduledSkill).toContain('name: submoduled-skill');
+
+    const skills = await discoverSkills(cloneDir);
+    expect(skills.map((skill) => skill.name)).toContain('submoduled-skill');
+
+    await cleanupTempDir(cloneDir);
+    tempDirs.splice(tempDirs.indexOf(cloneDir), 1);
+  }, 30_000);
+});


### PR DESCRIPTION
> **Provenance:** investigated, patched, and tested by Claude Code (Opus 5) in my terminal. I can't independently vouch for the source-level analysis the way someone who works in this codebase could, so weigh it accordingly — though everything below was actually run end to end, not proposed untested.

## Summary

`skills add` installs nothing from a repository that composes its skills as git submodules. The clone step never passed `--recurse-submodules`, so each submodule directory is created but left empty, and discovery finds no `SKILL.md` to read.

Reproduced on `skills@1.5.23` against a public repository with 5 submodules holding 9 `SKILL.md` files at inconsistent depths:

```console
$ npx skills add mbac/my-skills --list
No skills found
```

## Root cause

`src/git.ts` builds a fixed flag list for each clone path, and none of them recursed into submodules:

- `cloneRepo` — `['--depth', '1']`, the primary `simple-git` clone
- `tryGhClone` — `['--depth=1']`, the `gh repo clone` authentication fallback

The SSH fallback reuses `cloneRepo`'s `cloneOptions`, so it inherits the same gap. A plain shallow clone leaves each submodule path present but empty, and discovery then has nothing to match.

Discovery itself is not at fault. `discoverSkills` already walks skill-container directories and stops descending below a found `SKILL.md`, so once submodule content is on disk the existing traversal picks it up with no further change.

## Impact

A repository that aggregates skills by reference installs zero skills, with no error — the clone succeeds and the result is simply empty. That is the shape people reach for when collecting skills from several repos into one installable source.

`--full-depth` does not cover this case (see #45): it controls scan depth over an already-cloned tree and cannot populate an empty submodule directory.

## The change

Add `--recurse-submodules --shallow-submodules` to the clone flags in both places. Two edits cover all three clone paths, since the SSH fallback shares `cloneOptions`.

`--shallow-submodules` keeps submodule history at the same `--depth=1` as the superproject, so the added cost is the submodule trees themselves rather than their history.

## Verification

Against the same 5-submodule repository:

| Case | Skills discovered |
|---|---:|
| `skills@1.5.23`, unpatched | 0 |
| this branch | 9 |

`tests/submodule-clone.test.ts` is new. It builds a superproject-plus-submodule fixture, clones it through `cloneRepo`, and asserts the nested skill is both present on disk and returned by `discoverSkills`. Reverting `src/git.ts` alone makes it fail with `ENOENT` on the submodule's `SKILL.md`, so it pins the regression rather than the implementation.

Three assertions in `src/git.test.ts` pinned the exact clone flag list and are updated to match.

Full suite: 774 passed, 3 failed, 777 total. The three failures are in `src/detect-agent.test.ts` (Cursor environment detection); they fail identically on unmodified `main` in the same environment and are unrelated to this change.

## Related upstream work

- #492 — the open issue this fixes.
- #45 — closed pointing at `--full-depth`, which addresses scan depth rather than submodule population, so the submodule case stayed broken.
- #53 — proposes the same clone-flag change and has been open since January. It is based on an `add-skill@1.0.21` snapshot from before the `skills@1.5.x` rewrite and currently reports as conflicting, so it cannot merge as-is. If @quuu would rather rebase that one, I am happy to close this in its favour — this is meant to unblock the issue, not to claim the idea.
