### PR TITLE
fix(update): migrate relocated skill paths

### DIFF
--- a/src/skill-relocation.test.ts
+++ b/src/skill-relocation.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSkillLocations } from './skill-relocation.ts';
+
+const lock = (skillPath: string) => ({
+  'swiftui-expert-skill': { skillPath },
+});
+
+describe('resolveSkillLocations', () => {
+  it('keeps an unchanged exact path', () => {
+    const result = resolveSkillLocations(
+      ['swiftui-expert-skill'],
+      lock('skills/swiftui-expert-skill/SKILL.md'),
+      [
+        {
+          name: 'swiftui-expert-skill',
+          skillPath: 'skills/swiftui-expert-skill/SKILL.md',
+        },
+      ]
+    );
+
+    expect(result.resolvedPaths.get('swiftui-expert-skill')).toBe(
+      'skills/swiftui-expert-skill/SKILL.md'
+    );
+    expect(result.deletedSkills).toEqual([]);
+    expect(result.ambiguousSkills).toEqual([]);
+  });
+
+  it('resolves a uniquely relocated skill by name', () => {
+    const result = resolveSkillLocations(
+      ['swiftui-expert-skill'],
+      lock('swiftui-expert-skill/SKILL.md'),
+      [
+        {
+          name: 'swiftui-expert-skill',
+          skillPath: 'skills/swiftui-expert-skill/SKILL.md',
+        },
+      ]
+    );
+
+    expect(result.resolvedPaths.get('swiftui-expert-skill')).toBe(
+      'skills/swiftui-expert-skill/SKILL.md'
+    );
+    expect(result.deletedSkills).toEqual([]);
+  });
+
+  it('matches normalized skill names', () => {
+    const result = resolveSkillLocations(
+      ['SwiftUI Expert Skill'],
+      { 'SwiftUI Expert Skill': { skillPath: 'old/location/SKILL.md' } },
+      [
+        {
+          name: 'swiftui_expert_skill',
+          skillPath: 'new/location/SKILL.md',
+        },
+      ]
+    );
+
+    expect(result.resolvedPaths.get('SwiftUI Expert Skill')).toBe('new/location/SKILL.md');
+  });
+
+  it('marks a missing skill as deleted', () => {
+    const result = resolveSkillLocations(
+      ['swiftui-expert-skill'],
+      lock('swiftui-expert-skill/SKILL.md'),
+      []
+    );
+
+    expect(result.deletedSkills).toEqual(['swiftui-expert-skill']);
+    expect(result.resolvedPaths.size).toBe(0);
+  });
+
+  it('fails closed when multiple current paths have the same name', () => {
+    const result = resolveSkillLocations(
+      ['swiftui-expert-skill'],
+      lock('old/swiftui-expert-skill/SKILL.md'),
+      [
+        {
+          name: 'swiftui-expert-skill',
+          skillPath: 'skills/swiftui-expert-skill/SKILL.md',
+        },
+        {
+          name: 'swiftui-expert-skill',
+          skillPath: 'plugins/swiftui-expert-skill/SKILL.md',
+        },
+      ]
+    );
+
+    expect(result.ambiguousSkills).toEqual(['swiftui-expert-skill']);
+    expect(result.deletedSkills).toEqual([]);
+    expect(result.resolvedPaths.size).toBe(0);
+  });
+
+  it('fails closed on duplicate names even when one path matches exactly', () => {
+    const result = resolveSkillLocations(
+      ['swiftui-expert-skill'],
+      lock('skills/swiftui-expert-skill/SKILL.md'),
+      [
+        {
+          name: 'swiftui-expert-skill',
+          skillPath: 'skills/swiftui-expert-skill/SKILL.md',
+        },
+        {
+          name: 'swiftui-expert-skill',
+          skillPath: 'plugins/swiftui-expert-skill/SKILL.md',
+        },
+      ]
+    );
+
+    expect(result.ambiguousSkills).toEqual(['swiftui-expert-skill']);
+    expect(result.deletedSkills).toEqual([]);
+    expect(result.resolvedPaths.size).toBe(0);
+  });
+
+  it('normalizes path separators before exact matching', () => {
+    const result = resolveSkillLocations(
+      ['swiftui-expert-skill'],
+      lock('skills\\swiftui-expert-skill\\SKILL.md'),
+      [
+        {
+          name: 'different-frontmatter-name',
+          skillPath: 'skills/swiftui-expert-skill/SKILL.md',
+        },
+      ]
+    );
+
+    expect(result.resolvedPaths.get('swiftui-expert-skill')).toBe(
+      'skills/swiftui-expert-skill/SKILL.md'
+    );
+    expect(result.deletedSkills).toEqual([]);
+  });
+});

