### PR TITLE
Support pinning skills add installs to a commit SHA

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -8,6 +8,10 @@ import { isGitHubHost } from './github-host.ts';
 
 const DEFAULT_CLONE_TIMEOUT_MS = 300_000; // 5 minutes
 const ALLOWED_GIT_PROTOCOLS = 'https:http:ssh:git:file';
+// Git's `--branch` clone flag only resolves refs the remote advertises as
+// branches or tags — it doesn't accept a bare commit SHA. When `ref` looks
+// like one, we fetch it directly instead (see cloneRepoAtSha below).
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 const CLONE_TIMEOUT_MS = (() => {
   const raw = process.env.SKILLS_CLONE_TIMEOUT_MS;
   if (!raw) return DEFAULT_CLONE_TIMEOUT_MS;
@@ -21,6 +25,10 @@ interface GitHubRepoInfo {
   repo: string;
   slug: string;
   sshUrl: string;
+}
+
+function isCommitSha(ref: string): boolean {
+  return COMMIT_SHA_PATTERN.test(ref);
 }
 
 export class GitCloneError extends Error {
@@ -174,6 +182,30 @@ async function resetTempDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true });
 }
 
+// Fetches exactly `sha` from `remote` into the repo at `git`'s cwd and checks
+// it out, instead of relying on `--branch`, which cannot resolve a bare SHA.
+// GitHub (and most forges) allow fetching any reachable commit this way even
+// without a branch/tag pointing at it.
+async function fetchAndCheckoutSha(
+  git: ReturnType<typeof createGitClient>,
+  remote: string,
+  sha: string
+): Promise<void> {
+  await git.raw(['fetch', '--depth=1', remote, sha]);
+  await git.raw(['checkout', 'FETCH_HEAD']);
+}
+
+async function cloneRepoAtSha(
+  url: string,
+  tempDir: string,
+  sha: string,
+  sshCommand?: string
+): Promise<void> {
+  const git = createGitClient(sshCommand).cwd(tempDir);
+  await git.init();
+  await fetchAndCheckoutSha(git, url, sha);
+}
+
 async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): Promise<boolean> {
   let cloneTarget = repo.slug;
   const host = repo.sshUrl.match(/^git@([^:]+):/)?.[1] || 'github.com';
@@ -191,7 +223,8 @@ async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): 
     return false;
   }
 
-  const gitFlags = ref ? ['--depth=1', '--branch', ref] : ['--depth=1'];
+  const shaRef = ref && isCommitSha(ref) ? ref : undefined;
+  const gitFlags = ref && !shaRef ? ['--depth=1', '--branch', ref] : ['--depth=1'];
   await execFileAsync('gh', ['repo', 'clone', cloneTarget, tempDir, '--', ...gitFlags], {
     timeout: CLONE_TIMEOUT_MS,
     env: {
@@ -200,6 +233,14 @@ async function tryGhClone(repo: GitHubRepoInfo, tempDir: string, ref?: string): 
       GIT_ALLOW_PROTOCOL: ALLOWED_GIT_PROTOCOLS,
     },
   });
+
+  if (shaRef) {
+    // `gh repo clone` leaves the credential-aware `origin` remote it just
+    // proved works — reuse it to fetch the pinned commit instead of the raw
+    // URL, which wouldn't carry gh's auth.
+    await fetchAndCheckoutSha(createGitClient().cwd(tempDir), 'origin', shaRef);
+  }
+
   return true;
 }
 
@@ -238,11 +279,16 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
   }
 
   const tempDir = await mkdtemp(join(tmpdir(), 'skills-'));
