### PR TITLE
feat: respect AGENTS_HOME for the global skills directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ src/
 ├── agents.ts        # Agent definitions and detection
 ├── installer.ts     # Skill installation logic (symlink/copy) + listInstalledSkills
 ├── skills.ts        # Skill discovery and parsing
-├── skill-lock.ts    # Global lock file management (~/.agents/.skill-lock.json)
+├── skill-lock.ts    # Global lock file management ($AGENTS_HOME/.skill-lock.json, default ~/.agents)
 ├── local-lock.ts    # Local lock file management (skills-lock.json, checked in)
 ├── sync.ts          # Sync command - crawl node_modules for skills
 ├── source-parser.ts # Parse git URLs, GitHub shorthand, local paths
@@ -82,7 +82,7 @@ tests/
 
 ### How `skills check` and `skills update` Work
 
-1. Read `~/.agents/.skill-lock.json` for installed skills
+1. Read `$AGENTS_HOME/.skill-lock.json` (default `~/.agents`) for installed skills
 2. Filter to GitHub-backed skills that have both `skillFolderHash` and `skillPath`
 3. For each skill, call `fetchSkillFolderHash(source, skillPath, token)`. Tree requests start anonymously, then use an explicit `GITHUB_TOKEN`/`GH_TOKEN`, then `gh api` without exporting the GitHub CLI credential.
 4. `fetchSkillFolderHash` calls the GitHub Trees API (`/git/trees/<branch>?recursive=1` for `main`, then `master` fallback); update checks fall back to an authenticated Git clone when API access is unavailable.

--- a/README.md
+++ b/README.md
@@ -530,10 +530,16 @@ Ensure you have write access to the target directory.
 | `DO_NOT_TRACK`            | Alternative way to disable telemetry                                       |
 | `GITHUB_TOKEN`            | Optional explicit token for authenticated GitHub API requests              |
 | `GH_TOKEN`                | Fallback explicit token for authenticated GitHub API requests              |
+| `AGENTS_HOME`             | Root of the global skills store (default `~/.agents`); holds `skills/` and the global lock. Pair with the agent's own home variable (e.g. `CLAUDE_CONFIG_DIR`, `CODEX_HOME`) to keep one store per account or workspace |
 
 ```bash
 # Install internal skills
 INSTALL_INTERNAL_SKILLS=1 npx skills add vercel-labs/agent-skills --list
+```
+
+```bash
+# Keep a separate global store and lock for a work account
+AGENTS_HOME=~/.agents-work CLAUDE_CONFIG_DIR=~/.claude-work npx skills add vercel-labs/agent-skills -g
 ```
 
 ## Telemetry

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,17 @@
+import { homedir } from 'os';
+import { join } from 'path';
+
 export const AGENTS_DIR = '.agents';
 export const SKILLS_SUBDIR = 'skills';
 export const UNIVERSAL_SKILLS_DIR = '.agents/skills';
 
 /** Maximum skill-directory depth searched inside a known container by default. */
 export const DEFAULT_SKILL_CONTAINER_DEPTH = 3;
