### PR TITLE
Reject symbolic links when copying disk-backed skills

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -476,6 +476,10 @@ async function copyDirectory(src: string, dest: string, agentType?: AgentType): 
         const srcPath = join(src, entry.name);
         const destPath = join(dest, entry.name);
 
+        if (entry.isSymbolicLink()) {
+          throw new Error(`Refusing to copy symbolic link from skill: ${srcPath}`);
+        }
+
         if (entry.isDirectory()) {
           await copyDirectory(srcPath, destPath, agentType);
         } else {
@@ -489,28 +493,12 @@ async function copyDirectory(src: string, dest: string, agentType?: AgentType): 
             }
 
             await cp(srcPath, destPath, {
-              // If the file is a symlink to elsewhere in a remote skill, it may not
-              // resolve correctly once it has been copied to the local location.
-              // `dereference: true` tells Node to copy the file instead of copying
-              // the symlink. `recursive: true` handles symlinks pointing to directories.
-              dereference: true,
               recursive: true,
             });
             const sourceStats = await stat(srcPath);
             await chmod(destPath, sourceStats.mode & 0o777);
           } catch (err: unknown) {
-            // Skip broken symlinks (e.g., pointing to absolute paths on another machine)
-            // instead of aborting the entire install.
-            if (
-              err instanceof Error &&
-              'code' in err &&
-              (err as NodeJS.ErrnoException).code === 'ENOENT' &&
-              entry.isSymbolicLink()
-            ) {
-              console.warn(`Skipping broken symlink: ${srcPath}`);
-            } else {
-              throw err;
-            }
+            throw err;
           }
         }
       })

--- a/src/use.test.ts
+++ b/src/use.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as tar from 'tar';
@@ -175,6 +175,25 @@ describe('use command', () => {
 
       expect(readFileSync(join(materialized.skillDir, 'reference.md'), 'utf-8')).toBe('Reference');
       expect(materialized.hasSupportingFiles).toBe(true);
+    });
+
+    it('rejects disk-skill symbolic links without materializing their targets', async () => {
+      const skillDir = join(testDir, 'disk-skill');
+      const sentinelDir = join(testDir, 'sentinel');
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), '# Disk skill');
+      mkdirSync(sentinelDir, { recursive: true });
+      writeFileSync(join(sentinelDir, 'sentinel.txt'), 'test sentinel only');
+      symlinkSync(sentinelDir, join(skillDir, 'linked-sentinel'), 'junction');
+
+      await expect(
+        materializeUseSkill({
+          kind: 'disk',
+          name: 'Disk Skill',
+          directoryName: 'disk-skill',
+          path: skillDir,
+        })
+      ).rejects.toThrow('Refusing to copy symbolic link from skill');
     });
   });
 

--- a/src/use.ts
+++ b/src/use.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
-import { cp, mkdir, mkdtemp, readdir, readFile, writeFile } from 'fs/promises';
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'fs/promises';
 import { dirname, join, normalize, relative, resolve, sep } from 'path';
 import { tmpdir } from 'os';
 import { agents } from './agents.ts';
@@ -161,24 +161,29 @@ export async function materializeUseSkill(skill: UseSkill): Promise<Materialized
   const tempRoot = await mkdtemp(join(tmpdir(), 'skills-use-'));
   const skillDir = join(tempRoot, sanitizeName(skill.directoryName || skill.name));
 