-  const cloneOptions = ref ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
+  const shaRef = ref && isCommitSha(ref) ? ref : undefined;
+  const cloneOptions = ref && !shaRef ? ['--depth', '1', '--branch', ref] : ['--depth', '1'];
   const repo = parseGitHubRepoUrl(url);
 
   try {
-    await createGitClient().clone(url, tempDir, cloneOptions);
+    if (shaRef) {
+      await cloneRepoAtSha(url, tempDir, shaRef);
+    } else {
+      await createGitClient().clone(url, tempDir, cloneOptions);
+    }
     return tempDir;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -277,11 +323,12 @@ export async function cloneRepo(url: string, ref?: string): Promise<string> {
 
       try {
         await resetTempDir(tempDir);
-        await createGitClient(process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes').clone(
-          repo.sshUrl,
-          tempDir,
-          cloneOptions
-        );
+        const sshCommand = process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes';
+        if (shaRef) {
+          await cloneRepoAtSha(repo.sshUrl, tempDir, shaRef, sshCommand);
+        } else {
+          await createGitClient(sshCommand).clone(repo.sshUrl, tempDir, cloneOptions);
+        }
         return tempDir;
       } catch {
         // Fall through to the targeted auth error below.

--- a/tests/git-sha-pin-clone.test.ts
+++ b/tests/git-sha-pin-clone.test.ts
@@ -1,0 +1,129 @@
+import { execFile } from 'child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanupTempDir, cloneRepo, GitCloneError } from '../src/git.ts';
+
+function runGit(args: string[], cwd?: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { cwd }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function runGitOutput(args: string[], cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { cwd }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+}
+
+describe('cloneRepo commit SHA pinning', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('clones and checks out an exact commit SHA that has no branch or tag', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-sha-pin-test-'));
+    tempDirs.push(root);
+    const source = join(root, 'source');
+
+    await runGit(['init', source]);
+    await runGit(['config', 'user.email', 'skills-test@example.com'], source);
+    await runGit(['config', 'user.name', 'Skills Test'], source);
+
+    await writeFile(join(source, 'file.txt'), 'first\n');
+    await runGit(['add', '.'], source);
+    await runGit(['commit', '-m', 'first commit'], source);
+    const pinnedSha = (await runGitOutput(['rev-parse', 'HEAD'], source)).trim();
+
+    // A later commit moves the default branch forward with no tag anywhere,
+    // so the only way to reach the first commit is by its bare SHA.
+    await writeFile(join(source, 'file.txt'), 'second\n');
+    await runGit(['add', '.'], source);
+    await runGit(['commit', '-m', 'second commit'], source);
+
+    const cloneDir = await cloneRepo(source, pinnedSha);
+    tempDirs.push(cloneDir);
+
+    const checkedOutSha = (await runGitOutput(['rev-parse', 'HEAD'], cloneDir)).trim();
+    expect(checkedOutSha).toBe(pinnedSha);
+
+    const contents = await readFile(join(cloneDir, 'file.txt'), 'utf8');
+    expect(contents.replaceAll('\r\n', '\n')).toBe('first\n');
+
+    await cleanupTempDir(cloneDir);
+    tempDirs.splice(tempDirs.indexOf(cloneDir), 1);
+  }, 20_000);
+
+  it('still clones the default branch when no ref is given', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-sha-pin-test-'));
+    tempDirs.push(root);
+    const source = join(root, 'source');
+
+    await runGit(['init', source]);
+    await runGit(['config', 'user.email', 'skills-test@example.com'], source);
+    await runGit(['config', 'user.name', 'Skills Test'], source);
+    await writeFile(join(source, 'file.txt'), 'only\n');
+    await runGit(['add', '.'], source);
+    await runGit(['commit', '-m', 'only commit'], source);
+
+    const cloneDir = await cloneRepo(source);
+    tempDirs.push(cloneDir);
+
+    const contents = await readFile(join(cloneDir, 'file.txt'), 'utf8');
+    expect(contents.replaceAll('\r\n', '\n')).toBe('only\n');
+
+    await cleanupTempDir(cloneDir);
+    tempDirs.splice(tempDirs.indexOf(cloneDir), 1);
+  }, 20_000);
+
+  it('still uses --branch for a real branch name (unaffected by the SHA path)', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-sha-pin-test-'));
+    tempDirs.push(root);
+    const source = join(root, 'source');
+
+    await runGit(['init', source]);
+    await runGit(['config', 'user.email', 'skills-test@example.com'], source);
+    await runGit(['config', 'user.name', 'Skills Test'], source);
+    await writeFile(join(source, 'file.txt'), 'main\n');
+    await runGit(['add', '.'], source);
+    await runGit(['commit', '-m', 'main commit'], source);
+    await runGit(['checkout', '-b', 'feature'], source);
+    await writeFile(join(source, 'file.txt'), 'feature\n');
+    await runGit(['add', '.'], source);
+    await runGit(['commit', '-m', 'feature commit'], source);
+
+    const cloneDir = await cloneRepo(source, 'feature');
+    tempDirs.push(cloneDir);
+
+    const contents = await readFile(join(cloneDir, 'file.txt'), 'utf8');
+    expect(contents.replaceAll('\r\n', '\n')).toBe('feature\n');
+
+    await cleanupTempDir(cloneDir);
+    tempDirs.splice(tempDirs.indexOf(cloneDir), 1);
+  }, 20_000);
+
+  it('fails with a clear error for a SHA that does not exist in the repo', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'skills-sha-pin-test-'));
+    tempDirs.push(root);
+    const source = join(root, 'source');
+
+    await runGit(['init', source]);
+    await runGit(['config', 'user.email', 'skills-test@example.com'], source);
+    await runGit(['config', 'user.name', 'Skills Test'], source);
+    await writeFile(join(source, 'file.txt'), 'only\n');
+    await runGit(['add', '.'], source);
+    await runGit(['commit', '-m', 'only commit'], source);
+
+    const bogusSha = '0'.repeat(40);
+    await expect(cloneRepo(source, bogusSha)).rejects.toThrow(GitCloneError);
+  }, 20_000);
+});


### PR DESCRIPTION
`skills add owner/repo#<ref>` builds the clone as `git clone --depth 1 --branch <ref>`, and `--branch` only resolves names the remote advertises as a branch or tag. Pass a bare commit SHA and it fails with `fatal: Remote branch <sha> not found in upstream origin`, even though git and GitHub both support fetching an arbitrary reachable commit directly.

This teaches `cloneRepo`/`tryGhClone` to recognize a ref that looks like a commit SHA (`/^[0-9a-f]{7,40}$/i`) and, for that case only, `git init` + `git fetch --depth=1 <remote> <sha>` + `git checkout FETCH_HEAD` instead of the branch-based clone. Branch and tag refs go through the exact same path as before. The gh-CLI and SSH auth-retry fallbacks got the same treatment so a SHA pin doesn't get silently dropped if the primary HTTPS clone hits an auth error first.

Verified against a local git fixture (own commit history, no tags) that a pinned SHA checks out the right commit while the default-branch and named-branch paths are unaffected, plus that a nonexistent SHA still fails with a clear `GitCloneError`. I also confirmed the same shallow fetch-by-SHA works over HTTPS against a real public GitHub repo. `npm run type-check` and the full `vitest` suite pass (existing tests untouched).

Fixes #2032