--- a/src/skill-relocation.ts
+++ b/src/skill-relocation.ts
@@ -1,0 +1,74 @@
+export interface DiscoveredSkillLocation {
+  name: string;
+  skillPath: string;
+}
+
+export interface SkillLocationResolution {
+  deletedSkills: string[];
+  ambiguousSkills: string[];
+  resolvedPaths: Map<string, string>;
+}
+
+function normalizeSkillName(name: string): string {
+  return name.toLowerCase().replace(/[\s_]+/g, '-');
+}
+
+function normalizeSkillPath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+/g, '/');
+}
+
+/**
+ * Resolve locked skills against their currently discovered locations.
+ *
+ * Exact paths always win. A missing path is treated as a relocation only when
+ * exactly one discovered skill has the same normalized name. Ambiguous matches
+ * fail closed: they are neither migrated nor offered for deletion.
+ */
+export function resolveSkillLocations(
+  lockedSkillNames: string[],
+  lockSkills: Record<string, { skillPath?: string }>,
+  discovered: DiscoveredSkillLocation[]
+): SkillLocationResolution {
+  const discoveredPaths = new Set(discovered.map((skill) => normalizeSkillPath(skill.skillPath)));
+  const pathsByName = new Map<string, Set<string>>();
+
+  for (const skill of discovered) {
+    const key = normalizeSkillName(skill.name);
+    const paths = pathsByName.get(key) ?? new Set<string>();
+    paths.add(normalizeSkillPath(skill.skillPath));
+    pathsByName.set(key, paths);
+  }
+
+  const deletedSkills: string[] = [];
+  const ambiguousSkills: string[] = [];
+  const resolvedPaths = new Map<string, string>();
+
+  for (const name of lockedSkillNames) {
+    const lockedPath = lockSkills[name]?.skillPath;
+    if (!lockedPath) continue;
+
+    const normalizedLockedPath = normalizeSkillPath(lockedPath);
+    const candidates = [...(pathsByName.get(normalizeSkillName(name)) ?? [])];
+
+    // Update reinstallation ultimately selects by skill name. If more than one
+    // current location has that name, even an exact locked path is not enough
+    // to guarantee that every source type will reinstall the same one.
+    if (candidates.length > 1) {
+      ambiguousSkills.push(name);
+      continue;
+    }
+
+    if (discoveredPaths.has(normalizedLockedPath)) {
+      resolvedPaths.set(name, normalizedLockedPath);
+      continue;
+    }
+
+    if (candidates.length === 1) {
+      resolvedPaths.set(name, candidates[0]!);
+    } else {
+      deletedSkills.push(name);
+    }
+  }
+
+  return { deletedSkills, ambiguousSkills, resolvedPaths };
+}

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -159,6 +159,8 @@ export interface DiscoverSkillsOptions {
   includeInternal?: boolean;
   /** Search all subdirectories even when a root SKILL.md exists */
   fullDepth?: boolean;
+  /** Preserve duplicate skill names so callers can detect ambiguous locations */
+  includeDuplicateNames?: boolean;
 }
 
 /**
@@ -269,7 +271,7 @@ export async function discoverSkills(
   const tryAddSkillAt = async (skillDir: string): Promise<boolean> => {
     if (!(await hasSkillMd(skillDir))) return false;
     let skill = await parseSkillAt(skillDir);
-    if (!skill || seenNames.has(skill.name)) return true;
+    if (!skill || (!options?.includeDuplicateNames && seenNames.has(skill.name))) return true;
     if (isInstalledProjectSkill(skill)) return true;
     skill = enhanceSkill(skill);
     skills.push(skill);
@@ -309,7 +311,11 @@ export async function discoverSkills(
 
     for (const skillDir of allSkillDirs) {
       let skill = await parseSkillAt(skillDir);
-      if (skill && !seenNames.has(skill.name) && !isInstalledProjectSkill(skill)) {
+      if (
+        skill &&
+        (options?.includeDuplicateNames || !seenNames.has(skill.name)) &&
+        !isInstalledProjectSkill(skill)
+      ) {
         skill = enhanceSkill(skill);
         skills.push(skill);
         seenNames.add(skill.name);

--- a/src/update.ts
+++ b/src/update.ts
@@ -17,6 +17,11 @@ import {
 import { cloneRepo, cleanupTempDir, getGitTreeHash } from './git.ts';
 import { discoverSkills } from './skills.ts';
 import { fetchRepoTree, getSkillFolderHashFromTree } from './blob.ts';
+import {
+  resolveSkillLocations,
+  type DiscoveredSkillLocation,
+  type SkillLocationResolution,
+} from './skill-relocation.ts';
 import { wellKnownProvider, computeWellKnownSkillDigest } from './providers/index.ts';
 import { removeCommand } from './remove.ts';
 import { sanitizeMetadata } from './sanitize.ts';
@@ -294,16 +299,22 @@ export async function checkAndPromptForDeletions(
   lockSkills: Record<string, { skillPath?: string }>,
   isGlobal: boolean,
   options: UpdateCheckOptions,
-  discoveredPaths: string[]
-): Promise<string[]> {
-  const deletedSkills = allLockedForSource.filter((name) => {
-    const entry = lockSkills[name];
-    if (!entry?.skillPath) return false;
-    return !discoveredPaths.includes(entry.skillPath);
-  });
+  discovered: DiscoveredSkillLocation[]
+): Promise<SkillLocationResolution> {
+  const resolution = resolveSkillLocations(allLockedForSource, lockSkills, discovered);
 
-  await promptDeletions(source, deletedSkills, isGlobal, options);
-  return deletedSkills;
+  if (resolution.ambiguousSkills.length > 0) {
+    console.log();
+    console.log(
+      `${DIM}Warning:${RESET} Multiple current paths match these skills from ${DIM}${source}${RESET}; skipping them rather than deleting or migrating the wrong skill:`
+    );
+    for (const name of resolution.ambiguousSkills) {
+      console.log(`  ${DIM}•${RESET} ${sanitizeMetadata(name)}`);
+    }
+  }
+
+  await promptDeletions(source, resolution.deletedSkills, isGlobal, options);
+  return resolution;
 }
 
 export interface WellKnownUpdateItem {
@@ -570,66 +581,67 @@ export async function updateGlobalSkills(
             .filter(([_, entry]) => entry.source === source && entry.ref === firstEntry.ref)
             .map(([name, _]) => name);
 
-          const deletedSkills = await checkAndPromptForDeletions(
-            source,
-            allLockedForSource,
-            lock.skills,
-            true,
-            options,
-            discoveredPaths
+          const hasMissingLockedPath = allLockedForSource.some(
+            (name) =>
+              lock.skills[name]?.skillPath &&
+              !discoveredPaths.includes(lock.skills[name]!.skillPath!)
           );
 
-          const deletedSkillSet = new Set(deletedSkills);
-
-          for (const { name: skillName, entry } of itemsForSource) {
-            if (deletedSkillSet.has(skillName)) continue;
-
-            const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
-            if (latestHash && latestHash !== entry.skillFolderHash) {
-              updates.push({ name: skillName, source, entry });
+          if (!hasMissingLockedPath) {
+            for (const { name: skillName, entry } of itemsForSource) {
+              const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath!);
+              if (latestHash && latestHash !== entry.skillFolderHash) {
+                updates.push({ name: skillName, source, entry });
+              }
             }
+
+            continue;
           }
 
-          continue;
+          console.log(`  ${DIM}Skill paths changed; resolving via Git clone${RESET}`);
+        } else {
+          console.log(`  ${DIM}GitHub API unavailable; checking via Git clone${RESET}`);
         }
-
-        console.log(`  ${DIM}GitHub API unavailable; checking via Git clone${RESET}`);
       }
 
       tempDir = await cloneRepo(sourceUrl, firstEntry.ref);
-      const discoveredPaths = (await discoverSkills(tempDir, undefined, { fullDepth: true })).map(
-        (skill) => {
-          return join(relative(tempDir!, skill.path), 'SKILL.md').split(sep).join('/');
-        }
-      );
+      const discovered = await discoverSkills(tempDir, undefined, {
+        fullDepth: true,
+        includeDuplicateNames: true,
+      });
+      const discoveredLocations = discovered.map((skill) => ({
+        name: skill.name,
+        skillPath: join(relative(tempDir!, skill.path), 'SKILL.md').split(sep).join('/'),
+      }));
 
       const allLockedForSource = Object.entries(lock.skills)
         .filter(([_, entry]) => entry.source === source && entry.ref === firstEntry.ref)
         .map(([name, _]) => name);
 
-      const deletedSkills = await checkAndPromptForDeletions(
+      const resolution = await checkAndPromptForDeletions(
         source,
         allLockedForSource,
         lock.skills,
         true,
         options,
-        discoveredPaths
+        discoveredLocations
       );
 
-      const deletedSkillSet = new Set(deletedSkills);
+      const deletedSkillSet = new Set(resolution.deletedSkills);
 
       for (const { name: skillName, entry } of itemsForSource) {
         if (deletedSkillSet.has(skillName)) continue;
 
-        const skillPath = entry.skillPath!;
-        if (!discoveredPaths.includes(skillPath)) continue;
+        const skillPath = resolution.resolvedPaths.get(skillName);
+        if (!skillPath) continue;
 
         const usesGitTreeHash = isGitHubSource && /^[0-9a-f]{40}$/i.test(entry.skillFolderHash);
         const latestHash = usesGitTreeHash
           ? await getGitTreeHash(tempDir, skillPath)
           : await computeSkillFolderHash(join(tempDir, dirname(skillPath)));
-        if (latestHash && latestHash !== entry.skillFolderHash) {
-          updates.push({ name: skillName, source, entry });
+        const relocated = skillPath !== entry.skillPath;
+        if (relocated || (latestHash && latestHash !== entry.skillFolderHash)) {
+          updates.push({ name: skillName, source, entry: { ...entry, skillPath } });
         }
       }
     } catch (error) {
@@ -842,6 +854,7 @@ export async function updateProjectSkills(
 
     let tempDir: string | null = null;
     let deletedSkills: string[] = [];
+    let resolvedPaths: Map<string, string> | null = null;
 
     if (cloneSource === null) {
       failCount += skillsForSource.length;
@@ -853,21 +866,26 @@ export async function updateProjectSkills(
 
     try {
       tempDir = await cloneRepo(cloneSource, ref);
-      const discovered = await discoverSkills(tempDir, undefined, { fullDepth: true });
-
-      const discoveredPaths = discovered.map((s) => {
-        const relPath = relative(tempDir!, s.path);
-        return join(relPath, 'SKILL.md').split(sep).join('/');
+      const discovered = await discoverSkills(tempDir, undefined, {
+        fullDepth: true,
+        includeDuplicateNames: true,
       });
 
-      deletedSkills = await checkAndPromptForDeletions(
+      const discoveredLocations = discovered.map((skill) => ({
+        name: skill.name,
+        skillPath: join(relative(tempDir!, skill.path), 'SKILL.md').split(sep).join('/'),
+      }));
+
+      const resolution = await checkAndPromptForDeletions(
         source,
         allLockedForSource,
         localLock.skills,
         false,
         options,
-        discoveredPaths
+        discoveredLocations
       );
+      deletedSkills = resolution.deletedSkills;
+      resolvedPaths = resolution.resolvedPaths;
     } catch (error) {
       console.log(`${DIM}✗ Failed to check for deleted skills from ${source}${RESET}`);
     } finally {
@@ -876,12 +894,22 @@ export async function updateProjectSkills(
       }
     }
 
+    if (resolvedPaths === null) {
+      failCount += skillsForSource.length;
+      continue;
+    }
+
     const remainingSkills = skillsForSource.filter((s) => !deletedSkills.includes(s.name));
 
     for (const skill of remainingSkills) {
       const safeName = sanitizeMetadata(skill.name);
+      const resolvedPath = resolvedPaths?.get(skill.name);
+      if (resolvedPaths && !resolvedPath) {
+        continue;
+      }
+      const entry = resolvedPath ? { ...skill.entry, skillPath: resolvedPath } : skill.entry;
       console.log(`${TEXT}Updating ${safeName}…${RESET}`);
-      const installUrl = buildLocalUpdateSource(skill.entry);
+      const installUrl = buildLocalUpdateSource(entry);
       if (!installUrl) {
         failCount++;
         console.log(
@@ -895,7 +923,7 @@ export async function updateProjectSkills(
       const subagentArgs = skill.entry.subagents?.length
         ? ['--subagent', ...skill.entry.subagents.map((s) => (s === '' ? 'root' : s))]
         : [];
-      const fullDepthArgs = shouldUseFullDepthForUpdate(skill.entry) ? ['--full-depth'] : [];
+      const fullDepthArgs = shouldUseFullDepthForUpdate(entry) ? ['--full-depth'] : [];
 
       const result = spawnSync(
         process.execPath,
@@ -912,7 +940,7 @@ export async function updateProjectSkills(
         {
           stdio: ['inherit', 'pipe', 'pipe'],
           encoding: 'utf-8',
-          env: getUpdateChildEnv(skill.entry.sourceType),
+          env: getUpdateChildEnv(entry.sourceType),
           // Never spawn through a shell — same reasoning as updateGlobalSkills:
           // execPath is absolute (no shell resolution needed) and installUrl/ref
           // come from the lock file, so a shell would allow command injection on

--- a/tests/full-depth-discovery.test.ts
+++ b/tests/full-depth-discovery.test.ts
@@ -201,4 +201,33 @@ description: Nested skill with same name
     expect(skills).toHaveLength(1);
     expect(skills[0].name).toBe('my-skill');
   });
+
+  it('can preserve duplicate names for ambiguity detection', async () => {
+    mkdirSync(join(testDir, 'skills', 'first'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'first', 'SKILL.md'),
+      `---
+name: shared-name
+description: First location
+---
+`
+    );
+    mkdirSync(join(testDir, 'skills', 'second'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'skills', 'second', 'SKILL.md'),
+      `---
+name: shared-name
+description: Second location
+---
+`
+    );
+
+    const skills = await discoverSkills(testDir, undefined, {
+      fullDepth: true,
+      includeDuplicateNames: true,
+    });
+
+    expect(skills).toHaveLength(2);
+    expect(skills.map((skill) => skill.name)).toEqual(['shared-name', 'shared-name']);
+  });
 });

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -229,9 +229,135 @@ describe('Update Cleanup Unit Tests', () => {
 
       expect(skills.discoverSkills).toHaveBeenCalledWith('/tmp/repo', undefined, {
         fullDepth: true,
+        includeDuplicateNames: true,
       });
       expect(p.confirm).not.toHaveBeenCalled();
       expect(remove.removeCommand).not.toHaveBeenCalled();
+    });
+
+    it('updates a relocated project skill from its canonical path', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'swiftui-expert-skill': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'swiftui-expert-skill/SKILL.md',
+            computedHash: 'same-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'swiftui-expert-skill',
+          path: '/tmp/repo/skills/swiftui-expert-skill',
+          description: 'SwiftUI guidance',
+          rawContent: '',
+        },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      expect(installCall![1]).toContain('owner/repo/skills/swiftui-expert-skill');
+    });
+
+    it('skips an ambiguous relocated project skill without deleting it', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'old/skill-a/SKILL.md',
+            computedHash: 'old-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'skill-a',
+          path: '/tmp/repo/skills/skill-a',
+          description: 'First',
+          rawContent: '',
+        },
+        {
+          name: 'skill-a',
+          path: '/tmp/repo/plugins/example/skill-a',
+          description: 'Second',
+          rawContent: '',
+        },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+
+    it('does not reinstall an ambiguous exact-path skill from a generic Git source', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'git@example.com:owner/repo.git',
+            sourceType: 'git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            computedHash: 'old-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'skill-a',
+          path: '/tmp/repo/skills/skill-a',
+          description: 'Locked location',
+          rawContent: '',
+        },
+        {
+          name: 'skill-a',
+          path: '/tmp/repo/plugins/example/skill-a',
+          description: 'Conflicting location',
+          rawContent: '',
+        },
+      ]);
+
+      await updateProjectSkills({ yes: true });
+
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+
+    it('does not reinstall project skills when source discovery fails', async () => {
+      vi.mocked(localLock.readLocalLock).mockResolvedValue({
+        version: 1,
+        skills: {
+          'skill-a': {
+            source: 'owner/repo',
+            sourceUrl: 'git@example.com:owner/repo.git',
+            sourceType: 'git',
+            skillPath: 'skills/skill-a/SKILL.md',
+            computedHash: 'old-hash',
+          },
+        },
+      });
+      vi.mocked(git.cloneRepo).mockRejectedValue(new Error('clone failed'));
+
+      const result = await updateProjectSkills({ yes: true });
+
+      expect(result.failCount).toBe(1);
+      expect(spawnSync).not.toHaveBeenCalled();
     });
 
     it('uses sourceUrl for self-hosted GitLab project updates', async () => {
@@ -397,6 +523,10 @@ describe('Update Cleanup Unit Tests', () => {
         ],
       });
       vi.mocked(blob.findSkillMdPaths).mockReturnValue(['skills/skill-a/SKILL.md']);
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        { name: 'skill-a', path: '/tmp/repo/skills/skill-a', description: 'A', rawContent: '' },
+      ]);
 
       vi.mocked(p.confirm).mockResolvedValue(true);
 
@@ -407,6 +537,63 @@ describe('Update Cleanup Unit Tests', () => {
         ['skill-b'],
         expect.objectContaining({ yes: true, global: true })
       );
+    });
+
+    it('reinstalls a relocated global skill even when its content hash is unchanged', async () => {
+      const treeHash = 'a'.repeat(40);
+      vi.mocked(skillLock.readSkillLock).mockResolvedValue({
+        version: 3,
+        skills: {
+          'swiftui-expert-skill': {
+            source: 'owner/repo',
+            sourceType: 'github',
+            skillPath: 'swiftui-expert-skill/SKILL.md',
+            skillFolderHash: treeHash,
+            installedAt: '',
+            updatedAt: '',
+          },
+        },
+      });
+      vi.mocked(blob.fetchRepoTree).mockResolvedValue({
+        sha: 'rootsha',
+        branch: 'main',
+        tree: [
+          {
+            path: 'skills/swiftui-expert-skill/SKILL.md',
+            type: 'blob',
+            sha: 'blobsha',
+          },
+          {
+            path: 'skills/swiftui-expert-skill',
+            type: 'tree',
+            sha: treeHash,
+          },
+        ],
+      });
+      vi.mocked(git.cloneRepo).mockResolvedValue('/tmp/repo');
+      vi.mocked(skills.discoverSkills).mockResolvedValue([
+        {
+          name: 'swiftui-expert-skill',
+          path: '/tmp/repo/skills/swiftui-expert-skill',
+          description: 'SwiftUI guidance',
+          rawContent: '',
+        },
+      ]);
+      vi.mocked(git.getGitTreeHash).mockResolvedValue(treeHash);
+
+      await updateGlobalSkills({ yes: true });
+
+      expect(p.confirm).not.toHaveBeenCalled();
+      expect(remove.removeCommand).not.toHaveBeenCalled();
+      expect(git.getGitTreeHash).toHaveBeenCalledWith(
+        '/tmp/repo',
+        'skills/swiftui-expert-skill/SKILL.md'
+      );
+      const installCall = vi
+        .mocked(spawnSync)
+        .mock.calls.find((call) => Array.isArray(call[1]) && call[1].includes('add'));
+      expect(installCall).toBeDefined();
+      expect(installCall![1]).toContain('owner/repo/skills/swiftui-expert-skill');
     });
 
     it('does not report a locked plugin skill as deleted when it exists in the GitHub tree', async () => {
@@ -612,6 +799,7 @@ describe('Update Cleanup Unit Tests', () => {
 
       expect(skills.discoverSkills).toHaveBeenCalledWith('/tmp/repo', undefined, {
         fullDepth: true,
+        includeDuplicateNames: true,
       });
       expect(p.confirm).not.toHaveBeenCalled();
       expect(remove.removeCommand).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Fixes #2121.

When a repository moves a skill without changing its frontmatter name, `skills update` currently treats the old lock path as deleted. This PR resolves a uniquely matching current path, reinstalls from that canonical location, and lets the existing `add` flow rewrite the lock.

- preserve duplicate skill names during update-only discovery so ambiguity is visible
- prompt for deletion only when no current skill matches
- fail closed when multiple locations have the same name
- force one global reinstall when a path changed, even if content is unchanged
- use the resolved path for project/global reinstall sources
- fall back from the GitHub tree fast path to clone discovery only when a locked path disappeared

## Why not only suppress the warning?

The folder-name fallback in #1401 prevents the deletion prompt, but hashing and reinstall still use the stale path. That leaves the lock unmigrated. This change carries the resolved path through the complete update flow.

## Safety

Exact paths remain unchanged. Relocation occurs only for one uniquely named discovered skill. Duplicate-name matches and source-discovery failures skip reinstallation rather than deleting or selecting an arbitrary skill.

## Verification

- `pnpm test` — 59 files, 789 tests passed
- `pnpm type-check`
- `pnpm build`
- `pnpm format:check`
- real project-scoped migration against `AvdLee/SwiftUI-Agent-Skill`
- real global migration against `AvdLee/SwiftUI-Agent-Skill`, including unchanged content hash

Tests and builds ran on the minimum supported Node 22.20.0.

## Related

- #1401 contains an unmerged partial relocation fix bundled with SSH/auth changes
- #1916 / #1919 cover another false-deletion path mismatch
- #2020 covers path casing