### PR TITLE
feat: add judgment-day — Dual adversarial review (Zylos 6-pattern taxonomy)

### DIFF
--- a/skills/judgment-day/SKILL.md
+++ b/skills/judgment-day/SKILL.md
@@ -1,0 +1,88 @@
+﻿---
+name: judgment-day
+description: "Dual adversarial review orchestrator — 2 profile-scoped code-review-agent instances, verdict synthesis"
+triggers: "Judgment day, JD, dual review, juzgar, adversarial review, LLM-as-judge, judge patterns, online verifier"
+changelog: "2026-09-01 R2-4 — add Zylos 6-pattern taxonomy + small/large judge guidance (KB r2-zylos-llm-judge); 2026-09-01 wiring jd-verifier.ps1 (p2/p4/p5 enforcement)"
+token_budget: 4200
+---
+
+## When to Use
+Dual adversarial code review — 2× `code-review-agent`, blind, verdict synthesis. ROJA-zone only.
+
+## Rules
+
+1. ROJA only — skip AMARILLA/VERDE
+2. Blind separation — no cross-contamination
+3. Max 2 re-judge → ASK user
+4. Identical profiles → force second "security"
+5. FIX/BLOCKER → `external-auditor`
+6. Block push ROJA until JD clearance
+
+## Protocol
+
+### P0: Zone Filter
+`review-rules.jsonc` → strip JSONC (3-pass: `//`, `/* */`). ROJA→dual, AMARILLA→single, VERDE→skip.
+
+### P1: Profiles → 2× code-review-agent
+Parse `jd_profile_selector` (ordered, first-match): `match=path|basename|fallback`. Missing→"architect". Identical→`[profile, "security"]`. 2 parallel, each `"## Profile Focus\n{instructions}"`. Blind. 120s timeout, retry once.
+P1 fast-path: `scripts/jd-verifier.ps1 -Zone <AMARILLA|ROJA> -FastPath` before deciding dual-judge → VERIFY-OK or ESCALATE; wiring `references/jd-patterns-wiring.md`.
+
+### P2: Synthesize
+
+| Scenario | Verdict |
+|----------|---------|
+| Both CLEAN | APPROVED |
+| Same root-cause (file ±5 lines) | Confirmed |
+| Different findings | Triage → fix → re-judge |
+| Re-judge | Max 2 rounds (diff delta only) |
+P2 synthesize: `SELF-CONSISTENCY: profiles A/B = majority-of-2 (diverge → tie-break by higher severity)` per `scripts/jd-verifier.ps1`.
+
+### P3: Calibration
+FIX/BLOCKER → `external-auditor` on diff. Gap >1.5 severity → `immune-system` permanent fix.
+
+## Judge Patterns Taxonomy (R2-4 — Zylos 2026-04-10, 6 patterns)
+
+| # | Pattern | Latency/Cost | When (JD mapping) |
+|---|---------|--------------|-------------------|
+| 1 | Offline eval | async, large judge OK | This skill (ROJA dual blind) |
+| 2 | Online runtime verifier | 76–162ms budget, small judge (Luna-2 3–8B, Prometheus 7B, Lynx 8B ≈97% cheaper at 0.88–0.95 acc) | ROJA hotfix fast-path (optional, not default) |
+| 3 | Self-consistency / self-critique | Best-of-N + majority vote, cheapest, strongest in code/math | Our 2-profile blind → implicit majority-of-2 |
+| 4 | Reflexion | Only with external grounding (tests, git diff, retrieval) — intrinsic "check your work" degrades reasoning | Re-judge delta (max 2 rounds) already grounded on diff |
+| 5 | Constitutional / RLAIF | training-time; runtime = generate→critique against constitution→revise | Gap >1.5 → immune-system (constitution for ROJA repeats) |
+| 6 | Inference-time reward model | ranker over N samples, gated before output | Future: pre-push reward ranker (not yet wired) |
+
+> **3-boundary rule** (Zylos): judges before (a) user output, (b) irreversible exec (`git push`/Write), (c) memory writes. Gate covers (a)+(b); (c) future.
+
+**Small vs Large:** large for ROJA, small distilled inline.
+
+## Anti-Rationalization
+
+| Rationalization | Red Flag | Verification |
+|-----------------|----------|--------------|
+| "One reviewer is enough for ROJA" | Single perspective on ROJA diff | Must run 2× blind code-review-agent — any less is AMARILLA pattern |
+| "Re-judge 3rd time will pass" | Re-judge count >2 | Max 2 → ASK user (rule 3); >2 means synthesis failed, not review |
+| "External auditor not needed" | FIX/BLOCKER without `external-auditor` | `external-auditor` on diff before APPROVED (rule 5) |
+
+## Red Flags
+- Profiles not blind (second sees first's output) → cross-contamination, verdict invalid
+- Verdict without `review-rules.jsonc` zone filter → zone misclassification
+
+## Verification
+- Synthesize table: Both CLEAN or Same root-cause (±5 lines) → Confirmed; else Triage→fix→re-judge
+- `BLOCKER` without `.breaker-cleared` → gate blocks push until clearance
+
+## Pipeline
+`review-pipeline` Phase 2b for ROJA. Pre-commit #9: warn ROJA without JD.
+
+## Output
+```
+JD-{target} | Profiles: {A}/{B} | 4R | Confirmed:N | JDGMNT: APPROVED/ESCALATED | CALIB: OK/GAP
+```
+---
+
+## Reference Materials
+→ docs/skills/judgment-day/reference.md · wiring `references/jd-patterns-wiring.md`
+
+---
+## Refs
+Cross-Refs: code-review-agent | testing-strategy

--- a/skills/judgment-day/references/4r-checklist.md
+++ b/skills/judgment-day/references/4r-checklist.md
@@ -1,0 +1,26 @@
+# 4R Review Checklist
+
+## Risk (security/stability)
+- [ ] Input validation at all boundaries
+- [ ] SQL injection / command injection
+- [ ] Sensitive data exposure
+- [ ] Error messages leak internals?
+- [ ] Rate limiting / DoS surface
+
+## Readability (maintainability)
+- [ ] Consistent naming with project conventions
+- [ ] Functions < 50 lines
+- [ ] Comments explain WHY, not WHAT
+- [ ] No dead code / commented-out blocks
+
+## Reliability (correctness)
+- [ ] Error handling for all failure modes
+- [ ] Edge cases: empty, null, boundary values
+- [ ] Race conditions in async code
+- [ ] Idempotent operations where expected
+
+## Resilience (failure recovery)
+- [ ] Retry logic for transient failures
+- [ ] Circuit breaker / fallback
+- [ ] Graceful degradation
+- [ ] Clear error messages to user

--- a/skills/judgment-day/references/jd-patterns-wiring.md
+++ b/skills/judgment-day/references/jd-patterns-wiring.md
@@ -1,0 +1,30 @@
+# JD Patterns Wiring — Zylos 2/3/4/5 via jd-verifier.ps1
+
+Mechanical wiring for Zylos judge patterns. Pattern 6 (IRM) is future — no model infra.
+
+## P2 — Online Runtime Verifier (76–162ms, small judge)
+- P1 fast-path: `scripts/jd-verifier.ps1 -Zone <AMARILLA|ROJA> -FastPath` before deciding dual-judge. Zone is a param: AMARILLA fast-lane or ROJA pre-check, both valid.
+- Runs `bin/fast.exe --gate --json` if exists; `passed && elapsedMs≤162` → `VERIFY-OK mechanical (Xms)`.
+- Else → `ESCALATE dual-judge` (fail, over budget, timeout 5s, or parse failure).
+- Missing exe → `WARN: bin/fast.exe not found` (stderr) + `ESCALATE`, exit 1 (not crash); `-Json` sets `fastPath.passed=false`.
+- Override for tests/CI: `JD_FAST_EXE=/path/to/stub.ps1` honored ONLY when `PESTER_TEST=1`; otherwise always `bin/fast.exe`; `.ps1` stubs run via `pwsh -File`.
+- Timeout: 5s via `System.Diagnostics.Process` (`WaitForExit(5000)` → `Kill()` → `ESCALATE` + warn `timeout`).
+
+## P3 — Self-Consistency / Self-Critique
+- Always emitted: `SELF-CONSISTENCY: profiles A/B = majority-of-2 (diverge → tie-break by higher severity)`.
+- P2 synthesize: two blind `code-review-agent` profiles vote; majority-of-2, severity tie-break.
+
+## P4 — Reflexion (grounded only)
+- Re-judge capped at 2 rounds; ` -Rounds >2` → `ASK-USER (Reflexion cap)`, exit 2.
+- Never intrinsic loop — grounded on diff/tests only.
+
+## P5 — Constitutional / RLAIF
+- `-RepeatFinding` → `CONSTITUTIONAL → register via immune-system (.agents/skills/immune-system)`.
+- `gap >1.5` severity → permanent constitution entry.
+
+## Exit Codes
+- `0` VERIFY-OK, `1` ESCALATE, `2` rounds-cap ASK-USER.
+- `-Json` emits `{verifier, zone, fastPath:{ran,passed,elapsedMs,decision}, rounds:{value,capped}, constitutional, timestamp}`.
+
+## Rejected Alternatives
+- Signature/hash allowlist for fast.exe — REJECT: WDAC already enforces hash policy at OS level.


### PR DESCRIPTION
## Summary

Adds \judgment-day\ skill from [gentleman-agent-gh](https://github.com/LuisAlbertoMK/gentleman-agent-gh) (R2-2 distribution).

**What it does:** Dual adversarial review orchestrator — 2 profile-scoped \code-review-agent\ instances, blind, verdict synthesis. ROJA-zone only, with Zylos 6-pattern taxonomy (76–162ms, small/large judge guidance).

**KB reference:** \2-fundesk-skills-guide\ (24 sections) + \2-zylos-llm-judge\ (6-pattern taxonomy, benchmarked).

**Changelog:** 2026-09-01 R2-4 — add Zylos 6-pattern taxonomy + small/large judge guidance (KB r2-zylos-llm-judge); 2026-09-01 wiring jd-verifier.ps1 (p2/p4/p5 enforcement).

**Source:** \.agents/skills/judgment-day/SKILL.md\ (+ \eferences/4r-checklist.md\, \eferences/jd-patterns-wiring.md\) — frontmatter intact, anti-rationalization preserved. Token budget: 4200.

**Install after merge:**
\\\ash
npx skills add vercel-labs/skills@judgment-day
# or before merge:
npx skills add LuisAlbertoMK/skills@judgment-day
\\\

Part of 8-skill batch (catalog \scripts/skills-catalog-for-distribution.json\). Cluster A — see \docs/mejoras/2026-09-01-r2-2-skills-sh-listing.md\.

- [x] Follows \skills/<name>/SKILL.md\
- [x] Frontmatter complete
- [x] Anti-rationalization section preserved
