### PR TITLE
feat: show security warning details before install

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { sep, join, dirname } from 'path';
 import { parseSource, getOwnerRepo, parseOwnerRepo, isRepoPrivate } from './source-parser.ts';
-import { stripTerminalEscapes } from './sanitize.ts';
+import { sanitizeMetadata, stripTerminalEscapes } from './sanitize.ts';
 import { searchMultiselect } from './prompts/search-multiselect.ts';
 import { cloneRepo, cleanupTempDir, GitCloneError } from './git.ts';
 import { discoverSkills, getSkillDisplayName, filterSkills } from './skills.ts';
@@ -129,6 +129,58 @@ function socketLabel(audit: PartnerAudit | undefined): string {
   return count > 0 ? pc.red(`${count} alert${count !== 1 ? 's' : ''}`) : pc.green('0 alerts');
 }
 
+const AUDIT_PROVIDERS = [
+  { key: 'ath', label: 'Gen Agent Trust Hub', slug: 'agent-trust-hub' },
+  { key: 'socket', label: 'Socket', slug: 'socket' },
+  { key: 'snyk', label: 'Snyk', slug: 'snyk' },
+] as const;
+
+function isAuditWarning(audit: PartnerAudit | undefined): audit is PartnerAudit {
+  if (!audit) return false;
+  return (
+    audit.status === 'warn' ||
+    audit.status === 'fail' ||
+    (audit.alerts ?? 0) > 0 ||
+    audit.risk === 'medium' ||
+    audit.risk === 'high' ||
+    audit.risk === 'critical'
+  );
+}
+
+function wrapText(text: string, width = 88): string[] {
+  const words = stripTerminalEscapes(text).replace(/\s+/g, ' ').trim().split(' ');
+  const lines: string[] = [];
+  let line = '';
+
+  for (const word of words) {
+    if (!word) continue;
+    if (line && line.length + word.length + 1 > width) {
+      lines.push(line);
+      line = word;
+    } else {
+      line = line ? `${line} ${word}` : word;
+    }
+  }
+
+  if (line) lines.push(line);
+  return lines;
+}
+
+function auditWarningLabel(audit: PartnerAudit): string {
+  const status = (audit.status ?? 'warn').toUpperCase();
+  const severity = (audit.riskLevel ?? audit.risk).toUpperCase();
+  const label = severity === 'UNKNOWN' || severity === status ? status : `${status} · ${severity}`;
+  return sanitizeMetadata(label);
+}
+
+function auditWarningSummary(audit: PartnerAudit): string {
+  if (audit.summary) return audit.summary;
+  if ((audit.alerts ?? 0) > 0) {
+    return `${audit.alerts} alert${audit.alerts === 1 ? '' : 's'} reported.`;
+  }
+  return `${audit.risk.charAt(0).toUpperCase()}${audit.risk.slice(1)} risk reported.`;
+}
+
 /** Pad a string to a given visible width (ignoring ANSI escape codes). */
 function padEnd(str: string, width: number): string {
   // Strip ANSI codes to measure visible length
@@ -141,7 +193,7 @@ function padEnd(str: string, width: number): string {
  * Render a compact security table showing partner audit results.
  * Returns the lines to display, or empty array if no data.
  */
-function buildSecurityLines(
+export function buildSecurityLines(
   auditData: AuditResponse | null,
   skills: Array<{ slug: string; displayName: string }>,
   source: string
@@ -180,6 +232,41 @@ function buildSecurityLines(
     const snyk = data?.snyk ? riskLabel(data.snyk.risk) : pc.dim('--');
 
     lines.push(padEnd(pc.cyan(name), nameWidth + 2) + padEnd(ath, 18) + padEnd(socket, 18) + snyk);
+  }
+
+  const warnings = skills.flatMap((skill) => {
+    const data = auditData[skill.slug];
+    return AUDIT_PROVIDERS.flatMap((provider) => {
+      const audit = data?.[provider.key];
+      return isAuditWarning(audit) ? [{ skill, provider, audit }] : [];
+    });
+  });
+
+  if (warnings.length > 0) {
+    lines.push('');
+    lines.push(pc.yellow(pc.bold('Review before installing:')));
+
+    for (const { skill, provider, audit } of warnings) {
+      const providerName = sanitizeMetadata(audit.provider ?? provider.label);
+      const providerSlug = audit.providerSlug ?? provider.slug;
+      const categories = audit.categories?.length
+        ? ` · ${sanitizeMetadata(audit.categories.join(', ').replaceAll('_', ' '))}`
+        : '';
+
+      lines.push(
+        `${pc.cyan(skill.displayName)} ${pc.dim('·')} ${providerName} ${pc.dim('·')} ${pc.yellow(
+          auditWarningLabel(audit)
+        )}${pc.dim(categories)}`
+      );
+      for (const summaryLine of wrapText(auditWarningSummary(audit))) {
+        lines.push(`  ${summaryLine}`);
+      }
+      lines.push(
+        `  ${pc.dim('Review:')} ${pc.dim(
+          `https://skills.sh/${source}/${skill.slug}/security/${providerSlug}`
+        )}`
+      );
+    }
   }
 
   // Footer link

--- a/src/security-audit.test.ts
+++ b/src/security-audit.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { buildSecurityLines } from './add.js';
+import { stripTerminalEscapes } from './sanitize.js';
+import type { AuditResponse } from './telemetry.js';
+
+const skills = [
+  {
+    slug: 'connected-service-automation',
+    displayName: 'connected-service-automation',
+  },
+];
+
+function render(auditData: AuditResponse): string {
+  return stripTerminalEscapes(
+    buildSecurityLines(auditData, skills, 'colinalexander/super-skills').join('\n')
+  );
+}
+
+describe('security audit installation output', () => {
+  it('shows enriched warning details and a provider-specific review URL', () => {
+    const output = render({
+      'connected-service-automation': {
+        socket: {
+          risk: 'medium',
+          alerts: 1,
+          analyzedAt: '2026-08-31T00:00:00Z',
+          provider: 'Socket',
+          providerSlug: 'socket',
+          status: 'warn',
+          summary: 'Broad scope permits high-impact external actions.',
+          riskLevel: 'MEDIUM',
+          categories: ['ANOMALY'],
+        },
+      },
+    });
+
+    expect(output).toContain('Review before installing:');
+    expect(output).toContain('connected-service-automation · Socket · WARN · MEDIUM · ANOMALY');
+    expect(output).toContain('Broad scope permits high-impact external actions.');
+    expect(output).toContain(
+      'https://skills.sh/colinalexander/super-skills/connected-service-automation/security/socket'
+    );
+  });
+
+  it('falls back to the compact alert when detail enrichment is unavailable', () => {
+    const output = render({
+      'connected-service-automation': {
+        socket: {
+          risk: 'low',
+          alerts: 1,
+          analyzedAt: '2026-08-31T00:00:00Z',
+        },
+      },
+    });
+
+    expect(output).toContain('connected-service-automation · Socket · WARN · LOW');
+    expect(output).toContain('1 alert reported.');
+    expect(output).toContain('/connected-service-automation/security/socket');
+  });
+
+  it('keeps passing audits compact', () => {
+    const output = render({
+      'connected-service-automation': {
+        socket: {
+          risk: 'safe',
+          alerts: 0,
+          analyzedAt: '2026-08-31T00:00:00Z',
+        },
+      },
+    });
+
+    expect(output).not.toContain('Review before installing:');
+    expect(output).toContain('0 alerts');
+  });
+
+  it('strips terminal escapes from remote audit text', () => {
+    const output = buildSecurityLines(
+      {
+        'connected-service-automation': {
+          socket: {
+            risk: 'medium',
+            alerts: 1,
+            analyzedAt: '2026-08-31T00:00:00Z',
+            provider: '\u001b]8;;https://example.com\u0007Socket\u001b]8;;\u0007',
+            status: 'warn',
+            summary: '\u001b[31mRemote warning\u001b[0m',
+            riskLevel: 'MEDIUM',
+          },
+        },
+      },
+      skills,
+      'colinalexander/super-skills'
+    ).join('\n');
+
+    expect(output).not.toContain('\u001b]8;;https://example.com');
+    expect(output).not.toContain('\u001b[31mRemote warning');
+    expect(stripTerminalEscapes(output)).toContain('Socket · WARN · MEDIUM');
+    expect(stripTerminalEscapes(output)).toContain('Remote warning');
+  });
+});

--- a/src/telemetry.test.ts
+++ b/src/telemetry.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchAuditData } from './telemetry.js';
+
+describe('fetchAuditData', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.DISABLE_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('enriches only flagged skills with detailed audit findings', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            warned: {
+              socket: {
+                risk: 'medium',
+                alerts: 1,
+                analyzedAt: '2026-08-31T00:00:00Z',
+              },
+            },
+            safe: {
+              socket: {
+                risk: 'safe',
+                alerts: 0,
+                analyzedAt: '2026-08-31T00:00:00Z',
+              },
+            },
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            audits: [
+              {
+                provider: 'Socket',
+                slug: 'socket',
+                status: 'warn',
+                summary: 'One actionable warning.',
+                auditedAt: '2026-08-31T00:00:00Z',
+                riskLevel: 'MEDIUM',
+              },
+            ],
+          })
+        )
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAuditData('owner/repo', ['warned', 'safe']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+      'https://skills.sh/api/v1/skills/audit/owner%2Frepo/warned'
+    );
+    expect(result?.warned?.socket).toMatchObject({
+      provider: 'Socket',
+      providerSlug: 'socket',
+      status: 'warn',
+      summary: 'One actionable warning.',
+      riskLevel: 'MEDIUM',
+    });
+    expect(result?.safe?.socket?.summary).toBeUndefined();
+  });
+
+  it('preserves compact findings when detail enrichment fails', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            warned: {
+              socket: {
+                risk: 'low',
+                alerts: 1,
+                analyzedAt: '2026-08-31T00:00:00Z',
+              },
+            },
+          })
+        )
+      )
+      .mockResolvedValueOnce(new Response('', { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAuditData('owner/repo', ['warned']);
+
+    expect(result?.warned?.socket).toMatchObject({ risk: 'low', alerts: 1 });
+    expect(result?.warned?.socket?.summary).toBeUndefined();
+  });
+});

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -98,10 +98,68 @@ export interface PartnerAudit {
   alerts?: number;
   score?: number;
   analyzedAt: string;
+  provider?: string;
+  providerSlug?: string;
+  status?: string;
+  summary?: string;
+  riskLevel?: string;
+  categories?: string[];
 }
 
 export type SkillAuditData = Record<string, PartnerAudit>;
 export type AuditResponse = Record<string, SkillAuditData>;
+
+interface DetailedPartnerAudit {
+  provider: string;
+  slug: string;
+  status: string;
+  summary: string;
+  riskLevel?: string;
+  categories?: string[];
+}
+
+interface SkillAuditDetails {
+  audits: DetailedPartnerAudit[];
+}
+
+const DETAIL_PROVIDER_KEYS: Record<string, string> = {
+  'agent-trust-hub': 'ath',
+  socket: 'socket',
+  snyk: 'snyk',
+};
+
+function needsAuditDetails(audit: PartnerAudit): boolean {
+  return (
+    (audit.alerts ?? 0) > 0 ||
+    audit.risk === 'medium' ||
+    audit.risk === 'high' ||
+    audit.risk === 'critical'
+  );
+}
+
+async function fetchSkillAuditDetails(
+  source: string,
+  skillSlug: string,
+  timeoutMs: number
+): Promise<SkillAuditDetails | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const encodedSource = encodeURIComponent(source);
+    const encodedSkill = encodeURIComponent(skillSlug);
+    const response = await fetch(
+      `https://skills.sh/api/v1/skills/audit/${encodedSource}/${encodedSkill}`,
+      { signal: controller.signal }
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as SkillAuditDetails;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 /**
  * Fetch security audit results for skills from the audit API.
@@ -130,7 +188,39 @@ export async function fetchAuditData(
     clearTimeout(timeout);
 
     if (!response.ok) return null;
-    return (await response.json()) as AuditResponse;
+    const auditData = (await response.json()) as AuditResponse;
+
+    // The compact endpoint only returns counts and risk levels. Enrich flagged
+    // skills with the provider's status and summary so users can review the
+    // finding before accepting the installation. Detail failures remain
+    // advisory: the compact result and a direct review URL are still shown.
+    const flaggedSkills = skillSlugs.filter((skillSlug) =>
+      Object.values(auditData[skillSlug] ?? {}).some(needsAuditDetails)
+    );
+
+    await Promise.all(
+      flaggedSkills.map(async (skillSlug) => {
+        const details = await fetchSkillAuditDetails(source, skillSlug, timeoutMs);
+        if (!details) return;
+
+        if (!Array.isArray(details.audits)) return;
+
+        for (const detail of details.audits) {
+          const providerKey = DETAIL_PROVIDER_KEYS[detail.slug];
+          const partnerAudit = providerKey ? auditData[skillSlug]?.[providerKey] : undefined;
+          if (!partnerAudit) continue;
+
+          partnerAudit.provider = detail.provider;
+          partnerAudit.providerSlug = detail.slug;
+          partnerAudit.status = detail.status;
+          partnerAudit.summary = detail.summary;
+          partnerAudit.riskLevel = detail.riskLevel;
+          partnerAudit.categories = detail.categories;
+        }
+      })
+    );
+
+    return auditData;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- enrich flagged security results with provider status, risk level, summary, and categories from the public per-skill audit endpoint
- print each warning with a direct provider-specific review URL before installation
- preserve the existing compact fallback when detail enrichment is unavailable
- sanitize all remote audit text before rendering it in the terminal

## User-visible delta

When a selected skill has a non-zero alert or medium-or-higher risk, `skills add` now expands the finding at the installation consent point. Users see the affected skill, provider, warning status, severity, summary, and exact skills.sh audit URL instead of only an alert count and collection-level link.

Passing audits remain in the existing compact table.

## How to verify

From this branch, run:

```bash
pnpm dev add colinalexander/super-skills \
  --skill connected-service-automation \
  --agent codex \
  --global
```

The current audit renders a `Review before installing` section for the Snyk warning with `WARN · MEDIUM`, `Risk: MEDIUM · 1 issue`, and this provider-specific URL:

```text
https://skills.sh/colinalexander/super-skills/connected-service-automation/security/snyk
```

## Delivery and activation

- Delivery state: implemented and validated on this PR branch
- Environment: `skills` CLI
- Activation state: not released; requires merge and a subsequent npm release by the maintainers
- Activation owner: `vercel-labs/skills` maintainers

## Evidence

A live local CLI run displayed the enriched warning inside `Security Risk Assessments` before installation work began. Focused tests cover enriched warnings, compact fallback behavior, passing audits, and terminal-escape sanitization.

## Validation

- `pnpm format:check`
- `pnpm type-check`
- `pnpm test` — 60 files, 782 tests passed
- `pnpm build`

## Review fixes

- Signature follow-up: re-signed the unchanged implementation tree with the GitHub-registered SSH signing key at head `23aa2c0ff5049e41c9239c95e2e7721f2e4e16fd`. No source or test content changed.

## Known limitations

- Security information remains advisory and fail-open, matching existing behavior. If detail enrichment times out, the compact alert and direct provider URL are still shown.
- Explicit non-interactive installation modes continue to skip confirmation; this change exposes the warning but does not alter those modes' consent semantics.

_gh-pr-review-loop v2026.08.30.2_
