### PR TITLE
Enable blob fast path for Remotion Skills

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1197,7 +1197,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Try the blob-based fast install for GitHub sources; skip for --full-depth.
       // Eligible per repo (a BLOB_ALLOWED_REPOS entry = self-hosted download URL) or
       // per owner (BLOB_ALLOWED_OWNERS = all their repos, skills.sh-hosted).
-      const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com'];
+      const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com', 'remotion-dev'];
       const ownerRepo = getOwnerRepo(parsed);
       const owner = ownerRepo?.split('/')[0]?.toLowerCase();
       const isSelfHostedRepo =

--- a/src/use.ts
+++ b/src/use.ts
@@ -77,7 +77,7 @@ interface UseAgentConfig {
   args: string[];
 }
 
-const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com'];
+const BLOB_ALLOWED_OWNERS = ['vercel', 'vercel-labs', 'heygen-com', 'remotion-dev'];
 const EXCLUDE_FILES = new Set(['metadata.json']);
 const EXCLUDE_DIRS = new Set(['.git', '__pycache__', '__pypackages__']);
 const USE_AGENT_CONFIGS: Partial<Record<AgentType, UseAgentConfig>> = {


### PR DESCRIPTION
As one of the more popular Skills, I would like to ask for the trust to be whitelisted for the blob download path.
We are adding a UI in our Studio to (un)install skills and manage them, and currently, there is quite some slowness in it.