### PR TITLE
fix(add): suggest matching agent names (#2111)

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -320,6 +320,25 @@ description: Test
     expect(result.exitCode).toBe(1);
   });
 
+  it('should suggest a matching agent name for common aliases', () => {
+    const skillDir = join(testDir, 'test-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: test-skill
+description: Test
+---
+# Test
+`
+    );
+
+    const result = runCli(['add', testDir, '-y', '--agent', 'claude'], testDir);
+    expect(result.stdout).toContain('Invalid agents: claude');
+    expect(result.stdout).toContain('Did you mean: claude-code?');
+    expect(result.exitCode).toBe(1);
+  });
+
   it('should support add command aliases (a, i, install)', () => {
     // Test that aliases work (just check they show missing source error)
     const resultA = runCli(['a'], testDir);

--- a/src/add.ts
+++ b/src/add.ts
@@ -229,6 +229,36 @@ export function formatEveInstallPromptMessage(skills: Skill[]): string {
   return `Detected an eve project. Install ${formatSkillPromptSubject(skills)} for your ${EVE_AGENT_LABEL} to use?`;
 }
 
+function getAgentSuggestions(invalidAgents: string[], validAgents: string[]): string[] {
+  const suggestions = new Set<string>();
+
+  for (const invalidAgent of invalidAgents) {
+    const normalizedInvalid = invalidAgent.toLowerCase();
+    if (normalizedInvalid.length < 3) continue;
+    for (const validAgent of validAgents) {
+      const normalizedValid = validAgent.toLowerCase();
+      if (
+        normalizedValid.startsWith(normalizedInvalid) ||
+        normalizedInvalid.startsWith(normalizedValid) ||
+        normalizedValid.includes(normalizedInvalid)
+      ) {
+        suggestions.add(validAgent);
+      }
+    }
+  }
+
+  return [...suggestions];
+}
+
+function logInvalidAgents(invalidAgents: string[], validAgents: string[]): void {
+  p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
+  const suggestions = getAgentSuggestions(invalidAgents, validAgents);
+  if (suggestions.length > 0) {
+    p.log.info(`Did you mean: ${suggestions.join(', ')}?`);
+  }
+  p.log.info(`Valid agents: ${validAgents.join(', ')}`);
+}
+
 /**
  * Splits agents into universal and non-universal (symlinked) groups.
  * Returns display names for each group.
@@ -695,8 +725,7 @@ async function handleWellKnownSkills(
     const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
 
     if (invalidAgents.length > 0) {
-      p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
-      p.log.info(`Valid agents: ${validAgents.join(', ')}`);
+      logInvalidAgents(invalidAgents, validAgents);
       process.exit(1);
     }
 
@@ -1412,8 +1441,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       const invalidAgents = options.agent.filter((a) => !validAgents.includes(a));
 
       if (invalidAgents.length > 0) {
-        p.log.error(`Invalid agents: ${invalidAgents.join(', ')}`);
-        p.log.info(`Valid agents: ${validAgents.join(', ')}`);
+        logInvalidAgents(invalidAgents, validAgents);
         await cleanup(tempDir);
         process.exit(1);
       }


### PR DESCRIPTION
## Summary

Fixes #2111 by suggesting close matches when an invalid agent name is supplied to `add`.

The suggestion helper uses case-insensitive prefix and substring matching and only suggests inputs with at least three characters. It is used by both agent-validation paths, including the `--all` path.

## Validation

- `pnpm test src/add.test.ts --run`
- `pnpm type-check`
- targeted Prettier check for the changed files
- `git diff --check`

The full test suite has five pre-existing Windows symlink-permission failures (`EPERM`) in `tests/list-installed.test.ts` and `tests/installer-symlink.test.ts`; the focused tests and type check pass.
