### PR TITLE
fix: disable ANSI colors when stdout is not a TTY or NO_COLOR is set

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { flushTelemetry } from './telemetry.ts';
 import { isRunningInAgent } from './detect-agent.ts';
 import { runUpdate } from './update.ts';
 import { runUse, parseUseOptions } from './use.ts';
+import { BOLD, DIM, GRAYS, RESET, TEXT } from './color.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -29,12 +30,6 @@ function getVersion(): string {
 const VERSION = getVersion();
 initTelemetry(VERSION);
 
-const RESET = '\x1b[0m';
-const BOLD = '\x1b[1m';
-// 256-color grays - visible on both light and dark backgrounds
-const DIM = '\x1b[38;5;102m'; // darker gray for secondary text
-const TEXT = '\x1b[38;5;145m'; // lighter gray for primary text
-
 const LOGO_LINES = [
   '███████╗██╗  ██╗██╗██╗     ██╗     ███████╗',
   '██╔════╝██║ ██╔╝██║██║     ██║     ██╔════╝',
@@ -42,16 +37,6 @@ const LOGO_LINES = [
   '╚════██║██╔═██╗ ██║██║     ██║     ╚════██║',
   '███████║██║  ██╗██║███████╗███████╗███████║',
   '╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝',
-];
-
-// 256-color middle grays - visible on both light and dark backgrounds
-const GRAYS = [
-  '\x1b[38;5;250m', // lighter gray
-  '\x1b[38;5;248m',
-  '\x1b[38;5;245m', // mid gray
-  '\x1b[38;5;243m',
-  '\x1b[38;5;240m',
-  '\x1b[38;5;238m', // darker gray
 ];
 
 function showLogo(): void {

--- a/src/color.test.ts
+++ b/src/color.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const CLI_PATH = join(import.meta.dirname, 'cli.ts');
+
+/**
+ * Runs `skills list` in a subprocess writing to a pipe, returning the RAW
+ * stdout (unlike runCli, which strips terminal escapes). The piped stdout is
+ * never a TTY, so this exercises exactly the surface where color output leaks
+ * as garbage into `| less`, `| code -`, CI logs, etc.
+ */
+function runListRaw(overrides: Record<string, string>): string {
+  const env: NodeJS.ProcessEnv = { ...process.env, DISABLE_TELEMETRY: '1' };
+  // Neither variable may leak in from the surrounding environment: the
+  // detector's contract is defined entirely by the overrides below.
+  delete env.NO_COLOR;
+  delete env.FORCE_COLOR;
+  Object.assign(env, overrides);
+
+  const cwd = mkdtempSync(join(tmpdir(), 'skills-color-test-'));
+  try {
+    return execFileSync(process.execPath, [CLI_PATH, 'list'], {
+      encoding: 'utf-8',
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe('color support detection', () => {
+  it('emits no ANSI codes when stdout is piped', () => {
+    const output = runListRaw({});
+    expect(output).toContain('No project skills found');
+    expect(output).not.toMatch(/\x1b\[/);
+  });
+
+  it('emits ANSI codes when FORCE_COLOR is set', () => {
+    const output = runListRaw({ FORCE_COLOR: '1' });
+    expect(output).toContain('No project skills found');
+    expect(output).toMatch(/\x1b\[/);
+  });
+
+  it('NO_COLOR wins over FORCE_COLOR', () => {
+    const output = runListRaw({ NO_COLOR: '1', FORCE_COLOR: '1' });
+    expect(output).toContain('No project skills found');
+    expect(output).not.toMatch(/\x1b\[/);
+  });
+});

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,0 +1,26 @@
+// Shared ANSI palette for the CLI commands. Escape codes are emitted only when
+// they can actually be interpreted: stdout is a TTY (or FORCE_COLOR is set) and
+// NO_COLOR is unset — see https://no-color.org. Piped output stays plain text
+// so `skills list | less` never renders escape codes as garbage. Semantics
+// mirror the picocolors dependency.
+const supportsColor =
+  !process.env.NO_COLOR &&
+  (!!process.env.FORCE_COLOR || (process.stdout.isTTY === true && process.env.TERM !== 'dumb'));
+
+export const RESET = supportsColor ? '\x1b[0m' : '';
+export const BOLD = supportsColor ? '\x1b[1m' : '';
+// 256-color grays - visible on both light and dark backgrounds
+export const DIM = supportsColor ? '\x1b[38;5;102m' : ''; // darker gray for secondary text
+export const TEXT = supportsColor ? '\x1b[38;5;145m' : ''; // lighter gray for primary text
+export const CYAN = supportsColor ? '\x1b[36m' : '';
+export const YELLOW = supportsColor ? '\x1b[33m' : '';
+
+// 256-color middle grays - visible on both light and dark backgrounds
+export const GRAYS = [
+  '\x1b[38;5;250m', // lighter gray
+  '\x1b[38;5;248m',
+  '\x1b[38;5;245m', // mid gray
+  '\x1b[38;5;243m',
+  '\x1b[38;5;240m',
+  '\x1b[38;5;238m', // darker gray
+].map((code) => (supportsColor ? code : ''));

--- a/src/find.ts
+++ b/src/find.ts
@@ -4,14 +4,7 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
 import { isRepoPrivate } from './source-parser.ts';
 import { isRunningInAgent } from './detect-agent.ts';
-
-const RESET = '\x1b[0m';
-const BOLD = '\x1b[1m';
-const DIM = '\x1b[38;5;102m';
-const TEXT = '\x1b[38;5;145m';
-const CYAN = '\x1b[36m';
-const MAGENTA = '\x1b[35m';
-const YELLOW = '\x1b[33m';
+import { BOLD, CYAN, DIM, RESET, TEXT, YELLOW } from './color.ts';
 
 // API endpoint for skills search
 const SEARCH_API_BASE = process.env.SKILLS_API_URL || 'https://skills.sh';

--- a/src/list.ts
+++ b/src/list.ts
@@ -5,13 +5,7 @@ import { listInstalledSkills, sanitizeName, type InstalledSkill } from './instal
 import { sanitizeMetadata } from './sanitize.ts';
 import { getAllLockedSkills } from './skill-lock.ts';
 import { readLocalLock } from './local-lock.ts';
-
-const RESET = '\x1b[0m';
-const BOLD = '\x1b[1m';
-const DIM = '\x1b[38;5;102m';
-const TEXT = '\x1b[38;5;145m';
-const CYAN = '\x1b[36m';
-const YELLOW = '\x1b[33m';
+import { BOLD, CYAN, DIM, RESET, YELLOW } from './color.ts';
 
 interface ListOptions {
   global?: boolean;

--- a/src/update.ts
+++ b/src/update.ts
@@ -23,13 +23,9 @@ import { sanitizeMetadata } from './sanitize.ts';
 import { track } from './telemetry.ts';
 import { agents, isUniversalAgent } from './agents.ts';
 import type { AgentType } from './types.ts';
+import { BOLD, DIM, RESET, TEXT } from './color.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const RESET = '\x1b[0m';
-const BOLD = '\x1b[1m';
-const DIM = '\x1b[38;5;102m';
-const TEXT = '\x1b[38;5;145m';
 
 // ============================================
 // Scope Detection and Prompt


### PR DESCRIPTION
Fixes #2126

## Problem

`list`, `find`, `update`, and the banner/help output in `cli.ts` embed hardcoded ANSI escape constants with no TTY detection, so piped output is full of escape sequences and `NO_COLOR` is ignored. `skills list -g | code -` (or `| less`, CI logs) renders the codes as garbage.

## Fix

- New `src/color.ts` holds the palette once, gated on:
  - `NO_COLOR` unset ([no-color.org](https://no-color.org)),
  - stdout being a TTY with `TERM != dumb`, or `FORCE_COLOR` being set — same semantics as the project's existing `picocolors` dependency.
- `list.ts`, `find.ts`, `update.ts`, `cli.ts` now import the constants instead of defining raw local ones (this also drops `TEXT` in `list.ts` and `MAGENTA` in `find.ts`, which were defined but never used). Terminal rendering is unchanged; piped output is plain text.
- New `src/color.test.ts` locks the contract in through a real CLI subprocess writing to a pipe: default → no ANSI; `FORCE_COLOR=1` → ANSI; `NO_COLOR=1` wins over `FORCE_COLOR`.

## Verification

- `pnpm type-check` clean.
- `pnpm exec vitest run`: 778/779 passed. The single failure (`tests/git-transport-allowlist.test.ts`) also fails on a clean `v1.5.23` checkout when git speaks a non-English locale (the test's regex expects the English message), unrelated to this change.
- Manual smoke tests on the real CLI:
  - `skills list -g | cat -v` → plain text
  - `FORCE_COLOR=1 skills list -g | cat -v` → colored
  - real PTY via `script` (`TERM=xterm`) → colored; PTY + `NO_COLOR=1` → plain
