### PR TITLE
feat: GH-#2137  - add CodeWhale agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [74 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -284,6 +284,7 @@ Skills can be installed to any of these agents:
 | CodeBuddy | `codebuddy` | `.codebuddy/skills/` | `~/.codebuddy/skills/` |
 | Codemaker | `codemaker` | `.codemaker/skills/` | `~/.codemaker/skills/` |
 | Code Studio | `codestudio` | `.codestudio/skills/` | `~/.codestudio/skills/` |
+| CodeWhale | `codewhale` | `.codewhale/skills/` | `~/.codewhale/skills/` |
 | Codex | `codex` | `.agents/skills/` | `~/.codex/skills/` |
 | Command Code | `command-code` | `.commandcode/skills/` | `~/.commandcode/skills/` |
 | Continue | `continue` | `.continue/skills/` | `~/.continue/skills/` |
@@ -425,6 +426,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `.codebuddy/skills/`
 - `.codemaker/skills/`
 - `.codestudio/skills/`
+- `.codewhale/skills/`
 - `.commandcode/skills/`
 - `.continue/skills/`
 - `.cortex/skills/`

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "codebuddy",
     "codemaker",
     "codestudio",
+    "codewhale",
     "codex",
     "command-code",
     "continue",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -9,6 +9,7 @@ const home = homedir();
 const configHome = xdgConfig ?? join(home, '.config');
 const codexHome = process.env.CODEX_HOME?.trim() || join(home, '.codex');
 const claudeHome = process.env.CLAUDE_CONFIG_DIR?.trim() || join(home, '.claude');
+const codewhaleHome = process.env.CODEWHALE_HOME?.trim() || join(home, '.codewhale');
 const vibeHome = process.env.VIBE_HOME?.trim() || join(home, '.vibe');
 const hermesHome = process.env.HERMES_HOME?.trim() || join(home, '.hermes');
 const autohandHome = process.env.AUTOHAND_HOME?.trim() || join(home, '.autohand');
@@ -214,6 +215,15 @@ export const agents: Record<AgentType, AgentConfig> = {
     globalSkillsDir: join(home, '.codestudio/skills'),
     detectInstalled: async () => {
       return existsSync(join(home, '.codestudio'));
+    },
+  },
+  codewhale: {
+    name: 'codewhale',
+    displayName: 'CodeWhale',
+    skillsDir: '.codewhale/skills',
+    globalSkillsDir: join(codewhaleHome, 'skills'),
+    detectInstalled: async () => {
+      return existsSync(codewhaleHome);
     },
   },
   codex: {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -375,9 +375,11 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
+    // Claude Code and CodeWhale are exempted since they can be explicitly selected as
+    // the install target even when .claude/ or .codewhale/ doesn't exist yet.
     if (!isGlobal && !isUniversalAgent(agentType)) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
+      if (!existsSync(agentRootDir) && agentType !== 'claude-code' && agentType !== 'codewhale') {
         return {
           success: true,
           path: canonicalDir,
@@ -1015,12 +1017,13 @@ export async function installBlobSkillForAgent(
     }
 
     // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. Claude Code is
-    // exempted since it can be explicitly selected as the install target even when
-    // .claude/ doesn't exist yet (see installSkillForAgent for the same exemption).
+    // whose config directory doesn't already exist in the project. Claude Code and
+    // CodeWhale are exempted since they can be explicitly selected as the install
+    // target even when .claude/ or .codewhale/ doesn't exist yet (see
+    // installSkillForAgent for the same exemption).
     if (!isGlobal && !isUniversalAgent(agentType)) {
       const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
+      if (!existsSync(agentRootDir) && agentType !== 'claude-code' && agentType !== 'codewhale') {
         return {
           success: true,
           path: canonicalDir,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type AgentType =
   | 'codebuddy'
   | 'codemaker'
   | 'codestudio'
+  | 'codewhale'
   | 'codex'
   | 'command-code'
   | 'continue'


### PR DESCRIPTION
- Register CodeWhale as a supported agent with `.codewhale/skills/` for project installs and `~/.codewhale/skills/` globally, honoring the `CODEWHALE_HOME` environment variable when set. Detection checks for the presence of the CodeWhale home directory.
- Exempt CodeWhale alongside Claude Code from the project-level symlink skip in both `installSkillForAgent` and `installBlobSkillForAgent`, so it can be explicitly selected as an install target before `.codewhale/` exists.
- Update the agent type union, the package.json keyword list, and the README agent table and container directory list (73 -> 74 additional agents).

Github: Closes Issue #2137