### PR TITLE
fix(add): honor explicit project agent selection

### DIFF
--- a/src/add.test.ts
+++ b/src/add.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFileSync } from 'child_process';
-import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, rmSync, mkdirSync, writeFileSync, lstatSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runCli, stripAnsi } from './test-utils.ts';
@@ -121,6 +121,103 @@ Instructions here.
     expect(result.stdout).toContain('my-skill');
     expect(result.stdout).toContain('Done!');
     expect(result.exitCode).toBe(0);
+  });
+
+  it('creates the project symlink for an explicitly selected non-universal agent', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'kiro-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: kiro-skill
+description: A Kiro test skill
+---
+
+# Kiro Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    mkdirSync(join(projectDir, '.claude'), { recursive: true });
+
+    const result = runCli(
+      ['add', sourceDir, '-y', '--agent', 'kiro-cli', 'claude-code'],
+      projectDir,
+      noDetectedAgentEnv
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(lstatSync(join(projectDir, '.kiro', 'skills', 'kiro-skill')).isSymbolicLink()).toBe(
+      true
+    );
+    expect(existsSync(join(projectDir, '.agents', 'skills', 'kiro-skill'))).toBe(true);
+    expect(result.stdout).toContain('symlinked: Kiro CLI');
+  });
+
+  it('reports a skipped project symlink for an automatically selected agent', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'augment-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: augment-skill
+description: An Augment test skill
+---
+
+# Augment Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    const isolatedHome = join(testDir, 'home');
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(join(isolatedHome, '.augment'), { recursive: true });
+
+    const result = runCli(['add', sourceDir, '-y'], projectDir, {
+      ...noDetectedAgentEnv,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      AUGMENT_AGENT: '1',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(projectDir, '.augment'))).toBe(false);
+    expect(result.stdout).toContain('skipped: Augment (project directory not found)');
+  });
+
+  it('omits an automatically skipped agent from JSON install results', () => {
+    const sourceDir = join(testDir, 'source');
+    const skillDir = join(sourceDir, 'skills', 'augment-json-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: augment-json-skill
+description: An Augment JSON test skill
+---
+
+# Augment JSON Skill
+`
+    );
+
+    const projectDir = join(testDir, 'project');
+    const isolatedHome = join(testDir, 'home');
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(join(isolatedHome, '.augment'), { recursive: true });
+
+    const result = runCli(['add', sourceDir, '-y', '--json'], projectDir, {
+      ...noDetectedAgentEnv,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      AUGMENT_AGENT: '1',
+    });
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout.trim());
+    expect(parsed[0].status).toBe('installed');
+    expect(parsed[0].agents).not.toContain('Augment');
   });
 
   it('should exit non-zero when the agent prompt cannot run without a TTY', () => {

--- a/src/add.ts
+++ b/src/add.ts
@@ -369,6 +369,7 @@ function buildResultLines(
     agent: string;
     symlinkFailed?: boolean;
     skipped?: boolean;
+    skipReason?: string;
   }>,
   targetAgents: AgentType[]
 ): string[] {
@@ -383,6 +384,14 @@ function buildResultLines(
     .filter((r) => !r.symlinkFailed && !r.skipped && !universal.includes(r.agent))
     .map((r) => r.agent);
   const failedSymlinks = results.filter((r) => r.symlinkFailed && !r.skipped).map((r) => r.agent);
+  const skippedSymlinks = results
+    .filter(
+      (r) =>
+        r.skipped &&
+        r.skipReason === 'missing-agent-project-directory' &&
+        symlinkAgents.includes(r.agent)
+    )
+    .map((r) => r.agent);
 
   if (universal.length > 0) {
     lines.push(`  ${pc.green('universal:')} ${formatList(universal)}`);
@@ -392,6 +401,11 @@ function buildResultLines(
   }
   if (failedSymlinks.length > 0) {
     lines.push(`  ${pc.yellow('copied:')} ${formatList(failedSymlinks)}`);
+  }
+  if (skippedSymlinks.length > 0) {
+    lines.push(
+      `  ${pc.yellow('skipped:')} ${formatList(skippedSymlinks)} ${pc.dim('(project directory not found)')}`
+    );
   }
 
   return lines;
@@ -1168,6 +1182,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
     emitJsonAndExit(1, 'Missing required argument: source');
   }
 
+  // Capture command-line intent before agent-context detection populates
+  // options.agent with automatic defaults.
+  const explicitlySelectedAgents = new Set<AgentType>(
+    options.agent?.includes('*') ? [] : ((options.agent as AgentType[] | undefined) ?? [])
+  );
+
   // --all implies --skill '*' and --agent '*' and -y
   if (options.all) {
     options.skill = ['*'];
@@ -1572,6 +1592,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
 
         if (useEve) {
           targetAgents = ['eve'];
+          if (!options.yes) explicitlySelectedAgents.add('eve');
           p.log.info(`Installing to: ${pc.cyan(EVE_AGENT_LABEL)}`);
         } else {
           const selected = await selectAgentsInteractive({ global: options.global });
@@ -1582,6 +1603,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           }
 
           targetAgents = selected as AgentType[];
+          for (const agent of targetAgents) explicitlySelectedAgents.add(agent);
         }
       } else if (installedAgents.length === 0) {
         if (options.yes) {
@@ -1609,6 +1631,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           }
 
           targetAgents = selected as AgentType[];
+          for (const agent of targetAgents) explicitlySelectedAgents.add(agent);
         }
       } else if (installedAgents.length === 1 || options.yes) {
         // Auto-select detected agents + ensure universal agents are included
@@ -1630,12 +1653,14 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
         }
 
         targetAgents = selected as AgentType[];
+        for (const agent of targetAgents) explicitlySelectedAgents.add(agent);
       }
     }
 
     // An explicit --subagent flag implies the user wants to target Eve.
-    if (options.subagent && options.subagent.length > 0 && !targetAgents.includes('eve')) {
-      targetAgents = [...targetAgents, 'eve'];
+    if (options.subagent && options.subagent.length > 0) {
+      explicitlySelectedAgents.add('eve');
+      if (!targetAgents.includes('eve')) targetAgents = [...targetAgents, 'eve'];
     }
 
     // Eve supports subagents, each with their own skills directory at
@@ -1882,6 +1907,8 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
       canonicalPath?: string;
       mode: InstallMode;
       symlinkFailed?: boolean;
+      skipped?: boolean;
+      skipReason?: string;
       error?: string;
       pluginName?: string;
     }[] = [];
@@ -1896,7 +1923,12 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           result = await installBlobSkillForAgent(
             { installName: blobSkill.name, files: blobSkill.files },
             agent,
-            { global: installGlobally, mode: installMode, eveSubagent: subagent }
+            {
+              global: installGlobally,
+              mode: installMode,
+              eveSubagent: subagent,
+              createMissingAgentRoot: explicitlySelectedAgents.has(agent),
+            }
           );
         } else {
           // Disk-based install: copy from cloned/local directory.
@@ -1908,6 +1940,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
             global: installGlobally,
             mode: installMode,
             eveSubagent: subagent,
+            createMissingAgentRoot: explicitlySelectedAgents.has(agent),
           });
         }
         results.push({
@@ -2118,7 +2151,7 @@ export async function runAdd(args: string[], options: AddOptions = {}): Promise<
           hash: installedSkillHashes.get(name) ?? null,
           path: skillResults[0]?.canonicalPath ?? skillResults[0]?.path,
           scope: installGlobally ? 'global' : 'project',
-          agents: skillResults.map((r) => r.agent),
+          agents: skillResults.filter((r) => !r.skipped).map((r) => r.agent),
           mode: skillResults[0]?.mode ?? installMode,
           security: buildJsonSecurity(auditDataForJson, name, ownerRepoForAudit),
         });

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -157,6 +157,8 @@ export const agents: Record<AgentType, AgentConfig> = {
     displayName: 'Claude Code',
     skillsDir: '.claude/skills',
     globalSkillsDir: join(claudeHome, 'skills'),
+    // Preserve the established project-install behavior from #1138 and #1607.
+    createProjectSkillsDirByDefault: true,
     detectInstalled: async () => {
       return existsSync(claudeHome);
     },

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -32,6 +32,15 @@ import { parseSkillMd } from './skills.ts';
 
 export type InstallMode = 'symlink' | 'copy';
 
+interface InstallOptions {
+  global?: boolean;
+  cwd?: string;
+  mode?: InstallMode;
+  eveSubagent?: string;
+  /** Create a missing agent-specific project root because the user selected this agent. */
+  createMissingAgentRoot?: boolean;
+}
+
 interface InstallResult {
   success: boolean;
   path: string;
@@ -39,6 +48,7 @@ interface InstallResult {
   mode: InstallMode;
   symlinkFailed?: boolean;
   skipped?: boolean;
+  skipReason?: 'missing-agent-project-directory';
   error?: string;
 }
 
@@ -80,6 +90,25 @@ function isPathSafe(basePath: string, targetPath: string): boolean {
 
 function pathsOverlap(pathA: string, pathB: string): boolean {
   return isPathSafe(pathA, pathB) || isPathSafe(pathB, pathA);
+}
+
+function shouldSkipProjectAgentSymlink(
+  agentType: AgentType,
+  isGlobal: boolean,
+  cwd: string,
+  createMissingAgentRoot: boolean
+): boolean {
+  if (
+    isGlobal ||
+    isUniversalAgent(agentType) ||
+    createMissingAgentRoot ||
+    agents[agentType].createProjectSkillsDirByDefault
+  ) {
+    return false;
+  }
+
+  const agentRoot = agents[agentType].skillsDir.split('/')[0]!;
+  return !existsSync(join(cwd, agentRoot));
 }
 
 // Dirent.isDirectory() is false for symlinks; follow and verify the target is a directory.
@@ -266,7 +295,7 @@ async function createSymlink(target: string, linkPath: string): Promise<boolean>
 export async function installSkillForAgent(
   skill: Skill,
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: InstallOptions = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -376,17 +405,22 @@ export async function installSkillForAgent(
     // whose config directory doesn't already exist in the project. This prevents
     // creating directories like .windsurf/, .kiro/, etc. when those agents aren't
     // actually used in this project. The skill is already available in .agents/skills/.
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
+    if (
+      shouldSkipProjectAgentSymlink(
+        agentType,
+        isGlobal,
+        cwd,
+        options.createMissingAgentRoot ?? false
+      )
+    ) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
+        skipReason: 'missing-agent-project-directory',
+      };
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);
@@ -907,7 +941,7 @@ export async function installWellKnownSkillForAgent(
 export async function installBlobSkillForAgent(
   skill: { installName: string; files: Array<{ path: string; contents: string }> },
   agentType: AgentType,
-  options: { global?: boolean; cwd?: string; mode?: InstallMode; eveSubagent?: string } = {}
+  options: InstallOptions = {}
 ): Promise<InstallResult> {
   const agent = agents[agentType];
   const isGlobal = options.global ?? false;
@@ -1019,20 +1053,24 @@ export async function installBlobSkillForAgent(
     }
 
     // For project-level installs, skip creating symlinks for non-universal agents
-    // whose config directory doesn't already exist in the project. Claude Code is
-    // exempted since it can be explicitly selected as the install target even when
-    // .claude/ doesn't exist yet (see installSkillForAgent for the same exemption).
-    if (!isGlobal && !isUniversalAgent(agentType)) {
-      const agentRootDir = join(cwd, agents[agentType].skillsDir.split('/')[0]!);
-      if (!existsSync(agentRootDir) && agentType !== 'claude-code') {
-        return {
-          success: true,
-          path: canonicalDir,
-          canonicalPath: canonicalDir,
-          mode: 'symlink',
-          skipped: true,
-        };
-      }
+    // whose config directory doesn't already exist in the project. Explicitly
+    // selected agents and agents with a compatibility policy are exempt.
+    if (
+      shouldSkipProjectAgentSymlink(
+        agentType,
+        isGlobal,
+        cwd,
+        options.createMissingAgentRoot ?? false
+      )
+    ) {
+      return {
+        success: true,
+        path: canonicalDir,
+        canonicalPath: canonicalDir,
+        mode: 'symlink',
+        skipped: true,
+        skipReason: 'missing-agent-project-directory',
+      };
     }
 
     const symlinkCreated = await createSymlink(canonicalDir, agentDir);

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,8 @@ export interface AgentConfig {
   showInUniversalList?: boolean;
   /** Whether to display this universal agent in the interactive locked section. Defaults to true. */
   showInUniversalPrompt?: boolean;
+  /** Whether automatic project installs may create this agent's missing skills root. */
+  createProjectSkillsDirByDefault?: boolean;
 }
 
 export interface ParsedSource {

--- a/tests/installer-symlink.test.ts
+++ b/tests/installer-symlink.test.ts
@@ -257,6 +257,43 @@ describe('installer symlink regression', () => {
     }
   });
 
+  it('creates a blob symlink when the caller allows the missing agent root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-'));
+    const projectDir = join(root, 'project');
+    await mkdir(projectDir, { recursive: true });
+
+    const skillName = 'explicit-kiro-blob-skill';
+
+    try {
+      const result = await installBlobSkillForAgent(
+        {
+          installName: skillName,
+          files: [
+            {
+              path: 'SKILL.md',
+              contents: `---\nname: ${skillName}\ndescription: test\n---\n`,
+            },
+          ],
+        },
+        'kiro-cli',
+        {
+          cwd: projectDir,
+          mode: 'symlink',
+          global: false,
+          createMissingAgentRoot: true,
+        }
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBeUndefined();
+      expect((await lstat(join(projectDir, '.kiro/skills', skillName))).isSymbolicLink()).toBe(
+        true
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   // Regression test for #294: universal-only global install should not create agent-specific symlinks
   it('does not create agent-specific symlinks for universal agents on global install', async () => {
     const root = await mkdtemp(join(tmpdir(), 'add-skill-'));


### PR DESCRIPTION
Fixes #2071.
Supersedes #2072 with explicit-selection provenance that remains correct when agent-context detection populates `options.agent`.

## What changed

- Capture explicitly requested agents before automatic agent detection mutates command options.
- Track interactive selections per agent rather than applying one boolean to the entire target set.
- Let explicitly selected non-universal agents create their required project skill directory.
- Keep automatic detection, `--all`, and `--agent '*'` conservative so they do not scatter agent directories through a project.
- Share the project-symlink skip policy between disk and blob installers.
- Replace the hard-coded Claude name check with a declarative compatibility flag, preserving the behavior fixed by #1138 and #1607.
- Report automatically skipped agent links in human output and omit those agents from JSON installation results.

## Tests

Added CLI-level regression coverage for:

- explicit `kiro-cli` + `claude-code` installation when `.kiro/` does not exist
- automatic Augment selection preserving the no-scatter behavior
- visible skipped-agent output
- JSON results excluding agents whose project link was skipped

Added blob-installer coverage for explicitly creating a missing Kiro project root. Existing Claude disk/blob regression tests continue to pass.

Validated locally with formatting, 825 applicable tests, type-check, build, and agent-registry validation.