-  if (!isPathSafe(tempRoot, skillDir)) {
-    throw new Error('Invalid skill name: potential path traversal detected');
+  try {
+    if (!isPathSafe(tempRoot, skillDir)) {
+      throw new Error('Invalid skill name: potential path traversal detected');
+    }
+
+    await mkdir(skillDir, { recursive: true });
+
+    if (skill.kind === 'blob') {
+      await writeSnapshotFiles(skillDir, skill.files);
+    } else if (skill.kind === 'well-known') {
+      await writeMapFiles(skillDir, skill.files);
+    } else {
+      await copySkillDirectory(skill.path, skillDir);
+    }
+
+    const skillMd = skill.rawContent ?? (await readFile(join(skillDir, 'SKILL.md'), 'utf-8'));
+    const hasSupportingFiles = await containsSupportingFiles(skillDir, skillDir);
+
+    return { tempRoot, skillDir, skillMd, hasSupportingFiles };
+  } catch (error) {
+    await rm(tempRoot, { recursive: true, force: true }).catch(() => {});
+    throw error;
   }
-
-  await mkdir(skillDir, { recursive: true });
-
-  if (skill.kind === 'blob') {
-    await writeSnapshotFiles(skillDir, skill.files);
-  } else if (skill.kind === 'well-known') {
-    await writeMapFiles(skillDir, skill.files);
-  } else {
-    await copySkillDirectory(skill.path, skillDir);
-  }
-
-  const skillMd = skill.rawContent ?? (await readFile(join(skillDir, 'SKILL.md'), 'utf-8'));
-  const hasSupportingFiles = await containsSupportingFiles(skillDir, skillDir);
-
-  return { tempRoot, skillDir, skillMd, hasSupportingFiles };
 }
 
 export async function runUse(
@@ -586,25 +591,16 @@ async function copySkillDirectory(src: string, dest: string): Promise<void> {
         const destPath = join(dest, entry.name);
         if (!isPathSafe(dest, destPath)) return;
 
+        if (entry.isSymbolicLink()) {
+          throw new Error(`Refusing to copy symbolic link from skill: ${srcPath}`);
+        }
+
         if (entry.isDirectory()) {
           await copySkillDirectory(srcPath, destPath);
           return;
         }
 
-        try {
-          await cp(srcPath, destPath, { dereference: true, recursive: true });
-        } catch (err) {
-          if (
-            err instanceof Error &&
-            'code' in err &&
-            (err as NodeJS.ErrnoException).code === 'ENOENT' &&
-            entry.isSymbolicLink()
-          ) {
-            console.error(`Skipping broken symlink: ${srcPath}`);
-            return;
-          }
-          throw err;
-        }
+        await cp(srcPath, destPath, { recursive: true });
       })
   );
 }

--- a/tests/installer-copy.test.ts
+++ b/tests/installer-copy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { access, chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installSkillForAgent } from '../src/installer.ts';
@@ -70,6 +70,39 @@ describe('installer copy mode', () => {
       const sourceMode = (await stat(scriptPath)).mode & 0o777;
       const installedMode = (await stat(installedScript)).mode & 0o777;
       expect(installedMode).toBe(sourceMode);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symbolic links without copying their targets', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-copy-link-'));
+    const projectDir = join(root, 'project');
+    const sentinelDir = join(root, 'sentinel');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'copy-link-skill';
+    const skillDir = await makeSkillSource(root, skillName);
+    await mkdir(sentinelDir, { recursive: true });
+    await writeFile(join(sentinelDir, 'sentinel.txt'), 'test sentinel only', 'utf-8');
+    await symlink(sentinelDir, join(skillDir, 'linked-sentinel'), 'junction');
+
+    try {
+      const result = await installSkillForAgent(
+        { name: skillName, description: 'test', path: skillDir },
+        'codex',
+        { cwd: projectDir, mode: 'copy', global: false }
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Refusing to copy symbolic link from skill');
+
+      const installedSentinel = join(
+        projectDir,
+        '.agents/skills',
+        skillName,
+        'linked-sentinel'
+      );
+      await expect(access(installedSentinel)).rejects.toThrow();
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Reject symbolic links before copying files from disk-backed skill directories.

This prevents the installer and `skills use` materialization paths from
dereferencing a link target outside the selected skill directory.

## Changes

- Reject symbolic-link entries in the installation copy flow.
- Reject symbolic-link entries in the `skills use` materialization flow.
- Clean up the temporary use directory when materialization fails.
- Add regression tests using only temporary harmless sentinel data.

## Validation

```text
vitest: 29 tests passed


No personal files, credentials, network requests, or external transmission are
used by the regression tests.