+
+/**
+ * Root of the global skills store (`~/.agents` by default). Holds the canonical
+ * `skills/` directory and the global lock file. Override with `AGENTS_HOME`.
+ */
+export function getAgentsHome(): string {
+  return process.env.AGENTS_HOME?.trim() || join(homedir(), AGENTS_DIR);
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -25,7 +25,7 @@ import {
   getEveSubagents,
   EVE_SUBAGENTS_DIR,
 } from './agents.ts';
-import { AGENTS_DIR, SKILLS_SUBDIR } from './constants.ts';
+import { AGENTS_DIR, getAgentsHome, SKILLS_SUBDIR } from './constants.ts';
 import { parseFrontmatter } from './frontmatter.ts';
 import { parseSkillMd } from './skills.ts';
 
@@ -96,8 +96,10 @@ async function isDirEntryOrSymlinkToDir(
 }
 
 export function getCanonicalSkillsDir(global: boolean, cwd?: string): string {
-  const baseDir = global ? homedir() : cwd || process.cwd();
-  return join(baseDir, AGENTS_DIR, SKILLS_SUBDIR);
+  if (global) {
+    return join(getAgentsHome(), SKILLS_SUBDIR);
+  }
+  return join(cwd || process.cwd(), AGENTS_DIR, SKILLS_SUBDIR);
 }
 
 /**

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -1,9 +1,8 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { join, dirname } from 'path';
-import { homedir } from 'os';
 import { createHash } from 'crypto';
+import { getAgentsHome } from './constants.ts';
 
-const AGENTS_DIR = '.agents';
 const LOCK_FILE = '.skill-lock.json';
 const CURRENT_VERSION = 3; // Bumped from 2 to 3 for folder hash support (GitHub tree SHA)
 
@@ -61,15 +60,15 @@ export interface SkillLockFile {
 
 /**
  * Get the path to the global skill lock file.
- * Use $XDG_STATE_HOME/skills/.skill-lock.json if set.
- * otherwise fall back to ~/.agents/.skill-lock.json
+ * Use $XDG_STATE_HOME/skills/.skill-lock.json if set,
+ * otherwise fall back to $AGENTS_HOME/.skill-lock.json (default ~/.agents).
  */
 export function getSkillLockPath(): string {
   const xdgStateHome = process.env.XDG_STATE_HOME;
   if (xdgStateHome) {
     return join(xdgStateHome, 'skills', LOCK_FILE);
   }
-  return join(homedir(), AGENTS_DIR, LOCK_FILE);
+  return join(getAgentsHome(), LOCK_FILE);
 }
 
 /**

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -69,6 +69,7 @@ export function createTestHomeEnvironment(home: string): Record<string, string> 
     XDG_CACHE_HOME: join(home, '.cache'),
     APPDATA: join(home, 'AppData', 'Roaming'),
     LOCALAPPDATA: join(home, 'AppData', 'Local'),
+    AGENTS_HOME: join(home, '.agents'),
     CODEX_HOME: join(home, '.codex'),
     CLAUDE_CONFIG_DIR: join(home, '.claude'),
     VIBE_HOME: join(home, '.vibe'),

--- a/tests/agents-home.test.ts
+++ b/tests/agents-home.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, lstatSync, readdirSync } from 'fs';
+import { rm } from 'fs/promises';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
+import { getAgentsHome } from '../src/constants.ts';
+import { getCanonicalSkillsDir } from '../src/installer.ts';
+import { getSkillLockPath } from '../src/skill-lock.ts';
+import { runCli } from '../src/test-utils.ts';
+
+describe('AGENTS_HOME', () => {
+  const originalAgentsHome = process.env.AGENTS_HOME;
+  const originalXdgStateHome = process.env.XDG_STATE_HOME;
+
+  afterEach(() => {
+    if (originalAgentsHome === undefined) delete process.env.AGENTS_HOME;
+    else process.env.AGENTS_HOME = originalAgentsHome;
+    if (originalXdgStateHome === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = originalXdgStateHome;
+  });
+
+  it('defaults to ~/.agents when unset or blank', () => {
+    delete process.env.AGENTS_HOME;
+    expect(getAgentsHome()).toBe(join(homedir(), '.agents'));
+    process.env.AGENTS_HOME = '   ';
+    expect(getAgentsHome()).toBe(join(homedir(), '.agents'));
+  });
+
+  it('relocates the global canonical skills dir but not the project one', () => {
+    const store = join(tmpdir(), 'agents-home-store');
+    process.env.AGENTS_HOME = store;
+    expect(getCanonicalSkillsDir(true)).toBe(join(store, 'skills'));
+    expect(getCanonicalSkillsDir(false, '/some/project')).toBe(
+      join('/some/project', '.agents', 'skills')
+    );
+  });
+
+  it('relocates the global lock file unless XDG_STATE_HOME takes precedence', () => {
+    const store = join(tmpdir(), 'agents-home-store');
+    process.env.AGENTS_HOME = store;
+    delete process.env.XDG_STATE_HOME;
+    expect(getSkillLockPath()).toBe(join(store, '.skill-lock.json'));
+    process.env.XDG_STATE_HOME = join(tmpdir(), 'xdg-state');
+    expect(getSkillLockPath()).toBe(join(tmpdir(), 'xdg-state', 'skills', '.skill-lock.json'));
+  });
+});
+
+describe('AGENTS_HOME (CLI)', () => {
+  let testDir: string;
+  let home: string;
+  let store: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'agents-home-cli-'));
+    home = join(testDir, 'home');
+    store = join(testDir, 'store');
+    mkdirSync(home, { recursive: true });
+
+    const skillDir = join(testDir, 'source', 'skills', 'store-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: store-skill
+description: Installed into a custom AGENTS_HOME
+---
+
+# Store skill
+`
+    );
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  const env = () => ({
+    HOME: home,
+    USERPROFILE: home,
+    AGENTS_HOME: store,
+    // Let the lock fall back to AGENTS_HOME instead of the isolated XDG state dir.
+    XDG_STATE_HOME: '',
+  });
+
+  it('installs, lists and removes global skills entirely inside AGENTS_HOME', () => {
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const add = runCli(
+      ['add', join(testDir, 'source'), '-y', '-g', '--agent', 'universal'],
+      projectDir,
+      env()
+    );
+    expect(add.exitCode).toBe(0);
+
+    const installed = join(store, 'skills', 'store-skill');
+    expect(existsSync(join(installed, 'SKILL.md'))).toBe(true);
+    expect(lstatSync(installed).isSymbolicLink()).toBe(false);
+    // Local-path sources are not tracked in the global lock; the lock location
+    // itself is covered by the getSkillLockPath unit test above.
+    expect(existsSync(join(home, '.agents'))).toBe(false);
+    expect(readdirSync(home)).not.toContain('.agents');
+
+    const list = runCli(['list', '-g', '--json'], projectDir, env());
+    expect(list.exitCode).toBe(0);
+    const entries = JSON.parse(list.stdout) as Array<{ name: string; path: string }>;
+    const entry = entries.find((e) => e.name === 'store-skill');
+    expect(entry?.path.startsWith(store)).toBe(true);
+
+    const remove = runCli(
+      ['remove', 'store-skill', '-y', '-g', '--agent', 'universal'],
+      projectDir,
+      env()
+    );
+    expect(remove.exitCode).toBe(0);
+    expect(existsSync(installed)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #896. Related: #222, #810.

Every agent's own directory can be moved with an env var (#82 CODEX_HOME, #140 CLAUDE_CONFIG_DIR), but the shared store cannot: `~/.agents/skills` and `~/.agents/.skill-lock.json` are fixed. Two accounts on one machine share one store and one lock.

`AGENTS_HOME` replaces `~/.agents` for the global store and lock.

```bash
AGENTS_HOME=~/.agents-work CLAUDE_CONFIG_DIR=~/.claude-work npx skills add vercel-labs/agent-skills -g
```

Unset falls back to `~/.agents`. Project scope and `XDG_STATE_HOME` precedence are unchanged. `update` spawns  `add`, so the env var carries through.

One helper in `src/constants.ts`, used by `getCanonicalSkillsDir` and `getSkillLockPath`. Tests in `tests/agents-home.test.ts`.