### PR TITLE
feat: install a single skill from a Notion page URL

### DIFF
--- a/src/add.ts
+++ b/src/add.ts
@@ -1124,7 +1124,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   try {
     let effectiveSource = source;
     let notionPackCount: number | null = null;
-    const notionSkillPageId = isNotionSource(source) ? null : parseNotionSkillUrl(source);
+    const notionSkill = isNotionSource(source) ? null : parseNotionSkillUrl(source);
     if (isNotionSource(source)) {
       const prepared = await prepareNotionPackSource(options);
       if (!prepared) return;
@@ -1135,8 +1135,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Pack selection replaces the ordinary per-skill selector. Every skill
       // inside the selected packs continues through the normal install flow.
       options.skill = ['*'];
-    } else if (notionSkillPageId) {
-      const prepared = await prepareNotionSkillSource(notionSkillPageId);
+    } else if (notionSkill) {
+      const prepared = await prepareNotionSkillSource(notionSkill.id);
 
       effectiveSource = prepared.rootDir;
       tempDir = prepared.tempDir;
@@ -1149,12 +1149,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     spinner.start('Parsing source…');
     const parsed = parseSource(effectiveSource);
     let directDownload =
-      parsed.type === 'download' || notionPackCount !== null || notionSkillPageId !== null;
+      parsed.type === 'download' || notionPackCount !== null || notionSkill !== null;
     spinner.stop(
       notionPackCount !== null
         ? `Source: ${notionPackCount} selected Notion pack${notionPackCount === 1 ? '' : 's'}`
-        : notionSkillPageId
-          ? `Source: Notion skill ${pc.cyan(notionSkillPageId)}`
+        : notionSkill
+          ? `Source: Notion page ${pc.cyan(notionSkill.title ?? notionSkill.id)}`
           : `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -576,11 +576,6 @@ function isSkillsShPackUrl(url: string): boolean {
   }
 }
 
-/**
- * Announce skills that were selected without a prompt. Naming the single skill
- * reads better than counting it — and a count of one ("Installing all 1
- * skills") is just wrong.
- */
 function logAutoSelectedSkills(entries: Array<{ label: string; description?: string }>): void {
   const only = entries.length === 1 ? entries[0]! : null;
   if (!only) {

--- a/src/add.ts
+++ b/src/add.ts
@@ -58,7 +58,12 @@ import {
   type BlobInstallResult,
 } from './blob.ts';
 import packageJson from '../package.json' with { type: 'json' };
-import { isNotionSource, prepareNotionPackSource } from './notion-test.ts';
+import {
+  isNotionSource,
+  parseNotionSkillUrl,
+  prepareNotionPackSource,
+  prepareNotionSkillSource,
+} from './notion-test.ts';
 
 // Helper to check if a value is a cancel symbol (works with both clack and our custom prompts)
 const isCancelled = (value: unknown): value is symbol => typeof value === 'symbol';
@@ -1104,6 +1109,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   try {
     let effectiveSource = source;
     let notionPackCount: number | null = null;
+    const notionSkillPageId = isNotionSource(source) ? null : parseNotionSkillUrl(source);
     if (isNotionSource(source)) {
       const prepared = await prepareNotionPackSource(options);
       if (!prepared) return;
@@ -1114,17 +1120,27 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Pack selection replaces the ordinary per-skill selector. Every skill
       // inside the selected packs continues through the normal install flow.
       options.skill = ['*'];
+    } else if (notionSkillPageId) {
+      const prepared = await prepareNotionSkillSource(notionSkillPageId);
+
+      effectiveSource = prepared.rootDir;
+      tempDir = prepared.tempDir;
+      // The page URL already named the skill, so skip the per-skill selector.
+      options.skill = ['*'];
     }
 
     const spinner = p.spinner();
 
     spinner.start('Parsing source…');
     const parsed = parseSource(effectiveSource);
-    let directDownload = parsed.type === 'download' || notionPackCount !== null;
+    let directDownload =
+      parsed.type === 'download' || notionPackCount !== null || notionSkillPageId !== null;
     spinner.stop(
       notionPackCount !== null
         ? `Source: ${notionPackCount} selected Notion pack${notionPackCount === 1 ? '' : 's'}`
-        : `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
+        : notionSkillPageId
+          ? `Source: Notion skill ${pc.cyan(notionSkillPageId)}`
+          : `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
 
     // Kick off the repo privacy check early so it runs in parallel with

--- a/src/add.ts
+++ b/src/add.ts
@@ -1124,7 +1124,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
   try {
     let effectiveSource = source;
     let notionPackCount: number | null = null;
-    const notionSkill = isNotionSource(source) ? null : parseNotionSkillUrl(source);
+    const notionSkillPageId = isNotionSource(source) ? null : parseNotionSkillUrl(source);
     if (isNotionSource(source)) {
       const prepared = await prepareNotionPackSource(options);
       if (!prepared) return;
@@ -1135,8 +1135,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       // Pack selection replaces the ordinary per-skill selector. Every skill
       // inside the selected packs continues through the normal install flow.
       options.skill = ['*'];
-    } else if (notionSkill) {
-      const prepared = await prepareNotionSkillSource(notionSkill.id);
+    } else if (notionSkillPageId) {
+      const prepared = await prepareNotionSkillSource(notionSkillPageId);
 
       effectiveSource = prepared.rootDir;
       tempDir = prepared.tempDir;
@@ -1149,12 +1149,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     spinner.start('Parsing source…');
     const parsed = parseSource(effectiveSource);
     let directDownload =
-      parsed.type === 'download' || notionPackCount !== null || notionSkill !== null;
+      parsed.type === 'download' || notionPackCount !== null || notionSkillPageId !== null;
     spinner.stop(
       notionPackCount !== null
         ? `Source: ${notionPackCount} selected Notion pack${notionPackCount === 1 ? '' : 's'}`
-        : notionSkill
-          ? `Source: Notion page ${pc.cyan(notionSkill.title ?? notionSkill.id)}`
+        : notionSkillPageId
+          ? 'Source: Notion page'
           : `Source: ${parsed.type === 'local' ? parsed.localPath! : parsed.url}${parsed.ref ? ` @ ${pc.yellow(parsed.ref)}` : ''}${parsed.subpath ? ` (${parsed.subpath})` : ''}${parsed.skillFilter ? ` ${pc.dim('@')}${pc.cyan(parsed.skillFilter)}` : ''}`
     );
 

--- a/src/add.ts
+++ b/src/add.ts
@@ -576,6 +576,21 @@ function isSkillsShPackUrl(url: string): boolean {
   }
 }
 
+/**
+ * Announce skills that were selected without a prompt. Naming the single skill
+ * reads better than counting it — and a count of one ("Installing all 1
+ * skills") is just wrong.
+ */
+function logAutoSelectedSkills(entries: Array<{ label: string; description?: string }>): void {
+  const only = entries.length === 1 ? entries[0]! : null;
+  if (!only) {
+    p.log.info(`Installing all ${entries.length} skills`);
+    return;
+  }
+  p.log.info(`Skill: ${pc.cyan(only.label)}`);
+  if (only.description) p.log.message(pc.dim(only.description));
+}
+
 async function handleWellKnownSkills(
   source: string,
   url: string,
@@ -620,11 +635,15 @@ async function handleWellKnownSkills(
 
   // Filter skills if --skill option is provided
   let selectedSkills: WellKnownSkill[];
+  const logWellKnown = (chosen: WellKnownSkill[]): void =>
+    logAutoSelectedSkills(
+      chosen.map((s) => ({ label: s.installName, description: s.description }))
+    );
 
   if (options.skill?.includes('*')) {
     // --skill '*' selects all skills
     selectedSkills = skills;
-    p.log.info(`Installing all ${skills.length} skills`);
+    logWellKnown(selectedSkills);
   } else if (options.skill && options.skill.length > 0) {
     selectedSkills = skills.filter((s) =>
       options.skill!.some(
@@ -642,13 +661,9 @@ async function handleWellKnownSkills(
       }
       process.exit(1);
     }
-  } else if (skills.length === 1) {
+  } else if (skills.length === 1 || options.yes) {
     selectedSkills = skills;
-    const firstSkill = skills[0]!;
-    p.log.info(`Skill: ${pc.cyan(firstSkill.installName)}`);
-  } else if (options.yes) {
-    selectedSkills = skills;
-    p.log.info(`Installing all ${skills.length} skills`);
+    logWellKnown(selectedSkills);
   } else {
     // Prompt user to select skills
     const skillChoices = skills.map((s) => ({
@@ -1323,11 +1338,15 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     }
 
     let selectedSkills: Skill[];
+    const logChosen = (chosen: Skill[]): void =>
+      logAutoSelectedSkills(
+        chosen.map((s) => ({ label: getSkillDisplayName(s), description: s.description }))
+      );
 
     if (options.skill?.includes('*')) {
       // --skill '*' selects all skills
       selectedSkills = skills;
-      p.log.info(`Installing all ${skills.length} skills`);
+      logChosen(selectedSkills);
     } else if (options.skill && options.skill.length > 0) {
       selectedSkills = filterSkills(skills, options.skill);
 
@@ -1344,14 +1363,9 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       p.log.info(
         `Selected ${selectedSkills.length} skill${selectedSkills.length !== 1 ? 's' : ''}: ${selectedSkills.map((s) => pc.cyan(getSkillDisplayName(s))).join(', ')}`
       );
-    } else if (skills.length === 1) {
+    } else if (skills.length === 1 || options.yes) {
       selectedSkills = skills;
-      const firstSkill = skills[0]!;
-      p.log.info(`Skill: ${pc.cyan(getSkillDisplayName(firstSkill))}`);
-      p.log.message(pc.dim(firstSkill.description));
-    } else if (options.yes) {
-      selectedSkills = skills;
-      p.log.info(`Installing all ${skills.length} skills`);
+      logChosen(selectedSkills);
     } else {
       // Sort skills by plugin name first, then by skill name
       const sortedSkills = [...skills].sort((a, b) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,6 +110,7 @@ ${BOLD}Manage Skills:${RESET}
   add <package>        Add a skill package (alias: a)
                        e.g. vercel-labs/agent-skills
                             notion
+                            https://notion.so/<skill-page>
                             https://github.com/vercel-labs/agent-skills
   use <package>@<skill>
                        Generate a prompt for using one skill without installing it

--- a/src/notion-test.test.ts
+++ b/src/notion-test.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchNotionPackDirectory,
   fetchNotionPacks,
+  fetchNotionWorkspaceName,
   isNotionSource,
   parseNotionSkillUrl,
   prepareNotionPackSource,
@@ -33,6 +34,10 @@ function listResponse(
     has_more: options.hasMore ?? false,
     type: 'plugin',
   });
+}
+
+function meResponse(workspaceName: unknown): string {
+  return JSON.stringify({ object: 'user', type: 'bot', bot: { workspace_name: workspaceName } });
 }
 
 describe('Notion pack prototype', () => {
@@ -155,6 +160,7 @@ describe('Notion pack prototype', () => {
     );
 
     const runNtn = vi.fn<NtnRunner>(async (args) => {
+      if (args[1] === '/v1/users/me') return meResponse('Acme HQ');
       if (args[1] === '/v1/ai/plugins') return listResponse([pack]);
       return JSON.stringify({
         id: pack.id,
@@ -180,7 +186,8 @@ describe('Notion pack prototype', () => {
       stagedSkills.map((skill) => ({ name: skill.name, pluginName: skill.pluginName }))
     ).toEqual([{ name: 'write-update', pluginName: 'Company-wide' }]);
     expect(prepared).toMatchObject({ packCount: 1, skillCount: 1 });
-    expect(runNtn).toHaveBeenCalledTimes(2);
+    // list + workspace probe (in parallel), then the per-pack directory lookup
+    expect(runNtn).toHaveBeenCalledTimes(3);
   });
 
   it('rejects invalid repeated pagination cursors', async () => {
@@ -258,12 +265,14 @@ describe('Notion single skill', () => {
       '---\nname: capture-meeting-decisions\ndescription: Capture decisions from meeting notes\n---\n'
     );
 
-    const runNtn = vi.fn<NtnRunner>(async () =>
-      JSON.stringify({
-        id: pageId,
-        version_id: 'c'.repeat(64),
-        url: 'https://downloads.example/capture-meeting-decisions.tgz',
-      })
+    const runNtn = vi.fn<NtnRunner>(async (args) =>
+      args[1] === '/v1/users/me'
+        ? meResponse('Acme HQ')
+        : JSON.stringify({
+            id: pageId,
+            version_id: 'c'.repeat(64),
+            url: 'https://downloads.example/capture-meeting-decisions.tgz',
+          })
     );
     const download = vi.fn(async () => ({
       rootDir: downloadRoot,
@@ -295,5 +304,57 @@ describe('Notion single skill', () => {
     ).rejects.toThrow(
       'ntn returned invalid JSON for Notion skill c169bd0a-546a-45d4-8344-ffacad25d763'
     );
+  });
+});
+
+describe('Notion workspace reporting', () => {
+  it('reads the workspace name from the authenticated ntn session', async () => {
+    const runNtn = vi.fn<NtnRunner>(async () => meResponse('Notion Developers'));
+
+    await expect(fetchNotionWorkspaceName({ runNtn })).resolves.toBe('Notion Developers');
+    expect(runNtn).toHaveBeenCalledWith(['api', '/v1/users/me', '--notion-version', '2026-03-11']);
+  });
+
+  it.each([
+    ['invalid JSON', async () => 'not json'],
+    ['a missing bot field', async () => JSON.stringify({ object: 'user' })],
+    ['a non-string workspace name', async () => meResponse(42)],
+    [
+      'an ntn failure',
+      async () => {
+        throw new Error('ntn api failed');
+      },
+    ],
+  ])('returns null rather than throwing on %s', async (_label, impl) => {
+    await expect(fetchNotionWorkspaceName({ runNtn: vi.fn<NtnRunner>(impl) })).resolves.toBeNull();
+  });
+
+  it('still installs a skill when the workspace lookup fails', async () => {
+    const pageId = 'c169bd0a-546a-45d4-8344-ffacad25d763';
+    const downloadTemp = mkdtempSync(join(tmpdir(), 'notion-skill-noworkspace-'));
+    cleanupDirs.push(downloadTemp);
+    const downloadRoot = join(downloadTemp, 'capture-meeting-decisions');
+    mkdirSync(downloadRoot, { recursive: true });
+    writeFileSync(join(downloadRoot, 'SKILL.md'), '---\nname: x\ndescription: y\n---\n');
+
+    const runNtn = vi.fn<NtnRunner>(async (args) => {
+      if (args[1] === '/v1/users/me') throw new Error('workspace probe exploded');
+      return JSON.stringify({
+        id: pageId,
+        version_id: 'c'.repeat(64),
+        url: 'https://downloads.example/x.tgz',
+      });
+    });
+
+    await expect(
+      prepareNotionSkillSource(pageId, {
+        runNtn,
+        download: vi.fn(async () => ({
+          rootDir: downloadRoot,
+          tempDir: downloadTemp,
+          kind: 'archive' as const,
+        })),
+      })
+    ).resolves.toEqual({ rootDir: downloadRoot, tempDir: downloadTemp });
   });
 });

--- a/src/notion-test.test.ts
+++ b/src/notion-test.test.ts
@@ -240,22 +240,7 @@ describe('Notion single skill', () => {
       'c169bd0a-546a-45d4-8344-ffacad25d763',
     ],
   ])('extracts the page ID from %s', (source, expected) => {
-    expect(parseNotionSkillUrl(source)?.id).toBe(expected);
-  });
-
-  it.each([
-    [
-      'https://app.notion.com/p/notiondevs/Capture-meeting-decisions-c169bd0a546a45d48344ffacad25d763?source=copy_link',
-      'Capture meeting decisions',
-    ],
-    [
-      'https://www.notion.so/Q3_planning_notes-c169bd0a546a45d48344ffacad25d763',
-      'Q3 planning notes',
-    ],
-    // A bare ID carries no slug, so there is no title to show.
-    ['https://notion.so/acme/c169bd0a-546a-45d4-8344-ffacad25d763', null],
-  ])('recovers the page title from %s', (source, expected) => {
-    expect(parseNotionSkillUrl(source)?.title).toBe(expected);
+    expect(parseNotionSkillUrl(source)).toBe(expected);
   });
 
   it.each([

--- a/src/notion-test.test.ts
+++ b/src/notion-test.test.ts
@@ -240,7 +240,22 @@ describe('Notion single skill', () => {
       'c169bd0a-546a-45d4-8344-ffacad25d763',
     ],
   ])('extracts the page ID from %s', (source, expected) => {
-    expect(parseNotionSkillUrl(source)).toBe(expected);
+    expect(parseNotionSkillUrl(source)?.id).toBe(expected);
+  });
+
+  it.each([
+    [
+      'https://app.notion.com/p/notiondevs/Capture-meeting-decisions-c169bd0a546a45d48344ffacad25d763?source=copy_link',
+      'Capture meeting decisions',
+    ],
+    [
+      'https://www.notion.so/Q3_planning_notes-c169bd0a546a45d48344ffacad25d763',
+      'Q3 planning notes',
+    ],
+    // A bare ID carries no slug, so there is no title to show.
+    ['https://notion.so/acme/c169bd0a-546a-45d4-8344-ffacad25d763', null],
+  ])('recovers the page title from %s', (source, expected) => {
+    expect(parseNotionSkillUrl(source)?.title).toBe(expected);
   });
 
   it.each([

--- a/src/notion-test.test.ts
+++ b/src/notion-test.test.ts
@@ -6,7 +6,9 @@ import {
   fetchNotionPackDirectory,
   fetchNotionPacks,
   isNotionSource,
+  parseNotionSkillUrl,
   prepareNotionPackSource,
+  prepareNotionSkillSource,
   type NotionPack,
   type NtnRunner,
 } from './notion-test.ts';
@@ -213,5 +215,85 @@ describe('Notion pack prototype', () => {
     'owner/notion',
   ])('does not treat %s as a Notion source', (source) => {
     expect(isNotionSource(source)).toBe(false);
+  });
+});
+
+describe('Notion single skill', () => {
+  it.each([
+    [
+      'https://app.notion.com/p/notiondevs/Capture-meeting-decisions-c169bd0a546a45d48344ffacad25d763?source=copy_link',
+      'c169bd0a-546a-45d4-8344-ffacad25d763',
+    ],
+    [
+      'https://www.notion.so/Capture-meeting-decisions-c169bd0a546a45d48344ffacad25d763',
+      'c169bd0a-546a-45d4-8344-ffacad25d763',
+    ],
+    [
+      'https://notion.so/acme/c169bd0a-546a-45d4-8344-ffacad25d763',
+      'c169bd0a-546a-45d4-8344-ffacad25d763',
+    ],
+  ])('extracts the page ID from %s', (source, expected) => {
+    expect(parseNotionSkillUrl(source)).toBe(expected);
+  });
+
+  it.each([
+    'notion',
+    'vercel-labs/agent-skills',
+    'https://github.com/vercel-labs/agent-skills',
+    'https://notion.so/acme',
+    'https://notion.example.com/p/c169bd0a546a45d48344ffacad25d763',
+    './local-skill',
+  ])('does not treat %s as a Notion skill URL', (source) => {
+    expect(parseNotionSkillUrl(source)).toBeNull();
+  });
+
+  it('downloads the skill directory for a page ID as a local install source', async () => {
+    const pageId = 'c169bd0a-546a-45d4-8344-ffacad25d763';
+    const downloadTemp = mkdtempSync(join(tmpdir(), 'notion-skill-download-test-'));
+    cleanupDirs.push(downloadTemp);
+    const downloadRoot = join(downloadTemp, 'capture-meeting-decisions');
+    mkdirSync(downloadRoot, { recursive: true });
+    writeFileSync(
+      join(downloadRoot, 'SKILL.md'),
+      '---\nname: capture-meeting-decisions\ndescription: Capture decisions from meeting notes\n---\n'
+    );
+
+    const runNtn = vi.fn<NtnRunner>(async () =>
+      JSON.stringify({
+        id: pageId,
+        version_id: 'c'.repeat(64),
+        url: 'https://downloads.example/capture-meeting-decisions.tgz',
+      })
+    );
+    const download = vi.fn(async () => ({
+      rootDir: downloadRoot,
+      tempDir: downloadTemp,
+      kind: 'archive' as const,
+    }));
+
+    const prepared = await prepareNotionSkillSource(pageId, { runNtn, download });
+
+    expect(prepared).toEqual({ rootDir: downloadRoot, tempDir: downloadTemp });
+    expect(runNtn).toHaveBeenCalledWith([
+      'api',
+      `/v1/ai/skills/${pageId}`,
+      '--notion-version',
+      '2026-03-11',
+    ]);
+    expect(download).toHaveBeenCalledWith(
+      'https://downloads.example/capture-meeting-decisions.tgz'
+    );
+    const skills = await discoverSkills(prepared.rootDir);
+    expect(skills.map((skill) => skill.name)).toEqual(['capture-meeting-decisions']);
+  });
+
+  it('reports invalid JSON returned by ntn for a skill', async () => {
+    const runNtn = vi.fn<NtnRunner>(async () => 'not json');
+
+    await expect(
+      prepareNotionSkillSource('c169bd0a-546a-45d4-8344-ffacad25d763', { runNtn })
+    ).rejects.toThrow(
+      'ntn returned invalid JSON for Notion skill c169bd0a-546a-45d4-8344-ffacad25d763'
+    );
   });
 });

--- a/src/notion-test.ts
+++ b/src/notion-test.ts
@@ -311,23 +311,13 @@ function formatPageId(rawId: string): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-export interface NotionSkillRef {
-  id: string;
-  /** Page title recovered from the URL slug, for display. Null when the URL
-   *  carries only a bare ID. Approximate by nature — the slug has already lost
-   *  the original punctuation and casing of words after the first. */
-  title: string | null;
-}
-
 /**
- * Recognize a Notion page URL and pull out the page ID plus, when the URL
- * carries one, the human-readable slug:
- * https://app.notion.com/p/team/Capture-meeting-decisions-c169bd0a…
- *   -> { id: 'c169bd0a-…', title: 'Capture meeting decisions' }
+ * Recognize a Notion page URL and return its page ID, e.g.
+ * https://app.notion.com/p/team/Capture-meeting-decisions-c169bd0a…  ->  c169bd0a-…
  * Returns null for anything that is not a Notion page URL so the caller can
  * fall through to the ordinary git/download source handling.
  */
-export function parseNotionSkillUrl(source: string): NotionSkillRef | null {
+export function parseNotionSkillUrl(source: string): string | null {
   let url: URL;
   try {
     url = new URL(source);
@@ -349,11 +339,7 @@ export function parseNotionSkillUrl(source: string): NotionSkillRef | null {
   }
 
   const match = decoded.toLowerCase().match(NOTION_PAGE_ID);
-  if (!match) return null;
-
-  const slug = decoded.slice(0, decoded.length - match[0]!.length);
-  const title = sanitizeMetadata(slug.replace(/[-_]+/g, ' ').trim());
-  return { id: formatPageId(match[1]!), title: title || null };
+  return match ? formatPageId(match[1]!) : null;
 }
 
 export async function fetchNotionSkillDirectory(

--- a/src/notion-test.ts
+++ b/src/notion-test.ts
@@ -31,7 +31,7 @@ interface NotionPackListResponse {
   has_more: boolean;
 }
 
-interface NotionPackDirectory {
+interface NotionDirectory {
   id: string;
   version_id: string;
   url: string;
@@ -42,6 +42,11 @@ export interface PreparedNotionPackSource {
   tempDir: string;
   packCount: number;
   skillCount: number;
+}
+
+export interface PreparedNotionSkillSource {
+  rootDir: string;
+  tempDir: string;
 }
 
 export interface NotionPackSelectorOptions {
@@ -60,6 +65,11 @@ interface PrepareNotionPackSourceOptions extends NotionPackSelectorOptions {
   runNtn?: NtnRunner;
   download?: (url: string) => Promise<DownloadedSource>;
   discover?: typeof discoverSkills;
+}
+
+interface PrepareNotionSkillSourceOptions {
+  runNtn?: NtnRunner;
+  download?: (url: string) => Promise<DownloadedSource>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -114,16 +124,24 @@ function parsePackList(value: unknown): NotionPackListResponse {
   };
 }
 
-function parsePackDirectory(value: unknown): NotionPackDirectory {
+function parseDirectory(value: unknown, label: string): NotionDirectory {
   if (!isRecord(value)) {
-    throw new Error('Notion Agent Plugins directory response is invalid');
+    throw new Error(`Notion ${label} directory response is invalid`);
   }
 
   return {
-    id: assertString(value.id, 'pack directory id'),
-    version_id: assertString(value.version_id, 'pack directory version_id'),
-    url: assertString(value.url, 'pack directory url'),
+    id: assertString(value.id, `${label} directory id`),
+    version_id: assertString(value.version_id, `${label} directory version_id`),
+    url: assertString(value.url, `${label} directory url`),
   };
+}
+
+function downloadNotionDirectory(url: string): Promise<DownloadedSource> {
+  return downloadSource(url, {
+    downloadMaxBytes: NOTION_DOWNLOAD_MAX_BYTES,
+    extractMaxBytes: NOTION_EXTRACT_MAX_BYTES,
+    extractMaxFiles: NOTION_EXTRACT_MAX_FILES,
+  });
 }
 
 function debugNtn(args: string[]): void {
@@ -227,7 +245,7 @@ export async function fetchNotionPacks(
 export async function fetchNotionPackDirectory(
   pack: NotionPack,
   options: FetchNotionPacksOptions = {}
-): Promise<NotionPackDirectory> {
+): Promise<NotionDirectory> {
   const runNtn = options.runNtn ?? runNtnApi;
   const path = `/v1/ai/plugins/${encodeURIComponent(pack.id)}`;
   const args = ['api', path, '--notion-version', NOTION_API_VERSION];
@@ -242,7 +260,7 @@ export async function fetchNotionPackDirectory(
     throw error;
   }
 
-  const directory = parsePackDirectory(value);
+  const directory = parseDirectory(value, 'pack');
   if (directory.id !== pack.id || directory.version_id !== pack.version_id) {
     throw new Error(
       `Notion pack ${JSON.stringify(pack.name)} changed while preparing installation`
@@ -253,6 +271,91 @@ export async function fetchNotionPackDirectory(
 
 export function isNotionSource(source: string): boolean {
   return source.toLowerCase() === 'notion';
+}
+
+const NOTION_HOSTNAME = /(^|\.)notion\.(so|com)$/;
+const NOTION_PAGE_ID =
+  /(?:^|-)([0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/;
+
+function formatPageId(rawId: string): string {
+  const hex = rawId.replace(/-/g, '');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/**
+ * Recognize a Notion page URL and return its page ID, e.g.
+ * https://app.notion.com/p/team/Capture-meeting-decisions-c169bd0a…  ->  c169bd0a-…
+ * Returns null for anything that is not a Notion page URL so the caller can
+ * fall through to the ordinary git/download source handling.
+ */
+export function parseNotionSkillUrl(source: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+  if (!NOTION_HOSTNAME.test(url.hostname.toLowerCase())) return null;
+
+  const lastSegment = url.pathname.split('/').filter(Boolean).pop();
+  if (!lastSegment) return null;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(lastSegment);
+  } catch {
+    decoded = lastSegment;
+  }
+
+  const match = decoded.toLowerCase().match(NOTION_PAGE_ID);
+  return match ? formatPageId(match[1]!) : null;
+}
+
+export async function fetchNotionSkillDirectory(
+  pageId: string,
+  options: FetchNotionPacksOptions = {}
+): Promise<NotionDirectory> {
+  const runNtn = options.runNtn ?? runNtnApi;
+  const path = `/v1/ai/skills/${encodeURIComponent(pageId)}`;
+  const args = ['api', path, '--notion-version', NOTION_API_VERSION];
+
+  let value: unknown;
+  try {
+    value = JSON.parse(await runNtn(args)) as unknown;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`ntn returned invalid JSON for Notion skill ${pageId}`);
+    }
+    throw error;
+  }
+
+  return parseDirectory(value, 'skill');
+}
+
+/**
+ * Download a single Notion skill directory. The archive holds one top-level
+ * directory with SKILL.md, so the extracted root is handed to the normal
+ * install flow as a local source.
+ */
+export async function prepareNotionSkillSource(
+  pageId: string,
+  options: PrepareNotionSkillSourceOptions = {}
+): Promise<PreparedNotionSkillSource> {
+  const download = options.download ?? downloadNotionDirectory;
+  const spinner = p.spinner();
+  spinner.start('Fetching Notion skill with ntn…');
+
+  try {
+    const directory = await fetchNotionSkillDirectory(pageId, { runNtn: options.runNtn });
+    const downloaded = await download(directory.url);
+    spinner.stop(`Downloaded Notion skill ${pc.dim(pageId)}`);
+    return { rootDir: downloaded.rootDir, tempDir: downloaded.tempDir };
+  } catch (error) {
+    spinner.stop(pc.red('Failed to prepare Notion skill'));
+    throw error;
+  }
 }
 
 function normalizeSelector(value: string): string {
@@ -346,14 +449,7 @@ export async function prepareNotionPackSource(
   const stagingDir = await mkdtemp(join(tmpdir(), 'skills-notion-'));
   const packsDir = join(stagingDir, 'packs');
   const manifestPlugins: Array<{ name: string; source: string; skills: string[] }> = [];
-  const download =
-    options.download ??
-    ((url: string) =>
-      downloadSource(url, {
-        downloadMaxBytes: NOTION_DOWNLOAD_MAX_BYTES,
-        extractMaxBytes: NOTION_EXTRACT_MAX_BYTES,
-        extractMaxFiles: NOTION_EXTRACT_MAX_FILES,
-      }));
+  const download = options.download ?? downloadNotionDirectory;
   const discover = options.discover ?? discoverSkills;
   let skillCount = 0;
 

--- a/src/notion-test.ts
+++ b/src/notion-test.ts
@@ -295,7 +295,7 @@ export async function fetchNotionWorkspaceName(
 }
 
 function inWorkspace(workspace: string | null): string {
-  return workspace ? ` in ${pc.cyan(workspace)}` : '';
+  return workspace ? ` workspace ${pc.cyan(workspace)}` : '';
 }
 
 export function isNotionSource(source: string): boolean {
@@ -311,13 +311,23 @@ function formatPageId(rawId: string): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
+export interface NotionSkillRef {
+  id: string;
+  /** Page title recovered from the URL slug, for display. Null when the URL
+   *  carries only a bare ID. Approximate by nature — the slug has already lost
+   *  the original punctuation and casing of words after the first. */
+  title: string | null;
+}
+
 /**
- * Recognize a Notion page URL and return its page ID, e.g.
- * https://app.notion.com/p/team/Capture-meeting-decisions-c169bd0a…  ->  c169bd0a-…
+ * Recognize a Notion page URL and pull out the page ID plus, when the URL
+ * carries one, the human-readable slug:
+ * https://app.notion.com/p/team/Capture-meeting-decisions-c169bd0a…
+ *   -> { id: 'c169bd0a-…', title: 'Capture meeting decisions' }
  * Returns null for anything that is not a Notion page URL so the caller can
  * fall through to the ordinary git/download source handling.
  */
-export function parseNotionSkillUrl(source: string): string | null {
+export function parseNotionSkillUrl(source: string): NotionSkillRef | null {
   let url: URL;
   try {
     url = new URL(source);
@@ -339,7 +349,11 @@ export function parseNotionSkillUrl(source: string): string | null {
   }
 
   const match = decoded.toLowerCase().match(NOTION_PAGE_ID);
-  return match ? formatPageId(match[1]!) : null;
+  if (!match) return null;
+
+  const slug = decoded.slice(0, decoded.length - match[0]!.length);
+  const title = sanitizeMetadata(slug.replace(/[-_]+/g, ' ').trim());
+  return { id: formatPageId(match[1]!), title: title || null };
 }
 
 export async function fetchNotionSkillDirectory(
@@ -384,7 +398,7 @@ export async function prepareNotionSkillSource(
       fetchNotionWorkspaceName({ runNtn: options.runNtn }),
     ]);
     const downloaded = await download(directory.url);
-    spinner.stop(`Downloaded Notion skill ${pc.dim(pageId)}${inWorkspace(workspace)}`);
+    spinner.stop(`Downloaded skill from Notion${inWorkspace(workspace)}`);
     return { rootDir: downloaded.rootDir, tempDir: downloaded.tempDir };
   } catch (error) {
     spinner.stop(pc.red('Failed to prepare Notion skill'));
@@ -439,7 +453,7 @@ export async function prepareNotionPackSource(
   }
 
   spinner.stop(
-    `Found ${pc.green(packs.length)} Notion pack${packs.length === 1 ? '' : 's'}${inWorkspace(workspace)}`
+    `Found ${pc.green(packs.length)} Notion pack${packs.length === 1 ? '' : 's'} in${inWorkspace(workspace)}`
   );
   if (packs.length === 0) {
     throw new Error('Notion returned no packs for the authenticated workspace');

--- a/src/notion-test.ts
+++ b/src/notion-test.ts
@@ -269,6 +269,35 @@ export async function fetchNotionPackDirectory(
   return directory;
 }
 
+/**
+ * Best-effort label for the workspace `ntn` is authenticated against. A machine
+ * can hold credentials for several workspaces (and `--env` switches between
+ * whole environments), so installing from the wrong one is an easy mistake to
+ * make and a hard one to notice. Every Notion install reports which workspace
+ * it used.
+ *
+ * Never fatal: a failed lookup just omits the label rather than blocking an
+ * install that would otherwise succeed.
+ */
+export async function fetchNotionWorkspaceName(
+  options: FetchNotionPacksOptions = {}
+): Promise<string | null> {
+  const runNtn = options.runNtn ?? runNtnApi;
+  try {
+    const args = ['api', '/v1/users/me', '--notion-version', NOTION_API_VERSION];
+    const value = JSON.parse(await runNtn(args)) as unknown;
+    if (!isRecord(value) || !isRecord(value.bot)) return null;
+    const name = value.bot.workspace_name;
+    return typeof name === 'string' && name.length > 0 ? sanitizeMetadata(name) : null;
+  } catch {
+    return null;
+  }
+}
+
+function inWorkspace(workspace: string | null): string {
+  return workspace ? ` in ${pc.cyan(workspace)}` : '';
+}
+
 export function isNotionSource(source: string): boolean {
   return source.toLowerCase() === 'notion';
 }
@@ -348,9 +377,14 @@ export async function prepareNotionSkillSource(
   spinner.start('Fetching Notion skill with ntn…');
 
   try {
-    const directory = await fetchNotionSkillDirectory(pageId, { runNtn: options.runNtn });
+    // The workspace lookup is independent of the skill lookup, so it rides
+    // along for free rather than adding a round trip.
+    const [directory, workspace] = await Promise.all([
+      fetchNotionSkillDirectory(pageId, { runNtn: options.runNtn }),
+      fetchNotionWorkspaceName({ runNtn: options.runNtn }),
+    ]);
     const downloaded = await download(directory.url);
-    spinner.stop(`Downloaded Notion skill ${pc.dim(pageId)}`);
+    spinner.stop(`Downloaded Notion skill ${pc.dim(pageId)}${inWorkspace(workspace)}`);
     return { rootDir: downloaded.rootDir, tempDir: downloaded.tempDir };
   } catch (error) {
     spinner.stop(pc.red('Failed to prepare Notion skill'));
@@ -393,14 +427,20 @@ export async function prepareNotionPackSource(
   spinner.start('Fetching Notion packs with ntn…');
 
   let packs: NotionPack[];
+  let workspace: string | null = null;
   try {
-    packs = await fetchNotionPacks({ runNtn: options.runNtn });
+    [packs, workspace] = await Promise.all([
+      fetchNotionPacks({ runNtn: options.runNtn }),
+      fetchNotionWorkspaceName({ runNtn: options.runNtn }),
+    ]);
   } catch (error) {
     spinner.stop(pc.red('Failed to load Notion packs'));
     throw error;
   }
 
-  spinner.stop(`Found ${pc.green(packs.length)} Notion pack${packs.length === 1 ? '' : 's'}`);
+  spinner.stop(
+    `Found ${pc.green(packs.length)} Notion pack${packs.length === 1 ? '' : 's'}${inWorkspace(workspace)}`
+  );
   if (packs.length === 0) {
     throw new Error('Notion returned no packs for the authenticated workspace');
   }


### PR DESCRIPTION
Adds `npx skills add <notion page url>`, which installs the single skill on that page via the new `GET /v1/ai/skills/{id}` endpoint.

```bash
npx skills add https://app.notion.com/p/notiondevs/Capture-meeting-decisions-c169bd0a546a45d48344ffacad25d763
```

This PR reuses some of the existing infrastructure for installing whole skill packs.