### PR TITLE
feat: add Plexon agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [74 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -269,75 +269,76 @@ Skills can be installed to any of these agents:
 <!-- supported-agents:start -->
 | Agent | `--agent` | Project Path | Global Path |
 |-------|-----------|--------------|-------------|
-| AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
-| Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
-| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
-| Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~/.gemini/antigravity-cli/skills/` |
-| AstrBot | `astrbot` | `data/skills/` | `~/.astrbot/data/skills/` |
-| Autohand Code CLI | `autohand-code` | `.autohand/skills/` | `~/.autohand/skills/` |
-| Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |
-| IBM Bob | `bob` | `.bob/skills/` | `~/.bob/skills/` |
-| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/` |
-| OpenClaw | `openclaw` | `skills/` | `~/.openclaw/skills/` |
-| Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~/.agents/skills/` |
-| CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~/.codeartsdoer/skills/` |
-| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
-| Codemaker | `codemaker` | `.codemaker/skills/` | `~/.codemaker/skills/` |
-| Code Studio | `codestudio` | `.codestudio/skills/` | `~/.codestudio/skills/` |
-| Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
-| Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
-| Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
-| Cortex Code | `cortex` | `.cortex/skills/` | `~/.snowflake/cortex/skills/` |
-| Crush | `crush` | `.crush/skills/` | `~/.config/crush/skills/` |
-| Cursor | `cursor` | `.agents/skills/` | `~/.cursor/skills/` |
-| Deep Agents | `deepagents` | `.agents/skills/` | `~/.deepagents/agent/skills/` |
-| Devin for Terminal | `devin` | `.devin/skills/` | `~/.config/devin/skills/` |
-| Droid | `droid` | `.factory/skills/` | `~/.factory/skills/` |
+| AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~\.aider-desk\skills/` |
+| Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~\.config\agents\skills/` |
+| Antigravity | `antigravity` | `.agents/skills/` | `~\.gemini\antigravity\skills/` |
+| Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~\.gemini\antigravity-cli\skills/` |
+| AstrBot | `astrbot` | `data/skills/` | `~\.astrbot\data\skills/` |
+| Autohand Code CLI | `autohand-code` | `.autohand/skills/` | `~\.autohand\skills/` |
+| Augment | `augment` | `.augment/skills/` | `~\.augment\skills/` |
+| IBM Bob | `bob` | `.bob/skills/` | `~\.bob\skills/` |
+| Claude Code | `claude-code` | `.claude/skills/` | `~\.claude\skills/` |
+| OpenClaw | `openclaw` | `skills/` | `~\.openclaw\skills/` |
+| Cline, Dexto, Kimi Code CLI, Loaf, Warp, Zed | `cline`, `dexto`, `kimi-code-cli`, `loaf`, `warp`, `zed` | `.agents/skills/` | `~\.agents\skills/` |
+| CodeArts Agent | `codearts-agent` | `.codeartsdoer/skills/` | `~\.codeartsdoer\skills/` |
+| CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~\.codebuddy\skills/` |
+| Codemaker | `codemaker` | `.codemaker/skills/` | `~\.codemaker\skills/` |
+| Code Studio | `codestudio` | `.codestudio/skills/` | `~\.codestudio\skills/` |
+| Codex | `codex` | `.agents/skills/` | `~\.codex\skills/` |
+| Command Code | `command-code` | `.commandcode/skills/` | `~\.commandcode\skills/` |
+| Continue | `continue` | `.continue/skills/` | `~\.continue\skills/` |
+| Cortex Code | `cortex` | `.cortex/skills/` | `~\.snowflake\cortex\skills/` |
+| Crush | `crush` | `.crush/skills/` | `~\.config\crush\skills/` |
+| Cursor | `cursor` | `.agents/skills/` | `~\.cursor\skills/` |
+| Deep Agents | `deepagents` | `.agents/skills/` | `~\.deepagents\agent\skills/` |
+| Devin for Terminal | `devin` | `.devin/skills/` | `~\.config\devin\skills/` |
+| Droid | `droid` | `.factory/skills/` | `~\.factory\skills/` |
 | Eve | `eve` | `agent/skills/` | N/A (project-only) |
-| Firebender | `firebender` | `.agents/skills/` | `~/.firebender/skills/` |
-| ForgeCode | `forgecode` | `.forge/skills/` | `~/.forge/skills/` |
-| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
-| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
-| Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
-| Grok Build | `grok` | `.grok/skills/` | `~/.grok/skills/` |
-| Hermes Agent | `hermes-agent` | `.hermes/skills/` | `~/.hermes/skills/` |
-| inference.sh | `inference-sh` | `.inferencesh/skills/` | `~/.inferencesh/skills/` |
-| Jazz | `jazz` | `.jazz/skills/` | `~/.jazz/skills/` |
-| Junie | `junie` | `.junie/skills/` | `~/.junie/skills/` |
-| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~/.iflow/skills/` |
-| Kilo Code | `kilo` | `.kilocode/skills/` | `~/.kilocode/skills/` |
-| Kimchi | `kimchi` | `.kimchi/skills/` | `~/.config/kimchi/harness/skills/` |
-| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
-| Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
-| Lingma | `lingma` | `.lingma/skills/` | `~/.lingma/skills/` |
-| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |
-| MiniMax Code | `minimax-code` | `.minimax/skills/` | `~/.minimax/skills/` |
-| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~/.vibe/skills/` |
-| Moxby | `moxby` | `.moxby/skills/` | `~/.moxby/skills/` |
-| Mux | `mux` | `.mux/skills/` | `~/.mux/skills/` |
-| OpenCode | `opencode` | `.agents/skills/` | `~/.config/opencode/skills/` |
-| OpenHands | `openhands` | `.openhands/skills/` | `~/.openhands/skills/` |
-| Ona | `ona` | `.ona/skills/` | `~/.ona/skills/` |
-| Pi | `pi` | `.pi/skills/` | `~/.pi/agent/skills/` |
-| Posit Assistant | `posit-assistant` | `.posit/assistant/skills/` | `~/.posit/assistant/skills/` |
-| Qoder | `qoder` | `.qoder/skills/` | `~/.qoder/skills/` |
-| Qoder CN | `qoder-cn` | `.qoder/skills/` | `~/.qoder-cn/skills/` |
-| Qwen Code | `qwen-code` | `.qwen/skills/` | `~/.qwen/skills/` |
-| Reasonix | `reasonix` | `.reasonix/skills/` | `~/.reasonix/skills/` |
-| Rovo Dev | `rovodev` | `.rovodev/skills/` | `~/.rovodev/skills/` |
-| Roo Code | `roo` | `.roo/skills/` | `~/.roo/skills/` |
-| Tabnine CLI | `tabnine-cli` | `.tabnine/agent/skills/` | `~/.tabnine/agent/skills/` |
-| Terramind | `terramind` | `.terramind/skills/` | `~/.terramind/skills/` |
-| Tinycloud | `tinycloud` | `.tinycloud/skills/` | `~/.tinycloud/skills/` |
-| Trae | `trae` | `.trae/skills/` | `~/.trae/skills/` |
-| Trae CN | `trae-cn` | `.trae/skills/` | `~/.trae-cn/skills/` |
-| Windsurf | `windsurf` | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
-| ZCode | `zcode` | `.zcode/skills/` | `~/.zcode/skills/` |
-| Zencoder, Zenflow | `zencoder`, `zenflow` | `.zencoder/skills/` | `~/.zencoder/skills/` |
-| Neovate | `neovate` | `.neovate/skills/` | `~/.neovate/skills/` |
-| Pochi | `pochi` | `.pochi/skills/` | `~/.pochi/skills/` |
+| Firebender | `firebender` | `.agents/skills/` | `~\.firebender\skills/` |
+| ForgeCode | `forgecode` | `.forge/skills/` | `~\.forge\skills/` |
+| Gemini CLI | `gemini-cli` | `.agents/skills/` | `~\.gemini\skills/` |
+| GitHub Copilot | `github-copilot` | `.agents/skills/` | `~\.copilot\skills/` |
+| Goose | `goose` | `.goose/skills/` | `~\.config\goose\skills/` |
+| Grok Build | `grok` | `.grok/skills/` | `~\.grok\skills/` |
+| Hermes Agent | `hermes-agent` | `.hermes/skills/` | `~\.hermes\skills/` |
+| inference.sh | `inference-sh` | `.inferencesh/skills/` | `~\.inferencesh\skills/` |
+| Jazz | `jazz` | `.jazz/skills/` | `~\.jazz\skills/` |
+| Junie | `junie` | `.junie/skills/` | `~\.junie\skills/` |
+| iFlow CLI | `iflow-cli` | `.iflow/skills/` | `~\.iflow\skills/` |
+| Kilo Code | `kilo` | `.kilocode/skills/` | `~\.kilocode\skills/` |
+| Kimchi | `kimchi` | `.kimchi/skills/` | `~\.config\kimchi\harness\skills/` |
+| Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~\.kiro\skills/` |
+| Kode | `kode` | `.kode/skills/` | `~\.kode\skills/` |
+| Lingma | `lingma` | `.lingma/skills/` | `~\.lingma\skills/` |
+| MCPJam | `mcpjam` | `.mcpjam/skills/` | `~\.mcpjam\skills/` |
+| MiniMax Code | `minimax-code` | `.minimax/skills/` | `~\.minimax\skills/` |
+| Mistral Vibe | `mistral-vibe` | `.vibe/skills/` | `~\.vibe\skills/` |
+| Moxby | `moxby` | `.moxby/skills/` | `~\.moxby\skills/` |
+| Mux | `mux` | `.mux/skills/` | `~\.mux\skills/` |
+| OpenCode | `opencode` | `.agents/skills/` | `~\.config\opencode\skills/` |
+| OpenHands | `openhands` | `.openhands/skills/` | `~\.openhands\skills/` |
+| Ona | `ona` | `.ona/skills/` | `~\.ona\skills/` |
+| Pi | `pi` | `.pi/skills/` | `~\.pi\agent\skills/` |
+| Posit Assistant | `posit-assistant` | `.posit/assistant/skills/` | `~\.posit\assistant\skills/` |
+| Qoder | `qoder` | `.qoder/skills/` | `~\.qoder\skills/` |
+| Qoder CN | `qoder-cn` | `.qoder/skills/` | `~\.qoder-cn\skills/` |
+| Qwen Code | `qwen-code` | `.qwen/skills/` | `~\.qwen\skills/` |
+| Reasonix | `reasonix` | `.reasonix/skills/` | `~\.reasonix\skills/` |
+| Rovo Dev | `rovodev` | `.rovodev/skills/` | `~\.rovodev\skills/` |
+| Plexon | `plexon` | `.plexon/skills/` | `~\.plexon\skills/` |
+| Roo Code | `roo` | `.roo/skills/` | `~\.roo\skills/` |
+| Tabnine CLI | `tabnine-cli` | `.tabnine/agent/skills/` | `~\.tabnine\agent\skills/` |
+| Terramind | `terramind` | `.terramind/skills/` | `~\.terramind\skills/` |
+| Tinycloud | `tinycloud` | `.tinycloud/skills/` | `~\.tinycloud\skills/` |
+| Trae | `trae` | `.trae/skills/` | `~\.trae\skills/` |
+| Trae CN | `trae-cn` | `.trae/skills/` | `~\.trae-cn\skills/` |
+| Windsurf | `windsurf` | `.windsurf/skills/` | `~\.codeium\windsurf\skills/` |
+| ZCode | `zcode` | `.zcode/skills/` | `~\.zcode\skills/` |
+| Zencoder, Zenflow | `zencoder`, `zenflow` | `.zencoder/skills/` | `~\.zencoder\skills/` |
+| Neovate | `neovate` | `.neovate/skills/` | `~\.neovate\skills/` |
+| Pochi | `pochi` | `.pochi/skills/` | `~\.pochi\skills/` |
 | PromptScript | `promptscript` | `.agents/skills/` | N/A (project-only) |
-| AdaL | `adal` | `.adal/skills/` | `~/.adal/skills/` |
+| AdaL | `adal` | `.adal/skills/` | `~\.adal\skills/` |
 <!-- supported-agents:end -->
 
 > [!NOTE]
@@ -458,6 +459,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.qwen/skills/`
 - `.reasonix/skills/`
 - `.rovodev/skills/`
+- `.plexon/skills/`
 - `.roo/skills/`
 - `.tabnine/agent/skills/`
 - `.terramind/skills/`

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "replit",
     "reasonix",
     "rovodev",
+    "plexon",
     "roo",
     "tabnine-cli",
     "terramind",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -628,6 +628,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.rovodev'));
     },
   },
