### PR TITLE
fix(installer): do not dereference symlinks that point outside the skill

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -497,7 +497,46 @@ function stripIgnoredEveFrontmatter(raw: string): string {
   return `---\n${frontmatter}\n---\n${content.replace(/^\r?\n/u, '')}`;
 }
 
-async function copyDirectory(src: string, dest: string, agentType?: AgentType): Promise<void> {
+/**
+ * Whether a symlink inside a skill points outside that skill's own directory.
+ *
+ * Skill files are copied with `dereference: true`, so a symlink is written to
+ * disk as a *copy of its target's contents*. That is right for a link pointing
+ * at a sibling file — the link would not resolve once the skill has moved — and
+ * wrong for one pointing anywhere else: a skill repo containing
+ * `reference.md -> /etc/passwd` would install a readable copy of that file.
+ *
+ * This matters more than an ordinary hostile-dependency risk, because a skill
+ * directory exists to be read into an agent's context. The copied bytes are not
+ * merely on disk; they are content the model reads.
+ *
+ * `readZipArchive` already refuses link entries outright ("Archive links are
+ * not supported"), so without this check the git path is strictly weaker than
+ * the archive path against the same threat.
+ *
+ * Compared with `realpath`, not lexically: the point is where the link actually
+ * lands, after any intermediate symlinks have been resolved.
+ */
+async function symlinkEscapesSkill(srcPath: string, skillRoot: string): Promise<boolean> {
+  try {
+    const [resolvedTarget, resolvedRoot] = await Promise.all([
+      realpath(srcPath),
+      realpath(skillRoot),
+    ]);
+    return !isPathSafe(resolvedRoot, resolvedTarget);
+  } catch {
+    // Broken link. The existing ENOENT handling below reports and skips it;
+    // treating it as an escape here would change that message for the worse.
+    return false;
+  }
+}
+
+async function copyDirectory(
+  src: string,
+  dest: string,
+  agentType?: AgentType,
+  skillRoot: string = src
+): Promise<void> {
   await mkdir(dest, { recursive: true });
 
   const entries = await readdir(src, { withFileTypes: true });
@@ -511,9 +550,22 @@ async function copyDirectory(src: string, dest: string, agentType?: AgentType): 
         const destPath = join(dest, entry.name);
 
         if (entry.isDirectory()) {
-          await copyDirectory(srcPath, destPath, agentType);
+          await copyDirectory(srcPath, destPath, agentType, skillRoot);
         } else {
           try {
+            // Checked before the copy, because the copy is what dereferences.
+            // Skipped rather than fatal, matching how this function already
+            // treats a broken symlink: one bad link should not abort an
+            // otherwise good install.
+            if (entry.isSymbolicLink() && (await symlinkEscapesSkill(srcPath, skillRoot))) {
+              console.warn(
+                `Skipping symlink that points outside the skill: ${entry.name}\n` +
+                  '  Skill files are copied by value, so this would install a copy of a file ' +
+                  'from elsewhere on your machine.'
+              );
+              return;
+            }
+
             if (agentType === 'eve' && entry.name.toLowerCase() === 'skill.md') {
               await writeFile(
                 destPath,

--- a/tests/installer-symlink-escape.test.ts
+++ b/tests/installer-symlink-escape.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Skill files are copied with `dereference: true`, so a symlink is written to
+ * disk as a copy of its target's contents. That is correct for a link pointing
+ * at a sibling file and wrong for one pointing anywhere else: a skill repo
+ * containing `reference.md -> /etc/passwd` would otherwise install a readable
+ * copy of that file.
+ *
+ * It matters more than an ordinary hostile-dependency risk because a skill
+ * directory exists to be read into an agent's context — the copied bytes are
+ * not merely on disk, they are content the model reads.
+ *
+ * `readZipArchive` already refuses link entries outright ("Archive links are
+ * not supported"), so without this the git path is strictly weaker than the
+ * archive path against the same threat.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, symlink, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { installSkillForAgent } from '../src/installer.ts';
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('symlinks that escape the skill directory', () => {
+  it('does not copy a file the symlink points to outside the skill', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-escape-'));
+    const projectDir = join(root, 'project');
+    const secretDir = join(root, 'secret');
+    const skillDir = join(root, 'source-skill');
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(secretDir, { recursive: true });
+    await mkdir(skillDir, { recursive: true });
+
+    const secretPath = join(secretDir, 'id_rsa');
+    await writeFile(secretPath, 'PRIVATE-KEY-DO-NOT-COPY', 'utf-8');
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: escape\ndescription: t\n---\n',
+      'utf-8'
+    );
+    await symlink(secretPath, join(skillDir, 'reference.md'));
+
+    const result = await installSkillForAgent(
+      { name: 'escape', description: 'test', path: skillDir },
+      'claude-code',
+      { cwd: projectDir, mode: 'copy', global: false }
+    );
+
+    expect(result.success).toBe(true);
+
+    const installed = join(projectDir, '.claude/skills/escape');
+    expect(await exists(join(installed, 'SKILL.md'))).toBe(true);
+    // The link is skipped rather than dereferenced, so no copy of the target.
+    expect(await exists(join(installed, 'reference.md'))).toBe(false);
+  });
+
+  it('does not copy a directory the symlink points to outside the skill', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-escape-dir-'));
+    const projectDir = join(root, 'project');
+    const secretDir = join(root, 'secret');
+    const skillDir = join(root, 'source-skill');
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(secretDir, { recursive: true });
+    await mkdir(skillDir, { recursive: true });
+
+    await writeFile(join(secretDir, 'id_rsa'), 'PRIVATE-KEY-DO-NOT-COPY', 'utf-8');
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: escapedir\ndescription: t\n---\n',
+      'utf-8'
+    );
+    await symlink(secretDir, join(skillDir, 'docs'));
+
+    await installSkillForAgent(
+      { name: 'escapedir', description: 'test', path: skillDir },
+      'claude-code',
+      { cwd: projectDir, mode: 'copy', global: false }
+    );
+
+    const installed = join(projectDir, '.claude/skills/escapedir');
+    expect(await exists(join(installed, 'docs/id_rsa'))).toBe(false);
+  });
+
+  it('still dereferences a symlink that stays inside the skill', async () => {
+    // The behaviour the `dereference: true` comment exists to protect: a link
+    // to a sibling would not resolve once the skill has been copied elsewhere.
+    const root = await mkdtemp(join(tmpdir(), 'add-skill-inside-'));
+    const projectDir = join(root, 'project');
+    const skillDir = join(root, 'source-skill');
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(join(skillDir, 'shared'), { recursive: true });
+
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: inside\ndescription: t\n---\n',
+      'utf-8'
+    );
+    await writeFile(join(skillDir, 'shared/common.md'), 'shared content', 'utf-8');
+    await symlink(join(skillDir, 'shared/common.md'), join(skillDir, 'alias.md'));
+
+    await installSkillForAgent(
+      { name: 'inside', description: 'test', path: skillDir },
+      'claude-code',
+      { cwd: projectDir, mode: 'copy', global: false }
+    );
+
+    const installed = join(projectDir, '.claude/skills/inside');
+    expect(await exists(join(installed, 'alias.md'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Skill files are copied with `dereference: true`, so a symlink is written to disk as a **copy of its target's contents**. That is correct for a link pointing at a sibling file — the link would not resolve once the skill has been copied elsewhere, which is what the existing comment describes — and wrong for a link pointing anywhere else.

A skill repo containing `reference.md -> /etc/passwd` currently installs a readable copy of that file into the skill directory. A directory symlink is followed too, because `recursive: true` is set alongside `dereference`.

## Why it matters

A skill directory exists to be read into an agent's context, so the copied bytes are not merely on disk — they are content the model reads and may transmit. Project-scoped installs are also commonly committed.

`readZipArchive` already refuses link entries outright (`Archive links are not supported`), so without this check the git path is strictly weaker than the archive path against the same threat.

Scope, as measured rather than assumed: it needs a hostile or compromised skill, and the attacker must guess an absolute path (`~` and globbing do not work in a symlink target). `/proc/self/environ` yields 0 bytes, so environment capture does not work. `/etc/passwd`, CI paths such as `/home/runner/...`, and Kubernetes service-account token paths do.

## Reproduction

```bash
mkdir -p repo/skills/helper
printf -- '---\nname: helper\ndescription: t\n---\nhi\n' > repo/skills/helper/SKILL.md
ln -s /etc/passwd repo/skills/helper/reference.md

cd some-project && npx skills add ../repo --agent claude-code --yes
cat .claude/skills/helper/reference.md   # before: /etc/passwd, as a regular file
```

## The fix

Compare the link's `realpath` against the skill root and skip a link that escapes it, reusing the existing `isPathSafe` containment helper. Links that stay inside the skill are still dereferenced, so the behaviour the original comment protects is unchanged.

Skipping rather than failing the install matches how `copyDirectory` already handles a broken symlink: one bad link should not abort an otherwise good install. Refusing outright, as the archive reader does, is also defensible — happy to switch if you prefer that.

## Tests

Three regression tests: an escaping file link, an escaping directory link, and an in-skill link that must still be followed.

Full suite with the patch: **826 passed**, up from 823, with the same 4 pre-existing failures on `main` (3 in `src/detect-agent.test.ts`, which fail whenever ambient agent env vars are present, and 1 in `tests/private-repo-add-security.test.ts`, whose `vi.mock` of `../src/git.ts` omits `GitCloneError` so the case throws before asserting). Happy to open those separately if useful.