### PR TITLE
fix: don't treat a github.com path segment on another host as GitHub

### DIFF
--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -269,6 +269,20 @@ function isHostedArtifactUrl(input: string): boolean {
   }
 }
 
+/**
+ * Remove the query string from an HTTP(S) URL before it is matched against the
+ * repository URL patterns. Git hosts append query parameters to browse URLs
+ * (e.g. GitLab's `?ref_type=heads`), and those must not leak into the parsed
+ * ref or subpath. Non-HTTP inputs (local paths, shorthand) are returned as-is.
+ */
+function stripQueryString(input: string): string {
+  if (!/^https?:\/\//i.test(input)) {
+    return input;
+  }
+  const queryIndex = input.indexOf('?');
+  return queryIndex === -1 ? input : input.slice(0, queryIndex);
+}
+
 export function parseSource(input: string): ParsedSource {
   // Local path: absolute, relative, or current directory
   if (isLocalPath(input)) {
@@ -348,8 +362,17 @@ export function parseSource(input: string): ParsedSource {
     }
   }
 
+  // Repository browse URLs may carry a query string (e.g. GitLab's
+  // `?ref_type=heads`); it is not part of the ref or subpath.
+  const repoUrlInput = stripQueryString(input);
+
   // GitHub URL with path: https://github.com/owner/repo/tree/branch/path/to/skill
-  const githubTreeWithPathMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/);
+  // Anchored to the start of the URL so a "github.com" segment inside another
+  // host's path (e.g. a self-hosted GitLab mirror at
+  // https://gitlab.example.com/mirror/github.com/owner/repo) is not treated as GitHub.
+  const githubTreeWithPathMatch = repoUrlInput.match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+)/
+  );
   if (githubTreeWithPathMatch) {
     const [, owner, repo, ref, subpath] = githubTreeWithPathMatch;
     return {
@@ -361,7 +384,9 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // GitHub URL with branch only: https://github.com/owner/repo/tree/branch
-  const githubTreeMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/);
+  const githubTreeMatch = repoUrlInput.match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)$/
+  );
   if (githubTreeMatch) {
     const [, owner, repo, ref] = githubTreeMatch;
     return {
@@ -372,7 +397,9 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // GitHub URL: https://github.com/owner/repo
-  const githubRepoMatch = input.match(/github\.com\/([^/]+)\/([^/]+)/);
+  const githubRepoMatch = repoUrlInput.match(
+    /^(?:https?:\/\/)?(?:www\.)?github\.com\/([^/]+)\/([^/]+)/
+  );
   if (githubRepoMatch) {
     const [, owner, repo] = githubRepoMatch;
     const cleanRepo = repo!.replace(/\.git$/, '');
@@ -386,7 +413,7 @@ export function parseSource(input: string): ParsedSource {
   // GitLab URL with path (any GitLab instance): https://gitlab.com/owner/repo/-/tree/branch/path
   // Key identifier is the "/-/tree/" path pattern unique to GitLab.
   // Supports subgroups by using a non-greedy match for the repository path.
-  const gitlabTreeWithPathMatch = input.match(
+  const gitlabTreeWithPathMatch = repoUrlInput.match(
     /^(https?):\/\/([^/]+)\/(.+?)\/-\/tree\/([^/]+)\/(.+)/
   );
   if (gitlabTreeWithPathMatch) {
@@ -402,7 +429,7 @@ export function parseSource(input: string): ParsedSource {
   }
 
   // GitLab URL with branch only (any GitLab instance): https://gitlab.com/owner/repo/-/tree/branch
-  const gitlabTreeMatch = input.match(/^(https?):\/\/([^/]+)\/(.+?)\/-\/tree\/([^/]+)$/);
+  const gitlabTreeMatch = repoUrlInput.match(/^(https?):\/\/([^/]+)\/(.+?)\/-\/tree\/([^/]+)$/);
   if (gitlabTreeMatch) {
     const [, protocol, hostname, repoPath, ref] = gitlabTreeMatch;
     if (hostname !== 'github.com' && repoPath) {
@@ -417,7 +444,9 @@ export function parseSource(input: string): ParsedSource {
   // GitLab.com URL: https://gitlab.com/owner/repo or https://gitlab.com/group/subgroup/repo
   // Only for the official gitlab.com domain for user convenience.
   // Supports nested subgroups (e.g., gitlab.com/group/subgroup1/subgroup2/repo).
-  const gitlabRepoMatch = input.match(/gitlab\.com\/(.+?)(?:\.git)?\/?$/);
+  const gitlabRepoMatch = repoUrlInput.match(
+    /^(?:https?:\/\/)?(?:www\.)?gitlab\.com\/(.+?)(?:\.git)?\/?$/
+  );
   if (gitlabRepoMatch) {
     const repoPath = gitlabRepoMatch[1]!;
     // Must have at least owner/repo (one slash)

--- a/tests/source-parser.test.ts
+++ b/tests/source-parser.test.ts
@@ -42,6 +42,16 @@ describe('parseSource', () => {
       expect(result.ref).toBeUndefined();
     });
 
+    it('GitHub URL - query string is not part of the subpath', () => {
+      const result = parseSource(
+        'https://github.com/owner/repo/tree/main/skills/my-skill?tab=readme'
+      );
+      expect(result.type).toBe('github');
+      expect(result.url).toBe('https://github.com/owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('skills/my-skill');
+    });
+
     it('GitHub URL - tree with branch only', () => {
       const result = parseSource('https://github.com/owner/repo/tree/feature-branch');
       expect(result.type).toBe('github');
@@ -142,6 +152,60 @@ describe('parseSource', () => {
       const result = parseSource('https://gitlab.com/group/subgroup/repo/');
       expect(result.type).toBe('gitlab');
       expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
+    });
+
+    it('GitLab URL - self-hosted instance mirroring a github.com path', () => {
+      const result = parseSource(
+        'http://gitlab.example.com/mirror/github.com/openai/skills/-/tree/main/skills/my-skill'
+      );
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('http://gitlab.example.com/mirror/github.com/openai/skills.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('skills/my-skill');
+    });
+
+    it('GitLab URL - self-hosted instance mirroring a github.com path, branch only', () => {
+      const result = parseSource(
+        'https://gitlab.example.com/mirror/github.com/openai/skills/-/tree/main'
+      );
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.example.com/mirror/github.com/openai/skills.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('GitLab URL - query string is not part of the subpath', () => {
+      const result = parseSource(
+        'https://gitlab.com/group/subgroup/repo/-/tree/main/path/to/skill?ref_type=heads'
+      );
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/group/subgroup/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('path/to/skill');
+    });
+
+    it('GitLab URL - query string is not part of the ref', () => {
+      const result = parseSource('https://gitlab.com/owner/repo/-/tree/develop?ref_type=heads');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/owner/repo.git');
+      expect(result.ref).toBe('develop');
+      expect(result.subpath).toBeUndefined();
+    });
+
+    it('GitLab URL - query string is not part of the repo path', () => {
+      const result = parseSource('https://gitlab.com/owner/repo?ref_type=heads');
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://gitlab.com/owner/repo.git');
+    });
+
+    it("GitLab URL - gitlab.com in another host's path is not treated as gitlab.com", () => {
+      const result = parseSource(
+        'https://git.example.com/mirror/gitlab.com/owner/repo/-/tree/main/skills/my-skill'
+      );
+      expect(result.type).toBe('gitlab');
+      expect(result.url).toBe('https://git.example.com/mirror/gitlab.com/owner/repo.git');
+      expect(result.ref).toBe('main');
+      expect(result.subpath).toBe('skills/my-skill');
     });
   });
 


### PR DESCRIPTION
Fixes #2122.

## Problem

`parseSource()` ran the GitHub URL patterns before the GitLab ones, and those patterns were unanchored — they matched `github.com/<owner>/<repo>` **anywhere** in the input, including inside the path of a different host.

Self-hosted GitLab instances commonly mirror upstream repos under a path that mirrors the origin. For such a URL the parser threw away the real host:

```js
parseSource('http://gitlab.example.com/mirror/github.com/openai/skills/-/tree/main/skills/my-skill?ref_type=heads')
// => { type: 'github', url: 'https://github.com/openai/skills.git' }
```

so `skills add` cloned `github.com` and failed with `Could not resolve host: github.com` on networks that have no GitHub access. The GitLab matchers, which already support any instance, were never reached — and no URL spelling worked, since the `.git` and `git@` forms hit the same substring match.

Second bug in the same code path: the query string was not stripped, so GitLab's `?ref_type=heads` (present on every URL copied from the GitLab UI) ended up inside `ref` / `subpath`:

```js
parseSource('https://gitlab.com/group/repo/-/tree/main/skills/foo?ref_type=heads')
// => subpath: 'skills/foo?ref_type=heads'   // never found in the clone
```

## Fix

- Anchor the `github.com` and `gitlab.com` patterns to the start of the URL (`^(?:https?://)?(?:www\.)?`), so only the **host** decides the source type. The `gitlab.com` pattern had the mirror-image of the same bug.
- Add `stripQueryString()` and match the repo URL patterns against the query-free input, so `?ref_type=heads` no longer leaks into `ref` or `subpath`.

Both changes are confined to the GitHub/GitLab repo-URL matchers. Hosted artifact URLs (`/-/archive/`, `/releases/download/`) and well-known URLs are resolved earlier or later and keep their query string, which some of them need.

After:

```js
parseSource('http://gitlab.example.com/mirror/github.com/openai/skills/-/tree/main/skills/my-skill?ref_type=heads')
// => { type: 'gitlab',
//      url: 'http://gitlab.example.com/mirror/github.com/openai/skills.git',
//      ref: 'main', subpath: 'skills/my-skill' }
```

## Tests

Added to `tests/source-parser.test.ts`:

- self-hosted GitLab mirroring a `github.com` path, with and without a subpath
- `gitlab.com` inside another host's path is not treated as gitlab.com
- query string is not part of the `subpath` / `ref` / repo path (GitLab and GitHub)

`pnpm test tests/source-parser.test.ts src/source-parser.test.ts` — 102 passed. `pnpm type-check` and `pnpm format:check` clean. On the full suite, the 3 failures in `src/detect-agent.test.ts` are pre-existing and environment-dependent (they also fail on an unmodified tree here, because the tests run inside an agent CLI).

## Not covered

A non-tree URL on a self-hosted GitLab (`https://gitlab.example.com/group/repo`) still resolves to `well-known` rather than `gitlab`, as it did before this change — the `gitlab` branch only recognizes `gitlab.com` or a `/-/tree/` path. Left alone to keep this fix scoped; happy to follow up if you want that handled too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