+  plexon: {
+    name: 'plexon',
+    displayName: 'Plexon',
+    skillsDir: '.plexon/skills',
+    globalSkillsDir: join(home, '.plexon/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.plexon'));
+    },
+  },
   roo: {
     name: 'roo',
     displayName: 'Roo Code',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -330,6 +330,7 @@ const PRIORITY_PREFIXES = [
   '.opencode/skills/',
   '.openhands/skills/',
   '.pi/skills/',
+  '.plexon/skills/',
   '.posit/assistant/skills/',
   '.qoder/skills/',
   '.roo/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -31,6 +31,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.opencode/skills',
   '.openhands/skills',
   '.pi/skills',
+  '.plexon/skills',
   '.posit/assistant/skills',
   '.qoder/skills',
   '.roo/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export type AgentType =
   | 'qwen-code'
   | 'replit'
   | 'reasonix'
+  | 'plexon'
   | 'roo'
   | 'rovodev'
   | 'tabnine-cli'

--- a/tests/plexon-agent.test.ts
+++ b/tests/plexon-agent.test.ts
@@ -1,0 +1,18 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { describe, expect, it } from 'vitest';
+import { agents } from '../src/agents.ts';
+
+describe('Plexon agent support', () => {
+  it('uses ~/.plexon/skills for global skills', () => {
+    expect(agents.plexon.name).toBe('plexon');
+    expect(agents.plexon.displayName).toBe('Plexon');
+    expect(agents.plexon.skillsDir).toBe('.plexon/skills');
+    expect(agents.plexon.globalSkillsDir).toBe(join(homedir(), '.plexon', 'skills'));
+  });
+
+  it('detects Plexon from its home directory', async () => {
+    expect(typeof agents.plexon.detectInstalled).toBe('function');
+    expect(typeof (await agents.plexon.detectInstalled())).toBe('boolean');
+  });
+});


### PR DESCRIPTION
Adds Plexon to the agents registry.

**Agent Name:** Plexon — a cross-platform desktop AI assistant (Electron + Go daemon).

**Skills Documentation URL:** https://plexon.ai/features/skills/

**Project Skills Directory:** `.plexon/skills`

**Global Skills Directory:** `~/.plexon/skills`

**Detection Path:** `~/.plexon`

Plexon stores each skill as a `<name>/SKILL.md` directory with Claude-compatible YAML frontmatter (`name`, `description`), the same shape this CLI installs, and follows symlinks and Windows junctions when scanning, so both the symlink and copy install modes work as-is.

Followed AGENTS.md: added the entry in `src/agents.ts`, the project dir in `src/skills.ts` and `src/blob.ts`, the type in `src/types.ts`, a package.json keyword, ran `scripts/validate-agents.ts` and `scripts/sync-agents.ts` (README regenerated), `pnpm format`, `pnpm type-check`, and `pnpm test` (the 8 pre-existing failures on Windows without Developer Mode — symlink-privilege and Cursor env tests — fail identically on `main`; the new `tests/plexon-agent.test.ts` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
