### PR TITLE
feat(add): support --agent none for universal-only installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ npx skills add owner/repo --skill "Convex Best Practices"
 # Install to specific agents
 npx skills add vercel-labs/agent-skills -a claude-code -a opencode
 
+# Install only to the universal .agents/skills directory (no agent-specific directories)
+npx skills add vercel-labs/agent-skills -a none
+
 # Non-interactive installation (CI/CD friendly)
 npx skills add vercel-labs/agent-skills --skill frontend-design -g -a claude-code -y
 

--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -320,6 +320,81 @@ description: Test
     expect(result.exitCode).toBe(1);
   });
 
+  it('should install only to universal agents with --agent none', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'none-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: none-skill
+description: Universal-only install test
+---
+
+# None Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = runCli(['add', sourceDir, '-y', '--agent', 'none'], projectDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('universal');
+    expect(existsSync(join(projectDir, '.agents', 'skills', 'none-skill'))).toBe(true);
+    // No agent-specific directories should be created
+    expect(existsSync(join(projectDir, '.claude'))).toBe(false);
+    expect(existsSync(join(projectDir, '.codex'))).toBe(false);
+  });
+
+  it('should reject --agent none combined with other agents', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'none-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: none-skill
+description: Universal-only install test
+---
+
+# None Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = runCli(['add', sourceDir, '-y', '--agent', 'none', 'claude-code'], projectDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('--agent none cannot be combined');
+    expect(existsSync(join(projectDir, '.agents', 'skills', 'none-skill'))).toBe(false);
+  });
+
+  it("should reject --agent none combined with the '*' wildcard", () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'none-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: none-skill
+description: Universal-only install test
+---
+
+# None Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(projectDir, { recursive: true });
+
+    const result = runCli(['add', sourceDir, '-y', '--agent', 'none', '*'], projectDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain('--agent none cannot be combined');
+    expect(existsSync(join(projectDir, '.agents', 'skills', 'none-skill'))).toBe(false);
+  });
+
   it('should support add command aliases (a, i, install)', () => {
     // Test that aliases work (just check they show missing source error)
     const resultA = runCli(['a'], testDir);

--- a/src/add.ts
+++ b/src/add.ts
@@ -362,6 +362,41 @@ function ensureUniversalAgents(targetAgents: AgentType[]): AgentType[] {
 }
 
 /**
+ * Resolves the special `--agent none` selection: install only to universal
+ * agents (.agents/skills) with no agent-specific targets.
+ *
+ * Returns the universal agents to install to, an `error` message when `none`
+ * is combined with other agent names or the '*' wildcard, or null when `none`
+ * was not requested.
+ */
+function resolveNoneAgentSelection(
+  requestedAgents: string[] | undefined,
+  options: { global?: boolean }
+): { targetAgents: AgentType[] } | { error: string } | null {
+  if (!requestedAgents?.includes('none')) {
+    return null;
+  }
+
+  const combined = requestedAgents.filter((a) => a !== 'none');
+  if (combined.length > 0) {
+    return {
+      error:
+        `--agent none cannot be combined with other agents: ${combined.join(', ')}. ` +
+        'Use --agent none by itself to install only to universal agents (.agents/skills).',
+    };
+  }
+
+  const universalTargets = getUniversalAgents().filter(
+    (a) => !options.global || agents[a].globalSkillsDir
+  );
+  if (universalTargets.length === 0) {
+    return { error: 'No universal agents support global installation.' };
+  }
+
+  return { targetAgents: universalTargets };
+}
+
+/**
  * Builds result lines from installation results, splitting by universal vs symlinked
  */
 function buildResultLines(
@@ -687,7 +722,16 @@ async function handleWellKnownSkills(
   let targetAgents: AgentType[];
   const validAgents = Object.keys(agents);
 
-  if (options.agent?.includes('*')) {
+  const noneSelection = resolveNoneAgentSelection(options.agent, options);
+
+  if (noneSelection && 'error' in noneSelection) {
+    p.log.error(noneSelection.error);
+    process.exit(1);
+  } else if (noneSelection) {
+    // --agent none installs only to universal agents
+    targetAgents = noneSelection.targetAgents;
+    p.log.info('Installing to universal agents only (.agents/skills)');
+  } else if (options.agent?.includes('*')) {
     // --agent '*' selects all agents
     targetAgents = validAgents as AgentType[];
     p.log.info(`Installing to all ${targetAgents.length} agents`);
@@ -1404,7 +1448,17 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     let targetAgents: AgentType[];
     const validAgents = Object.keys(agents);
 
-    if (options.agent?.includes('*')) {
+    const noneSelection = resolveNoneAgentSelection(options.agent, options);
+
+    if (noneSelection && 'error' in noneSelection) {
+      p.log.error(noneSelection.error);
+      await cleanup(tempDir);
+      process.exit(1);
+    } else if (noneSelection) {
+      // --agent none installs only to universal agents
+      targetAgents = noneSelection.targetAgents;
+      p.log.info('Installing to universal agents only (.agents/skills)');
+    } else if (options.agent?.includes('*')) {
       // --agent '*' selects all agents
       targetAgents = validAgents as AgentType[];
       p.log.info(`Installing to all ${targetAgents.length} agents`);


### PR DESCRIPTION
Implements #2176: `skills add -a none` installs skills only to the universal `.agents/skills` directory, with no agent-specific targets.

The same result was already possible via the undocumented `-a universal` agent name; this adds the explicit, documented `none` spelling the issue asks for, and validates that it is not combined with other agents or the `'*'` wildcard. Interactively, universal-only installation is already possible by deselecting all agents (the locked Universal section remains), so no prompt changes were needed.

## Changes

- `src/add.ts`: resolve `--agent none` to universal agents in both add flows (`handleWellKnownSkills` and `runAdd`); reject combinations with other agent names or `*`; respects `--global` by filtering to universal agents that support global installs
- `README.md`: document `-a none` in the add examples
- `src/add.test.ts`: three tests (universal-only install, rejection with another agent, rejection with `*`)

## Test plan

- `pnpm exec vitest run`: 814 tests pass across 60 files, including the 3 new tests
- `pnpm type-check` and `pnpm format:check` clean
- Manual e2e: `skills add <local> -y -a none` installs only to `./.agents/skills/`; `-g -a none` installs only to the global universal dir; `-a none claude-code` exits 1 with a clear error

Closes #2176