### PR TITLE
feat(add): install from several sources in one command

### DIFF
--- a/src/add-many.test.ts
+++ b/src/add-many.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runCli } from './test-utils.ts';
+import { buildChildArgs, groupSources } from './add-many.ts';
+
+function writeSkill(root: string, name: string): void {
+  const dir = join(root, 'skills', name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: Test skill ${name}\n---\n\n# ${name}\n`
+  );
+}
+
+describe('groupSources', () => {
+  it('keeps distinct repositories apart and reads @skill selections', () => {
+    expect(
+      groupSources([
+        'anthropics/skills',
+        'cloudflare/skills@wrangler,workers-best-practices',
+        'vercel-labs/skills@find-skills',
+      ])
+    ).toEqual([
+      { token: 'anthropics/skills', label: 'anthropics/skills' },
+      {
+        token: 'cloudflare/skills@wrangler,workers-best-practices',
+        label: 'cloudflare/skills',
+        skills: ['wrangler', 'workers-best-practices'],
+      },
+      {
+        token: 'vercel-labs/skills@find-skills',
+        label: 'vercel-labs/skills',
+        skills: ['find-skills'],
+      },
+    ]);
+  });
+
+  it('merges tokens that name the same repository into one group', () => {
+    expect(
+      groupSources(['cloudflare/skills@wrangler', 'cloudflare/skills@durable-objects,wrangler'])
+    ).toEqual([
+      {
+        token: 'cloudflare/skills@wrangler',
+        label: 'cloudflare/skills',
+        skills: ['wrangler', 'durable-objects'],
+      },
+    ]);
+  });
+
+  it('a token without a selection widens the group to the whole source', () => {
+    expect(groupSources(['cloudflare/skills@wrangler', 'cloudflare/skills'])).toEqual([
+      { token: 'cloudflare/skills', label: 'cloudflare/skills' },
+    ]);
+  });
+
+  it('treats different refs of one repository as different sources', () => {
+    const groups = groupSources(['owner/repo#main@a', 'owner/repo#v2@b']);
+    expect(groups.map((g) => g.label)).toEqual(['owner/repo#main', 'owner/repo#v2']);
+    expect(groups.map((g) => g.skills)).toEqual([['a'], ['b']]);
+  });
+
+  it('accepts URLs, git addresses and local paths', () => {
+    const groups = groupSources([
+      'https://github.com/owner/repo',
+      'git@github.com:owner/other.git',
+      '/tmp/some/skills',
+    ]);
+    expect(groups.map((g) => g.label)).toEqual([
+      'https://github.com/owner/repo',
+      'git@github.com:owner/other.git',
+      '/tmp/some/skills',
+    ]);
+  });
+});
+
+describe('buildChildArgs', () => {
+  it('runs each source as a non-interactive json install with the shared flags', () => {
+    expect(
+      buildChildArgs(
+        { token: 'o/r@a', label: 'o/r', skills: ['a', 'b'] },
+        { global: true, agent: ['claude-code', 'universal'], copy: true, fullDepth: true }
+      )
+    ).toEqual([
+      'add',
+      'o/r@a',
+      '--json',
+      '-y',
+      '--skill',
+      'a',
+      'b',
+      '-g',
+      '--agent',
+      'claude-code',
+      'universal',
+      '--copy',
+      '--full-depth',
+    ]);
+  });
+
+  it('forwards --list instead of installing', () => {
+    expect(buildChildArgs({ token: 'o/r', label: 'o/r' }, { list: true })).toEqual([
+      'add',
+      'o/r',
+      '--list',
+    ]);
+  });
+});
+
+describe('add with several sources', () => {
+  let root: string;
+  let home: string;
+  let sourceA: string;
+  let sourceB: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'skills-add-many-'));
+    home = join(root, 'home');
+    mkdirSync(home);
+    sourceA = join(root, 'source-a');
+    sourceB = join(root, 'source-b');
+    writeSkill(sourceA, 'alpha');
+    writeSkill(sourceA, 'alpha-two');
+    writeSkill(sourceB, 'beta');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // Local-path sources are not recorded in the global lock (upstream behaviour:
+  // getOwnerRepo() is null for them), so these tests assert on installed files.
+  // The lock plumbing is covered by lock-entries.test.ts and the project-scope
+  // test below, whose skills-lock.json is written through the same child →
+  // entries file → parent merge path.
+  const installedSkills = () =>
+    existsSync(join(home, '.claude', 'skills'))
+      ? readdirSync(join(home, '.claude', 'skills')).sort()
+      : [];
+
+  it('installs every source and prints one line per source', () => {
+    const result = runCli(['add', sourceA, sourceB, '-g', '--agent', 'claude-code', '-y'], root, {
+      HOME: home,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(`+ ${sourceA}: `);
+    expect(result.stdout).toContain('alpha');
+    expect(result.stdout).toContain('alpha-two');
+    expect(result.stdout).toContain(`+ ${sourceB}: beta`);
+    expect(result.stdout).toMatch(/Installed 3 skills from 2 of 2 sources in \d+\.\ds/);
+    // Single-source decoration must not leak through.
+    expect(result.stdout).not.toContain('Done!');
+    expect(installedSkills()).toEqual(['alpha', 'alpha-two', 'beta']);
+  });
+
+  it('rejects --skill with several sources and points at the @skill form', () => {
+    const result = runCli(
+      ['add', sourceA, sourceB, '-s', 'alpha', '-g', '--agent', 'claude-code', '-y'],
+      root,
+      { HOME: home }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--skill is ambiguous with several sources');
+    expect(result.stderr).toContain('owner/repo@alpha');
+    expect(installedSkills()).toEqual([]);
+  });
+
+  it('--json prints one merged array with the source on every entry', () => {
+    const result = runCli(
+      ['add', sourceA, sourceB, '-g', '--agent', 'claude-code', '-y', '--json'],
+      root,
+      { HOME: home }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const entries = JSON.parse(result.stdout);
+    expect(entries.map((e: any) => [e.source, e.name, e.status, e.scope])).toEqual([
+      [sourceA, 'alpha', 'installed', 'global'],
+      [sourceA, 'alpha-two', 'installed', 'global'],
+      [sourceB, 'beta', 'installed', 'global'],
+    ]);
+  });
+
+  it('reports a failed source, keeps installing the others and exits non-zero', () => {
+    const missing = join(root, 'does-not-exist');
+    const result = runCli(['add', sourceB, missing, '-g', '--agent', 'claude-code', '-y'], root, {
+      HOME: home,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain(`+ ${sourceB}: beta`);
+    expect(result.stdout).toContain(`FAILED ${missing}: `);
+    expect(result.stdout).toContain('does not exist');
+    expect(result.stdout).toMatch(/Installed 1 skill from 1 of 2 sources in \d+\.\ds \(1 failed\)/);
+    expect(installedSkills()).toEqual(['beta']);
+  });
+
+  it('project scope merges every source into skills-lock.json', () => {
+    const project = join(root, 'project');
+    mkdirSync(project);
+    const result = runCli(['add', sourceA, sourceB, '--agent', 'claude-code', '-y'], project, {
+      HOME: home,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const lock = JSON.parse(readFileSync(join(project, 'skills-lock.json'), 'utf-8'));
+    expect(Object.keys(lock.skills).sort()).toEqual(['alpha', 'alpha-two', 'beta']);
+    expect(existsSync(join(project, '.claude', 'skills', 'beta'))).toBe(true);
+  });
+
+  it('a prompt that cannot run without a TTY surfaces as a failure instead of hanging', () => {
+    // No --agent and no detected agents: the child would have to ask.
+    const result = runCli(['add', sourceA, sourceB, '-g', '-y'], root, { HOME: home }, 20000);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('FAILED');
+    expect(result.stdout).toContain('(2 failed)');
+  });
+});

--- a/src/add-many.ts
+++ b/src/add-many.ts
@@ -1,0 +1,309 @@
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import type { AddJsonResult, AddOptions } from './add.ts';
+import { parseSource } from './source-parser.ts';
+import { LOCK_ENTRIES_FILE_ENV, mergeLockEntriesFiles } from './skill-lock.ts';
+import { LOCAL_LOCK_ENTRIES_FILE_ENV, mergeLocalLockEntriesFiles } from './local-lock.ts';
+import { stripTerminalEscapes } from './sanitize.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Sources installed at once. Each is one clone or snapshot download plus a tree fetch. */
+const MAX_CONCURRENCY = 6;
+
+/**
+ * One repository (or path) to install from, merged from every command-line
+ * token that names it. `skills` is undefined when a token asked for the whole
+ * source; otherwise it is the union of the `@skill[,skill]` selections.
+ */
+export interface SourceGroup {
+  /** First token naming this source, passed to the child `add` as typed. */
+  token: string;
+  /** Token without its `@skill` suffix, for display. */
+  label: string;
+  skills?: string[];
+}
+
+/** Outcome of one child `add <source> --json` run. */
+export interface SourceResult {
+  label: string;
+  exitCode: number;
+  entries: AddJsonResult[];
+}
+
+/**
+ * Group the sources of a multi-source `add` by repository.
+ *
+ * Skill selection rides on the token (`owner/repo@a,b`, upstream's `@skill`
+ * syntax plus comma lists), so tokens that resolve to the same repository at
+ * the same ref merge into one group and one clone.
+ */
+export function groupSources(sources: string[]): SourceGroup[] {
+  const groups = new Map<string, SourceGroup>();
+  for (const token of sources) {
+    const parsed = parseSource(token);
+    const key = JSON.stringify([
+      parsed.type,
+      parsed.url,
+      parsed.localPath,
+      parsed.ref,
+      parsed.subpath,
+    ]);
+    const skills = parsed.skillFilter?.split(',').filter(Boolean);
+    const label =
+      parsed.skillFilter && token.endsWith(`@${parsed.skillFilter}`)
+        ? token.slice(0, -(parsed.skillFilter.length + 1))
+        : token;
+
+    const group = groups.get(key);
+    if (!group) {
+      groups.set(key, { token, label, ...(skills && skills.length > 0 ? { skills } : {}) });
+      continue;
+    }
+    if (!skills || skills.length === 0) {
+      // A token without a selection asks for everything from this source.
+      group.skills = undefined;
+      group.token = token;
+      group.label = label;
+    } else if (group.skills) {
+      for (const skill of skills) if (!group.skills.includes(skill)) group.skills.push(skill);
+    }
+  }
+  return [...groups.values()];
+}
+
+/** Argument list for one child install. Exported for tests. */
+export function buildChildArgs(group: SourceGroup, options: AddOptions): string[] {
+  const args = ['add', group.token];
+  if (options.list) args.push('--list');
+  else args.push('--json', '-y');
+  // The child merges the token's own @skill selection with --skill, so passing
+  // the whole union is harmless and covers skills named by the other tokens.
+  if (group.skills && group.skills.length > 0) args.push('--skill', ...group.skills);
+  if (options.global) args.push('-g');
+  if (options.agent && options.agent.length > 0) args.push('--agent', ...options.agent);
+  if (options.subagent && options.subagent.length > 0) args.push('--subagent', ...options.subagent);
+  if (options.all) args.push('--all');
+  if (options.copy) args.push('--copy');
+  if (options.fullDepth) args.push('--full-depth');
+  if (options.metadata) args.push('--metadata', options.metadata);
+  return args;
+}
+
+/**
+ * `skills add` with several sources.
+ *
+ * `runAdd` is written around one source: it owns the terminal (clack
+ * spinners, prompts, a monkey-patched stdout in json mode) and exits the
+ * process on failure, so sources cannot share it in-process. Like `update`,
+ * each source runs as a child `add <source> --json -y`; the parent collects
+ * the JSON, folds the children's lock entries into the lock file once, and
+ * prints either one merged JSON array or a one-line-per-source summary.
+ * Several sources are therefore always non-interactive.
+ */
+export async function runAddMany(sources: string[], options: AddOptions): Promise<void> {
+  const jsonMode = options.json === true;
+
+  if (options.skill && options.skill.length > 0) {
+    // With one source --skill has an obvious owner; with several it does not,
+    // and guessing (first? last? all?) is exactly the ambiguity to avoid.
+    console.error(
+      'Error: --skill is ambiguous with several sources. Name skills on the source instead: ' +
+        `owner/repo@${options.skill.join(',')}`
+    );
+    if (jsonMode) console.log('[]');
+    process.exit(1);
+  }
+
+  const cliEntry = join(__dirname, '..', 'bin', 'cli.mjs');
+  if (!existsSync(cliEntry)) {
+    console.error(`CLI entrypoint not found at ${cliEntry}`);
+    process.exit(1);
+  }
+
+  const groups = groupSources(sources);
+
+  if (options.list) {
+    // Listing is read-only and human-oriented: run the sources one after
+    // another with the terminal attached instead of collecting JSON.
+    for (const group of groups) {
+      const code = await new Promise<number>((resolve) => {
+        spawn(process.execPath, [cliEntry, ...buildChildArgs(group, options)], {
+          stdio: 'inherit',
+          shell: false,
+        }).on('close', (c) => resolve(c ?? 1));
+      });
+      if (code !== 0) process.exitCode = 1;
+    }
+    return;
+  }
+
+  const started = Date.now();
+  const spinner = !jsonMode && process.stdout.isTTY ? p.spinner() : null;
+  spinner?.start(`Installing from ${groups.length} sources…`);
+
+  const workDir = await mkdtemp(join(tmpdir(), 'skills-add-'));
+  const results: SourceResult[] = new Array(groups.length);
+  try {
+    let next = 0;
+    const worker = async (): Promise<void> => {
+      while (next < groups.length) {
+        const index = next++;
+        results[index] = await runChild(cliEntry, groups[index]!, options, workDir, index);
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(MAX_CONCURRENCY, groups.length) }, worker));
+
+    await mergeLockEntriesFiles(groups.map((_, i) => globalEntriesFile(workDir, i)));
+    await mergeLocalLockEntriesFiles(groups.map((_, i) => projectEntriesFile(workDir, i)));
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+
+  const failed = results.filter((r) => !sourceSucceeded(r));
+  spinner?.stop(
+    failed.length === 0
+      ? `Installed from ${results.length} sources`
+      : `${failed.length} of ${results.length} sources failed`
+  );
+
+  if (jsonMode) {
+    // Children already report the normalized source on installed entries; the
+    // label fills in for failures so every entry is attributable.
+    const entries = results.flatMap((r) => r.entries.map((e) => ({ source: r.label, ...e })));
+    console.log(JSON.stringify(entries, null, 2));
+  } else {
+    printSummary(results, Date.now() - started);
+  }
+
+  if (failed.length > 0) process.exitCode = 1;
+}
+
+function globalEntriesFile(workDir: string, index: number): string {
+  return join(workDir, `global-${index}.jsonl`);
+}
+
+function projectEntriesFile(workDir: string, index: number): string {
+  return join(workDir, `project-${index}.jsonl`);
+}
+
+function runChild(
+  cliEntry: string,
+  group: SourceGroup,
+  options: AddOptions,
+  workDir: string,
+  index: number
+): Promise<SourceResult> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cliEntry, ...buildChildArgs(group, options)], {
+      // stdin is closed: a child that would prompt fails with the non-TTY
+      // message instead of hanging.
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        [LOCK_ENTRIES_FILE_ENV]: globalEntriesFile(workDir, index),
+        [LOCAL_LOCK_ENTRIES_FILE_ENV]: projectEntriesFile(workDir, index),
+      },
+      // Sources come straight from the command line; argv keeps them inert.
+      shell: false,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      resolve({
+        label: group.label,
+        exitCode: 1,
+        entries: [{ status: 'failed', error: error.message }],
+      });
+    });
+
+    child.on('close', (code) => {
+      const exitCode = code ?? 1;
+      const fallbackError = lastLines(stderr) || `add exited with code ${exitCode}`;
+      let entries = parseJsonArray(stdout);
+      if (!entries) {
+        entries = [{ status: 'failed', error: fallbackError }];
+      } else if (exitCode !== 0 && !entries.some((e) => e.status === 'failed')) {
+        entries.push({ status: 'failed', error: fallbackError });
+      }
+      resolve({ label: group.label, exitCode, entries });
+    });
+  });
+}
+
+function parseJsonArray(text: string): AddJsonResult[] | null {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return Array.isArray(parsed) ? (parsed as AddJsonResult[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function lastLines(text: string, count = 3): string {
+  return stripTerminalEscapes(text)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-count)
+    .join(' ');
+}
+
+function sourceSucceeded(result: SourceResult): boolean {
+  return result.exitCode === 0 && !result.entries.some((e) => e.status === 'failed');
+}
+
+/** One line per source, then a total. Names and errors are remote content, so they are sanitized. */
+function printSummary(results: SourceResult[], elapsedMs: number): void {
+  const clean = (text: string | undefined): string => stripTerminalEscapes(text ?? '');
+  let installedCount = 0;
+  let okSources = 0;
+
+  for (const result of results) {
+    const label = clean(result.label);
+    const installed = result.entries
+      .filter((e) => e.status === 'installed')
+      .map((e) => clean(e.name));
+    const failures = result.entries.filter((e) => e.status === 'failed');
+    const skipped = result.entries.filter((e) => e.status === 'skipped');
+
+    if (sourceSucceeded(result)) {
+      okSources++;
+      installedCount += installed.length;
+      console.log(
+        `${pc.green('+')} ${label}: ${installed.length > 0 ? installed.join(', ') : pc.dim('nothing installed')}`
+      );
+    } else {
+      const reason = failures.map((f) => clean(f.error) || 'Installation failed').join('; ');
+      console.log(`${pc.red('FAILED')} ${label}: ${reason}`);
+      if (installed.length > 0) {
+        installedCount += installed.length;
+        console.log(`  ${pc.dim('installed:')} ${installed.join(', ')}`);
+      }
+    }
+    for (const entry of skipped) {
+      console.log(`  ${pc.yellow('skipped')} ${clean(entry.name)}: ${clean(entry.reason)}`);
+    }
+  }
+
+  const failedSources = results.length - okSources;
+  const seconds = (elapsedMs / 1000).toFixed(1);
+  console.log(
+    `Installed ${installedCount} skill${installedCount === 1 ? '' : 's'} from ${okSources} of ${results.length} sources in ${seconds}s` +
+      (failedSources > 0 ? pc.red(` (${failedSources} failed)`) : '')
+  );
+}

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -17,6 +17,27 @@ function countPathLinesForSkill(text: string, skillName: string): number {
   ).length;
 }
 
+const noDetectedAgentEnv = {
+  AI_AGENT: '',
+  ANTIGRAVITY_AGENT: '',
+  AUGMENT_AGENT: '',
+  CLAUDE_CODE: '',
+  CLAUDE_CODE_IS_COWORK: '',
+  CLAUDECODE: '',
+  CODEX_CI: '',
+  CODEX_SANDBOX: '',
+  CODEX_THREAD_ID: '',
+  COPILOT_ALLOW_ALL: '',
+  COPILOT_GITHUB_TOKEN: '',
+  COPILOT_MODEL: '',
+  CURSOR_AGENT: '',
+  CURSOR_EXTENSION_HOST_ROLE: '',
+  CURSOR_TRACE_ID: '',
+  GEMINI_CLI: '',
+  OPENCODE_CLIENT: '',
+  REPL_ID: '',
+};
+
 describe('add command', () => {
   let testDir: string;
 
@@ -335,6 +356,164 @@ description: Test
   it('should restore from lock file with experimental_install', () => {
     const result = runCli(['experimental_install'], testDir);
     expect(result.stdout).toContain('No project skills found in skills-lock.json');
+  });
+
+  describe('--json output', () => {
+    const writeSkill = (dir: string, name: string): void => {
+      const skillDir = join(dir, 'skills', name);
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, 'SKILL.md'),
+        `---\nname: ${name}\ndescription: A ${name} test skill\n---\n# ${name}\n`
+      );
+    };
+
+    it('should output an installed entry as a JSON array', () => {
+      const sourceDir = join(testDir, 'source');
+      const projectDir = join(testDir, 'project');
+      writeSkill(sourceDir, 'json-add-skill');
+      mkdirSync(projectDir, { recursive: true });
+
+      const result = runCli(
+        ['add', sourceDir, '-y', '--agent', 'claude-code', '--json'],
+        projectDir,
+        noDetectedAgentEnv
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].name).toBe('json-add-skill');
+      expect(parsed[0].status).toBe('installed');
+      expect(parsed[0].source).toContain('source');
+      expect(parsed[0].ref).toBeNull();
+      expect(typeof parsed[0].hash).toBe('string');
+      expect(parsed[0].hash.length).toBeGreaterThan(0);
+      expect(typeof parsed[0].path).toBe('string');
+      expect(parsed[0].path.length).toBeGreaterThan(0);
+      expect(parsed[0].scope).toBe('project');
+      expect(parsed[0].agents).toEqual(['Claude Code']);
+      expect(parsed[0].mode).toBe('copy');
+      // No ANSI codes, no banner, no clack boxes on stdout
+      expect(result.stdout).not.toMatch(/\x1b\[/);
+      expect(result.stdout).not.toContain('Installation Summary');
+    });
+
+    it('should output one entry per skill for multi-skill installs', () => {
+      const sourceDir = join(testDir, 'source');
+      const projectDir = join(testDir, 'project');
+      writeSkill(sourceDir, 'skill-one');
+      writeSkill(sourceDir, 'skill-two');
+      mkdirSync(projectDir, { recursive: true });
+
+      const result = runCli(
+        [
+          'add',
+          sourceDir,
+          '-y',
+          '--agent',
+          'claude-code',
+          '--skill',
+          'skill-one',
+          'skill-two',
+          '--json',
+        ],
+        projectDir,
+        noDetectedAgentEnv
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.length).toBe(2);
+      const names = parsed.map((e: any) => e.name);
+      expect(names).toContain('skill-one');
+      expect(names).toContain('skill-two');
+      expect(parsed.every((e: any) => e.status === 'installed')).toBe(true);
+    });
+
+    it('should report requested skills that match nothing as skipped', () => {
+      const sourceDir = join(testDir, 'source');
+      const projectDir = join(testDir, 'project');
+      writeSkill(sourceDir, 'skill-one');
+      mkdirSync(projectDir, { recursive: true });
+
+      const result = runCli(
+        [
+          'add',
+          sourceDir,
+          '-y',
+          '--agent',
+          'claude-code',
+          '--skill',
+          'skill-one',
+          'no-such-skill',
+          '--json',
+        ],
+        projectDir,
+        noDetectedAgentEnv
+      );
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(parsed.length).toBe(2);
+      const skipped = parsed.find((e: any) => e.name === 'no-such-skill');
+      expect(skipped.status).toBe('skipped');
+      expect(skipped.reason).toContain('No matching skill');
+      const installed = parsed.find((e: any) => e.name === 'skill-one');
+      expect(installed.status).toBe('installed');
+    });
+
+    it('should emit a failed entry and parseable array for a bad source', () => {
+      const result = runCli(
+        ['add', './definitely-missing-path', '-y', '--json'],
+        testDir,
+        noDetectedAgentEnv
+      );
+
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].status).toBe('failed');
+      expect(parsed[0].error).toContain('Local path does not exist');
+      // Human error text goes to stderr, never stdout
+      expect(result.stderr).toContain('Local path does not exist');
+    });
+
+    it('should fail cleanly instead of prompting when --json is used without -y', () => {
+      const sourceDir = join(testDir, 'source');
+      writeSkill(sourceDir, 'skill-one');
+
+      const result = runCli(['add', sourceDir, '--json'], testDir, noDetectedAgentEnv);
+
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(result.stderr).toContain('--yes');
+    });
+
+    it('should emit a parseable array when source is missing', () => {
+      const result = runCli(['add', '--json'], testDir, noDetectedAgentEnv);
+
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout.trim());
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed[0].status).toBe('failed');
+      expect(result.stderr).toContain('Missing required argument: source');
+    });
+
+    it('should emit a parseable array when flag parsing fails', () => {
+      const result = runCli(
+        ['add', 'some/source', '--json', '-y', '--metadata', 'not-json'],
+        testDir,
+        noDetectedAgentEnv
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(JSON.parse(result.stdout.trim())).toEqual([]);
+      expect(result.stderr).toContain('--metadata must be valid JSON');
+    });
   });
 
   describe('internal skills', () => {
@@ -691,6 +870,19 @@ describe('parseAddOptions', () => {
     const result = parseAddOptions(['source', '--full-depth']);
     expect(result.source).toEqual(['source']);
     expect(result.options.fullDepth).toBe(true);
+  });
+
+  it('should parse --json flag', () => {
+    const result = parseAddOptions(['source', '--json']);
+    expect(result.source).toEqual(['source']);
+    expect(result.options.json).toBe(true);
+  });
+
+  it('should parse --json alongside other flags', () => {
+    const result = parseAddOptions(['source', '--json', '-y', '--skill', 'my-skill']);
+    expect(result.options.json).toBe(true);
+    expect(result.options.yes).toBe(true);
+    expect(result.options.skill).toEqual(['my-skill']);
   });
 
   it('should parse --full-depth with other flags', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -556,6 +556,46 @@ export interface AddOptions {
    * selects the root agent. Implies installing for Eve.
    */
   subagent?: string[];
+  /** Output results as a JSON array (machine-readable, no ANSI codes). */
+  json?: boolean;
+}
+
+/** One entry per skill in `add --json` output. */
+export interface AddJsonResult {
+  name?: string;
+  status: 'installed' | 'skipped' | 'failed';
+  source?: string;
+  ref?: string | null;
+  hash?: string | null;
+  path?: string;
+  scope?: 'project' | 'global';
+  agents?: string[];
+  mode?: InstallMode;
+  security?: {
+    gen?: string;
+    socket?: string;
+    snyk?: string;
+    details?: string;
+  } | null;
+  reason?: string;
+  error?: string;
+}
+
+/** Build the `security` field for a JSON entry from partner audit data. */
+function buildJsonSecurity(
+  auditData: AuditResponse | null,
+  skillName: string,
+  source: string | null
+): AddJsonResult['security'] {
+  const data = auditData?.[skillName];
+  if (!data || Object.keys(data).length === 0) return null;
+  const socketAlerts = data.socket?.alerts ?? 0;
+  return {
+    ...(data.ath && { gen: data.ath.risk }),
+    ...(data.socket && { socket: `${socketAlerts} alert${socketAlerts !== 1 ? 's' : ''}` }),
+    ...(data.snyk && { snyk: data.snyk.risk }),
+    ...(source && { details: `https://skills.sh/${source}` }),
+  };
 }
 
 /**
@@ -904,6 +944,7 @@ async function handleWellKnownSkills(
   console.log();
   const successful = results.filter((r) => r.success);
   const failed = results.filter((r) => !r.success);
+  const successfulSkillNames = new Set(successful.map((r) => r.skill));
 
   // Build skillFiles map: { skillName: sourceUrl }
   const skillFiles: Record<string, string> = {};
@@ -929,7 +970,6 @@ async function handleWellKnownSkills(
 
   // Add to skill lock file for update tracking (only for global installs)
   if (successful.length > 0 && installGlobally) {
-    const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
       if (successfulSkillNames.has(skill.installName)) {
         try {
@@ -950,7 +990,6 @@ async function handleWellKnownSkills(
 
   // Add to local lock file for project-scoped installs
   if (successful.length > 0 && !installGlobally) {
-    const successfulSkillNames = new Set(successful.map((r) => r.skill));
     for (const skill of selectedSkills) {
       if (successfulSkillNames.has(skill.installName)) {
         try {
@@ -1052,6 +1091,72 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   const source = args[0];
   let installTipShown = false;
 
+  // ─── JSON output mode ───
+  // Suppress all decorated stdout (clack banners, spinners, notes) and emit a
+  // single JSON array on stdout instead. Human error text goes to stderr.
+  const jsonMode = options.json === true;
+  const jsonResults: AddJsonResult[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  let stdoutSuppressed = false;
+  if (jsonMode) {
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    stdoutSuppressed = true;
+  }
+
+  const restoreStdout = (): void => {
+    if (stdoutSuppressed) {
+      process.stdout.write = originalStdoutWrite;
+      stdoutSuppressed = false;
+    }
+  };
+
+  let jsonEmitted = false;
+  const emitJson = (): void => {
+    if (!jsonMode || jsonEmitted) return;
+    jsonEmitted = true;
+    restoreStdout();
+    console.log(JSON.stringify(jsonResults, null, 2));
+  };
+
+  /**
+   * Every exit path must emit exactly one JSON array in json mode.
+   * In non-json mode this is a plain process.exit(code).
+   *
+   * The explicit type annotation (not just a return annotation) is what lets
+   * TypeScript narrow control flow after calls, like `process.exit` does.
+   */
+  const emitJsonAndExit: (code: number, errorMessage?: string) => never = (code, errorMessage) => {
+    if (jsonMode) {
+      if (errorMessage !== undefined) console.error(errorMessage);
+      if (code !== 0 && jsonResults.length === 0) {
+        jsonResults.push({ status: 'failed', error: errorMessage ?? 'Installation failed' });
+      }
+      emitJson();
+    }
+    process.exit(code);
+  };
+
+  if (jsonMode) {
+    // Safety net for exit paths outside this function (e.g. nested helpers):
+    // guarantee stdout carries one parseable array even then.
+    process.once('exit', emitJson);
+  }
+
+  // Interactive cancel, or a prompt that cannot run because stdin is not a TTY
+  // (#1991). In json mode the notice goes to stderr so stdout stays exactly
+  // one parseable array.
+  const cancelInstallation: () => never = () => {
+    if (!jsonMode) exitInstallationCancelled();
+    if (!process.stdin.isTTY) {
+      emitJsonAndExit(
+        1,
+        'Interactive prompt required but stdin is not a TTY. Nothing was installed. ' +
+          `Use --agent <name> (or --agent '*') and -y to run non-interactively.`
+      );
+    }
+    emitJsonAndExit(0, 'Installation cancelled');
+  };
+
   const showInstallTip = (): void => {
     if (installTipShown) return;
     p.log.message(
@@ -1072,7 +1177,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     console.log(pc.dim('  Example:'));
     console.log(`    ${pc.cyan('npx skills add')} ${pc.yellow('vercel-labs/agent-skills')}`);
     console.log();
-    process.exit(1);
+    emitJsonAndExit(1, 'Missing required argument: source');
   }
 
   // --all implies --skill '*' and --agent '*' and -y
@@ -1095,6 +1200,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
   }
 
+  // --json is machine-oriented: never prompt. Require an explicit
+  // non-interactive mode instead of hanging on (or cancelling) a prompt.
+  if (jsonMode && !options.yes) {
+    emitJsonAndExit(1, 'The --json flag requires --yes (or --all) to run non-interactively.');
+  }
+
   console.log();
   if (!agentResult.isAgent) {
     p.intro(pc.bgCyan(pc.black(' skills ')));
@@ -1113,7 +1224,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   let tempDir: string | null = null;
 
   try {
-    const spinner = p.spinner();
+    // In json mode, use an inert spinner: clack spinners poll the terminal and
+    // write frames/cursor sequences that must never reach stdout.
+    const spinner = jsonMode
+      ? ({
+          start: () => {},
+          stop: () => {},
+          message: () => {},
+        } as unknown as ReturnType<typeof p.spinner>)
+      : p.spinner();
 
     spinner.start('Parsing source…');
     const parsed = parseSource(source);
@@ -1140,6 +1259,11 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     // Handle arbitrary URLs by trying well-known discovery first, then
     // falling back to a direct SKILL.md/archive download.
     if (parsed.type === 'well-known') {
+      if (jsonMode) {
+        // The well-known flow has its own prompts and exit paths that do not
+        // feed the JSON accumulator yet.
+        emitJsonAndExit(1, '--json is not yet supported for well-known skill sources.');
+      }
       const handled = await handleWellKnownSkills(source, parsed.url, options, spinner);
       if (handled) return;
       directDownload = true;
@@ -1173,7 +1297,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       if (!existsSync(parsed.localPath!)) {
         spinner.stop(pc.red('Path not found'));
         p.outro(pc.red(`Local path does not exist: ${parsed.localPath}`));
-        process.exit(1);
+        emitJsonAndExit(1, `Local path does not exist: ${parsed.localPath}`);
       }
       spinner.stop('Local path validated');
 
@@ -1250,7 +1374,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         pc.red('No valid skills found. Skills require a SKILL.md with name and description.')
       );
       await cleanup(tempDir);
-      process.exit(1);
+      emitJsonAndExit(
+        1,
+        'No valid skills found. Skills require a SKILL.md with name and description.'
+      );
     }
 
     if (!blobResult) {
@@ -1304,7 +1431,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       console.log();
       p.outro('Use --skill <name> to install specific skills');
       await cleanup(tempDir);
-      process.exit(0);
+      emitJsonAndExit(0);
     }
 
     let selectedSkills: Skill[];
@@ -1316,6 +1443,19 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     } else if (options.skill && options.skill.length > 0) {
       selectedSkills = filterSkills(skills, options.skill);
 
+      // Requested names that matched nothing are reported as skipped entries.
+      if (jsonMode) {
+        for (const requested of options.skill) {
+          if (filterSkills(skills, [requested]).length === 0) {
+            jsonResults.push({
+              name: requested,
+              status: 'skipped',
+              reason: 'No matching skill found in source',
+            });
+          }
+        }
+      }
+
       if (selectedSkills.length === 0) {
         p.log.error(`No matching skills found for: ${options.skill.join(', ')}`);
         p.log.info('Available skills:');
@@ -1323,7 +1463,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           p.log.message(`  - ${getSkillDisplayName(s)}`);
         }
         await cleanup(tempDir);
-        process.exit(1);
+        emitJsonAndExit(1, `No matching skills found for: ${options.skill.join(', ')}`);
       }
 
       p.log.info(
@@ -1380,7 +1520,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       if (isCancelled(selected)) {
         await cleanup(tempDir);
-        exitInstallationCancelled();
+        cancelInstallation();
       }
 
       selectedSkills = selected as Skill[];
@@ -1415,7 +1555,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
         p.log.info(`Valid agents: ${validAgents.join(', ')}`);
         await cleanup(tempDir);
-        process.exit(1);
+        emitJsonAndExit(1, `Invalid agents: ${invalidAgents.join(', ')}`);
       }
 
       targetAgents = options.agent as AgentType[];
@@ -1435,7 +1575,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
         if (p.isCancel(useEve)) {
           await cleanup(tempDir);
-          exitInstallationCancelled();
+          cancelInstallation();
         }
 
         if (useEve) {
@@ -1446,7 +1586,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
           if (isCancelled(selected)) {
             await cleanup(tempDir);
-            exitInstallationCancelled();
+            cancelInstallation();
           }
 
           targetAgents = selected as AgentType[];
@@ -1473,7 +1613,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
           if (isCancelled(selected)) {
             await cleanup(tempDir);
-            exitInstallationCancelled();
+            cancelInstallation();
           }
 
           targetAgents = selected as AgentType[];
@@ -1494,7 +1634,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
         if (isCancelled(selected)) {
           await cleanup(tempDir);
-          exitInstallationCancelled();
+          cancelInstallation();
         }
 
         targetAgents = selected as AgentType[];
@@ -1537,7 +1677,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
         if (p.isCancel(selectedSubagents)) {
           await cleanup(tempDir);
-          exitInstallationCancelled();
+          cancelInstallation();
         }
 
         eveSubagentTargets = (selectedSubagents as string[]).map((s) => (s === '' ? undefined : s));
@@ -1570,7 +1710,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       if (p.isCancel(scope)) {
         await cleanup(tempDir);
-        exitInstallationCancelled();
+        cancelInstallation();
       }
 
       installGlobally = scope as boolean;
@@ -1605,7 +1745,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       if (p.isCancel(modeChoice)) {
         await cleanup(tempDir);
-        exitInstallationCancelled();
+        cancelInstallation();
       }
 
       installMode = modeChoice as InstallMode;
@@ -1710,8 +1850,10 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     // Await and display security audit results (started earlier in parallel)
     // Wrapped in try/catch so a failed audit fetch never blocks installation.
+    let auditDataForJson: AuditResponse | null = null;
     try {
       const auditData = await auditPromise;
+      auditDataForJson = auditData;
       if (auditData && ownerRepoForAudit) {
         const securityLines = buildSecurityLines(
           auditData,
@@ -1734,7 +1876,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
       if (p.isCancel(confirmed) || !confirmed) {
         await cleanup(tempDir);
-        exitInstallationCancelled();
+        cancelInstallation();
       }
     }
 
@@ -1790,6 +1932,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     console.log();
     const successful = results.filter((r) => r.success);
     const failed = results.filter((r) => !r.success);
+    const successfulSkillNames = new Set(successful.map((r) => r.skill));
     // Track installation result
     // Build skillFiles map: { skillName: relative path to SKILL.md from repo root }
     const skillFiles: Record<string, string> = {};
@@ -1856,10 +1999,28 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       }
     }
 
+    // Content hash per installed skill (blob snapshot or folder hash), for the
+    // project lock below and --json. The global lock derives its own from the
+    // repo tree, so skip the walk when neither consumer needs it.
+    const installedSkillHashes = new Map<string, string>();
+    if (successful.length > 0 && (jsonMode || !installGlobally)) {
+      for (const skill of selectedSkills) {
+        const skillDisplayName = getSkillDisplayName(skill);
+        if (!successfulSkillNames.has(skillDisplayName)) continue;
+        try {
+          const computedHash =
+            blobResult && 'snapshotHash' in skill
+              ? (skill as BlobSkill).snapshotHash
+              : await computeSkillFolderHash(skill.path);
+          installedSkillHashes.set(skillDisplayName, computedHash);
+        } catch {
+          // Hash is informational; lock writing skips skills without one.
+        }
+      }
+    }
+
     // Add to skill lock file for update tracking (only for global installs)
     if (successful.length > 0 && installGlobally && normalizedSource) {
-      const successfulSkillNames = new Set(successful.map((r) => r.skill));
-
       // For GitHub clone installs, fetch the repo tree once and reuse it
       // for all skills — avoids N sequential API calls that take ~400ms each.
       let cachedTree: Awaited<ReturnType<typeof fetchRepoTree>> | undefined;
@@ -1904,7 +2065,6 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
     // Add to local lock file for project-scoped installs
     if (successful.length > 0 && !installGlobally && !directDownload) {
-      const successfulSkillNames = new Set(successful.map((r) => r.skill));
       // Record Eve subagent placement (root = '') so `update` can restore it.
       // Only meaningful when Eve is among the targets and a non-root subagent
       // was selected; otherwise omit for a clean, minimal lock entry.
@@ -1917,11 +2077,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         const skillDisplayName = getSkillDisplayName(skill);
         if (successfulSkillNames.has(skillDisplayName)) {
           try {
-            // For blob skills, use the snapshot hash; for disk skills, compute from files
-            const computedHash =
-              blobResult && 'snapshotHash' in skill
-                ? (skill as BlobSkill).snapshotHash
-                : await computeSkillFolderHash(skill.path);
+            // Reuse the hash computed above (blob snapshot or folder hash)
+            const computedHash = installedSkillHashes.get(skillDisplayName);
+            if (computedHash === undefined) continue;
             const skillPathValue = skillFiles[skill.name];
             await addSkillToLocalLock(
               skill.name,
@@ -1941,6 +2099,41 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           }
         }
       }
+    }
+
+    // JSON output: one entry per skill, collapsing per-skill×agent results.
+    // A skill is failed if any target failed, otherwise installed.
+    if (jsonMode) {
+      const jsonSource =
+        normalizedSource ?? (parsed.type === 'local' ? parsed.localPath! : parsed.url);
+      for (const skill of selectedSkills) {
+        const name = getSkillDisplayName(skill);
+        const skillResults = results.filter((r) => r.skill === name);
+        const failures = skillResults.filter((r) => !r.success);
+        if (failures.length > 0) {
+          jsonResults.push({
+            name,
+            status: 'failed',
+            error: failures[0]!.error ?? 'Installation failed',
+          });
+          continue;
+        }
+        jsonResults.push({
+          name,
+          status: 'installed',
+          source: jsonSource,
+          ref: parsed.ref ?? null,
+          hash: installedSkillHashes.get(name) ?? null,
+          path: skillResults[0]?.canonicalPath ?? skillResults[0]?.path,
+          scope: installGlobally ? 'global' : 'project',
+          agents: skillResults.map((r) => r.agent),
+          mode: skillResults[0]?.mode ?? installMode,
+          security: buildJsonSecurity(auditDataForJson, name, ownerRepoForAudit),
+        });
+      }
+      emitJson();
+      if (failed.length > 0) process.exitCode = 1;
+      return; // the finally block handles tempDir cleanup
     }
 
     if (successful.length > 0) {
@@ -2066,8 +2259,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
     showInstallTip();
     p.outro(pc.red('Installation failed'));
-    process.exit(1);
+    const errorMessage =
+      error instanceof GitCloneError
+        ? `Failed to clone repository\n${error.message}`
+        : error instanceof Error
+          ? error.message
+          : 'Unknown error occurred';
+    emitJsonAndExit(1, errorMessage);
   } finally {
+    restoreStdout();
     await cleanup(tempDir);
   }
 }
@@ -2213,6 +2413,8 @@ export function parseAddOptions(args: string[]): {
       }
     } else if (arg === '--full-depth') {
       options.fullDepth = true;
+    } else if (arg === '--json') {
+      options.json = true;
     } else if (arg === '--copy') {
       options.copy = true;
     } else if (arg === '--subagent') {

--- a/src/add.ts
+++ b/src/add.ts
@@ -1270,12 +1270,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     // If skillFilter is present from @skill syntax (e.g., owner/repo@skill-name),
-    // merge it into options.skill
+    // merge it into options.skill. `owner/repo@a,b` names several skills (skill
+    // names never contain commas); the blob fast path below takes a single
+    // skillFilter, so it is cleared when more than one was named and the
+    // selection happens through options.skill instead.
     if (parsed.skillFilter) {
       options.skill = options.skill || [];
-      if (!options.skill.includes(parsed.skillFilter)) {
-        options.skill.push(parsed.skillFilter);
+      const names = parsed.skillFilter.split(',').filter(Boolean);
+      for (const name of names) {
+        if (!options.skill.includes(name)) options.skill.push(name);
       }
+      if (names.length !== 1) parsed.skillFilter = undefined;
     }
 
     // Include internal skills when a specific skill is explicitly requested

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,6 +143,7 @@ ${BOLD}Add Options:${RESET}
   --subagent <names>     Install to Eve subagents (use 'root' for the root agent)
   --all                  Shorthand for --skill '*' --agent '*' -y
   --full-depth           Search all subdirectories even when a root SKILL.md exists
+  --json                 Output results as JSON (machine-readable, no ANSI codes)
 
 ${BOLD}Use Options:${RESET}
   -s, --skill <skill>    Specify the skill to use
@@ -176,6 +177,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills add vercel-labs/agent-skills -g
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --agent claude-code cursor
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --skill pr-review commit
+  ${DIM}$${RESET} skills add vercel-labs/agent-skills --json -y ${DIM}# JSON output${RESET}
   ${DIM}$${RESET} skills remove                        ${DIM}# interactive remove${RESET}
   ${DIM}$${RESET} skills remove web-design             ${DIM}# remove by name${RESET}
   ${DIM}$${RESET} skills rm --global frontend-design
@@ -352,10 +354,13 @@ async function main(): Promise<void> {
     case 'install':
     case 'a':
     case 'add': {
-      if (!inAgent) showLogo();
       const { source: addSource, options: addOpts, errors } = parseAddOptions(restArgs);
+      // JSON mode must keep stdout parseable — no logo
+      if (!inAgent && !addOpts.json) showLogo();
       if (errors.length > 0) {
         for (const error of errors) console.error(`Error: ${error}`);
+        // JSON mode promises exactly one JSON value on stdout, even here
+        if (addOpts.json) console.log('[]');
         process.exitCode = 1;
         break;
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
 import { basename, join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { runAdd, parseAddOptions, initTelemetry } from './add.ts';
+import { runAddMany } from './add-many.ts';
 import { runFind } from './find.ts';
 import { runInstallFromLock } from './install.ts';
 import { runList } from './list.ts';
@@ -107,9 +108,10 @@ function showHelp(): void {
 ${BOLD}Usage:${RESET} skills <command> [options]
 
 ${BOLD}Manage Skills:${RESET}
-  add <package>        Add a skill package (alias: a)
+  add <package>...     Add skill packages (alias: a); several install concurrently
                        e.g. vercel-labs/agent-skills
                             https://github.com/vercel-labs/agent-skills
+                            owner/repo@skill-a,skill-b   (pick skills per package)
   use <package>@<skill>
                        Generate a prompt for using one skill without installing it
   remove [skills]      Remove installed skills
@@ -178,6 +180,7 @@ ${BOLD}Examples:${RESET}
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --agent claude-code cursor
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --skill pr-review commit
   ${DIM}$${RESET} skills add vercel-labs/agent-skills --json -y ${DIM}# JSON output${RESET}
+  ${DIM}$${RESET} skills add owner/tools@lint,test other/skills@deploy -g -y ${DIM}# several packages${RESET}
   ${DIM}$${RESET} skills remove                        ${DIM}# interactive remove${RESET}
   ${DIM}$${RESET} skills remove web-design             ${DIM}# remove by name${RESET}
   ${DIM}$${RESET} skills rm --global frontend-design
@@ -362,6 +365,10 @@ async function main(): Promise<void> {
         // JSON mode promises exactly one JSON value on stdout, even here
         if (addOpts.json) console.log('[]');
         process.exitCode = 1;
+        break;
+      }
+      if (addSource.length > 1) {
+        await runAddMany(addSource, addOpts);
         break;
       }
       await runAdd(addSource, addOpts);

--- a/src/local-lock.ts
+++ b/src/local-lock.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, readdir, stat } from 'fs/promises';
+import { readFile, writeFile, readdir, stat, appendFile } from 'fs/promises';
 import { isAbsolute, join, relative, resolve, sep } from 'path';
 import { createHash } from 'crypto';
 
@@ -184,6 +184,34 @@ async function collectFiles(
 }
 
 /**
+ * Project-scope counterpart of `SKILLS_LOCK_ENTRIES_FILE` (see skill-lock.ts):
+ * children of a multi-source `add` append here; the parent writes skills-lock.json once.
+ */
+export const LOCAL_LOCK_ENTRIES_FILE_ENV = 'SKILLS_LOCAL_LOCK_ENTRIES_FILE';
+
+type PendingLocalLockEntry = { name: string; entry: LocalSkillLockEntry };
+
+/**
+ * Fold entries files written by child installs into skills-lock.json in one write.
+ * Missing or empty files are skipped. Returns the number of entries applied.
+ */
+export async function mergeLocalLockEntriesFiles(files: string[], cwd?: string): Promise<number> {
+  const pending: PendingLocalLockEntry[] = [];
+  for (const file of files) {
+    const content = await readFile(file, 'utf-8').catch(() => '');
+    for (const line of content.split('\n')) {
+      if (line.trim()) pending.push(JSON.parse(line) as PendingLocalLockEntry);
+    }
+  }
+  if (pending.length === 0) return 0;
+
+  const lock = await readLocalLock(cwd);
+  for (const { name, entry } of pending) lock.skills[name] = entry;
+  await writeLocalLock(lock, cwd);
+  return pending.length;
+}
+
+/**
  * Add or update a skill entry in the local lock file.
  */
 export async function addSkillToLocalLock(
@@ -191,6 +219,13 @@ export async function addSkillToLocalLock(
   entry: LocalSkillLockEntry,
   cwd?: string
 ): Promise<void> {
+  const entriesFile = process.env[LOCAL_LOCK_ENTRIES_FILE_ENV];
+  if (entriesFile) {
+    const pending: PendingLocalLockEntry = { name: skillName, entry };
+    await appendFile(entriesFile, JSON.stringify(pending) + '\n', 'utf-8');
+    return;
+  }
+
   const lock = await readLocalLock(cwd);
   lock.skills[skillName] = entry;
   await writeLocalLock(lock, cwd);

--- a/src/lock-entries.test.ts
+++ b/src/lock-entries.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  addSkillToLock,
+  getSkillLockPath,
+  mergeLockEntriesFiles,
+  readSkillLock,
+  writeSkillLock,
+  LOCK_ENTRIES_FILE_ENV,
+} from './skill-lock.ts';
+import {
+  addSkillToLocalLock,
+  mergeLocalLockEntriesFiles,
+  readLocalLock,
+  LOCAL_LOCK_ENTRIES_FILE_ENV,
+} from './local-lock.ts';
+
+const entry = (source: string) => ({
+  source,
+  sourceType: 'github',
+  sourceUrl: `https://github.com/${source}.git`,
+  skillFolderHash: 'abc',
+});
+
+describe('lock entries files (concurrent multi-source add)', () => {
+  let dir: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'skills-lock-entries-'));
+    for (const key of ['XDG_STATE_HOME', LOCK_ENTRIES_FILE_ENV, LOCAL_LOCK_ENTRIES_FILE_ENV]) {
+      saved[key] = process.env[key];
+    }
+    // Keep the global lock inside the temp dir.
+    process.env.XDG_STATE_HOME = join(dir, 'state');
+    delete process.env[LOCK_ENTRIES_FILE_ENV];
+    delete process.env[LOCAL_LOCK_ENTRIES_FILE_ENV];
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('addSkillToLock appends to the entries file instead of touching the lock when the env is set', async () => {
+    const entriesFile = join(dir, 'global-0.jsonl');
+    process.env[LOCK_ENTRIES_FILE_ENV] = entriesFile;
+
+    await addSkillToLock('one', entry('o/r'));
+    await addSkillToLock('two', entry('o/r'));
+
+    expect(existsSync(getSkillLockPath())).toBe(false);
+    const lines = readFileSync(entriesFile, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!)).toEqual({ name: 'one', entry: entry('o/r') });
+  });
+
+  it('mergeLockEntriesFiles folds every file into one lock write and keeps installedAt', async () => {
+    await writeSkillLock({
+      version: 3,
+      skills: {
+        one: {
+          ...entry('o/r'),
+          installedAt: '2020-01-01T00:00:00.000Z',
+          updatedAt: '2020-01-01T00:00:00.000Z',
+        },
+      },
+      dismissed: {},
+    });
+    const a = join(dir, 'a.jsonl');
+    const b = join(dir, 'b.jsonl');
+    writeFileSync(a, JSON.stringify({ name: 'one', entry: entry('o/r') }) + '\n');
+    writeFileSync(
+      b,
+      JSON.stringify({ name: 'two', entry: entry('x/y') }) +
+        '\n' +
+        JSON.stringify({ name: 'three', entry: entry('x/y') }) +
+        '\n'
+    );
+
+    const applied = await mergeLockEntriesFiles([a, b, join(dir, 'missing.jsonl')]);
+    expect(applied).toBe(3);
+
+    const lock = await readSkillLock();
+    expect(Object.keys(lock.skills).sort()).toEqual(['one', 'three', 'two']);
+    expect(lock.skills.one!.installedAt).toBe('2020-01-01T00:00:00.000Z');
+    expect(lock.skills.one!.updatedAt).not.toBe('2020-01-01T00:00:00.000Z');
+    expect(lock.skills.two!.source).toBe('x/y');
+  });
+
+  it('mergeLockEntriesFiles is a no-op when no entries exist', async () => {
+    expect(await mergeLockEntriesFiles([join(dir, 'missing.jsonl')])).toBe(0);
+    expect(existsSync(getSkillLockPath())).toBe(false);
+  });
+
+  it('project lock: entries file redirect and merge', async () => {
+    const project = join(dir, 'project');
+    const entriesFile = join(dir, 'project-0.jsonl');
+    const localEntry = {
+      source: 'o/r',
+      sourceType: 'github',
+      skillPath: 'skills/one/SKILL.md',
+      skillFolderHash: 'h',
+    };
+
+    process.env[LOCAL_LOCK_ENTRIES_FILE_ENV] = entriesFile;
+    await addSkillToLocalLock('one', localEntry as any, project);
+    expect(existsSync(join(project, 'skills-lock.json'))).toBe(false);
+    delete process.env[LOCAL_LOCK_ENTRIES_FILE_ENV];
+
+    const { mkdirSync } = await import('fs');
+    mkdirSync(project, { recursive: true });
+    expect(await mergeLocalLockEntriesFiles([entriesFile], project)).toBe(1);
+    const lock = await readLocalLock(project);
+    expect(Object.keys(lock.skills)).toEqual(['one']);
+  });
+});

--- a/src/skill-lock.ts
+++ b/src/skill-lock.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, appendFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
@@ -172,12 +172,57 @@ export async function fetchSkillFolderHash(
 }
 
 /**
+ * When set, `addSkillToLock` appends `{ name, entry }` JSON lines to this file
+ * instead of rewriting the lock. `add` with several sources runs one child
+ * process per source concurrently, and the lock's read-modify-write below is
+ * unsynchronised, so the parent hands each child its own entries file and
+ * folds them into the lock with a single write (see add-many.ts).
+ */
+export const LOCK_ENTRIES_FILE_ENV = 'SKILLS_LOCK_ENTRIES_FILE';
+
+type PendingLockEntry = { name: string; entry: Omit<SkillLockEntry, 'installedAt' | 'updatedAt'> };
+
+/**
+ * Fold entries files written by child installs into the lock file in one write.
+ * Missing or empty files are skipped. Returns the number of entries applied.
+ */
+export async function mergeLockEntriesFiles(files: string[]): Promise<number> {
+  const pending: PendingLockEntry[] = [];
+  for (const file of files) {
+    const content = await readFile(file, 'utf-8').catch(() => '');
+    for (const line of content.split('\n')) {
+      if (line.trim()) pending.push(JSON.parse(line) as PendingLockEntry);
+    }
+  }
+  if (pending.length === 0) return 0;
+
+  const lock = await readSkillLock();
+  const now = new Date().toISOString();
+  for (const { name, entry } of pending) {
+    lock.skills[name] = {
+      ...entry,
+      installedAt: lock.skills[name]?.installedAt ?? now,
+      updatedAt: now,
+    };
+  }
+  await writeSkillLock(lock);
+  return pending.length;
+}
+
+/**
  * Add or update a skill entry in the lock file.
  */
 export async function addSkillToLock(
   skillName: string,
   entry: Omit<SkillLockEntry, 'installedAt' | 'updatedAt'>
 ): Promise<void> {
+  const entriesFile = process.env[LOCK_ENTRIES_FILE_ENV];
+  if (entriesFile) {
+    const pending: PendingLockEntry = { name: skillName, entry };
+    await appendFile(entriesFile, JSON.stringify(pending) + '\n', 'utf-8');
+    return;
+  }
+
   const lock = await readSkillLock();
   const now = new Date().toISOString();
 


### PR DESCRIPTION
## Summary

`skills add` accepts several sources in one command and installs them concurrently:

```bash
npx skills add -g -a claude-code -y \
  anthropics/skills@pdf,xlsx \
  cloudflare/skills@wrangler,durable-objects \
  vercel-labs/skills@find-skills \
  vercel-labs/agent-skills@vercel-react-best-practices
```

```
+ anthropics/skills: xlsx, pdf
+ cloudflare/skills: wrangler, durable-objects
+ vercel-labs/skills: find-skills
+ vercel-labs/agent-skills: vercel-react-best-practices
Installed 6 skills from 4 of 4 sources in 1.3s
```

Motivation: environment setup scripts (CI images, agent sandboxes) install a fixed list of skills from several repos on every boot. Today that is one `skills add` per repo, run sequentially, each paying process startup and its own network round trips; and because `add` prints decorated output only, scripts end up parsing `ls --json` afterwards to report what was installed. This PR makes the setup a single command, and `--json` a single array.

## Grammar

- Every bare argument is a source. `parseAddOptions` already collected them into `source[]`; `runAdd` used only the first and silently dropped the rest. The parser is unchanged.
- Skills are picked **on the source** with the existing `owner/repo@skill` syntax, extended to comma lists: `cloudflare/skills@wrangler,durable-objects`. Skill names are kebab-case and never contain commas; refs keep using `#`, so `@` stays unambiguous. Comma lists also work with a single source.
- Tokens that resolve to the same repository at the same ref merge into one clone.
- `--skill` with several sources is rejected: it would have no clear owner (first source? last? all?), and guessing is worse than an error. The message points at the `@skill` form. Single-source `--skill` is unchanged.
- Several sources are always non-interactive (`-y` implied for the children); pass `--agent`. `--list` runs the sources one after another with the terminal attached.

## Implementation

`runAdd` owns the terminal (clack spinners, prompts, a monkey-patched stdout in json mode) and exits the process on failure, so sources cannot share it in-process. Like `update`, the parent spawns one child `add <source> --json -y` per source (bounded at 6), collects the JSON, and prints one merged array (`--json`) or one line per source plus a total. Exit code is 1 if any source failed; a failed source does not stop the others.

Concurrent children would race on the lock files' read-modify-write and drop entries, so `addSkillToLock` / `addSkillToLocalLock` append to `SKILLS_LOCK_ENTRIES_FILE` / `SKILLS_LOCAL_LOCK_ENTRIES_FILE` when set (one file per child) and the parent folds them into the lock with a single write.

The single-source install path is untouched except for the comma list where `@skill` merges into `options.skill`; when more than one name is given, the single-skill blob shortcut is skipped and selection goes through `options.skill`.

## Depends on #1686

The child protocol is `add --json`, so this PR includes @hcjmartin's #1686 rebased onto current `main` as its first commit (author preserved). The only conflicts were with #1991: the interactive cancel exits now go through `cancelInstallation()`, which keeps the non-TTY exit code 1 and emits the JSON array before exiting. If #1686 lands first, this PR shrinks to the second commit.

## Tests

- `src/add-many.test.ts`: grouping by repository/ref, `@skill,skill` parsing, child argv, and end-to-end runs through the CLI with local sources: one line per source, `--json` merge, a failed source alongside a good one, `--skill` rejection, project-scope `skills-lock.json` merge, and the non-TTY prompt case.
- `src/lock-entries.test.ts`: the entries-file redirect and merge for both lock files.
- Full suite: 837 passing (`pnpm test`), `pnpm type-check`, `pnpm format:check`, `pnpm build`.

Verified against real sources (GitHub shorthand, `@skill,skill`, a private repo through `gh`, the skills.sh blob path and the clone path) on Linux under Node and Bun.
