### PR TITLE
feat: add GigaCode CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The CLI for the open agent skills ecosystem.
 
 <!-- agent-list:start -->
-Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [75 more](#supported-agents).
+Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [76 more](#supported-agents).
 <!-- agent-list:end -->
 
 [![skills.sh](https://skills.sh/b/vercel-labs/skills)](https://skills.sh/vercel-labs/skills)
@@ -298,6 +298,7 @@ Skills can be installed to any of these agents:
 | ForgeCode | `forgecode` | `.forge/skills/` | `~/.forge/skills/` |
 | fx | `fx` | `.fx/skills/` | `~/.fx/skills/` |
 | Gemini CLI | `gemini-cli` | `.agents/skills/` | `~/.gemini/skills/` |
+| GigaCode CLI | `gigacode` | `.gigacode/skills/` | `~/.gigacode/skills/` |
 | GitHub Copilot | `github-copilot` | `.agents/skills/` | `~/.copilot/skills/` |
 | Goose | `goose` | `.goose/skills/` | `~/.config/goose/skills/` |
 | Grok Build | `grok` | `.grok/skills/` | `~/.grok/skills/` |
@@ -434,6 +435,7 @@ discover `SKILL.md` files outside these container directories (e.g. under
 - `agent/skills/`
 - `.forge/skills/`
 - `.fx/skills/`
+- `.gigacode/skills/`
 - `.goose/skills/`
 - `.grok/skills/`
 - `.hermes/skills/`
@@ -559,6 +561,7 @@ GitHub repository and skill identifiers are sent only for repositories that GitH
 - [Cursor Skills Documentation](https://cursor.com/docs/context/skills)
 - [Firebender Skills Documentation](https://docs.firebender.com/multi-agent/skills)
 - [Gemini CLI Skills Documentation](https://geminicli.com/docs/cli/skills/)
+- [GigaCode CLI Skills Documentation](https://gitverse.ru/docs/ai/ai-assistant-gigacode/gigacode-cli/skills)
 - [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
 - [iFlow CLI Skills Documentation](https://platform.iflow.cn/en/cli/examples/skill)
 - [Kimi Code CLI Skills Documentation](https://moonshotai.github.io/kimi-code/en/customization/skills)

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "forgecode",
     "fx",
     "gemini-cli",
+    "gigacode",
     "github-copilot",
     "goose",
     "grok",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -364,6 +364,15 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, '.gemini'));
     },
   },
+  gigacode: {
+    name: 'gigacode',
+    displayName: 'GigaCode CLI',
+    skillsDir: '.gigacode/skills',
+    globalSkillsDir: join(home, '.gigacode/skills'),
+    detectInstalled: async () => {
+      return existsSync(join(home, '.gigacode'));
+    },
+  },
   'github-copilot': {
     name: 'github-copilot',
     displayName: 'GitHub Copilot',

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -317,6 +317,7 @@ const PRIORITY_PREFIXES = [
   '.commandcode/skills/',
   '.continue/skills/',
   '.factory/skills/',
+  '.gigacode/skills/',
   '.github/skills/',
   '.goose/skills/',
   '.grok/skills/',

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -18,6 +18,7 @@ const AGENT_PROJECT_SKILL_DIRS = [
   '.commandcode/skills',
   '.continue/skills',
   '.factory/skills',
+  '.gigacode/skills',
   '.github/skills',
   '.goose/skills',
   '.grok/skills',

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export type AgentType =
   | 'forgecode'
   | 'fx'
   | 'gemini-cli'
+  | 'gigacode'
   | 'github-copilot'
   | 'goose'
   | 'grok'


### PR DESCRIPTION
Adds GigaCode CLI support via `-a gigacode` for `npx skills add`, `npx skills list`, and `npx skills remove`.

Installs skills to `.gigacode/skills/` in projects and `~/.gigacode/skills/` globally, following the [GigaCode CLI documentation](https://gitverse.ru/docs/ai/ai-assistant-gigacode/gigacode-cli/skills). Detects the agent through `~/.gigacode`.

GigaCode CLI 0.13.1 prioritizes native skills over entries with the same name in `.agents/skills` within the same scope. Using the native directory preserves that precedence.

Also adds `.gigacode/skills/` to local repository and GitHub tree discovery, and updates the README and package keywords.

Validation:

- Agent validation, type checking, formatting, and build passed.
- Full test suite passed: 811 tests.
- Rerunning agent synchronization produced no changes.
- Local `skills` CLI checks covered project and global `add` → `list` → `remove`, including fresh projects and copy installs.
- Shared symlink installs were checked with another agent using existing configuration directories. Removing GigaCode's link preserved the other agent's skill.
- Discovery fixtures covered `.gigacode/skills/` alongside the standard `skills/` directory.
