### PR TITLE
fix(agents): fix Antigravity and Antigravity CLI global skills directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,7 @@ Skills can be installed to any of these agents:
 |-------|-----------|--------------|-------------|
 | AiderDesk | `aider-desk` | `.aider-desk/skills/` | `~/.aider-desk/skills/` |
 | Amp, Replit, Universal | `amp`, `replit`, `universal` | `.agents/skills/` | `~/.config/agents/skills/` |
-| Antigravity | `antigravity` | `.agents/skills/` | `~/.gemini/antigravity/skills/` |
-| Antigravity CLI | `antigravity-cli` | `.agents/skills/` | `~/.gemini/antigravity-cli/skills/` |
+| Antigravity, Antigravity CLI | `antigravity`, `antigravity-cli` | `.agents/skills/` | `~/.gemini/config/skills/` |
 | AstrBot | `astrbot` | `data/skills/` | `~/.astrbot/data/skills/` |
 | Autohand Code CLI | `autohand-code` | `.autohand/skills/` | `~/.autohand/skills/` |
 | Augment | `augment` | `.augment/skills/` | `~/.augment/skills/` |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -100,20 +100,25 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: 'antigravity',
     displayName: 'Antigravity',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity/skills'),
-    showInUniversalPrompt: false,
+    globalSkillsDir: join(home, '.gemini/config/skills'),
+    universal: false,
     detectInstalled: async () => {
-      return existsSync(join(home, '.gemini/antigravity'));
+      return (
+        existsSync(join(home, '.gemini/antigravity')) || existsSync(join(home, '.gemini/config'))
+      );
     },
   },
   'antigravity-cli': {
     name: 'antigravity-cli',
     displayName: 'Antigravity CLI',
     skillsDir: '.agents/skills',
-    globalSkillsDir: join(home, '.gemini/antigravity-cli/skills'),
-    showInUniversalPrompt: false,
+    globalSkillsDir: join(home, '.gemini/config/skills'),
+    universal: false,
     detectInstalled: async () => {
-      return existsSync(join(home, '.gemini/antigravity-cli'));
+      return (
+        existsSync(join(home, '.gemini/antigravity-cli')) ||
+        existsSync(join(home, '.gemini/config'))
+      );
     },
   },
   astrbot: {
@@ -871,9 +876,7 @@ export function getEveSubagents(cwd: string = process.cwd()): string[] {
  */
 export function getUniversalAgents(): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
-    .filter(
-      ([_, config]) => config.skillsDir === '.agents/skills' && config.showInUniversalList !== false
-    )
+    .filter(([type, config]) => isUniversalAgent(type) && config.showInUniversalList !== false)
     .map(([type]) => type);
 }
 
@@ -884,8 +887,8 @@ export function getUniversalAgents(): AgentType[] {
 export function getVisibleUniversalAgents(): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
     .filter(
-      ([_, config]) =>
-        config.skillsDir === '.agents/skills' &&
+      ([type, config]) =>
+        isUniversalAgent(type) &&
         config.showInUniversalList !== false &&
         config.showInUniversalPrompt !== false
     )
@@ -898,7 +901,7 @@ export function getVisibleUniversalAgents(): AgentType[] {
  */
 export function getNonUniversalAgents(): AgentType[] {
   return (Object.entries(agents) as [AgentType, AgentConfig][])
-    .filter(([_, config]) => config.skillsDir !== '.agents/skills')
+    .filter(([type]) => !isUniversalAgent(type))
     .map(([type]) => type);
 }
 
@@ -906,5 +909,6 @@ export function getNonUniversalAgents(): AgentType[] {
  * Check if an agent uses the universal .agents/skills directory.
  */
 export function isUniversalAgent(type: AgentType): boolean {
-  return agents[type].skillsDir === '.agents/skills';
+  const config = agents[type];
+  return config.universal ?? config.skillsDir === '.agents/skills';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,15 @@ export interface AgentConfig {
   showInUniversalList?: boolean;
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
+  /**
+   * Whether this agent shares the canonical `.agents/skills` directory for BOTH
+   * workspace and global installs. Defaults to true when `skillsDir` is
+   * `.agents/skills`. Set to `false` for agents that read workspace skills from
+   * `.agents/skills` but have their own global skills directory (e.g. Antigravity,
+   * which uses `~/.gemini/config/skills` globally). Such agents are symlinked
+   * to their global directory instead of solely writing to ~/.agents/skills.
+   */
+  universal?: boolean;
 }
 
 export interface ParsedSource {

--- a/tests/xdg-config-paths.test.ts
+++ b/tests/xdg-config-paths.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect } from 'vitest';
 import { homedir } from 'os';
 import { join } from 'path';
-import { agents } from '../src/agents.ts';
+import { agents, isUniversalAgent } from '../src/agents.ts';
 
 describe('XDG config paths', () => {
   const home = homedir();
@@ -72,16 +72,21 @@ describe('XDG config paths', () => {
     });
   });
 
-  describe('Antigravity CLI', () => {
-    it('uses ~/.gemini/antigravity-cli/skills for global skills', () => {
-      const expected = join(home, '.gemini', 'antigravity-cli', 'skills');
+  describe('Antigravity', () => {
+    it('uses ~/.gemini/config/skills for global skills across CLI and IDE', () => {
+      const expected = join(home, '.gemini', 'config', 'skills');
+      expect(agents.antigravity.globalSkillsDir).toBe(expected);
       expect(agents['antigravity-cli'].globalSkillsDir).toBe(expected);
     });
 
-    it('uses a distinct global directory from the Antigravity IDE', () => {
-      expect(agents['antigravity-cli'].globalSkillsDir).not.toBe(
-        agents.antigravity.globalSkillsDir
-      );
+    it('is not universal so global installs target its own globalSkillsDir', () => {
+      expect(isUniversalAgent('antigravity')).toBe(false);
+      expect(isUniversalAgent('antigravity-cli')).toBe(false);
+    });
+
+    it('still reads workspace skills from the canonical .agents/skills dir', () => {
+      expect(agents.antigravity.skillsDir).toBe('.agents/skills');
+      expect(agents['antigravity-cli'].skillsDir).toBe('.agents/skills');
     });
   });
 


### PR DESCRIPTION
### Summary

Fixes the global skills installation directory and discovery mechanism for **Antigravity** and **Antigravity CLI** (`agy`).

Closes #1470.
Supersedes #1483 (replaces conflicting/stale branch with unified `~/.gemini/config/skills` targeting and fixes global symlink creation).

### Problem

1. **Incorrect Global Discovery Directory**: In `src/agents.ts`, `antigravity` pointed to `~/.gemini/antigravity/skills` (does not exist) and `antigravity-cli` pointed to `~/.gemini/antigravity-cli/skills` (Antigravity's private CLI runtime directory containing conversation sqlite DBs, logs, etc.).
   - Per Google Antigravity official specification and binary string inspection, all Antigravity surfaces (Antigravity 2.0, Antigravity IDE, and Antigravity CLI `agy`) use the unified shared customization root **`~/.gemini/config/`**, discovering global skills exclusively in **`~/.gemini/config/skills/<skill-name>/SKILL.md`**.
2. **Universal Agent Global Install Bypass**: In `src/agents.ts`, both agents defined `skillsDir: '.agents/skills'`, which caused `isUniversalAgent()` to return `true`. In `installer.ts`, global installs for universal agents immediately return after writing to `~/.agents/skills/`, skipping symlink creation into `agent.globalSkillsDir`. Since Antigravity does not scan `~/.agents/skills` globally, skills installed with `skills add <pkg> -g` were never discovered.

### Solution

- **Add `universal?: boolean` to `AgentConfig`**: Allows an agent to share the canonical `.agents/skills` directory for workspace installs while still maintaining a dedicated `globalSkillsDir` with symlinks for global installs.
- **Update `antigravity` and `antigravity-cli` entries**:
  - `globalSkillsDir`: `join(home, '.gemini/config/skills')`
  - `universal: false`: ensures global installs create symlinks in `~/.gemini/config/skills/`
  - `detectInstalled`: checks for `~/.gemini/antigravity`, `~/.gemini/antigravity-cli`, or `~/.gemini/config`
- **Update Tests and README**:
  - Updated `tests/xdg-config-paths.test.ts` to assert `~/.gemini/config/skills` across Antigravity CLI and IDE.
  - Re-synced `README.md` and `package.json` tables via `scripts/sync-agents.ts`.

### Testing

- `npx vitest run tests/xdg-config-paths.test.ts` (15/15 passed)
- `npm run type-check` (0 errors)
- `npm run format:check` (clean)
- `npm run build` (successful build)