### PR TITLE
feat: add Kit agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [75 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [76 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -309,6 +309,7 @@ Skills can be installed to any of these agents:
 | Kilo Code | `kilo` | `.agents/skills/` | `~/.kilo/skills/` |
 | Kimchi | `kimchi` | `.kimchi/skills/` | `~/.config/kimchi/harness/skills/` |
 | Kiro CLI | `kiro-cli` | `.kiro/skills/` | `~/.kiro/skills/` |
+| Kit | `kit` | `.agents/skills/` | `~/.config/kit/skills/` |
 | Kode | `kode` | `.kode/skills/` | `~/.kode/skills/` |
 | Lingma | `lingma` | `.lingma/skills/` | `~/.lingma/skills/` |
 | MCPJam | `mcpjam` | `.mcpjam/skills/` | `~/.mcpjam/skills/` |

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "kimchi",
     "kimi-code-cli",
     "kiro-cli",
+    "kit",
     "kode",
     "lingma",
     "loaf",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -474,6 +474,23 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.kiro'));
     },
   },
+  kit: {
+    name: 'kit',
+    displayName: 'Kit',
+    // Kit reads .agents/skills and ~/.agents/skills as compatibility
+    // locations, so installing there avoids defining the same skill twice.
+    // globalSkillsDir stays on Kit's native ~/.config/kit/skills so `list`
+    // and `remove` still detect and clean up skills placed there directly.
+    skillsDir: '.agents/skills',
+    globalSkillsDir: join(configHome, 'kit/skills'),
+    detectInstalled: async () => {
+      return (
+        existsSync(join(home, '.kit')) ||
+        existsSync(join(home, '.kit.yml')) ||
+        existsSync(join(configHome, 'kit'))
+      );
+    },
+  },
   kode: {
     name: 'kode',
     displayName: 'Kode',

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type AgentType =
   | 'kimchi'
   | 'kimi-code-cli'
   | 'kiro-cli'
+  | 'kit'
   | 'kode'
   | 'lingma'
   | 'loaf'


### PR DESCRIPTION
## Summary

Adds support for installing/using skills with [Kit](https://github.com/BuildKit-run/kit), a lightweight AI coding agent CLI.

Per `kit skill --help`, Kit discovers skills from four locations:

- `<project>/.agents/skills` and `<project>/.kit/skills` (project)
- `~/.agents/skills` and `~/.config/kit/skills` (global)

Since Kit already reads the universal `.agents/skills` path, `skillsDir` is set to `.agents/skills` so it's treated as a universal agent for installs — no symlinking needed, and skills already shared across other universal agents (Cline, Dexto, Warp, Zed, etc.) are picked up automatically.

`globalSkillsDir` is set to Kit's own `~/.config/kit/skills`, not `~/.agents/skills`, so `skills list`/`skills remove` still detect and clean up skills placed there directly. This mirrors the existing pattern for Droid, whose `globalSkillsDir` stays on `~/.factory/skills` for the same reason.

`detectInstalled` checks for `~/.kit` (session data dir), `~/.kit.yml` (default config file), or `~/.config/kit` (extensions/trusted-projects config).

## Changes

- `src/types.ts` — add `'kit'` to `AgentType`
- `src/agents.ts` — register the `kit` agent config
- `README.md`, `package.json` — regenerated via `node scripts/sync-agents.ts`

## Testing

- `node scripts/validate-agents.ts` — no duplicate names/paths
- `pnpm type-check`
- `pnpm format:check`
- `pnpm test` — 811/811 passing